### PR TITLE
fix CommandLineParser usage in samples

### DIFF
--- a/modules/aruco/samples/calibrate_camera.cpp
+++ b/modules/aruco/samples/calibrate_camera.cpp
@@ -158,7 +158,7 @@ int main(int argc, char *argv[]) {
     }
 
     int markersX = parser.get<int>("w");
-    int markersY = parser.get<int>("w");
+    int markersY = parser.get<int>("h");
     float markerLength = parser.get<float>("l");
     float markerSeparation = parser.get<float>("s");
     int dictionaryId = parser.get<int>("d");

--- a/modules/xfeatures2d/samples/surf_matcher.cpp
+++ b/modules/xfeatures2d/samples/surf_matcher.cpp
@@ -137,11 +137,11 @@ static Mat drawGoodMatches(
 int main(int argc, char* argv[])
 {
     const char* keys =
-        "{ h help     | false            | print help message  }"
+        "{ h help     |                  | print help message  }"
         "{ l left     | box.png          | specify left image  }"
         "{ r right    | box_in_scene.png | specify right image }"
         "{ o output   | SURF_output.jpg  | specify output save path }"
-        "{ m cpu_mode | false            | run without OpenCL }";
+        "{ m cpu_mode |                  | run without OpenCL }";
 
     CommandLineParser cmd(argc, argv, keys);
     if (cmd.has("help"))


### PR DESCRIPTION

resolves https://github.com/opencv/opencv/issues/7151

### This pullrequest changes
remove "false" as default value for args used with CommandLineParser::has()
