### PR TITLE
SURF OCL: now enabled

### DIFF
--- a/modules/xfeatures2d/src/surf.cpp
+++ b/modules/xfeatures2d/src/surf.cpp
@@ -893,7 +893,7 @@ void SURF_Impl::detectAndCompute(InputArray _img, InputArray _mask,
     CV_Assert(_descriptors.needed() || !useProvidedKeypoints);
 
 #ifdef HAVE_OPENCL
-    if( ocl::useOpenCL() )
+    if( ocl::useOpenCL() && _img.isUMat())
     {
         SURF_OCL ocl_surf;
         UMat gpu_kpt;

--- a/modules/xfeatures2d/src/surf.ocl.cpp
+++ b/modules/xfeatures2d/src/surf.ocl.cpp
@@ -95,7 +95,7 @@ bool SURF_OCL::init(const SURF_Impl* p)
                 return false;
             haveImageSupport = false;//dev.imageSupport();
             kerOpts = haveImageSupport ? "-D HAVE_IMAGE2D -D DOUBLE_SUPPORT" : "";
-//            status = 1;
+            status = 1;
         }
     }
     return status > 0;


### PR DESCRIPTION
Changes:
- Uncommented status=1 - the only way to set "SURF can use OpenCL" to
  True"
- To match with Transparent-API: OpenCL version will run only if UMat
  was passed

It seems, that OpenCL version of SURF was unavailable at all.

Can somebody explain, why that line with status=1 was commented?
