### PR TITLE
matlab: fix bindings generation for xfeatures2d

### DIFF
--- a/modules/matlab/CMakeLists.txt
+++ b/modules/matlab/CMakeLists.txt
@@ -218,7 +218,7 @@ add_custom_command(
             --jinja2     ${JINJA2_PATH}
             --hdrparser  ${HDR_PARSER_PATH}
             --rstparser  ${RST_PARSER_PATH}
-            --moduleroot ${CMAKE_SOURCE_DIR}/modules
+            --moduleroot ${CMAKE_SOURCE_DIR}/modules ${OPENCV_EXTRA_MODULES_PATH}
             --modules    ${opencv_modules}
             --extra      ${opencv_extra_hdrs}
             --outdir     ${CMAKE_CURRENT_BINARY_DIR}


### PR DESCRIPTION
This PR aims to fix the problem with Matlab bindings generation for xfeatures2d. The latter fails as gen_matlab.py fails to read the module's header due to incorrectly assuming it to be ${CMAKE_SOURCE_DIR}/modules/xfeatures2d/include/opencv2/xfeatures2d.hpp.

Therefore, gen_matlab.py script is extended to accept multiple values for --modules-root argument, and to check for a module's header in all possible paths. This way, both ${CMAKE_SOURCE_DIR}/modules and
${OPENCV_EXTRA_MODULES_PATH} can be passed as modules root paths, and the main header for xfeatures2d module can be correctly located.
