### PR TITLE
Change Rect to Rect2d in Tracker::update() and ::init()

### DIFF
--- a/modules/tracking/doc/common_interfaces_tracker.rst
+++ b/modules/tracking/doc/common_interfaces_tracker.rst
@@ -15,9 +15,9 @@ Base abstract class for the long-term tracker::
    {
      virtual ~Tracker();
 
-     bool init( const Mat& image, const Rect& boundingBox );
+     bool init( const Mat& image, const Rect2d& boundingBox );
 
-     bool update( const Mat& image, Rect& boundingBox );
+     bool update( const Mat& image, Rect2d& boundingBox );
 
      static Ptr<Tracker> create( const String& trackerType );
 
@@ -28,11 +28,13 @@ Tracker::init
 
 Initialize the tracker with a know bounding box that surrounding the target
 
-.. ocv:function:: bool Tracker::init( const Mat& image, const Rect& boundingBox )
+.. ocv:function:: bool Tracker::init( const Mat& image, const Rect2d& boundingBox )
 
     :param image: The initial frame
 
     :param boundingBox: The initial boundig box
+
+    :return: True if initialization went succesfully, false otherwise
 
 
 Tracker::update
@@ -40,11 +42,13 @@ Tracker::update
 
 Update the tracker, find the new most likely bounding box for the target
 
-.. ocv:function:: bool Tracker::update( const Mat& image, Rect& boundingBox )
+.. ocv:function:: bool Tracker::update( const Mat& image, Rect2d& boundingBox )
 
     :param image: The current frame
 
-    :param boundingBox: The boundig box that represent the new target location
+    :param boundingBox: The boundig box that represent the new target location, if true was returned, not modified otherwise
+
+    :return: True means that target was located and false means that tracker cannot locate target in current frame. Note, that latter *does not* imply that tracker has failed, maybe target is indeed missing from the frame (say, out of sight)
 
 
 Tracker::create
@@ -83,8 +87,8 @@ Example of creating specialized Tracker ``TrackerMIL`` : ::
      ...
 
     protected:
-     bool initImpl( const Mat& image, const Rect& boundingBox );
-     bool updateImpl( const Mat& image, Rect& boundingBox );
+     bool initImpl( const Mat& image, const Rect2d& boundingBox );
+     bool updateImpl( const Mat& image, Rect2d& boundingBox );
      ...
    };
 
@@ -192,7 +196,7 @@ Example of creating specialized TrackerModel ``TrackerMILModel`` : ::
 
 And add it in your Tracker : ::
 
