### PR TITLE
Fix Board draw function in aruco module

### DIFF
--- a/modules/aruco/src/aruco.cpp
+++ b/modules/aruco/src/aruco.cpp
@@ -1542,22 +1542,22 @@ void _drawPlanarBoardImpl(Board *_board, Size outSize, OutputArray _img, int mar
             // remove negativity
             p1.x = p0.x - minX;
             p1.y = p0.y - minY;
-            pf.x = p1.x * float(markerZone.cols - 1) / sizeX;
-            pf.y = float(markerZone.rows - 1) - p1.y * float(markerZone.rows - 1) / sizeY;
+            pf.x = p1.x * float(markerZone.cols) / sizeX;
+            pf.y = float(markerZone.rows - 1) - p1.y * float(markerZone.rows) / sizeY;
             outCorners[j] = pf;
         }
 
         // get tiny marker
-        int tinyMarkerSize = 10 * dictionary.markerSize + 2;
+        int tinyMarkerSize = 10 * (dictionary.markerSize + 2 * borderBits);
         Mat tinyMarker;
         dictionary.drawMarker(_board->ids[m], tinyMarkerSize, tinyMarker, borderBits);
 
         // interpolate tiny marker to marker position in markerZone
         Mat inCorners(4, 1, CV_32FC2);
         inCorners.ptr< Point2f >(0)[0] = Point2f(0, 0);
-        inCorners.ptr< Point2f >(0)[1] = Point2f((float)tinyMarker.cols, 0);
-        inCorners.ptr< Point2f >(0)[2] = Point2f((float)tinyMarker.cols, (float)tinyMarker.rows);
-        inCorners.ptr< Point2f >(0)[3] = Point2f(0, (float)tinyMarker.rows);
+        inCorners.ptr< Point2f >(0)[1] = Point2f((float)tinyMarker.cols-1, 0);
+        inCorners.ptr< Point2f >(0)[2] = Point2f((float)tinyMarker.cols-1, (float)tinyMarker.rows-1);
+        inCorners.ptr< Point2f >(0)[3] = Point2f(0, (float)tinyMarker.rows-1);
 
         // remove perspective
         Mat transformation = getPerspectiveTransform(inCorners, outCorners);


### PR DESCRIPTION
For instance:
./bin/example_aruco_create_board --bb=1 -d=4 -l=120 -m=0 -s=24 -w=4 -h=2 image.png
creates a board with a (incorrect) white border on bottom and right.

Also, marker border (`borderBits` variable) is not used correctly.