### PR TITLE
fix compiling reg module after separating imgcodecs from highgui

### DIFF
--- a/modules/reg/test/test_reg.cpp
+++ b/modules/reg/test/test_reg.cpp
@@ -42,7 +42,7 @@
 //M*/
 
 #include "test_precomp.hpp"
-#include <opencv2/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
 #include <opencv2/core.hpp>
 
 #include "opencv2/reg/mapaffine.hpp"


### PR DESCRIPTION
fix compile error in reg tests
