### PR TITLE
Fix wrong matrix allocation in omnidir::stereoCalibrate

### DIFF
--- a/modules/ccalib/src/omnidir.cpp
+++ b/modules/ccalib/src/omnidir.cpp
@@ -1306,8 +1306,8 @@ double cv::omnidir::stereoCalibrate(InputOutputArrayOfArrays objectPoints, Input
     }
     if (om.empty())
     {
-        om.create(1, 3, CV_64F);
-        T.create(1, 3, CV_64F);
+        om.create(3, 1, CV_64F);
+        T.create(3, 1, CV_64F);
     }
     if (omL.empty())
     {


### PR DESCRIPTION
resolves #725 
