### PR TITLE
Fix building waldboost_detector with opencv_world

### DIFF
--- a/modules/xobjdetect/tools/waldboost_detector/CMakeLists.txt
+++ b/modules/xobjdetect/tools/waldboost_detector/CMakeLists.txt
@@ -19,7 +19,7 @@ file(GLOB ${the_target}_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 
 add_executable(${the_target} ${${the_target}_SOURCES})
 
-target_link_libraries(${the_target} ${OPENCV_${the_target}_DEPS})
+ocv_target_link_libraries(${the_target} ${OPENCV_${the_target}_DEPS})
 
 set_target_properties(${the_target} PROPERTIES
                       DEBUG_POSTFIX "${OPENCV_DEBUG_POSTFIX}"


### PR DESCRIPTION
resolves Itseez/opencv_contrib#497

Works on static builds, i.e. BUILD_SHARED_LIBS unset.
Non-static builds will fail for other irrelevant issues as before.