### PR TITLE
Add threshold setter for FaceRecognizer class

### DIFF
--- a/modules/face/include/opencv2/face.hpp
+++ b/modules/face/include/opencv2/face.hpp
@@ -357,7 +357,7 @@ public:
     info.
      */
     CV_WRAP virtual std::vector<int> getLabelsByString(const String& str) const;
-    /** @brief threshhold parameter accessor - required for default BestMinDist collector */
+    /** @brief threshold parameter accessor - required for default BestMinDist collector */
     virtual double getThreshold() const = 0;
 protected:
     // Stored pairs "label id - string info"

--- a/modules/face/include/opencv2/face.hpp
+++ b/modules/face/include/opencv2/face.hpp
@@ -359,6 +359,8 @@ public:
     CV_WRAP virtual std::vector<int> getLabelsByString(const String& str) const;
     /** @brief threshold parameter accessor - required for default BestMinDist collector */
     virtual double getThreshold() const = 0;
+    /** @brief Sets threshold of model */
+    virtual void setThreshold(double val) = 0;
 protected:
     // Stored pairs "label id - string info"
     std::map<int, String> _labelsInfo;


### PR DESCRIPTION
### Add virtual method to set threshold for FaceRecognizer class

This pull request adds virtual method `setThreshold` to `FaceRecognizer` class.
This method is already implemented in its child classes: `BasicFaceRecognizer` and `LBPHFaceRecognizer`.
Currently `FaceRecognizer` has only getter `getThreshold`.