### PR TITLE
comment off #include "opencv2/core/private.hpp". 

### DIFF
--- a/modules/line_descriptor/include/opencv2/line_descriptor/descriptor.hpp
+++ b/modules/line_descriptor/include/opencv2/line_descriptor/descriptor.hpp
@@ -50,7 +50,7 @@
 #include <iostream>
 
 #include "opencv2/core/utility.hpp"
-#include "opencv2/core/private.hpp"
+//#include "opencv2/core/private.hpp"
 #include <opencv2/imgproc.hpp>
 #include <opencv2/features2d.hpp>
 #include <opencv2/highgui.hpp>


### PR DESCRIPTION
comment off #include "opencv2/core/private.hpp". It prevent the project from being referenced from outside the opencv library.
