### PR TITLE
Added size_t conversion for class Bridge.  Need when compiling extra …

### DIFF
--- a/modules/matlab/include/opencv2/matlab/bridge.hpp
+++ b/modules/matlab/include/opencv2/matlab/bridge.hpp
@@ -293,6 +293,10 @@ public:
   int toInt() { return ptr_.scalar<int>(); }
   operator int() { return toInt(); }
 
+  // --------------------------- size_t -----------------------------------------
+  Bridge& operator=(const size_t&) { return *this; }
+  size_t toSizeT() { return ptr_.scalar<size_t>(); }
+  operator size_t() { return toSizeT(); }
 
 
 


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
When compiling the latest opencv 3.1 for matlab with contrib modules, the bridge class need size_t conversions to complete.  Added these conversion to bridge.hpp

…modules into matlab.