### PR TITLE
StructuredEdgeDetection to python

### DIFF
--- a/modules/ximgproc/include/opencv2/ximgproc/structured_edge_detection.hpp
+++ b/modules/ximgproc/include/opencv2/ximgproc/structured_edge_detection.hpp
@@ -107,7 +107,7 @@ public:
      * \param dst : destination image (grayscale, float, in [0;1])
      *              where edges are drawn
      */
-    CV_WRAP virtual void detectEdges(const Mat &src, Mat &dst) const = 0;
+    CV_WRAP virtual void detectEdges(const Mat &src, CV_OUT Mat &dst) const = 0;
 };
 
 /*!
@@ -119,7 +119,7 @@ public:
 *                           own forest, pass NULL otherwise
 */
 CV_EXPORTS_W Ptr<StructuredEdgeDetection> createStructuredEdgeDetection(const String &model,
-    const RFFeatureGetter *howToGetFeatures = NULL);
+    Ptr<const RFFeatureGetter> howToGetFeatures = Ptr<RFFeatureGetter>());
 
 }
 }

--- a/modules/ximgproc/src/structured_edge_detection.cpp
+++ b/modules/ximgproc/src/structured_edge_detection.cpp
@@ -339,11 +339,11 @@ public:
      * \param filename : name of the file where the model is stored
      */
     StructuredEdgeDetectionImpl(const cv::String &filename,
-        const RFFeatureGetter *_howToGetFeatures)
+        Ptr<const RFFeatureGetter> _howToGetFeatures)
         : name("StructuredEdgeDetection"),
-          howToGetFeatures( _howToGetFeatures != NULL
+          howToGetFeatures( (!_howToGetFeatures.empty())
                           ? _howToGetFeatures
-                          : createRFFeatureGetter() )
+                          : createRFFeatureGetter().staticCast<const RFFeatureGetter>() )
     {
         cv::FileStorage modelFile(filename, FileStorage::READ);
         CV_Assert( modelFile.isOpened() );
@@ -631,7 +631,7 @@ protected:
     String name;
 
     /*! optional feature getter (getFeatures method) */
-    const RFFeatureGetter *howToGetFeatures;
+    Ptr<const RFFeatureGetter> howToGetFeatures;
 
     /*! random forest used to detect edges */
     struct RandomForest
@@ -684,7 +684,7 @@ protected:
 };
 
 Ptr<StructuredEdgeDetection> createStructuredEdgeDetection(const String &model,
-    const RFFeatureGetter *howToGetFeatures)
+    Ptr<const RFFeatureGetter> howToGetFeatures)
 {
         return makePtr<StructuredEdgeDetectionImpl>(model, howToGetFeatures);
 }


### PR DESCRIPTION
Preparations needed for exposing `StructuredEdgeDetection` to python.
Corresponding PR to `opencv` will follow after this PR is merged (remove header from blacklist and some fixes)
