### PR TITLE
add HDF5_INCLUDE_DIR for compiled with Caffe

### DIFF
--- a/modules/cnn_3dobj/CMakeLists.txt
+++ b/modules/cnn_3dobj/CMakeLists.txt
@@ -24,6 +24,13 @@ else()
   message(STATUS "Glog:   NO")
 endif()
 
+find_path(HDF5_INCLUDE_DIR NAMES hdf5.h
+    HINTS
+    /usr/include/hdf5)
+find_library(HDF5_LIBS NAMES hdf5
+    HINTS
+    /usr/lib)
+
 if(HAVE_CAFFE)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cnn_3dobj_config.hpp.in
                ${CMAKE_CURRENT_SOURCE_DIR}/include/opencv2/cnn_3dobj_config.hpp @ONLY)
@@ -31,12 +38,12 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cnn_3dobj_config.hpp.in
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 if(${Caffe_FOUND})
-  include_directories(${Caffe_INCLUDE_DIR})
+  include_directories(${Caffe_INCLUDE_DIR} ${HDF5_INCLUDE_DIR})
 endif()
   set(the_description "CNN for 3D object recognition and pose estimation including a completed Sphere View on 3D objects")
   ocv_define_module(cnn_3dobj opencv_core opencv_imgproc opencv_viz opencv_highgui OPTIONAL WRAP python)
 
 if(${Caffe_FOUND})
-  target_link_libraries(opencv_cnn_3dobj ${Caffe_LIBS} ${Glog_LIBS} ${Protobuf_LIBS})
+  target_link_libraries(opencv_cnn_3dobj ${Caffe_LIBS} ${Glog_LIBS} ${Protobuf_LIBS} ${HDF5_LIBS})
 endif()
 endif()


### PR DESCRIPTION
add `HDF5_INCLUDE_DIR` and `HDF5_INCLUDE_LIBS` to `modules/cnn_3dobj/CMakeLists.txt` for compile OpenCV with Caffe.

For  Debian-based Linux Systems, `HDF5_INCLUDE_DIR` may be `/usr/include/hdf5/serial` or `/usr/include/hdf5/openmpi`. If Caffe is compiled with HD5, this may be a problem.
