### PR TITLE
build(freetype): move 3rdparty include files from precomp.hpp

### DIFF
--- a/modules/freetype/src/freetype.cpp
+++ b/modules/freetype/src/freetype.cpp
@@ -47,6 +47,13 @@
 
 #include "precomp.hpp"
 
+#include <ft2build.h>
+#include FT_FREETYPE_H
+#include FT_OUTLINE_H
+
+#include <hb.h>
+#include <hb-ft.h>
+
 namespace cv {
 namespace freetype {
 

--- a/modules/freetype/src/precomp.hpp
+++ b/modules/freetype/src/precomp.hpp
@@ -57,11 +57,4 @@
 #include <iostream>
 #include <cstdio>
 #include <vector>
-
-#include <ft2build.h>
-#include FT_FREETYPE_H
-#include FT_OUTLINE_H
-
-#include <hb.h>
-#include <hb-ft.h>
 #endif


### PR DESCRIPTION
resolves https://github.com/opencv/opencv/issues/7886