-   bool TrackerMIL::initImpl( const Mat& image, const Rect& boundingBox )
+   bool TrackerMIL::initImpl( const Mat& image, const Rect2d& boundingBox )
    {
      ...
      //model is the general TrackerModel field od the general Tracker

--- a/modules/tracking/doc/common_interfaces_tracker_feature_set.rst
+++ b/modules/tracking/doc/common_interfaces_tracker_feature_set.rst
@@ -83,7 +83,7 @@ The modes available now:
 
 * ``"HAAR"`` -- Haar Feature-based
 
-The modes available soon:
+The modes that will be available soon:
 
 * ``"HOG"`` -- Histogram of Oriented Gradients features
 
@@ -170,7 +170,7 @@ The modes available now:
 
 * ``"HAAR"`` -- Haar Feature-based
 
-The modes available soon:
+The modes that will be available soon:
 
 * ``"HOG"`` -- Histogram of Oriented Gradients features
 

--- a/modules/tracking/include/opencv2/tracking/tracker.hpp
+++ b/modules/tracking/include/opencv2/tracking/tracker.hpp
@@ -482,7 +482,7 @@ class CV_EXPORTS_W Tracker : public virtual Algorithm
    * \param boundingBox    The bounding box.
    * \return true the tracker is initialized, false otherwise
    */
-  bool init( const Mat& image, const Rect& boundingBox );
+  bool init( const Mat& image, const Rect2d& boundingBox );
 
   /**
    * \brief Update the tracker at the next frames.
@@ -490,7 +490,7 @@ class CV_EXPORTS_W Tracker : public virtual Algorithm
    * \param boundingBox    The bounding box.
    * \return true the tracker is updated, false otherwise
    */
-  bool update( const Mat& image, Rect& boundingBox );
+  bool update( const Mat& image, Rect2d& boundingBox );
 
   /**
    * \brief Create tracker by tracker type MIL - BOOSTING.
@@ -499,8 +499,8 @@ class CV_EXPORTS_W Tracker : public virtual Algorithm
 
  protected:
 
-  virtual bool initImpl( const Mat& image, const Rect& boundingBox ) = 0;
-  virtual bool updateImpl( const Mat& image, Rect& boundingBox ) = 0;
+  virtual bool initImpl( const Mat& image, const Rect2d& boundingBox ) = 0;
+  virtual bool updateImpl( const Mat& image, Rect2d& boundingBox ) = 0;
 
   bool isInit;
 
@@ -981,8 +981,8 @@ class CV_EXPORTS_W TrackerMIL : public Tracker
 
  protected:
 
-  bool initImpl( const Mat& image, const Rect& boundingBox );
-  bool updateImpl( const Mat& image, Rect& boundingBox );
+  bool initImpl( const Mat& image, const Rect2d& boundingBox );
+  bool updateImpl( const Mat& image, Rect2d& boundingBox );
   void compute_integral( const Mat & img, Mat & ii_img );
 
   Params params;
@@ -1029,8 +1029,8 @@ class CV_EXPORTS_W TrackerBoosting : public Tracker
 
  protected:
 
-  bool initImpl( const Mat& image, const Rect& boundingBox );
-  bool updateImpl( const Mat& image, Rect& boundingBox );
+  bool initImpl( const Mat& image, const Rect2d& boundingBox );
+  bool updateImpl( const Mat& image, Rect2d& boundingBox );
 
   Params params;
   AlgorithmInfo* info() const;

--- a/modules/tracking/perf/perf_Tracker.cpp
+++ b/modules/tracking/perf/perf_Tracker.cpp
@@ -161,7 +161,8 @@ PERF_TEST_P(tracking, mil, testing::Combine(TESTSET_NAMES, SEGMENTS))
   int endFrame = 0;
   getSegment( segmentId, numSegments, bbCounter, startFrame, endFrame );
 
-  Rect currentBB = gtBBs[startFrame - gtStartFrame];
+  Rect currentBBi = gtBBs[startFrame - gtStartFrame];
+  Rect2d currentBB(currentBBi);
 
   TEST_CYCLE_N(1)
   {
@@ -231,7 +232,8 @@ PERF_TEST_P(tracking, boosting, testing::Combine(TESTSET_NAMES, SEGMENTS))
   int endFrame = 0;
   getSegment( segmentId, numSegments, bbCounter, startFrame, endFrame );
 
-  Rect currentBB = gtBBs[startFrame - gtStartFrame];
+  Rect currentBBi = gtBBs[startFrame - gtStartFrame];
+  Rect2d currentBB(currentBBi);
 
   TEST_CYCLE_N(1)
   {

--- a/modules/tracking/samples/tracker.cpp
+++ b/modules/tracking/samples/tracker.cpp
@@ -7,7 +7,7 @@ using namespace std;
 using namespace cv;
 
 static Mat image;
-static Rect boundingBox;
+static Rect2d boundingBox;
 static bool paused;
 static bool selectObject = false;
 static bool startSelection = false;

--- a/modules/tracking/src/tracker.cpp
+++ b/modules/tracking/src/tracker.cpp
@@ -52,7 +52,7 @@ Tracker::~Tracker()
 {
 }
 
-bool Tracker::init( const Mat& image, const Rect& boundingBox )
+bool Tracker::init( const Mat& image, const Rect2d& boundingBox )
 {
 
   if( isInit )
@@ -84,7 +84,7 @@ bool Tracker::init( const Mat& image, const Rect& boundingBox )
   return initTracker;
 }
 
-bool Tracker::update( const Mat& image, Rect& boundingBox )
+bool Tracker::update( const Mat& image, Rect2d& boundingBox )
 {
 
   if( !isInit )

--- a/modules/tracking/src/trackerBoosting.cpp
+++ b/modules/tracking/src/trackerBoosting.cpp
@@ -106,7 +106,7 @@ void TrackerBoosting::write( cv::FileStorage& fs ) const
   params.write( fs );
 }
 
-bool TrackerBoosting::initImpl( const Mat& image, const Rect& boundingBox )
+bool TrackerBoosting::initImpl( const Mat& image, const Rect2d& boundingBox )
 {
   srand (1);
   //sampling
@@ -190,7 +190,7 @@ bool TrackerBoosting::initImpl( const Mat& image, const Rect& boundingBox )
   return true;
 }
 
-bool TrackerBoosting::updateImpl( const Mat& image, Rect& boundingBox )
+bool TrackerBoosting::updateImpl( const Mat& image, Rect2d& boundingBox )
 {
   Mat_<int> intImage;
   Mat_<double> intSqImage;

--- a/modules/tracking/src/trackerMIL.cpp
+++ b/modules/tracking/src/trackerMIL.cpp
@@ -122,7 +122,7 @@ void TrackerMIL::compute_integral( const Mat & img, Mat & ii_img )
   ii_img = ii_imgs[0];
 }
 
-bool TrackerMIL::initImpl( const Mat& image, const Rect& boundingBox )
+bool TrackerMIL::initImpl( const Mat& image, const Rect2d& boundingBox )
 {
   srand (1);
   Mat intImage;
@@ -184,7 +184,7 @@ bool TrackerMIL::initImpl( const Mat& image, const Rect& boundingBox )
   return true;
 }
 
-bool TrackerMIL::updateImpl( const Mat& image, Rect& boundingBox )
+bool TrackerMIL::updateImpl( const Mat& image, Rect2d& boundingBox )
 {
   Mat intImage;
   compute_integral( image, intImage );

--- a/modules/tracking/test/test_trackerOPE.cpp
+++ b/modules/tracking/test/test_trackerOPE.cpp
@@ -176,7 +176,8 @@ void TrackerOPETest::distanceTest()
   Mat frame;
   bool initialized = false;
 
-  Rect currentBB = bbs.at( 0 );
+  Rect currentBBi = bbs.at( 0 );
+  Rect2d currentBB(currentBBi);
   float sumDistance = 0;
   int frameCounter = 0;
   int frameCounterSucc = 0;
@@ -230,7 +231,8 @@ void TrackerOPETest::overlapTest()
 {
   Mat frame;
   bool initialized = false;
-  Rect currentBB = bbs.at( 0 );
+  Rect currentBBi = bbs.at( 0 );
+  Rect2d currentBB(currentBBi);
   float sumOverlap = 0;
   string folder = cvtest::TS::ptr()->get_data_path() + TRACKING_DIR + "/" + video + "/" + FOLDER_IMG;
 

--- a/modules/tracking/test/test_trackerSRE.cpp
+++ b/modules/tracking/test/test_trackerSRE.cpp
@@ -180,7 +180,8 @@ void TrackerSRETest::distanceTest()
   Mat frame;
   bool initialized = false;
 
-  Rect currentBB = bbs.at( 0 );
+  Rect currentBBi = bbs.at( 0 );
+  Rect2d currentBB(currentBBi);
   float sumDistance = 0;
   int frameCounter = 0;
   int frameCounterSucc = 0;
@@ -235,7 +236,8 @@ void TrackerSRETest::overlapTest()
 {
   Mat frame;
   bool initialized = false;
-  Rect currentBB = bbs.at( 0 );
+  Rect currentBBi = bbs.at( 0 );
+  Rect2d currentBB(currentBBi);
   float sumOverlap = 0;
   string folder = cvtest::TS::ptr()->get_data_path() + TRACKING_DIR + "/" + video + "/" + FOLDER_IMG;
 

--- a/modules/tracking/test/test_trackerTRE.cpp
+++ b/modules/tracking/test/test_trackerTRE.cpp
@@ -190,7 +190,8 @@ void TrackerTRETest::distanceTest()
 
   int fc = ( startFrame - gtStartFrame );
 
-  Rect currentBB = bbs.at( fc );
+  Rect currentBBi = bbs.at( fc );
+  Rect2d currentBB(currentBBi);
   float sumDistance = 0;
   string folder = cvtest::TS::ptr()->get_data_path() + TRACKING_DIR + "/" + video + "/" + FOLDER_IMG;
 
@@ -250,7 +251,8 @@ void TrackerTRETest::overlapTest()
   bool initialized = false;
 
   int fc = ( startFrame - gtStartFrame );
-  Rect currentBB = bbs.at( fc );
+  Rect currentBBi = bbs.at( fc );
+  Rect2d currentBB(currentBBi);
   float sumOverlap = 0;
   string folder = cvtest::TS::ptr()->get_data_path() + TRACKING_DIR + "/" + video + "/" + FOLDER_IMG;
 


### PR DESCRIPTION
I've changed Rect to Rect2d in Tracker::update(), Tracker::init() and
all related methods (including documentation). This allows to initialize
trackers with double-valued rectangles, thus adding versality. Besides,
trackers also can output double-valued rectangles, which may be
beneficial in some scenarios.

However, it remains to change UML diagrams in documentation to tracker
module, as they still display methods above with old signatures.
