### PR TITLE
Fix KCF tracker when used in Python

### DIFF
--- a/modules/tracking/src/trackerKCF.cpp
+++ b/modules/tracking/src/trackerKCF.cpp
@@ -336,13 +336,13 @@ namespace cv{
       minMaxLoc( response, &minVal, &maxVal, &minLoc, &maxLoc );
       roi.x+=(maxLoc.x-roi.width/2+1);
       roi.y+=(maxLoc.y-roi.height/2+1);
-
-      // update the bounding box
-      boundingBox.x=(resizeImage?roi.x*2:roi.x)+(resizeImage?roi.width*2:roi.width)/4;
-      boundingBox.y=(resizeImage?roi.y*2:roi.y)+(resizeImage?roi.height*2:roi.height)/4;
-      boundingBox.width = (resizeImage?roi.width*2:roi.width)/2;
-      boundingBox.height = (resizeImage?roi.height*2:roi.height)/2;
     }
+
+    // update the bounding box
+    boundingBox.x=(resizeImage?roi.x*2:roi.x)+(resizeImage?roi.width*2:roi.width)/4;
+    boundingBox.y=(resizeImage?roi.y*2:roi.y)+(resizeImage?roi.height*2:roi.height)/4;
+    boundingBox.width = (resizeImage?roi.width*2:roi.width)/2;
+    boundingBox.height = (resizeImage?roi.height*2:roi.height)/2;
 
     // extract the patch for learning purpose
     // get non compressed descriptors

--- a/modules/tracking/src/trackerKCF.cpp
+++ b/modules/tracking/src/trackerKCF.cpp
@@ -338,8 +338,10 @@ namespace cv{
       roi.y+=(maxLoc.y-roi.height/2+1);
 
       // update the bounding box
-      boundingBox.x=(resizeImage?roi.x*2:roi.x)+boundingBox.width/2;
-      boundingBox.y=(resizeImage?roi.y*2:roi.y)+boundingBox.height/2;
+      boundingBox.x=(resizeImage?roi.x*2:roi.x)+(resizeImage?roi.width*2:roi.width)/4;
+      boundingBox.y=(resizeImage?roi.y*2:roi.y)+(resizeImage?roi.height*2:roi.height)/4;
+      boundingBox.width = (resizeImage?roi.width*2:roi.width)/2;
+      boundingBox.height = (resizeImage?roi.height*2:roi.height)/2;
     }
 
     // extract the patch for learning purpose


### PR DESCRIPTION
Description of the issue in https://github.com/Itseez/opencv_contrib/issues/640

To solve the problem I used the member variable roi to set the boundingBox variable  as follows:

    boundingBox.x=(resizeImage?roi.x*2:roi.x)+(resizeImage?roi.width*2:roi.width)/4;
    boundingBox.y=(resizeImage?roi.y*2:roi.y)+(resizeImage?roi.height*2:roi.height)/4;
    boundingBox.width = (resizeImage?roi.width*2:roi.width)/2;
    boundingBox.height = (resizeImage?roi.height*2:roi.height)/2;

It is worth noticing that roi width and hight are double the boundingBox size as roi is used as searching area for the next frame. 
I have moved the update bounding box code ouside the block if( frame > 0) because in the examples:

modules/tracking/samples/tracker.py
modules/tracking/samples/multitracker.py

the update function is called after init even in the first frame.