### PR TITLE
fixing build with extra modules

### DIFF
--- a/modules/xfeatures2d/perf/perf_precomp.hpp
+++ b/modules/xfeatures2d/perf/perf_precomp.hpp
@@ -18,11 +18,11 @@
 #include "opencv2/opencv_modules.hpp"
 
 #ifdef HAVE_OPENCV_OCL
-#  include "opencv2/nonfree/ocl.hpp"
+#  include "opencv2/ocl.hpp"
 #endif
 
 #ifdef HAVE_CUDA
-#  include "opencv2/nonfree/cuda.hpp"
+#  include "opencv2/xfeatures2d/cuda.hpp"
 #endif
 
 #ifdef GTEST_CREATE_SHARED_LIBRARY

--- a/modules/xfeatures2d/test/test_precomp.hpp
+++ b/modules/xfeatures2d/test/test_precomp.hpp
@@ -22,11 +22,11 @@
 #include "cvconfig.h"
 
 #ifdef HAVE_OPENCV_OCL
-#  include "opencv2/nonfree/ocl.hpp"
+#  include "opencv2/ocl.hpp"
 #endif
 
 #ifdef HAVE_CUDA
-#  include "opencv2/nonfree/cuda.hpp"
+#  include "opencv2/xfeatures2d/cuda.hpp"
 #endif
 
 #endif


### PR DESCRIPTION
when building with CMAKE command

cmake -D CMAKE_BUILD_TYPE=RELEASE -D CMAKE_INSTALL_PREFIX=/usr/local -D WITH_CUBLAS=ON -D WITH_CUFFT=ON -D WITH_EIGEN=OFF -D WITH_OPENGL=ON -D WITH_QT=ON -D WITH_TBB=ON -D BUILD_EXAMPLES=ON -D BUILD_TESTS=ON -D CUDA_ARCH_BIN="3.0" -D WITH_IPP=ON -D OPENCV_EXTRA_MODULES_PATH=../opencv_contrib/modules/ ../opencv_3.0_alpha/

You get an error at about 33% saying

Generating perf_precomp.hpp.gch/opencv_perf_cuda_RELEASE.gch
In file included from /data/builds/opencv_3.0_alpha/modules/xfeatures2d/opencv_perf_xfeatures2d_pch_dephelp.cxx:1:0:
/data/builds/opencv_contrib/modules/xfeatures2d/perf/perf_precomp.hpp:25:38: fatal error: opencv2/nonfree/cuda.hpp: No such file or directory
 #  include "opencv2/nonfree/cuda.hpp" 
                                      ^
compilation terminated.
In file included from /data/builds/opencv_3.0_alpha/modules/xfeatures2d/opencv_test_xfeatures2d_pch_dephelp.cxx:1:0:
/data/builds/opencv_contrib/modules/xfeatures2d/test/test_precomp.hpp:29:38: fatal error: opencv2/nonfree/cuda.hpp: No such file or directory
 #  include "opencv2/nonfree/cuda.hpp" 
                                      ^
compilation terminated.

This fixes the issue. However still issues at 99% will try to fix those too.
