### PR TITLE
Fix debug build broken issue.

### DIFF
--- a/modules/latentsvm/CMakeLists.txt
+++ b/modules/latentsvm/CMakeLists.txt
@@ -1,2 +1,2 @@
 set(the_description "Object Detection")
-ocv_define_module(latentsvm opencv_core opencv_imgproc opencv_objdetect opencv_ts OPTIONAL opencv_highgui)
+ocv_define_module(latentsvm opencv_core opencv_imgproc opencv_objdetect OPTIONAL opencv_highgui)


### PR DESCRIPTION
Fix the following error:
/usr/bin/ld: ../../lib/libopencv_ts.a(ts_gtest.cpp.o): relocation
R_X86_64_32 against `.rodata' can not be used when making a shared object;
recompile with -fPIC
../../lib/libopencv_ts.a: could not read symbols: Bad value
collect2: error: ld returned 1 exit status
make[2]: **\* [lib/cv2.so] Error 1
make[1]: **\* [modules/python2/CMakeFiles/opencv_python2.dir/all] Error 2
make: **\* [all] Error 2
