### PR TITLE
Added a forced include of limits to fix compilation on ubuntu 16.04.

### DIFF
--- a/modules/optflow/include/opencv2/optflow/sparse_matching_gpc.hpp
+++ b/modules/optflow/include/opencv2/optflow/sparse_matching_gpc.hpp
@@ -54,6 +54,7 @@ the use of this software, even if advised of the possibility of such damage.
 #include "opencv2/core.hpp"
 #include "opencv2/core/hal/intrin.hpp"
 #include "opencv2/imgproc.hpp"
+#include <limits>
 
 namespace cv
 {


### PR DESCRIPTION
### This pullrequest adds

A forced include on the <limits> dependency so that it will compile on ubuntu 16.04.  This probably fixes builds on other platforms as well.