### PR TITLE
fix typo which confuses everything

### DIFF
--- a/modules/xfeatures2d/doc/extra_features.rst
+++ b/modules/xfeatures2d/doc/extra_features.rst
@@ -1,5 +1,5 @@
-Non-free 2D Features Algorithms
-=================================
+Experimental 2D Features Algorithms
+===================================
 
 This section describes experimental algorithms for 2d feature detection.
 


### PR DESCRIPTION
A typo that can make it very confusing. The experimental features 2 d algorithms are still free to use and not under any patent or license besides the opencv one.

See: http://answers.opencv.org/question/41000/star-detector-brief-and-freak-listed-in-nonfree/
