### PR TITLE
Close unused resource in HDF, otherwise the file will not be closed after calling close (e.g. delayed close).

### DIFF
--- a/modules/hdf/src/hdf5.cpp
+++ b/modules/hdf/src/hdf5.cpp
@@ -536,7 +536,7 @@ void HDF5Impl::dscreate( const int n_dims, const int* sizes, const int type,
     }
 
     // create data
-    H5Dcreate( m_h5_file_id, dslabel.c_str(), dstype,
+    hid_t dsdata = H5Dcreate( m_h5_file_id, dslabel.c_str(), dstype,
                dspace, H5P_DEFAULT, dsdcpl, H5P_DEFAULT );
 
     if ( channs > 1 )
@@ -548,6 +548,7 @@ void HDF5Impl::dscreate( const int n_dims, const int* sizes, const int type,
 
     H5Pclose( dsdcpl );
     H5Sclose( dspace );
+    H5Dclose( dsdata );
 }
 
 // overload
@@ -663,6 +664,7 @@ void HDF5Impl::dsread( OutputArray Array, String dslabel,
     delete [] mxdims;
     delete [] foffset;
 
+    H5Tclose (h5type );
     H5Tclose( dstype );
     H5Sclose( dspace );
     H5Sclose( fspace );


### PR DESCRIPTION
Close unused resource in dscreate and dsread. Otherwise, the file will not be close when close() is called.

See  the following for Delayed close, which is close dataset after exe terminate: https://www.hdfgroup.org/HDF5/doc/RM/RM_H5F.html#File-Close