### PR TITLE
fix for feature2d java wrappers as described in this post: http://ans…

### DIFF
--- a/modules/xfeatures2d/CMakeLists.txt
+++ b/modules/xfeatures2d/CMakeLists.txt
@@ -1,3 +1,3 @@
 set(the_description "Contributed/Experimental Algorithms for Salient 2D Features Detection")
 ocv_define_module(xfeatures2d opencv_core opencv_imgproc opencv_features2d opencv_calib3d opencv_shape opencv_highgui opencv_videoio opencv_ml
-                  OPTIONAL opencv_cudaarithm WRAP python)
+                  OPTIONAL opencv_cudaarithm WRAP python java)


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->

…wers.opencv.org/question/101675/surfsift-java-wrapper-for-opencv-3xosx-1011/

This is to enable java wrappers generation on xfeatures2d module. This requires fix in opencv as in [this pull request](https://github.com/opencv/opencv/pull/7426). 