### PR TITLE
Python wrapper for both RGBD and Surface Matching modules

### DIFF
--- a/modules/rgbd/include/opencv2/rgbd.hpp
+++ b/modules/rgbd/include/opencv2/rgbd.hpp
@@ -109,7 +109,7 @@ namespace rgbd
   public:
     CV_WRAP enum
     {
-      RGBD_NORMALS_METHOD_FALS = 1, RGBD_NORMALS_METHOD_LINEMOD = 2, RGBD_NORMALS_METHOD_SRI = 3,
+      RGBD_NORMALS_METHOD_FALS = 0, RGBD_NORMALS_METHOD_LINEMOD = 1, RGBD_NORMALS_METHOD_SRI = 2,
     };
 
     CV_WRAP RgbdNormals()
@@ -119,7 +119,7 @@ namespace rgbd
           depth_(0),
           K_(Mat()),
           window_size_(0),
-          method_(RgbdNormals::RGBD_NORMALS_METHOD_FALS),
+          method_(RGBD_NORMALS_METHOD_FALS),
           rgbd_normals_impl_(0)
     {
     }
@@ -228,7 +228,7 @@ namespace rgbd
      */
     CV_WRAP enum
     {
-      DEPTH_CLEANER_NIL
+      DEPTH_CLEANER_NIL = 0,
     };
 
     CV_WRAP DepthCleaner()
@@ -371,7 +371,7 @@ namespace rgbd
   public:
     CV_WRAP enum
     {
-      RGBD_PLANE_METHOD_DEFAULT
+      RGBD_PLANE_METHOD_DEFAULT = 0,
     };
 
     CV_WRAP RgbdPlane(int method = RgbdPlane::RGBD_PLANE_METHOD_DEFAULT)

--- a/modules/rgbd/include/opencv2/rgbd.hpp
+++ b/modules/rgbd/include/opencv2/rgbd.hpp
@@ -1063,7 +1063,7 @@ namespace rgbd
    */
   CV_EXPORTS_W
   void
-  warpFrame(const InputArray image, const InputArray depth, const InputArray mask, const Mat& Rt, const Mat& cameraMatrix,
+  warpFrame(InputArray image, InputArray depth, InputArray mask, const Mat& Rt, const Mat& cameraMatrix,
             const Mat& distCoeff, OutputArray warpedImage, OutputArray warpedDepth = noArray(), OutputArray warpedMask = noArray());
 
 // TODO Depth interpolation

--- a/modules/rgbd/include/opencv2/rgbd.hpp
+++ b/modules/rgbd/include/opencv2/rgbd.hpp
@@ -56,42 +56,42 @@ namespace rgbd
    * a limit. For a float/double, we just check if it is a NaN
    * @param depth the depth to check for validity
    */
-  CV_EXPORTS
+  CV_EXPORTS_W
   inline bool
   isValidDepth(const float & depth)
   {
     return !cvIsNaN(depth);
   }
-  CV_EXPORTS
+  CV_EXPORTS_W
   inline bool
   isValidDepth(const double & depth)
   {
     return !cvIsNaN(depth);
   }
-  CV_EXPORTS
+  CV_EXPORTS_W
   inline bool
-  isValidDepth(const short int & depth)
+  isValidDepth(const short & depth)
   {
-    return (depth != std::numeric_limits<short int>::min()) && (depth != std::numeric_limits<short int>::max());
+    return (depth != std::numeric_limits<short>::min()) && (depth != std::numeric_limits<short>::max());
   }
-  CV_EXPORTS
+  CV_EXPORTS_W
   inline bool
-  isValidDepth(const unsigned short int & depth)
+  isValidDepth(const ushort & depth)
   {
-    return (depth != std::numeric_limits<unsigned short int>::min())
-        && (depth != std::numeric_limits<unsigned short int>::max());
+    return (depth != std::numeric_limits<ushort>::min())
+        && (depth != std::numeric_limits<ushort>::max());
   }
-  CV_EXPORTS
+  CV_EXPORTS_W
   inline bool
   isValidDepth(const int & depth)
   {
     return (depth != std::numeric_limits<int>::min()) && (depth != std::numeric_limits<int>::max());
   }
-  CV_EXPORTS
+  CV_EXPORTS_W
   inline bool
-  isValidDepth(const unsigned int & depth)
+  isValidDepth(const uint & depth)
   {
-    return (depth != std::numeric_limits<unsigned int>::min()) && (depth != std::numeric_limits<unsigned int>::max());
+    return (depth != std::numeric_limits<uint>::min()) && (depth != std::numeric_limits<uint>::max());
   }
 
   /** Object that can compute the normals in an image.
@@ -104,22 +104,22 @@ namespace rgbd
    * ``Gradient Response Maps for Real-Time Detection of Texture-Less Objects``
    * by S. Hinterstoisser, C. Cagniart, S. Ilic, P. Sturm, N. Navab, P. Fua, and V. Lepetit
    */
-  class CV_EXPORTS RgbdNormals: public Algorithm
+  class CV_EXPORTS_W RgbdNormals: public Algorithm
   {
   public:
-    enum RGBD_NORMALS_METHOD
+    CV_WRAP enum
     {
-      RGBD_NORMALS_METHOD_FALS, RGBD_NORMALS_METHOD_LINEMOD, RGBD_NORMALS_METHOD_SRI
+      RGBD_NORMALS_METHOD_FALS = 1, RGBD_NORMALS_METHOD_LINEMOD = 2, RGBD_NORMALS_METHOD_SRI = 3,
     };
 
-    RgbdNormals()
+    CV_WRAP RgbdNormals()
         :
           rows_(0),
           cols_(0),
           depth_(0),
           K_(Mat()),
           window_size_(0),
-          method_(RGBD_NORMALS_METHOD_FALS),
+          method_(RgbdNormals::RGBD_NORMALS_METHOD_FALS),
           rgbd_normals_impl_(0)
     {
     }
@@ -132,10 +132,10 @@ namespace rgbd
      * @param window_size the window size to compute the normals: can only be 1,3,5 or 7
      * @param method one of the methods to use: RGBD_NORMALS_METHOD_SRI, RGBD_NORMALS_METHOD_FALS
      */
-    RgbdNormals(int rows, int cols, int depth, InputArray K, int window_size = 5, int method =
-        RGBD_NORMALS_METHOD_FALS);
+    CV_WRAP RgbdNormals(int rows, int cols, int depth, InputArray K, int window_size = 5, int method =
+        RgbdNormals::RGBD_NORMALS_METHOD_FALS);
 
-    ~RgbdNormals();
+    CV_WRAP ~RgbdNormals();
 
     /** Given a set of 3d points in a depth image, compute the normals at each point.
      * @param points a rows x cols x 3 matrix of CV_32F/CV64F or a rows x cols x 1 CV_U16S
@@ -144,57 +144,64 @@ namespace rgbd
     void
     operator()(InputArray points, OutputArray normals) const;
 
+    /** Given a set of 3d points in a depth image, compute the normals at each point.
+     * @param points a rows x cols x 3 matrix of CV_32F/CV64F or a rows x cols x 1 CV_U16S
+     * @param normals a rows x cols x 3 matrix
+     */
+    CV_WRAP void
+    compute(InputArray points, OutputArray normals) const;
+
     /** Initializes some data that is cached for later computation
      * If that function is not called, it will be called the first time normals are computed
      */
-    void
+    CV_WRAP void
     initialize() const;
 
-    int getRows() const
+    CV_WRAP int getRows() const
     {
         return rows_;
     }
-    void setRows(int val)
+    CV_WRAP void setRows(int val)
     {
         rows_ = val;
     }
-    int getCols() const
+    CV_WRAP int getCols() const
     {
         return cols_;
     }
-    void setCols(int val)
+    CV_WRAP void setCols(int val)
     {
         cols_ = val;
     }
-    int getWindowSize() const
+    CV_WRAP int getWindowSize() const
     {
         return window_size_;
     }
-    void setWindowSize(int val)
+    CV_WRAP void setWindowSize(int val)
     {
         window_size_ = val;
     }
-    int getDepth() const
+    CV_WRAP int getDepth() const
     {
         return depth_;
     }
-    void setDepth(int val)
+    CV_WRAP void setDepth(int val)
     {
         depth_ = val;
     }
-    cv::Mat getK() const
+    CV_WRAP cv::Mat getK() const
     {
         return K_;
     }
-    void setK(const cv::Mat &val)
+    CV_WRAP void setK(const cv::Mat &val)
     {
         K_ = val;
     }
-    int getMethod() const
+    CV_WRAP int getMethod() const
     {
         return method_;
     }
-    void setMethod(int val)
+    CV_WRAP void setMethod(int val)
     {
         method_ = val;
     }
@@ -212,23 +219,23 @@ namespace rgbd
 
   /** Object that can clean a noisy depth image
    */
-  class CV_EXPORTS DepthCleaner: public Algorithm
+  class CV_EXPORTS_W DepthCleaner: public Algorithm
   {
   public:
     /** NIL method is from
      * ``Modeling Kinect Sensor Noise for Improved 3d Reconstruction and Tracking``
      * by C. Nguyen, S. Izadi, D. Lovel
      */
-    enum DEPTH_CLEANER_METHOD
+    CV_WRAP enum
     {
       DEPTH_CLEANER_NIL
     };
 
-    DepthCleaner()
+    CV_WRAP DepthCleaner()
         :
           depth_(0),
           window_size_(0),
-          method_(DEPTH_CLEANER_NIL),
+          method_(DepthCleaner::DEPTH_CLEANER_NIL),
           depth_cleaner_impl_(0)
     {
     }
@@ -238,9 +245,9 @@ namespace rgbd
      * @param window_size the window size to compute the normals: can only be 1,3,5 or 7
      * @param method one of the methods to use: RGBD_NORMALS_METHOD_SRI, RGBD_NORMALS_METHOD_FALS
      */
-    DepthCleaner(int depth, int window_size = 5, int method = DEPTH_CLEANER_NIL);
+    CV_WRAP DepthCleaner(int depth, int window_size = 5, int method = DepthCleaner::DEPTH_CLEANER_NIL);
 
-    ~DepthCleaner();
+    CV_WRAP ~DepthCleaner();
 
     /** Given a set of 3d points in a depth image, compute the normals at each point.
      * @param points a rows x cols x 3 matrix of CV_32F/CV64F or a rows x cols x 1 CV_U16S
@@ -249,33 +256,40 @@ namespace rgbd
     void
     operator()(InputArray points, OutputArray depth) const;
 
+    /** Given a set of 3d points in a depth image, compute the normals at each point.
+     * @param points a rows x cols x 3 matrix of CV_32F/CV64F or a rows x cols x 1 CV_U16S
+     * @param depth a rows x cols matrix of the cleaned up depth
+     */
+    CV_WRAP void
+    compute(InputArray points, OutputArray depth) const;
+
     /** Initializes some data that is cached for later computation
      * If that function is not called, it will be called the first time normals are computed
      */
-    void
+    CV_WRAP void
     initialize() const;
 
-    int getWindowSize() const
+    CV_WRAP int getWindowSize() const
     {
         return window_size_;
     }
-    void setWindowSize(int val)
+    CV_WRAP void setWindowSize(int val)
     {
         window_size_ = val;
     }
-    int getDepth() const
+    CV_WRAP int getDepth() const
     {
         return depth_;
     }
-    void setDepth(int val)
+    CV_WRAP void setDepth(int val)
     {
         depth_ = val;
     }
-    int getMethod() const
+    CV_WRAP int getMethod() const
     {
         return method_;
     }
-    void setMethod(int val)
+    CV_WRAP void setMethod(int val)
     {
         method_ = val;
     }
@@ -309,7 +323,7 @@ namespace rgbd
    * @param registeredDepth the result of transforming the depth into the external camera
    * @param depthDilation whether or not the depth is dilated to avoid holes and occlusion errors (optional)
    */
-  CV_EXPORTS
+  CV_EXPORTS_W
   void
   registerDepth(InputArray unregisteredCameraMatrix, InputArray registeredCameraMatrix, InputArray registeredDistCoeffs,
                 InputArray Rt, InputArray unregisteredDepth, const Size& outputImagePlaneSize,
@@ -321,7 +335,7 @@ namespace rgbd
    * @param in_points the list of xy coordinates
    * @param points3d the resulting 3d points
    */
-  CV_EXPORTS
+  CV_EXPORTS_W
   void
   depthTo3dSparse(InputArray depth, InputArray in_K, InputArray in_points, OutputArray points3d);
 
@@ -334,7 +348,7 @@ namespace rgbd
    *        depth of `K` if `depth` is of depth CV_U
    * @param mask the mask of the points to consider (can be empty)
    */
-  CV_EXPORTS
+  CV_EXPORTS_W
   void
   depthTo3d(InputArray depth, InputArray K, OutputArray points3d, InputArray mask = noArray());
 
@@ -346,21 +360,21 @@ namespace rgbd
    * @param depth the desired output depth (floats or double)
    * @param out The rescaled float depth image
    */
-  CV_EXPORTS
+  CV_EXPORTS_W
   void
   rescaleDepth(InputArray in, int depth, OutputArray out);
 
   /** Object that can compute planes in an image
    */
-  class CV_EXPORTS RgbdPlane: public Algorithm
+  class CV_EXPORTS_W RgbdPlane: public Algorithm
   {
   public:
-    enum RGBD_PLANE_METHOD
+    CV_WRAP enum
     {
       RGBD_PLANE_METHOD_DEFAULT
     };
 
-    RgbdPlane(RGBD_PLANE_METHOD method = RGBD_PLANE_METHOD_DEFAULT)
+    CV_WRAP RgbdPlane(int method = RgbdPlane::RGBD_PLANE_METHOD_DEFAULT)
         :
           method_(method),
           block_size_(40),
@@ -384,6 +398,18 @@ namespace rgbd
     operator()(InputArray points3d, InputArray normals, OutputArray mask,
                OutputArray plane_coefficients);
 
+    /** Find The planes in a depth image
+     * @param points3d the 3d points organized like the depth image: rows x cols with 3 channels
+     * @param normals the normals for every point in the depth image
+     * @param mask An image where each pixel is labeled with the plane it belongs to
+     *        and 255 if it does not belong to any plane
+     * @param plane_coefficients the coefficients of the corresponding planes (a,b,c,d) such that ax+by+cz+d=0, norm(a,b,c)=1
+     *        and c < 0 (so that the normal points towards the camera)
+     */
+    CV_WRAP void
+    find(InputArray points3d, InputArray normals, OutputArray mask,
+               OutputArray plane_coefficients);
+
     /** Find The planes in a depth image but without doing a normal check, which is faster but less accurate
      * @param points3d the 3d points organized like the depth image: rows x cols with 3 channels
      * @param mask An image where each pixel is labeled with the plane it belongs to
@@ -393,59 +419,68 @@ namespace rgbd
     void
     operator()(InputArray points3d, OutputArray mask, OutputArray plane_coefficients);
 
-    int getBlockSize() const
+    /** Find The planes in a depth image but without doing a normal check, which is faster but less accurate
+     * @param points3d the 3d points organized like the depth image: rows x cols with 3 channels
+     * @param mask An image where each pixel is labeled with the plane it belongs to
+     *        and 255 if it does not belong to any plane
+     * @param plane_coefficients the coefficients of the corresponding planes (a,b,c,d) such that ax+by+cz+d=0
+     */
+    CV_WRAP void
+    find(InputArray points3d, OutputArray mask, OutputArray plane_coefficients);
+
+    CV_WRAP int getBlockSize() const
     {
         return block_size_;
     }
-    void setBlockSize(int val)
+    CV_WRAP void setBlockSize(int val)
     {
         block_size_ = val;
     }
-    int getMinSize() const
+    CV_WRAP int getMinSize() const
     {
         return min_size_;
     }
-    void setMinSize(int val)
+    CV_WRAP void setMinSize(int val)
     {
         min_size_ = val;
     }
-    int getMethod() const
+    CV_WRAP int getMethod() const
     {
         return method_;
     }
-    void setMethod(int val)
+    CV_WRAP void setMethod(int val)
     {
         method_ = val;
     }
-    double getThreshold() const
+    CV_WRAP double getThreshold() const
     {
         return threshold_;
     }
-    void setThreshold(double val)
+    CV_WRAP void setThreshold(double val)
     {
         threshold_ = val;
     }
-    double getSensorErrorA() const
+    CV_WRAP double getSensorErrorA() const
     {
         return sensor_error_a_;
     }
-    void setSensorErrorA(double val)
+    CV_WRAP void setSensorErrorA(double val)
     {
         sensor_error_a_ = val;
     }
-    double getSensorErrorB() const
+    CV_WRAP double getSensorErrorB() const
     {
         return sensor_error_b_;
     }
-    void setSensorErrorB(double val)
+    CV_WRAP void setSensorErrorB(double val)
     {
         sensor_error_b_ = val;
     }
-    double getSensorErrorC() const
+    CV_WRAP double getSensorErrorC() const
     {
         return sensor_error_c_;
     }
-    void setSensorErrorC(double val)
+    CV_WRAP void setSensorErrorC(double val)
     {
         sensor_error_c_ = val;
     }
@@ -465,27 +500,27 @@ namespace rgbd
 
   /** Object that contains a frame data.
    */
-  struct CV_EXPORTS RgbdFrame
+  struct CV_EXPORTS_W RgbdFrame
   {
-      RgbdFrame();
-      RgbdFrame(const Mat& image, const Mat& depth, const Mat& mask=Mat(), const Mat& normals=Mat(), int ID=-1);
-      virtual ~RgbdFrame();
+      CV_WRAP RgbdFrame();
+      CV_WRAP RgbdFrame(const Mat& image, const Mat& depth, const Mat& mask=Mat(), const Mat& normals=Mat(), int ID=-1);
+      CV_WRAP virtual ~RgbdFrame();
 
-      virtual void
+      CV_WRAP virtual void
       release();
 
-      int ID;
-      Mat image;
-      Mat depth;
-      Mat mask;
-      Mat normals;
+      CV_PROP_RW int ID;
+      CV_PROP_RW Mat image;
+      CV_PROP_RW Mat depth;
+      CV_PROP_RW Mat mask;
+      CV_PROP_RW Mat normals;
   };
 
   /** Object that contains a frame data that is possibly needed for the Odometry.
    * It's used for the efficiency (to pass precomputed/cached data of the frame that participates
    * in the Odometry processing several times).
    */
-  struct CV_EXPORTS OdometryFrame : public RgbdFrame
+  struct CV_EXPORTS_W OdometryFrame : public RgbdFrame
   {
     /** These constants are used to set a type of cache which has to be prepared depending on the frame role:
      * srcFrame or dstFrame (see compute method of the Odometry class). For the srcFrame and dstFrame different cache data may be required,
@@ -494,72 +529,72 @@ namespace rgbd
      * @param CACHE_DST The cache data for the dstFrame will be prepared.
      * @param CACHE_ALL The cache data for both srcFrame and dstFrame roles will be computed.
      */
-    enum
+    CV_WRAP enum
     {
       CACHE_SRC = 1, CACHE_DST = 2, CACHE_ALL = CACHE_SRC + CACHE_DST
     };
 
-    OdometryFrame();
-    OdometryFrame(const Mat& image, const Mat& depth, const Mat& mask=Mat(), const Mat& normals=Mat(), int ID=-1);
+    CV_WRAP OdometryFrame();
+    CV_WRAP OdometryFrame(const Mat& image, const Mat& depth, const Mat& mask=Mat(), const Mat& normals=Mat(), int ID=-1);
 
-    virtual void
+    CV_WRAP virtual void
     release();
 
-    void
+    CV_WRAP void
     releasePyramids();
 
-    std::vector<Mat> pyramidImage;
-    std::vector<Mat> pyramidDepth;
-    std::vector<Mat> pyramidMask;
+    CV_PROP_RW std::vector<Mat> pyramidImage;
+    CV_PROP_RW std::vector<Mat> pyramidDepth;
+    CV_PROP_RW std::vector<Mat> pyramidMask;
 
-    std::vector<Mat> pyramidCloud;
+    CV_PROP_RW std::vector<Mat> pyramidCloud;
 
-    std::vector<Mat> pyramid_dI_dx;
-    std::vector<Mat> pyramid_dI_dy;
-    std::vector<Mat> pyramidTexturedMask;
+    CV_PROP_RW std::vector<Mat> pyramid_dI_dx;
+    CV_PROP_RW std::vector<Mat> pyramid_dI_dy;
+    CV_PROP_RW std::vector<Mat> pyramidTexturedMask;
 
-    std::vector<Mat> pyramidNormals;
-    std::vector<Mat> pyramidNormalsMask;
+    CV_PROP_RW std::vector<Mat> pyramidNormals;
+    CV_PROP_RW std::vector<Mat> pyramidNormalsMask;
   };
 
   /** Base class for computation of odometry.
    */
-  class CV_EXPORTS Odometry: public Algorithm
+  class CV_EXPORTS_W Odometry: public Algorithm
   {
   public:
 
     /** A class of transformation*/
-    enum
+    CV_WRAP enum
     {
       ROTATION = 1, TRANSLATION = 2, RIGID_BODY_MOTION = 4
     };
 
-    static inline float
+    CV_WRAP static inline float
     DEFAULT_MIN_DEPTH()
     {
       return 0.f; // in meters
     }
-    static inline float
+    CV_WRAP static inline float
     DEFAULT_MAX_DEPTH()
     {
       return 4.f; // in meters
     }
-    static inline float
+    CV_WRAP static inline float
     DEFAULT_MAX_DEPTH_DIFF()
     {
       return 0.07f; // in meters
     }
-    static inline float
+    CV_WRAP static inline float
     DEFAULT_MAX_POINTS_PART()
     {
       return 0.07f; // in [0, 1]
     }
-    static inline float
+    CV_WRAP static inline float
     DEFAULT_MAX_TRANSLATION()
     {
       return 0.15f; // in meters
     }
-    static inline float
+    CV_WRAP static inline float
     DEFAULT_MAX_ROTATION()
     {
       return 15; // in degrees
@@ -583,14 +618,14 @@ namespace rgbd
      Rt is 4x4 matrix of CV_64FC1 type.
      * @param initRt Initial transformation from the source frame to the destination one (optional)
      */
-    bool
+    CV_WRAP bool
     compute(const Mat& srcImage, const Mat& srcDepth, const Mat& srcMask, const Mat& dstImage, const Mat& dstDepth,
             const Mat& dstMask, Mat& Rt, const Mat& initRt = Mat()) const;
 
     /** One more method to compute a transformation from the source frame to the destination one.
      * It is designed to save on computing the frame data (image pyramids, normals, etc.).
      */
-    bool
+    CV_WRAP bool
     compute(Ptr<OdometryFrame>& srcFrame, Ptr<OdometryFrame>& dstFrame, Mat& Rt, const Mat& initRt = Mat()) const;
 
     /** Prepare a cache for the frame. The function checks the precomputed/passed data (throws the error if this data
@@ -599,18 +634,18 @@ namespace rgbd
      * @param frame The odometry which will process the frame.
      * @param cacheType The cache type: CACHE_SRC, CACHE_DST or CACHE_ALL.
      */
-    virtual Size prepareFrameCache(Ptr<OdometryFrame>& frame, int cacheType) const;
+    CV_WRAP virtual Size prepareFrameCache(Ptr<OdometryFrame>& frame, int cacheType) const;
 
-    static Ptr<Odometry> create(const String & odometryType);
+    CV_WRAP static Ptr<Odometry> create(const String & odometryType);
 
     /** @see setCameraMatrix */
-    virtual cv::Mat getCameraMatrix() const = 0;
+    CV_WRAP virtual cv::Mat getCameraMatrix() const = 0;
     /** @copybrief getCameraMatrix @see getCameraMatrix */
-    virtual void setCameraMatrix(const cv::Mat &val) = 0;
+    CV_WRAP virtual void setCameraMatrix(const cv::Mat &val) = 0;
     /** @see setTransformType */
-    virtual int getTransformType() const = 0;
+    CV_WRAP virtual int getTransformType() const = 0;
     /** @copybrief getTransformType @see getTransformType */
-    virtual void setTransformType(int val) = 0;
+    CV_WRAP virtual void setTransformType(int val) = 0;
 
   protected:
     virtual void
@@ -624,10 +659,10 @@ namespace rgbd
   /** Odometry based on the paper "Real-Time Visual Odometry from Dense RGB-D Images",
    * F. Steinbucker, J. Strum, D. Cremers, ICCV, 2011.
    */
-  class CV_EXPORTS RgbdOdometry: public Odometry
+  class CV_EXPORTS_W RgbdOdometry: public Odometry
   {
   public:
-    RgbdOdometry();
+    CV_WRAP RgbdOdometry();
     /** Constructor.
      * @param cameraMatrix Camera matrix
      * @param minDepth Pixels with depth less than minDepth will not be used (in meters)
@@ -640,90 +675,90 @@ namespace rgbd
      * @param maxPointsPart The method uses a random pixels subset of size frameWidth x frameHeight x pointsPart
      * @param transformType Class of transformation
      */
-    RgbdOdometry(const Mat& cameraMatrix, float minDepth = DEFAULT_MIN_DEPTH(), float maxDepth = DEFAULT_MAX_DEPTH(),
-                 float maxDepthDiff = DEFAULT_MAX_DEPTH_DIFF(), const std::vector<int>& iterCounts = std::vector<int>(),
-                 const std::vector<float>& minGradientMagnitudes = std::vector<float>(), float maxPointsPart = DEFAULT_MAX_POINTS_PART(),
-                 int transformType = RIGID_BODY_MOTION);
+    CV_WRAP RgbdOdometry(const Mat& cameraMatrix, float minDepth = Odometry::DEFAULT_MIN_DEPTH(), float maxDepth = Odometry::DEFAULT_MAX_DEPTH(),
+                 float maxDepthDiff = Odometry::DEFAULT_MAX_DEPTH_DIFF(), const std::vector<int>& iterCounts = std::vector<int>(),
+                 const std::vector<float>& minGradientMagnitudes = std::vector<float>(), float maxPointsPart = Odometry::DEFAULT_MAX_POINTS_PART(),
+                 int transformType = Odometry::RIGID_BODY_MOTION);
 
-    virtual Size prepareFrameCache(Ptr<OdometryFrame>& frame, int cacheType) const;
+    CV_WRAP virtual Size prepareFrameCache(Ptr<OdometryFrame>& frame, int cacheType) const;
 
-    cv::Mat getCameraMatrix() const
+    CV_WRAP cv::Mat getCameraMatrix() const
     {
         return cameraMatrix;
     }
-    void setCameraMatrix(const cv::Mat &val)
+    CV_WRAP void setCameraMatrix(const cv::Mat &val)
     {
         cameraMatrix = val;
     }
-    double getMinDepth() const
+    CV_WRAP double getMinDepth() const
     {
         return minDepth;
     }
-    void setMinDepth(double val)
+    CV_WRAP void setMinDepth(double val)
     {
         minDepth = val;
     }
-    double getMaxDepth() const
+    CV_WRAP double getMaxDepth() const
     {
         return maxDepth;
     }
-    void setMaxDepth(double val)
+    CV_WRAP void setMaxDepth(double val)
     {
         maxDepth = val;
     }
-    double getMaxDepthDiff() const
+    CV_WRAP double getMaxDepthDiff() const
     {
         return maxDepthDiff;
     }
-    void setMaxDepthDiff(double val)
+    CV_WRAP void setMaxDepthDiff(double val)
     {
         maxDepthDiff = val;
     }
-    cv::Mat getIterationCounts() const
+    CV_WRAP cv::Mat getIterationCounts() const
     {
         return iterCounts;
     }
-    void setIterationCounts(const cv::Mat &val)
+    CV_WRAP void setIterationCounts(const cv::Mat &val)
     {
         iterCounts = val;
     }
-    cv::Mat getMinGradientMagnitudes() const
+    CV_WRAP cv::Mat getMinGradientMagnitudes() const
     {
         return minGradientMagnitudes;
     }
-    void setMinGradientMagnitudes(const cv::Mat &val)
+    CV_WRAP void setMinGradientMagnitudes(const cv::Mat &val)
     {
         minGradientMagnitudes = val;
     }
-    double getMaxPointsPart() const
+    CV_WRAP double getMaxPointsPart() const
     {
         return maxPointsPart;
     }
-    void setMaxPointsPart(double val)
+    CV_WRAP void setMaxPointsPart(double val)
     {
         maxPointsPart = val;
     }
-    int getTransformType() const
+    CV_WRAP int getTransformType() const
     {
         return transformType;
     }
-    void setTransformType(int val)
+    CV_WRAP void setTransformType(int val)
     {
         transformType = val;
     }
-    double getMaxTranslation() const
+    CV_WRAP double getMaxTranslation() const
     {
         return maxTranslation;
     }
-    void setMaxTranslation(double val)
+    CV_WRAP void setMaxTranslation(double val)
     {
         maxTranslation = val;
     }
-    double getMaxRotation() const
+    CV_WRAP double getMaxRotation() const
     {
         return maxRotation;
     }
-    void setMaxRotation(double val)
+    CV_WRAP void setMaxRotation(double val)
     {
         maxRotation = val;
     }
@@ -754,10 +789,10 @@ namespace rgbd
   /** Odometry based on the paper "KinectFusion: Real-Time Dense Surface Mapping and Tracking",
    * Richard A. Newcombe, Andrew Fitzgibbon, at al, SIGGRAPH, 2011.
    */
-  class ICPOdometry: public Odometry
+  class CV_EXPORTS_W ICPOdometry: public Odometry
   {
   public:
-    ICPOdometry();
+    CV_WRAP ICPOdometry();
     /** Constructor.
      * @param cameraMatrix Camera matrix
      * @param minDepth Pixels with depth less than minDepth will not be used
@@ -768,85 +803,85 @@ namespace rgbd
      * @param iterCounts Count of iterations on each pyramid level.
      * @param transformType Class of trasformation
      */
-    ICPOdometry(const Mat& cameraMatrix, float minDepth = DEFAULT_MIN_DEPTH(), float maxDepth = DEFAULT_MAX_DEPTH(),
-                float maxDepthDiff = DEFAULT_MAX_DEPTH_DIFF(), float maxPointsPart = DEFAULT_MAX_POINTS_PART(),
-                const std::vector<int>& iterCounts = std::vector<int>(), int transformType = RIGID_BODY_MOTION);
+    CV_WRAP ICPOdometry(const Mat& cameraMatrix, float minDepth = Odometry::DEFAULT_MIN_DEPTH(), float maxDepth = Odometry::DEFAULT_MAX_DEPTH(),
+                float maxDepthDiff = Odometry::DEFAULT_MAX_DEPTH_DIFF(), float maxPointsPart = Odometry::DEFAULT_MAX_POINTS_PART(),
+                const std::vector<int>& iterCounts = std::vector<int>(), int transformType = Odometry::RIGID_BODY_MOTION);
 
-    virtual Size prepareFrameCache(Ptr<OdometryFrame>& frame, int cacheType) const;
+    CV_WRAP virtual Size prepareFrameCache(Ptr<OdometryFrame>& frame, int cacheType) const;
 
-    cv::Mat getCameraMatrix() const
+    CV_WRAP cv::Mat getCameraMatrix() const
     {
         return cameraMatrix;
     }
-    void setCameraMatrix(const cv::Mat &val)
+    CV_WRAP void setCameraMatrix(const cv::Mat &val)
     {
         cameraMatrix = val;
     }
-    double getMinDepth() const
+    CV_WRAP double getMinDepth() const
     {
         return minDepth;
     }
-    void setMinDepth(double val)
+    CV_WRAP void setMinDepth(double val)
     {
         minDepth = val;
     }
-    double getMaxDepth() const
+    CV_WRAP double getMaxDepth() const
     {
         return maxDepth;
     }
-    void setMaxDepth(double val)
+    CV_WRAP void setMaxDepth(double val)
     {
         maxDepth = val;
     }
-    double getMaxDepthDiff() const
+    CV_WRAP double getMaxDepthDiff() const
     {
         return maxDepthDiff;
     }
-    void setMaxDepthDiff(double val)
+    CV_WRAP void setMaxDepthDiff(double val)
     {
         maxDepthDiff = val;
     }
-    cv::Mat getIterationCounts() const
+    CV_WRAP cv::Mat getIterationCounts() const
     {
         return iterCounts;
     }
-    void setIterationCounts(const cv::Mat &val)
+    CV_WRAP void setIterationCounts(const cv::Mat &val)
     {
         iterCounts = val;
     }
-    double getMaxPointsPart() const
+    CV_WRAP double getMaxPointsPart() const
     {
         return maxPointsPart;
     }
-    void setMaxPointsPart(double val)
+    CV_WRAP void setMaxPointsPart(double val)
     {
         maxPointsPart = val;
     }
-    int getTransformType() const
+    CV_WRAP int getTransformType() const
     {
         return transformType;
     }
-    void setTransformType(int val)
+    CV_WRAP void setTransformType(int val)
     {
         transformType = val;
     }
-    double getMaxTranslation() const
+    CV_WRAP double getMaxTranslation() const
     {
         return maxTranslation;
     }
-    void setMaxTranslation(double val)
+    CV_WRAP void setMaxTranslation(double val)
     {
         maxTranslation = val;
     }
-    double getMaxRotation() const
+    CV_WRAP double getMaxRotation() const
     {
         return maxRotation;
     }
-    void setMaxRotation(double val)
+    CV_WRAP void setMaxRotation(double val)
     {
         maxRotation = val;
     }
-    Ptr<RgbdNormals> getNormalsComputer() const
+    CV_WRAP Ptr<RgbdNormals> getNormalsComputer() const
     {
         return normalsComputer;
     }
@@ -878,10 +913,10 @@ namespace rgbd
   /** Odometry that merges RgbdOdometry and ICPOdometry by minimize sum of their energy functions.
    */
 
-  class RgbdICPOdometry: public Odometry
+  class CV_EXPORTS_W RgbdICPOdometry: public Odometry
   {
   public:
-    RgbdICPOdometry();
+    CV_WRAP RgbdICPOdometry();
     /** Constructor.
      * @param cameraMatrix Camera matrix
      * @param minDepth Pixels with depth less than minDepth will not be used
@@ -894,95 +929,95 @@ namespace rgbd
      *                              if they have gradient magnitude less than minGradientMagnitudes[level].
      * @param transformType Class of trasformation
      */
-    RgbdICPOdometry(const Mat& cameraMatrix, float minDepth = DEFAULT_MIN_DEPTH(), float maxDepth = DEFAULT_MAX_DEPTH(),
-                    float maxDepthDiff = DEFAULT_MAX_DEPTH_DIFF(), float maxPointsPart = DEFAULT_MAX_POINTS_PART(),
+    CV_WRAP RgbdICPOdometry(const Mat& cameraMatrix, float minDepth = Odometry::DEFAULT_MIN_DEPTH(), float maxDepth = Odometry::DEFAULT_MAX_DEPTH(),
+                    float maxDepthDiff = Odometry::DEFAULT_MAX_DEPTH_DIFF(), float maxPointsPart = Odometry::DEFAULT_MAX_POINTS_PART(),
                     const std::vector<int>& iterCounts = std::vector<int>(),
                     const std::vector<float>& minGradientMagnitudes = std::vector<float>(),
-                    int transformType = RIGID_BODY_MOTION);
+                    int transformType = Odometry::RIGID_BODY_MOTION);
 
-    virtual Size prepareFrameCache(Ptr<OdometryFrame>& frame, int cacheType) const;
+    CV_WRAP virtual Size prepareFrameCache(Ptr<OdometryFrame>& frame, int cacheType) const;
 
-    cv::Mat getCameraMatrix() const
+    CV_WRAP cv::Mat getCameraMatrix() const
     {
         return cameraMatrix;
     }
-    void setCameraMatrix(const cv::Mat &val)
+    CV_WRAP void setCameraMatrix(const cv::Mat &val)
     {
         cameraMatrix = val;
     }
-    double getMinDepth() const
+    CV_WRAP double getMinDepth() const
     {
         return minDepth;
     }
-    void setMinDepth(double val)
+    CV_WRAP void setMinDepth(double val)
     {
         minDepth = val;
     }
-    double getMaxDepth() const
+    CV_WRAP double getMaxDepth() const
     {
         return maxDepth;
     }
-    void setMaxDepth(double val)
+    CV_WRAP void setMaxDepth(double val)
     {
         maxDepth = val;
     }
-    double getMaxDepthDiff() const
+    CV_WRAP double getMaxDepthDiff() const
     {
         return maxDepthDiff;
     }
-    void setMaxDepthDiff(double val)
+    CV_WRAP void setMaxDepthDiff(double val)
     {
         maxDepthDiff = val;
     }
-    double getMaxPointsPart() const
+    CV_WRAP double getMaxPointsPart() const
     {
         return maxPointsPart;
     }
-    void setMaxPointsPart(double val)
+    CV_WRAP void setMaxPointsPart(double val)
     {
         maxPointsPart = val;
     }
-    cv::Mat getIterationCounts() const
+    CV_WRAP cv::Mat getIterationCounts() const
     {
         return iterCounts;
     }
-    void setIterationCounts(const cv::Mat &val)
+    CV_WRAP void setIterationCounts(const cv::Mat &val)
     {
         iterCounts = val;
     }
-    cv::Mat getMinGradientMagnitudes() const
+    CV_WRAP cv::Mat getMinGradientMagnitudes() const
     {
         return minGradientMagnitudes;
     }
-    void setMinGradientMagnitudes(const cv::Mat &val)
+    CV_WRAP void setMinGradientMagnitudes(const cv::Mat &val)
     {
         minGradientMagnitudes = val;
     }
-    int getTransformType() const
+    CV_WRAP int getTransformType() const
     {
         return transformType;
     }
-    void setTransformType(int val)
+    CV_WRAP void setTransformType(int val)
     {
         transformType = val;
     }
-    double getMaxTranslation() const
+    CV_WRAP double getMaxTranslation() const
     {
         return maxTranslation;
     }
-    void setMaxTranslation(double val)
+    CV_WRAP void setMaxTranslation(double val)
     {
         maxTranslation = val;
     }
-    double getMaxRotation() const
+    CV_WRAP double getMaxRotation() const
     {
         return maxRotation;
     }
-    void setMaxRotation(double val)
+    CV_WRAP void setMaxRotation(double val)
     {
         maxRotation = val;
     }
-    Ptr<RgbdNormals> getNormalsComputer() const
+    CV_WRAP Ptr<RgbdNormals> getNormalsComputer() const
     {
         return normalsComputer;
     }
@@ -1026,10 +1061,10 @@ namespace rgbd
    * @param warpedDepth The warped depth.
    * @param warpedMask The warped mask.
    */
-  CV_EXPORTS
+  CV_EXPORTS_W
   void
-  warpFrame(const Mat& image, const Mat& depth, const Mat& mask, const Mat& Rt, const Mat& cameraMatrix,
-            const Mat& distCoeff, Mat& warpedImage, Mat* warpedDepth = 0, Mat* warpedMask = 0);
+  warpFrame(const InputArray image, const InputArray depth, const InputArray mask, const Mat& Rt, const Mat& cameraMatrix,
+            const Mat& distCoeff, OutputArray warpedImage, OutputArray warpedDepth = noArray(), OutputArray warpedMask = noArray());
 
 // TODO Depth interpolation
 // Curvature

--- a/modules/rgbd/include/opencv2/rgbd/linemod.hpp
+++ b/modules/rgbd/include/opencv2/rgbd/linemod.hpp
@@ -101,14 +101,14 @@ public:
    * \param[out] dst The destination 8-bit image. For each pixel at most one bit is set,
    *                 representing its classification.
    */
-  virtual void quantize(Mat& dst) const =0;
+  virtual void quantize(CV_OUT Mat& dst) const =0;
 
   /**
    * \brief Extract most discriminant features at current pyramid level to form a new template.
    *
    * \param[out] templ The new template.
    */
-  virtual bool extractTemplate(Template& templ) const =0;
+  virtual bool extractTemplate(CV_OUT Template& templ) const =0;
 
   /**
    * \brief Go to the next pyramid level.
@@ -142,7 +142,7 @@ protected:
    * \param[in]  distance     Hint for desired distance between features.
    */
   static void selectScatteredFeatures(const std::vector<Candidate>& candidates,
-                                      std::vector<Feature>& features,
+                                      CV_OUT std::vector<Feature>& features,
                                       size_t num_features, float distance);
 };
 
@@ -324,7 +324,7 @@ public:
   /**
    * \brief Empty constructor, initialize with read().
    */
-  Detector();
+  CV_WRAP Detector();
 
   /**
    * \brief Constructor.
@@ -333,7 +333,7 @@ public:
    * \param T_pyramid        Value of the sampling step T at each pyramid level. The
    *                         number of pyramid levels is T_pyramid.size().
    */
-  Detector(const std::vector< Ptr<Modality> >& modalities, const std::vector<int>& T_pyramid);
+  CV_WRAP Detector(const std::vector< Ptr<Modality> >& modalities, const std::vector<int>& T_pyramid);
 
   /**
    * \brief Detect objects by template matching.
@@ -350,7 +350,7 @@ public:
    *                       the same size as sources.  Each element must be
    *                       empty or the same size as its corresponding source.
    */
-  void match(const std::vector<Mat>& sources, float threshold, std::vector<Match>& matches,
+  CV_WRAP void match(const std::vector<Mat>& sources, float threshold, CV_OUT std::vector<Match>& matches,
              const std::vector<String>& class_ids = std::vector<String>(),
              OutputArrayOfArrays quantized_images = noArray(),
              const std::vector<Mat>& masks = std::vector<Mat>()) const;
@@ -365,13 +365,13 @@ public:
    *
    * \return Template ID, or -1 if failed to extract a valid template.
    */
-  int addTemplate(const std::vector<Mat>& sources, const String& class_id,
-          const Mat& object_mask, Rect* bounding_box = NULL);
+  CV_WRAP int addTemplate(const std::vector<Mat>& sources, const String& class_id,
+          const Mat& object_mask, CV_OUT Rect* bounding_box = NULL);
 
   /**
    * \brief Add a new object template computed by external means.
    */
-  int addSyntheticTemplate(const std::vector<Template>& templates, const String& class_id);
+  CV_WRAP int addSyntheticTemplate(const std::vector<Template>& templates, const String& class_id);
 
   /**
    * \brief Get the modalities used by this detector.
@@ -379,17 +379,17 @@ public:
    * You are not permitted to add/remove modalities, but you may dynamic_cast them to
    * tweak parameters.
    */
-  const std::vector< Ptr<Modality> >& getModalities() const { return modalities; }
+  CV_WRAP const std::vector< Ptr<Modality> >& getModalities() const { return modalities; }
 
   /**
    * \brief Get sampling step T at pyramid_level.
    */
-  int getT(int pyramid_level) const { return T_at_level[pyramid_level]; }
+  CV_WRAP int getT(int pyramid_level) const { return T_at_level[pyramid_level]; }
 
   /**
    * \brief Get number of pyramid levels used by this detector.
    */
-  int pyramidLevels() const { return pyramid_levels; }
+  CV_WRAP int pyramidLevels() const { return pyramid_levels; }
 
   /**
    * \brief Get the template pyramid identified by template_id.
@@ -397,13 +397,13 @@ public:
    * For example, with 2 modalities (Gradient, Normal) and two pyramid levels
    * (L0, L1), the order is (GradientL0, NormalL0, GradientL1, NormalL1).
    */
-  const std::vector<Template>& getTemplates(const String& class_id, int template_id) const;
+  CV_WRAP const std::vector<Template>& getTemplates(const String& class_id, int template_id) const;
 
-  int numTemplates() const;
-  int numTemplates(const String& class_id) const;
-  int numClasses() const { return static_cast<int>(class_templates.size()); }
+  CV_WRAP int numTemplates() const;
+  CV_WRAP int numTemplates(const String& class_id) const;
+  CV_WRAP int numClasses() const { return static_cast<int>(class_templates.size()); }
 
-  std::vector<String> classIds() const;
+  CV_WRAP std::vector<String> classIds() const;
 
   void read(const FileNode& fn);
   void write(FileStorage& fs) const;
@@ -411,9 +411,9 @@ public:
   String readClass(const FileNode& fn, const String &class_id_override = "");
   void writeClass(const String& class_id, FileStorage& fs) const;
 
-  void readClasses(const std::vector<String>& class_ids,
+  CV_WRAP void readClasses(const std::vector<String>& class_ids,
                    const String& format = "templates_%s.yml.gz");
-  void writeClasses(const String& format = "templates_%s.yml.gz") const;
+  CV_WRAP void writeClasses(const String& format = "templates_%s.yml.gz") const;
 
 protected:
   std::vector< Ptr<Modality> > modalities;

--- a/modules/rgbd/include/opencv2/rgbd/linemod.hpp
+++ b/modules/rgbd/include/opencv2/rgbd/linemod.hpp
@@ -60,29 +60,29 @@ namespace linemod {
 /**
  * \brief Discriminant feature described by its location and label.
  */
-struct CV_EXPORTS Feature
+struct CV_EXPORTS_W Feature
 {
-  int x; ///< x offset
-  int y; ///< y offset
-  int label; ///< Quantization
+  CV_PROP_RW int x; ///< x offset
+  CV_PROP_RW int y; ///< y offset
+  CV_PROP_RW int label; ///< Quantization
 
-  Feature() : x(0), y(0), label(0) {}
-  Feature(int x, int y, int label);
+  CV_WRAP Feature() : x(0), y(0), label(0) {}
+  CV_WRAP Feature(int x, int y, int label);
 
-  void read(const FileNode& fn);
+  CV_WRAP void read(const FileNode& fn);
   void write(FileStorage& fs) const;
 };
 
 inline Feature::Feature(int _x, int _y, int _label) : x(_x), y(_y), label(_label) {}
 
-struct CV_EXPORTS Template
+struct CV_EXPORTS_W Template
 {
-  int width;
-  int height;
-  int pyramid_level;
-  std::vector<Feature> features;
+  CV_PROP_RW int width;
+  CV_PROP_RW int height;
+  CV_PROP_RW int pyramid_level;
+  CV_PROP_RW std::vector<Feature> features;
 
-  void read(const FileNode& fn);
+  CV_WRAP void read(const FileNode& fn);
   void write(FileStorage& fs) const;
 };
 
@@ -153,7 +153,7 @@ inline QuantizedPyramid::Candidate::Candidate(int x, int y, int label, float _sc
  *
  * \todo Max response, to allow optimization of summing (255/MAX) features as uint8
  */
-class CV_EXPORTS Modality
+class CV_EXPORTS_W Modality
 {
 public:
   // Virtual destructor
@@ -200,7 +200,7 @@ protected:
 /**
  * \brief Modality that computes quantized gradient orientations from a color image.
  */
-class CV_EXPORTS ColorGradient : public Modality
+class CV_EXPORTS_W ColorGradient : public Modality
 {
 public:
   /**
@@ -235,7 +235,7 @@ protected:
 /**
  * \brief Modality that computes quantized surface normals from a dense depth map.
  */
-class CV_EXPORTS DepthNormal : public Modality
+class CV_EXPORTS_W DepthNormal : public Modality
 {
 public:
   /**
@@ -279,13 +279,13 @@ void colormap(const Mat& quantized, Mat& dst);
 /**
  * \brief Represents a successful template match.
  */
-struct CV_EXPORTS Match
+struct CV_EXPORTS_W Match
 {
-  Match()
+  CV_WRAP Match()
   {
   }
 
-  Match(int x, int y, float similarity, const String& class_id, int template_id);
+  CV_WRAP Match(int x, int y, float similarity, const String& class_id, int template_id);
 
   /// Sort matches with high similarity to the front
   bool operator<(const Match& rhs) const
@@ -302,11 +302,11 @@ struct CV_EXPORTS Match
     return x == rhs.x && y == rhs.y && similarity == rhs.similarity && class_id == rhs.class_id;
   }
 
-  int x;
-  int y;
-  float similarity;
-  String class_id;
-  int template_id;
+  CV_PROP_RW int x;
+  CV_PROP_RW int y;
+  CV_PROP_RW float similarity;
+  CV_PROP_RW String class_id;
+  CV_PROP_RW int template_id;
 };
 
 inline
@@ -318,7 +318,7 @@ Match::Match(int _x, int _y, float _similarity, const String& _class_id, int _te
  * \brief Object detector using the LINE template matching algorithm with any set of
  * modalities.
  */
-class CV_EXPORTS Detector
+class CV_EXPORTS_W Detector
 {
 public:
   /**
@@ -440,7 +440,7 @@ protected:
  *
  * Default parameter settings suitable for VGA images.
  */
-CV_EXPORTS Ptr<Detector> getDefaultLINE();
+CV_EXPORTS_W Ptr<linemod::Detector> getDefaultLINE();
 
 /**
  * \brief Factory function for detector using LINE-MOD algorithm with color gradients
@@ -448,7 +448,7 @@ CV_EXPORTS Ptr<Detector> getDefaultLINE();
  *
  * Default parameter settings suitable for VGA images.
  */
-CV_EXPORTS Ptr<Detector> getDefaultLINEMOD();
+CV_EXPORTS_W Ptr<linemod::Detector> getDefaultLINEMOD();
 
 //! @}
 

--- a/modules/rgbd/misc/python/pyopencv_rgbd.hpp
+++ b/modules/rgbd/misc/python/pyopencv_rgbd.hpp
@@ -143,10 +143,10 @@ bool pyopencv_to(PyObject *o, linemod::Template &_template, const char *name)
 		_template = linemod::Template();
 		return true;
 	}
-	PyObject *features;
-	if (PyArg_ParseTuple(o, "iiiO", &_template.width, &_template.height, &_template.pyramid_level, features) <= 0)
+	PyObject o_features;
+	if (PyArg_ParseTuple(o, "iiiO", &_template.width, &_template.height, &_template.pyramid_level, &o_features) <= 0)
 		return false;
-	return pyopencv_to(features, _template.features, name);
+	return pyopencv_to(&o_features, _template.features, name);
 }
 
 template<>

--- a/modules/rgbd/misc/python/pyopencv_rgbd.hpp
+++ b/modules/rgbd/misc/python/pyopencv_rgbd.hpp
@@ -1,7 +1,16 @@
 #ifdef HAVE_OPENCV_RGBD
+typedef std::vector<linemod::Template> vector_Template;
+typedef std::vector<linemod::Match> vector_Match;
+typedef std::vector<Ptr<linemod::Modality>> vector_Ptr_Modality;
 
 template<>
 bool pyopencv_to(PyObject *o, linemod::Feature &feature, const char *name);
+template<>
+bool pyopencv_to(PyObject *o, linemod::Template &_template, const char *name);
+template<>
+bool pyopencv_to(PyObject *o, linemod::Match &match, const char *name);
+template<>
+bool pyopencv_to(PyObject *o, Ptr<linemod::Modality> &modality, const char *name);
 
 template<> struct pyopencvVecConverter<linemod::Feature>
 {
@@ -22,6 +31,63 @@ template<> struct pyopencvVecConverter<linemod::Feature>
     }
 };
 
+template<> struct pyopencvVecConverter<linemod::Template>
+{
+	static bool to(PyObject* obj, std::vector<linemod::Template>& value, const ArgInfo info)
+	{
+		if (PyArray_Check(obj))
+		{
+			value.resize(1);
+			return pyopencv_to(obj, value[0], info.name);
+		}
+
+		return pyopencv_to_generic_vec(obj, value, info);
+	}
+
+	static PyObject* from(const std::vector<linemod::Template>& value)
+	{
+		return pyopencv_from_generic_vec(value);
+	}
+};
+
+template<> struct pyopencvVecConverter<linemod::Match>
+{
+	static bool to(PyObject* obj, std::vector<linemod::Match>& value, const ArgInfo info)
+	{
+		if (PyArray_Check(obj))
+		{
+			value.resize(1);
+			return pyopencv_to(obj, value[0], info.name);
+		}
+
+		return pyopencv_to_generic_vec(obj, value, info);
+	}
+
+	static PyObject* from(const std::vector<linemod::Match>& value)
+	{
+		return pyopencv_from_generic_vec(value);
+	}
+};
+
+template<> struct pyopencvVecConverter<Ptr<linemod::Modality>>
+{
+	static bool to(PyObject* obj, std::vector<Ptr<linemod::Modality>>& value, const ArgInfo info)
+	{
+		if (PyArray_Check(obj))
+		{
+			value.resize(1);
+			return pyopencv_to(obj, value[0], info.name);
+		}
+
+		return pyopencv_to_generic_vec(obj, value, info);
+	}
+
+	static PyObject* from(const std::vector<Ptr<linemod::Modality>>& value)
+	{
+		return pyopencv_from_generic_vec(value);
+	}
+};
+
 template<>
 bool pyopencv_to(PyObject *o, std::vector<linemod::Feature> &features, const char *name) //required for std::vector<Feature> features
 {
@@ -29,24 +95,88 @@ bool pyopencv_to(PyObject *o, std::vector<linemod::Feature> &features, const cha
 }
 
 template<>
+bool pyopencv_to(PyObject *o, std::vector<linemod::Template> &templates, const char *name) //required for std::vector<Template> templates
+{
+	return pyopencvVecConverter<linemod::Template>::to(o, templates, ArgInfo(name, false));
+}
+
+template<>
+bool pyopencv_to(PyObject *o, std::vector<linemod::Match> &matches, const char *name) //required for std::vector<Match> matches
+{
+	return pyopencvVecConverter<linemod::Match>::to(o, matches, ArgInfo(name, false));
+}
+
+template<>
+bool pyopencv_to(PyObject *o, std::vector<Ptr<linemod::Modality>> &modalities, const char *name) //required for std::vector<Ptr<Modality>> modalities
+{
+	return pyopencvVecConverter<Ptr<linemod::Modality>>::to(o, modalities, ArgInfo(name, false));
+}
+
+template<>
 bool pyopencv_to(PyObject *o, linemod::Feature &feature, const char *name)
 {
-    std::vector<int> data;
-    if (!pyopencv_to_generic_vec(o, data, ArgInfo(name, false)))
-        return false;
-
-    feature = data.size() ? linemod::Feature(data[0], data[1], data[2]) : linemod::Feature();
-    return true;
+	(void)name;
+	if (!o || o == Py_None)
+		return true;
+	if (PyObject_Size(o) == 0)
+	{
+		feature = linemod::Feature();
+		return true;
+	}
+	return PyArg_ParseTuple(o, "iii", &feature.x, &feature.y, &feature.label) > 0;
 }
 
 template<>
 PyObject *pyopencv_from(const linemod::Feature &feature)
 {
-    std::vector<int> data;
-    data.push_back(feature.x);
-    data.push_back(feature.y);
-    data.push_back(feature.label);
-    return pyopencv_from_generic_vec(data);
+	return Py_BuildValue("(iii)", feature.x, feature.y, feature.label);
+}
+
+template<>
+bool pyopencv_to(PyObject *o, linemod::Template &_template, const char *name)
+{
+	(void)name;
+	if (!o || o == Py_None)
+		return true;
+	if (PyObject_Size(o) == 0)
+	{
+		_template = linemod::Template();
+		return true;
+	}
+	PyObject *features;
+	if (PyArg_ParseTuple(o, "iiiO", &_template.width, &_template.height, &_template.pyramid_level, features) <= 0)
+		return false;
+	return pyopencv_to(features, _template.features, name);
+}
+
+template<>
+PyObject *pyopencv_from(const linemod::Template &_template)
+{
+	return Py_BuildValue("(iiiO)", _template.width, _template.height, _template.pyramid_level, pyopencv_from(_template.features));
+}
+
+template<>
+bool pyopencv_to(PyObject *o, linemod::Match &match, const char *name)
+{
+	(void)name;
+	if (!o || o == Py_None)
+		return true;
+	if (PyObject_Size(o) == 0)
+	{
+		match = linemod::Match();
+		return true;
+	}
+	char class_id[128];
+	if (PyArg_ParseTuple(o, "iifsi", &match.x, &match.y, &match.similarity, class_id, &match.template_id) <= 0)
+		return false;
+	match.class_id = String(class_id);
+	return true;
+}
+
+template<>
+PyObject *pyopencv_from(const linemod::Match &match)
+{
+	return Py_BuildValue("(iifsi)", match.x, match.y, match.similarity, match.class_id.c_str(), match.template_id);
 }
 
 template<>

--- a/modules/rgbd/misc/python/pyopencv_rgbd.hpp
+++ b/modules/rgbd/misc/python/pyopencv_rgbd.hpp
@@ -1,0 +1,91 @@
+#ifdef HAVE_OPENCV_RGBD
+
+template<>
+bool pyopencv_to(PyObject *o, linemod::Feature &feature, const char *name);
+
+template<> struct pyopencvVecConverter<linemod::Feature>
+{
+    static bool to(PyObject* obj, std::vector<linemod::Feature>& value, const ArgInfo info)
+    {
+        if (PyArray_Check(obj))
+        {
+            value.resize(1);
+            return pyopencv_to(obj, value[0], info.name);
+        }
+
+        return pyopencv_to_generic_vec(obj, value, info);
+    }
+
+    static PyObject* from(const std::vector<linemod::Feature>& value)
+    {
+        return pyopencv_from_generic_vec(value);
+    }
+};
+
+template<>
+bool pyopencv_to(PyObject *o, std::vector<linemod::Feature> &features, const char *name) //required for std::vector<Feature> features
+{
+    return pyopencvVecConverter<linemod::Feature>::to(o, features, ArgInfo(name, false));
+}
+
+template<>
+bool pyopencv_to(PyObject *o, linemod::Feature &feature, const char *name)
+{
+    std::vector<int> data;
+    if (!pyopencv_to_generic_vec(o, data, ArgInfo(name, false)))
+        return false;
+
+    feature = data.size() ? linemod::Feature(data[0], data[1], data[2]) : linemod::Feature();
+    return true;
+}
+
+template<>
+PyObject *pyopencv_from(const linemod::Feature &feature)
+{
+    std::vector<int> data;
+    data.push_back(feature.x);
+    data.push_back(feature.y);
+    data.push_back(feature.label);
+    return pyopencv_from_generic_vec(data);
+}
+
+template<>
+bool pyopencv_to(PyObject *o, std::vector<Mat> &mats, const char *name)
+{
+    return pyopencvVecConverter<Mat>::to(o, mats, ArgInfo(name, false));
+}
+
+template<>
+bool pyopencv_to(PyObject *o, ushort &depth, const char *name)  //required for isValidDepth(const ushort & depth)
+{
+	std::vector<int> data;
+	if (!pyopencv_to_generic_vec(o, data, ArgInfo(name, false)))
+		return false;
+
+	depth = data.size() ? ushort(data[0]) : 0;
+	return true;
+}
+
+template<>
+bool pyopencv_to(PyObject *o, short &depth, const char *name)  //required for isValidDepth(const short & depth)
+{
+	std::vector<int> data;
+	if (!pyopencv_to_generic_vec(o, data, ArgInfo(name, false)))
+		return false;
+
+	depth = data.size() ? short(data[0]) : 0;
+	return true;
+}
+
+template<>
+bool pyopencv_to(PyObject *o, uint &depth, const char *name)  //required for isValidDepth(const uint & depth)
+{
+	std::vector<int> data;
+	if (!pyopencv_to_generic_vec(o, data, ArgInfo(name, false)))
+		return false;
+
+	depth = data.size() ? uint(data[0]) : 0;
+	return true;
+}
+
+#endif

--- a/modules/rgbd/misc/python/pyopencv_rgbd.hpp
+++ b/modules/rgbd/misc/python/pyopencv_rgbd.hpp
@@ -1,7 +1,7 @@
 #ifdef HAVE_OPENCV_RGBD
 typedef std::vector<linemod::Template> vector_Template;
 typedef std::vector<linemod::Match> vector_Match;
-typedef std::vector<Ptr<linemod::Modality>> vector_Ptr_Modality;
+typedef std::vector< Ptr<linemod::Modality> > vector_Ptr_Modality;
 
 template<>
 bool pyopencv_to(PyObject *o, linemod::Feature &feature, const char *name);
@@ -69,9 +69,9 @@ template<> struct pyopencvVecConverter<linemod::Match>
 	}
 };
 
-template<> struct pyopencvVecConverter<Ptr<linemod::Modality>>
+template<> struct pyopencvVecConverter< Ptr<linemod::Modality> >
 {
-	static bool to(PyObject* obj, std::vector<Ptr<linemod::Modality>>& value, const ArgInfo info)
+	static bool to(PyObject* obj, std::vector< Ptr<linemod::Modality> >& value, const ArgInfo info)
 	{
 		if (PyArray_Check(obj))
 		{
@@ -82,7 +82,7 @@ template<> struct pyopencvVecConverter<Ptr<linemod::Modality>>
 		return pyopencv_to_generic_vec(obj, value, info);
 	}
 
-	static PyObject* from(const std::vector<Ptr<linemod::Modality>>& value)
+	static PyObject* from(const std::vector< Ptr<linemod::Modality> >& value)
 	{
 		return pyopencv_from_generic_vec(value);
 	}
@@ -107,9 +107,9 @@ bool pyopencv_to(PyObject *o, std::vector<linemod::Match> &matches, const char *
 }
 
 template<>
-bool pyopencv_to(PyObject *o, std::vector<Ptr<linemod::Modality>> &modalities, const char *name) //required for std::vector<Ptr<Modality>> modalities
+bool pyopencv_to(PyObject *o, std::vector< Ptr<linemod::Modality> > &modalities, const char *name) //required for std::vector< Ptr<Modality> > modalities
 {
-	return pyopencvVecConverter<Ptr<linemod::Modality>>::to(o, modalities, ArgInfo(name, false));
+	return pyopencvVecConverter< Ptr<linemod::Modality> >::to(o, modalities, ArgInfo(name, false));
 }
 
 template<>

--- a/modules/rgbd/samples/linemod.cpp
+++ b/modules/rgbd/samples/linemod.cpp
@@ -191,7 +191,9 @@ int main(int argc, char * argv[])
   int num_modalities = (int)detector->getModalities().size();
 
   // Open Kinect sensor
-  cv::VideoCapture capture( cv::CAP_OPENNI );
+  cv::VideoCapture capture( cv::CAP_OPENNI2 );
+  if (!capture.isOpened())
+	  capture.open(cv::CAP_OPENNI);
   if (!capture.isOpened())
   {
     printf("Could not open OpenNI-capable sensor\n");
@@ -392,7 +394,7 @@ static void reprojectPoints(const std::vector<cv::Point3d>& proj, std::vector<cv
   }
 }
 
-static void filterPlane(IplImage * ap_depth, std::vector<IplImage *> & a_masks, std::vector<CvPoint> & a_chain, double f)
+static void filterPlane(const IplImage * ap_depth, const std::vector<IplImage *> & a_masks, const std::vector<CvPoint> & a_chain, const double f)
 {
   const int l_num_cost_pts = 200;
 

--- a/modules/rgbd/samples/python/linemod.py
+++ b/modules/rgbd/samples/python/linemod.py
@@ -1,0 +1,479 @@
+# Python wrapper by: Hamdi Sahloul <hamdisahloul AT hotmail.com>
+
+import cv2;
+import numpy as np;
+import sys;
+
+MATCH_X = 0;
+MATCH_Y = 1;
+MATCH_SIMILARITY = 2;
+MATCH_CLASS_ID = 3;
+MATCH_TEMPLATE_ID = 4;
+
+TEMPLATE_FEATURES = 3;
+
+FEATURE_X = 0;
+FEATURE_Y = 1;
+
+# Copy of cv_mouse from cv_utilities
+class Mouse:
+    m_event = -1;
+    m_x = 0;
+    m_y = 0;
+
+    @classmethod
+    def start(cls, a_img_name):
+            cv2.setMouseCallback(a_img_name, cls.cv_on_mouse, 0);
+
+    @classmethod
+    def event(cls):
+        l_event = cls.m_event;
+        cls.m_event = -1;
+        return l_event;
+
+    @classmethod
+    def x(cls):
+        return cls.m_x;
+
+    @classmethod
+    def y(cls):
+        return cls.m_y;
+
+    @classmethod
+    def cv_on_mouse(cls, a_event, a_x, a_y, *args, **kwargs):
+        cls.m_event = a_event;
+        cls.m_x = a_x;
+        cls.m_y = a_y;
+
+def help():
+    print("Usage: openni_demo.py\n\n" # [templates.yml]
+                 "Place your object on a planar, featureless surface. With the mouse,\n"
+                 "frame it in the 'color' window and right click to learn a first template.\n"
+                 "Then press 'l' to enter online learning mode, and move the camera around.\n"
+                 "When the match score falls between 90-95%% the demo will add a new template.\n\n"
+                 "Keys:\n"
+                 "\t h   -- This help page\n"
+                 "\t l   -- Toggle online learning\n"
+                 "\t m   -- Toggle printing match result\n"
+                 "\t t   -- Toggle printing timings\n"
+                 #"\t w   -- Write learned templates to disk\n"
+                 "\t [ ] -- Adjust matching threshold: '[' down,  ']' up\n"
+                 "\t q   -- Quit\n\n");
+
+# Adapted from cv_timer in cv_utilities
+class Timer:
+    def __init__(self, *args, **kwargs):
+        self.start_ = 0;
+        self.time_ = 0;
+
+    def start(self):
+        self.start_ = cv2.getTickCount();
+
+    def stop(self):
+        assert(self.start_ is not 0);
+        end = cv2.getTickCount();
+        self.time_ += end - self.start_;
+        self.start_ = 0;
+
+    def time(self):
+        ret = self.time_ / cv2.getTickFrequency();
+        time_ = 0;
+        return ret;
+
+# Functions to store detector and templates in single XML/YAML file
+#def readLinemod(filename):
+#    detector = cv2.linemod.Detector();
+#    fs = cv2.FileStorage(filename, cv2.FileStorage.READ);
+#    detector.read(fs.root());
+#
+#    fn = fs["classes"];
+#    for i in fn:
+#        detector.readClass(i);
+#
+#    return detector;
+
+#def writeLinemod(detector, filename):
+#    fs = cv2.FileStorage(filename, 1);
+#    detector.write(fs);
+#
+#    ids = detector.classIds();
+#    fs.write("classes" + "[");
+#    for id in ids:
+#        fs.write("{");
+#        detector.writeClass(id, fs);
+#        fs.write("}"); # current class
+#    fs.write("]"); # classes
+
+def subtractPlane(depth, chain, f):
+    mask = np.zeros(depth.shape, np.uint8);
+    a_masks = filterPlane(depth, [mask], chain, f);
+    return a_masks[0]
+
+def maskFromTemplate(templates, num_modalities, offset, size, dst):
+    mask = templateConvexHull(templates, num_modalities, offset, size);
+
+    OFFSET = 30;
+    mask = cv2.dilate(mask, None, iterations=OFFSET);
+
+    retval = cv2.findContours(mask.copy(), cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE);
+    if len(retval) == 3: retval = retval[1:];
+    contours, hierarchy = retval;
+    l_pts1 = contours[0].reshape((-1, 2));
+
+    cv2.polylines(dst, pts=[l_pts1], isClosed=True, color=(0, 255, 0), thickness=2);
+
+    return l_pts1, mask;
+
+# Adapted from cv_show_angles
+def displayQuantized(quantized):
+    color = np.ndarray((quantized.shape[0], quantized.shape[1], 3), np.uint8);
+    for r in range(quantized.rows):
+        quant_r = quantized.ptr(r);
+        color_r = color.ptr<cv2.Vec3b>(r);
+
+        for c in range(quantized.cols):
+            bgr = color_r[c];
+            if quant_r[c] == 0: bgr[0]= 0; bgr[1]= 0; bgr[2]= 0;
+            elif quant_r[c] == 1: bgr[0]= 55; bgr[1]= 55; bgr[2]= 55;
+            elif quant_r[c] == 2: bgr[0]= 80; bgr[1]= 80; bgr[2]= 80;
+            elif quant_r[c] == 4: bgr[0]=105; bgr[1]=105; bgr[2]=105;
+            elif quant_r[c] == 8: bgr[0]=130; bgr[1]=130; bgr[2]=130;
+            elif quant_r[c] == 16: bgr[0]=155; bgr[1]=155; bgr[2]=155;
+            elif quant_r[c] == 32: bgr[0]=180; bgr[1]=180; bgr[2]=180;
+            elif quant_r[c] == 64: bgr[0]=205; bgr[1]=205; bgr[2]=205;
+            elif quant_r[c] == 128: bgr[0]=230; bgr[1]=230; bgr[2]=230;
+            elif quant_r[c] == 255: bgr[0]= 0; bgr[1]= 0; bgr[2]=255;
+            else: bgr[0]= 0; bgr[1]=255; bgr[2]= 0;
+
+    return color;
+
+# Adapted from cv_line_template.convex_hull
+def templateConvexHull(templates, num_modalities, offset, size):
+    points = np.ndarray((num_modalities, 2), np.int);
+    for m in range(num_modalities):
+        for i in range(len(templates[m][TEMPLATE_FEATURES])):
+            f = templates[m][TEMPLATE_FEATURES][i];
+            points[m] = f[0:2] + offset;
+
+    hull = cv2.convexHull(points);
+
+    dst = np.zeros(size, np.uint8);
+    cv2.fillPoly(dst, [hull[0]], 255);
+    return dst
+
+def drawResponse(templates, num_modalities, dst, offset, T):
+    COLORS = [ np.array([255, 0, 0]),
+               np.array([0, 255, 0]),
+               np.array([0, 255, 255]),
+               np.array([0, 140, 255]),
+               np.array([0, 0, 255]) ];
+
+    for m in range(num_modalities):
+        # NOTE: Original demo recalculated max response for each feature in the TxT
+        # box around it and chose the display color based on that response. Here
+        # the display color just depends on the modality.
+        color = COLORS[m];
+
+        for i in range(len(templates[m][TEMPLATE_FEATURES])):
+            f = templates[m][TEMPLATE_FEATURES][i];
+            pt = tuple([f[FEATURE_X] + offset[0], f[FEATURE_Y] + offset[1]]);
+            cv2.circle(dst, pt, T / 2, color);
+
+def reprojectPoints(proj, f):
+    f_inv = 1.0 / f;
+
+    real = np.ndarray(proj.shape, proj.dtype);
+    for i in range(proj.shape[0]):
+        Z = proj[i, 2];
+        real[i, 0] = (proj[i, 0] - 320.) * (f_inv * Z);
+        real[i, 1] = (proj[i, 1] - 240.) * (f_inv * Z);
+        real[i, 2] = Z;
+    return real
+
+def filterPlane(ap_depth, a_masks, a_chain, f):
+    l_num_cost_pts = 200;
+
+    l_thres = 4;
+
+    lp_mask = np.zeros(ap_depth.shape, np.uint8);
+
+    l_chain_vector = [];
+
+    l_chain_length = 0;
+    lp_seg_length = [];
+
+    for l_i in range(a_chain.shape[0]):
+        x_diff = float(a_chain[(l_i + 1) % a_chain.shape[0], 0] - a_chain[l_i, 0]);
+        y_diff = float(a_chain[(l_i + 1) % a_chain.shape[0], 1] - a_chain[l_i, 1]);
+        lp_seg_length.append(np.sqrt(x_diff*x_diff + y_diff*y_diff));
+        l_chain_length += lp_seg_length[l_i];
+    for l_i in range(a_chain.shape[0]):
+        if lp_seg_length[l_i] > 0:
+            l_cur_num = np.rint(l_num_cost_pts * lp_seg_length[l_i] / l_chain_length).astype(int);
+            l_cur_len = lp_seg_length[l_i] / l_cur_num;
+
+            for l_j in range(l_cur_num):
+                l_ratio = (l_cur_len * l_j / lp_seg_length[l_i]);
+
+                l_pts = (np.rint(l_ratio * (a_chain[(l_i + 1) % a_chain.shape[0], 0] - a_chain[l_i, 0]) + a_chain[l_i, 0]).astype(int),
+                         np.rint(l_ratio * (a_chain[(l_i + 1) % a_chain.shape[0], 1] - a_chain[l_i, 1]) + a_chain[l_i, 1]).astype(int));
+
+                l_chain_vector.append(l_pts);
+
+    lp_src_3Dpts = np.ndarray((len(l_chain_vector), 3));
+    for l_i in range(lp_src_3Dpts.shape[0]):
+        lp_src_3Dpts[l_i, 0] = l_chain_vector[l_i][0];
+        lp_src_3Dpts[l_i, 1] = l_chain_vector[l_i][1];
+        lp_src_3Dpts[l_i, 2] = ap_depth[np.rint(lp_src_3Dpts[l_i, 1]).astype(int), np.rint(lp_src_3Dpts[l_i, 0]).astype(int)];
+        #lp_mask[int(lp_src_3Dpts[l_i, 1]),int(lp_src_3Dpts[l_i, 0])]=255;
+    #cv2.imshow("hallo2",lp_mask);
+
+    lp_src_3Dpts = reprojectPoints(lp_src_3Dpts, f);
+
+    lp_pts = np.hstack((lp_src_3Dpts, np.ones((lp_src_3Dpts.shape[0], 1))));
+    _, _, lp_v = np.linalg.svd(lp_pts);
+
+    l_n = lp_v[0:lp_src_3Dpts.shape[0], 3];
+    l_n /= np.linalg.norm(l_n);
+
+    l_max_dist = np.abs(np.sum(l_n * lp_pts, axis=1)).max();
+    del lp_pts;
+    del lp_v;
+
+    #print("plane: %f;%f;%f;%f maxdist: %f end" % (l_n[0], l_n[1], l_n[2], l_n[3], l_max_dist));
+    l_minx = ap_depth.shape[1];
+    l_miny = ap_depth.shape[0];
+    l_maxx = 0;
+    l_maxy = 0;
+
+    for l_i in range(a_chain.shape[0]):
+        l_minx = np.fmin(l_minx, a_chain[l_i,0]);
+        l_miny = np.fmin(l_miny, a_chain[l_i, 1]);
+        l_maxx = np.fmax(l_maxx, a_chain[l_i, 0]);
+        l_maxy = np.fmax(l_maxy, a_chain[l_i, 1]);
+    l_w = l_maxx - l_minx + 1;
+    l_h = l_maxy - l_miny + 1;
+    l_nn = a_chain.shape[0];
+
+    cv2.fillPoly(lp_mask, [a_chain], (255, 255, 255));
+
+    #cv2.imshow("hallo1",lp_mask);
+
+    lp_dst_3Dpts = np.ndarray((l_h * l_w, 3));
+
+    l_ind = 0;
+
+    for l_r in range(l_h):
+        for l_c in range(l_w):
+            lp_dst_3Dpts[l_ind, 0] = l_c + l_minx;
+            lp_dst_3Dpts[l_ind, 1] = l_r + l_miny;
+            lp_dst_3Dpts[l_ind, 2] = ap_depth[l_r + l_miny, l_c + l_minx];
+            l_ind += 1;
+    lp_dst_3Dpts = reprojectPoints(lp_dst_3Dpts, f);
+
+    lp_pts = np.hstack((lp_dst_3Dpts, np.ones((lp_dst_3Dpts.shape[0], 1))));
+
+    l_ind = 0;
+
+    for l_r in range(l_h):
+        for l_c in range(l_w):
+            l_dist = np.fabs(np.sum(l_n * lp_pts[l_ind]));
+            l_dist *= 3; #TODO: Fix this
+
+            l_ind += 1;
+
+            if lp_mask[l_r + l_miny, l_c + l_minx] is not 0:
+                if l_dist < np.fmax(l_thres, (l_max_dist * 2.0)):
+                    for l_p in range(len(a_masks)):
+                        l_col = np.rint((l_c + l_minx) / (l_p + 1.0)).astype(int);
+                        l_row = np.rint((l_r + l_miny) / (l_p + 1.0)).astype(int);
+
+                        a_masks[l_p][l_row, l_col] = 0;
+                else:
+                    for l_p in range(len(a_masks)):
+                        l_col = np.rint((l_c + l_minx) / (l_p + 1.0)).astype(int);
+                        l_row = np.rint((l_r + l_miny) / (l_p + 1.0)).astype(int);
+
+                        a_masks[l_p][l_row, l_col] = 255;
+    del lp_mask;
+    return a_masks
+
+if __name__ == "__main__":
+    # Various settings and flags
+    show_match_result = True;
+    show_timings = False;
+    learn_online = False;
+    num_classes = 0;
+    matching_threshold = 80;
+    roi_size = np.array([200, 200]);
+    learning_lower_bound = 90;
+    learning_upper_bound = 95;
+
+    # Timers
+    extract_timer = Timer();
+    match_timer = Timer();
+
+    # Initialize HighGUI
+    help();
+    cv2.namedWindow("color");
+    cv2.namedWindow("normals");
+    Mouse.start("color");
+
+    # Initialize LINEMOD data structures
+    detector = cv2.linemod.Detector();
+    if len(sys.argv) == 1:
+    #    filename = "linemod_templates.yml";
+        detector = cv2.linemod.getDefaultLINEMOD();
+    #else:
+    #    detector = readLinemod(sys.argv[1]);
+    #
+    #    ids = detector.classIds();
+    #    num_classes = detector.numClasses();
+    #    print("Loaded %s with %d classes and %d templates\n" %
+    #                 (sys.argv[1], num_classes, detector.numTemplates()));
+    #    if len(ids):
+    #        print("Class ids:\n");
+    #        print(ids)
+    num_modalities = len(detector.getModalities());
+
+    # Open Kinect sensor
+    capture = cv2.VideoCapture(cv2.CAP_OPENNI2);
+    if not capture.isOpened():
+            capture.open(cv2.CAP_OPENNI);
+    if not capture.isOpened():
+        print("Could not open OpenNI-capable sensor\n");
+        sys.exit(-1);
+    capture.set(cv2.CAP_PROP_OPENNI_REGISTRATION, 1);
+    focal_length = capture.get(cv2.CAP_OPENNI_DEPTH_GENERATOR_FOCAL_LENGTH);
+    #print("Focal length = %f\n" % focal_length);
+
+    # Main loop
+    while True:
+        # Capture next color/depth pair
+        capture.grab();
+        _, depth = capture.retrieve(0, cv2.CAP_OPENNI_DEPTH_MAP);
+        _, color = capture.retrieve(0, cv2.CAP_OPENNI_BGR_IMAGE);
+
+        sources = [];
+        sources.append(color);
+        sources.append(depth);
+        display = color.copy();
+
+        if not learn_online:
+            mouse = np.array([Mouse.x(), Mouse.y()]);
+            event = Mouse.event();
+
+            # Compute ROI centered on current mouse location
+            roi_offset = 0.5 * roi_size;
+            pt1 = tuple((mouse - roi_offset).astype(np.int)); # top left
+            pt2 = tuple((mouse + roi_offset).astype(np.int)); # bottom right
+
+            if event == cv2.EVENT_RBUTTONDOWN:
+                # Compute object mask by subtracting the plane within the ROI
+                chain = np.array([pt1, (pt2[0], pt1[1]), pt2, (pt1[0], pt2[1])], np.int);
+                mask = subtractPlane(depth, chain, focal_length);
+
+                cv2.imshow("mask", mask);
+
+                # Extract template
+                class_id = "class" + str(num_classes);
+                extract_timer.start();
+                template_id, bb = detector.addTemplate(sources, class_id, mask);
+                extract_timer.stop();
+                if template_id is not -1:
+                    print("*** Added template (id %d) for new object class %d***\n" %
+                                 (template_id, num_classes));
+                    #print("Extracted at (%d, %d) size %dx%d\n" % (bb.x, bb.y, bb.width, bb.height));
+
+                num_classes += 1;
+
+            # Draw ROI for display
+            cv2.rectangle(display, pt1, pt2, (0,0,0), 3);
+            cv2.rectangle(display, pt1, pt2, (0, 255, 255), 1);
+
+        # Perform matching
+        class_ids = [];
+        match_timer.start();
+        matches, quantized_images = detector.match(sources, float(matching_threshold), class_ids);
+        match_timer.stop();
+
+        classes_visited = 0;
+        visited = [];
+
+        for i in range(len(matches)):
+            if classes_visited >= num_classes: break;
+            m = matches[i];
+
+            if m[MATCH_CLASS_ID] not in visited:
+                visited.append(m[MATCH_CLASS_ID])
+                classes_visited += 1;
+
+                if show_match_result:
+                    print("Similarity: %5.1f%%; x: %3d; y: %3d; class: %s; template: %3d\n" %
+                                 (m[MATCH_SIMILARITY], m[MATCH_X], m[MATCH_Y], m[MATCH_CLASS_ID], m[MATCH_TEMPLATE_ID]));
+
+                # Draw matching template
+                templates = detector.getTemplates(m[MATCH_CLASS_ID], m[MATCH_TEMPLATE_ID]);
+                drawResponse(templates, num_modalities, display, ([m[MATCH_X], m[MATCH_Y]]), detector.getT(0));
+
+                if learn_online == True:
+                    #/ @todo Online learning possibly broken by new gradient feature extraction,
+                    #/ which assumes an accurate object outline.
+
+                    # Compute masks based on convex hull of matched template
+                    chain, _ = maskFromTemplate(templates, num_modalities,
+                                             np.array([m[MATCH_X], m[MATCH_Y]]), color.shape[0:2], display);
+                    depth_mask = subtractPlane(depth, chain, focal_length);
+
+                    cv2.imshow("mask", depth_mask);
+
+                    # If pretty sure (but not TOO sure), add new template
+                    if learning_lower_bound < m[MATCH_SIMILARITY] and m[MATCH_SIMILARITY] < learning_upper_bound:
+                        extract_timer.start();
+                        template_id, _ = detector.addTemplate(sources, m[MATCH_CLASS_ID], depth_mask);
+                        extract_timer.stop();
+                        if template_id is not -1:
+                            print("*** Added template (id %d) for existing object class %s***\n" %
+                                         (template_id, m[MATCH_CLASS_ID]));
+
+        if show_match_result and len(matches) == 0:
+            print("No matches found...\n");
+        if show_timings:
+            print("Training: %.2fs\n" % extract_timer.time());
+            print("Matching: %.2fs\n" % match_timer.time());
+        if show_match_result or show_timings:
+            print("------------------------------------------------------------\n");
+
+        cv2.imshow("color", display);
+        cv2.imshow("normals", quantized_images[1]);
+
+        #fs = cv2.FileStorage();
+        key = chr(cv2.waitKey(10));
+        if key == 'q':
+            break;
+        elif key == 'h':
+            help();
+        elif key == 'm':
+            # toggle printing match result
+            show_match_result = not show_match_result;
+            print("Show match result %s\n" % ("ON" if show_match_result else "OFF"));
+        elif key == 't':
+            # toggle printing timings
+            show_timings = not show_timings;
+            print("Show timings %s\n" % ("ON" if show_timings else "OFF"));
+        elif key == 'l':
+            # toggle online learning
+            learn_online = not learn_online;
+            print("Online learning %s\n" % ("ON" if learn_online else "OFF"));
+        elif key == '[':
+            # decrement threshold
+            matching_threshold = np.fmax(matching_threshold - 1, -100);
+            print("New threshold: %d\n" % matching_threshold);
+        elif key == ']':
+            # increment threshold
+            matching_threshold = np.fmin(matching_threshold + 1, +100);
+            print("New threshold: %d\n" % matching_threshold);
+        #elif key == 'w':
+        #    # write model to disk
+        #    writeLinemod(detector, filename);
+        #    print("Wrote detector and templates to %s\n" % filename);

--- a/modules/rgbd/src/depth_cleaner.cpp
+++ b/modules/rgbd/src/depth_cleaner.cpp
@@ -44,7 +44,7 @@ namespace rgbd
   class DepthCleanerImpl
   {
   public:
-    DepthCleanerImpl(int window_size, int depth, DepthCleaner::DEPTH_CLEANER_METHOD method)
+    DepthCleanerImpl(int window_size, int depth, int method)
         :
           depth_(depth),
           window_size_(window_size),
@@ -68,7 +68,7 @@ namespace rgbd
   protected:
     int depth_;
     int window_size_;
-    DepthCleaner::DEPTH_CLEANER_METHOD method_;
+    int method_;
   };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -84,7 +84,7 @@ namespace rgbd
     typedef Vec<T, 3> Vec3T;
     typedef Matx<T, 3, 3> Mat33T;
 
-    NIL(int window_size, int depth, DepthCleaner::DEPTH_CLEANER_METHOD method)
+    NIL(int window_size, int depth, int method)
         :
           DepthCleanerImpl(window_size, depth, method)
     {
@@ -272,6 +272,20 @@ namespace rgbd
       initialize_cleaner_impl();
     else if (!reinterpret_cast<DepthCleanerImpl *>(depth_cleaner_impl_)->validate(depth_, window_size_, method_))
       initialize_cleaner_impl();
+  }
+
+  /** Given a set of 3d points in a depth image, compute the normals at each point
+   * using the SRI method described in
+   * ``Fast and Accurate Computation of Surface Normals from Range Images``
+   * by H. Badino, D. Huber, Y. Park and T. Kanade
+   * @param depth depth a float depth image. Or it can be rows x cols x 3 is they are 3d points
+   * @param window_size the window size on which to compute the derivatives
+   * @return normals a rows x cols x 3 matrix
+   */
+  void
+  DepthCleaner::compute(InputArray depth_in_array, OutputArray depth_out_array) const
+  {
+      this->operator()(depth_in_array, depth_out_array);
   }
 
   /** Given a set of 3d points in a depth image, compute the normals at each point

--- a/modules/rgbd/src/normal.cpp
+++ b/modules/rgbd/src/normal.cpp
@@ -167,7 +167,7 @@ namespace rgbd
   {
   public:
     RgbdNormalsImpl(int rows, int cols, int window_size, int depth, const Mat &K,
-                    RgbdNormals::RGBD_NORMALS_METHOD method)
+                    int method)
         :
           rows_(rows),
           cols_(cols),
@@ -200,7 +200,7 @@ namespace rgbd
     int rows_, cols_, depth_;
     Mat K_, K_ori_;
     int window_size_;
-    RgbdNormals::RGBD_NORMALS_METHOD method_;
+    int method_;
   };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -218,7 +218,7 @@ namespace rgbd
     typedef Vec<T, 9> Vec9T;
     typedef Vec<T, 3> Vec3T;
 
-    FALS(int rows, int cols, int window_size, int depth, const Mat &K, RgbdNormals::RGBD_NORMALS_METHOD method)
+    FALS(int rows, int cols, int window_size, int depth, const Mat &K, int method)
         :
           RgbdNormalsImpl(rows, cols, window_size, depth, K, method)
     {
@@ -351,7 +351,7 @@ multiply_by_K_inv(const Matx<T, 3, 3> & K_inv, U a, U b, U c, Vec<T, 3> &res)
     typedef Matx<T, 3, 3> Mat33T;
 
     LINEMOD(int rows, int cols, int window_size, int depth, const Mat &K,
-            RgbdNormals::RGBD_NORMALS_METHOD method)
+        int method)
         :
           RgbdNormalsImpl(rows, cols, window_size, depth, K, method)
     {
@@ -505,7 +505,7 @@ multiply_by_K_inv(const Matx<T, 3, 3> & K_inv, U a, U b, U c, Vec<T, 3> &res)
     typedef Vec<T, 9> Vec9T;
     typedef Vec<T, 3> Vec3T;
 
-    SRI(int rows, int cols, int window_size, int depth, const Mat &K, RgbdNormals::RGBD_NORMALS_METHOD method)
+    SRI(int rows, int cols, int window_size, int depth, const Mat &K, int method)
         :
           RgbdNormalsImpl(rows, cols, window_size, depth, K, method),
           phi_step_(0),
@@ -782,6 +782,16 @@ multiply_by_K_inv(const Matx<T, 3, 3> & K_inv, U a, U b, U c, Vec<T, 3> &res)
       delete_normals_impl(rgbd_normals_impl_, method_, depth_);
       initialize_normals_impl(rows_, cols_, depth_, K_, window_size_, method_);
     }
+  }
+
+  /** Given a set of 3d points in a depth image, compute the normals at each point
+   * @param points3d_in depth a float depth image. Or it can be rows x cols x 3 is they are 3d points
+   * @param normals a rows x cols x 3 matrix
+   */
+  void
+  RgbdNormals::compute(InputArray points3d_in, OutputArray normals_out) const
+  {
+      this->operator()(points3d_in, normals_out);
   }
 
   /** Given a set of 3d points in a depth image, compute the normals at each point

--- a/modules/rgbd/src/normal.cpp
+++ b/modules/rgbd/src/normal.cpp
@@ -694,7 +694,7 @@ multiply_by_K_inv(const Matx<T, 3, 3> & K_inv, U a, U b, U c, Vec<T, 3> &res)
       return;
     switch (method_)
     {
-      case RgbdNormals::RGBD_NORMALS_METHOD_LINEMOD:
+      case (RgbdNormals::RGBD_NORMALS_METHOD_LINEMOD):
       {
         if (depth == CV_32F)
           delete reinterpret_cast<const LINEMOD<float> *>(rgbd_normals_impl_);
@@ -702,7 +702,7 @@ multiply_by_K_inv(const Matx<T, 3, 3> & K_inv, U a, U b, U c, Vec<T, 3> &res)
           delete reinterpret_cast<const LINEMOD<double> *>(rgbd_normals_impl_);
         break;
       }
-      case RgbdNormals::RGBD_NORMALS_METHOD_SRI:
+      case (RgbdNormals::RGBD_NORMALS_METHOD_SRI):
       {
         if (depth == CV_32F)
           delete reinterpret_cast<const SRI<float> *>(rgbd_normals_impl_);

--- a/modules/rgbd/src/odometry.cpp
+++ b/modules/rgbd/src/odometry.cpp
@@ -939,7 +939,7 @@ bool RGBDICPOdometryImpl(Mat& Rt, const Mat& initRt,
 
 template<class ImageElemType>
 static void
-warpFrameImpl(const InputArray _image, const InputArray _depth, const InputArray _mask,
+warpFrameImpl(InputArray _image, InputArray _depth, InputArray _mask,
               const Mat& Rt, const Mat& cameraMatrix, const Mat& distCoeff,
               OutputArray _warpedImage, OutputArray _warpedDepth, OutputArray _warpedMask)
 {
@@ -1407,7 +1407,7 @@ bool RgbdICPOdometry::computeImpl(const Ptr<OdometryFrame>& srcFrame, const Ptr<
 //
 
 void
-warpFrame(const InputArray image, const InputArray depth, const InputArray mask,
+warpFrame(InputArray image, InputArray depth, InputArray mask,
           const Mat& Rt, const Mat& cameraMatrix, const Mat& distCoeff,
           OutputArray warpedImage, OutputArray warpedDepth, OutputArray warpedMask)
 {

--- a/modules/rgbd/src/odometry.cpp
+++ b/modules/rgbd/src/odometry.cpp
@@ -49,8 +49,8 @@ namespace rgbd
 
 enum
 {
-    RGBD_ODOMETRY = 1, 
-    ICP_ODOMETRY = 2, 
+    RGBD_ODOMETRY = 1,
+    ICP_ODOMETRY = 2,
     MERGED_ODOMETRY = RGBD_ODOMETRY + ICP_ODOMETRY
 };
 
@@ -436,7 +436,7 @@ void computeProjectiveMatrix(const Mat& ksi, Mat& Rt)
 
     eigen2cv(g, Rt);
 #else
-    // TODO: check computeProjectiveMatrix when there is not eigen library, 
+    // TODO: check computeProjectiveMatrix when there is not eigen library,
     //       because it gives less accurate pose of the camera
     Rt = Mat::eye(4, 4, CV_64FC1);
 
@@ -462,7 +462,7 @@ void computeCorresps(const Mat& K, const Mat& K_inv, const Mat& Rt,
     CV_Assert(Rt.type() == CV_64FC1);
 
     Mat corresps(depth1.size(), CV_16SC2, Scalar::all(-1));
-    
+
     Rect r(0, 0, depth1.cols, depth1.rows);
     Mat Kt = Rt(Rect(3,0,1,3)).clone();
     Kt = K * Kt;
@@ -486,7 +486,7 @@ void computeCorresps(const Mat& K, const Mat& K_inv, const Mat& Rt,
             KRK_inv3_u1[u1] = (float)(KRK_inv_ptr[3] * u1);
             KRK_inv6_u1[u1] = (float)(KRK_inv_ptr[6] * u1);
         }
-        
+
         for(int v1 = 0; v1 < depth1.rows; v1++)
         {
             KRK_inv1_v1_plus_KRK_inv2[v1] = (float)(KRK_inv_ptr[1] * v1 + KRK_inv_ptr[2]);
@@ -506,16 +506,16 @@ void computeCorresps(const Mat& K, const Mat& K_inv, const Mat& Rt,
             if(mask1_row[u1])
             {
                 CV_DbgAssert(!cvIsNaN(d1));
-                float transformed_d1 = static_cast<float>(d1 * (KRK_inv6_u1[u1] + KRK_inv7_v1_plus_KRK_inv8[v1]) + 
+                float transformed_d1 = static_cast<float>(d1 * (KRK_inv6_u1[u1] + KRK_inv7_v1_plus_KRK_inv8[v1]) +
                                                           Kt_ptr[2]);
                 if(transformed_d1 > 0)
                 {
                     float transformed_d1_inv = 1.f / transformed_d1;
-                    int u0 = cvRound(transformed_d1_inv * (d1 * (KRK_inv0_u1[u1] + KRK_inv1_v1_plus_KRK_inv2[v1]) + 
+                    int u0 = cvRound(transformed_d1_inv * (d1 * (KRK_inv0_u1[u1] + KRK_inv1_v1_plus_KRK_inv2[v1]) +
                                                            Kt_ptr[0]));
-                    int v0 = cvRound(transformed_d1_inv * (d1 * (KRK_inv3_u1[u1] + KRK_inv4_v1_plus_KRK_inv5[v1]) + 
+                    int v0 = cvRound(transformed_d1_inv * (d1 * (KRK_inv3_u1[u1] + KRK_inv4_v1_plus_KRK_inv5[v1]) +
                                                            Kt_ptr[1]));
-                    
+
                     if(r.contains(Point(u0,v0)))
                     {
                         float d0 = depth0.at<float>(v0,u0);
@@ -527,7 +527,7 @@ void computeCorresps(const Mat& K, const Mat& K_inv, const Mat& Rt,
                             {
                                 int exist_u1 = c[0], exist_v1 = c[1];
 
-                                float exist_d1 = (float)(depth1.at<float>(exist_v1,exist_u1) * 
+                                float exist_d1 = (float)(depth1.at<float>(exist_v1,exist_u1) *
                                     (KRK_inv6_u1[exist_u1] + KRK_inv7_v1_plus_KRK_inv8[exist_v1]) + Kt_ptr[2]);
 
                                 if(transformed_d1 > exist_d1)
@@ -631,7 +631,7 @@ void calcICPEquationCoeffsTranslation(double* C, const Point3f& /*p0*/, const Ve
 typedef
 void (*CalcICPEquationCoeffsPtr)(double*, const Point3f&, const Vec3f&);
 
-static 
+static
 void calcRgbdLsmMatrices(const Mat& image0, const Mat& cloud0, const Mat& Rt,
                const Mat& image1, const Mat& dI_dx1, const Mat& dI_dy1,
                const Mat& corresps, double fx, double fy, double sobelScaleIn,
@@ -657,8 +657,8 @@ void calcRgbdLsmMatrices(const Mat& image0, const Mat& cloud0, const Mat& Rt,
          const Vec4i& c = corresps_ptr[correspIndex];
          int u0 = c[0], v0 = c[1];
          int u1 = c[2], v1 = c[3];
-              
-         diffs_ptr[correspIndex] = static_cast<float>(static_cast<int>(image0.at<uchar>(v0,u0)) - 
+
+         diffs_ptr[correspIndex] = static_cast<float>(static_cast<int>(image0.at<uchar>(v0,u0)) -
                                                       static_cast<int>(image1.at<uchar>(v1,u1)));
          sigma += diffs_ptr[correspIndex] * diffs_ptr[correspIndex];
     }
@@ -685,8 +685,8 @@ void calcRgbdLsmMatrices(const Mat& image0, const Mat& cloud0, const Mat& Rt,
          tp0.z = (float)(p0.x * Rt_ptr[8] + p0.y * Rt_ptr[9] + p0.z * Rt_ptr[10] + Rt_ptr[11]);
 
          func(A_ptr,
-              w_sobelScale * dI_dx1.at<short int>(v1,u1),
-              w_sobelScale * dI_dy1.at<short int>(v1,u1),
+              w_sobelScale * dI_dx1.at<short>(v1,u1),
+              w_sobelScale * dI_dy1.at<short>(v1,u1),
               tp0, fx, fy);
 
         for(int y = 0; y < transformDim; y++)
@@ -697,8 +697,8 @@ void calcRgbdLsmMatrices(const Mat& image0, const Mat& cloud0, const Mat& Rt,
 
             AtB_ptr[y] += A_ptr[y] * w * diffs_ptr[correspIndex];
         }
-    }		
-    
+    }
+
     for(int y = 0; y < transformDim; y++)
         for(int x = y+1; x < transformDim; x++)
             AtA.at<double>(x,y) = AtA.at<double>(y,x);
@@ -790,16 +790,16 @@ bool solveSystem(const Mat& AtA, const Mat& AtB, double detThreshold, Mat& x)
     return true;
 }
 
-static 
+static
 bool testDeltaTransformation(const Mat& deltaRt, double maxTranslation, double maxRotation)
 {
     double translation = norm(deltaRt(Rect(3, 0, 1, 3)));
-    
+
     Mat rvec;
     Rodrigues(deltaRt(Rect(0,0,3,3)), rvec);
-    
+
     double rotation = norm(rvec) * 180. / CV_PI;
-    
+
     return translation <= maxTranslation && rotation <= maxRotation;
 }
 
@@ -920,9 +920,9 @@ bool RGBDICPOdometryImpl(Mat& Rt, const Mat& initRt,
             isOk = true;
         }
     }
-    
+
     Rt = resultRt;
-        
+
     if(isOk)
     {
         Mat deltaRt;
@@ -939,34 +939,35 @@ bool RGBDICPOdometryImpl(Mat& Rt, const Mat& initRt,
 
 template<class ImageElemType>
 static void
-warpFrameImpl(const Mat& image, const Mat& depth, const Mat& mask,
+warpFrameImpl(const InputArray _image, const InputArray _depth, const InputArray _mask,
               const Mat& Rt, const Mat& cameraMatrix, const Mat& distCoeff,
-              Mat& warpedImage, Mat* warpedDepth, Mat* warpedMask)
+              OutputArray _warpedImage, OutputArray _warpedDepth, OutputArray _warpedMask)
 {
-    CV_Assert(image.size() == depth.size());
-    
+    CV_Assert(_image.getMat().size() == _depth.getMat().size());
+
     Mat cloud;
-    depthTo3d(depth, cameraMatrix, cloud);
-    
+    depthTo3d(_depth.getMat(), cameraMatrix, cloud);
+
     std::vector<Point2f> points2d;
     Mat transformedCloud;
     perspectiveTransform(cloud, transformedCloud, Rt);
     projectPoints(transformedCloud.reshape(3, 1), Mat::eye(3, 3, CV_64FC1), Mat::zeros(3, 1, CV_64FC1), cameraMatrix,
                 distCoeff, points2d);
 
-    warpedImage = Mat(image.size(), image.type(), Scalar::all(0));
+	_warpedImage.create(_image.getMat().size(), _image.getMat().type(), 0);
+	Mat warpedImage = _warpedImage.getMat();
 
-    Mat zBuffer(image.size(), CV_32FC1, std::numeric_limits<float>::max());
-    const Rect rect = Rect(0, 0, image.cols, image.rows);
-    
-    for (int y = 0; y < image.rows; y++)
+    Mat zBuffer(_image.getMat().size(), CV_32FC1, std::numeric_limits<float>::max());
+    const Rect rect = Rect(0, 0, _image.getMat().cols, _image.getMat().rows);
+
+    for (int y = 0; y < _image.getMat().rows; y++)
     {
         //const Point3f* cloud_row = cloud.ptr<Point3f>(y);
         const Point3f* transformedCloud_row = transformedCloud.ptr<Point3f>(y);
-        const Point2f* points2d_row = &points2d[y*image.cols];
-        const ImageElemType* image_row = image.ptr<ImageElemType>(y);
-        const uchar* mask_row = mask.empty() ? 0 : mask.ptr<uchar>(y);
-        for (int x = 0; x < image.cols; x++)
+        const Point2f* points2d_row = &points2d[y*_image.getMat().cols];
+        const ImageElemType* image_row = _image.getMat().ptr<ImageElemType>(y);
+        const uchar* mask_row = _mask.getMat().empty() ? 0 : _mask.getMat().ptr<uchar>(y);
+        for (int x = 0; x < _image.getMat().cols; x++)
         {
             const float transformed_z = transformedCloud_row[x].z;
             const Point2i p2d = points2d_row[x];
@@ -978,13 +979,15 @@ warpFrameImpl(const Mat& image, const Mat& depth, const Mat& mask,
         }
     }
 
-    if(warpedMask)
-        *warpedMask = zBuffer != std::numeric_limits<float>::max();
+	if (_warpedMask.needed())
+	{
+		Mat(zBuffer != std::numeric_limits<float>::max()).copyTo(_warpedMask);
+	}
 
-    if(warpedDepth)
+    if(_warpedDepth.needed())
     {
         zBuffer.setTo(std::numeric_limits<float>::quiet_NaN(), zBuffer == std::numeric_limits<float>::max());
-        *warpedDepth = zBuffer;
+		zBuffer.copyTo(_warpedDepth);
     }
 }
 
@@ -1404,9 +1407,9 @@ bool RgbdICPOdometry::computeImpl(const Ptr<OdometryFrame>& srcFrame, const Ptr<
 //
 
 void
-warpFrame(const Mat& image, const Mat& depth, const Mat& mask,
+warpFrame(const InputArray image, const InputArray depth, const InputArray mask,
           const Mat& Rt, const Mat& cameraMatrix, const Mat& distCoeff,
-          Mat& warpedImage, Mat* warpedDepth, Mat* warpedMask)
+          OutputArray warpedImage, OutputArray warpedDepth, OutputArray warpedMask)
 {
     if(image.type() == CV_8UC1)
         warpFrameImpl<uchar>(image, depth, mask, Rt, cameraMatrix, distCoeff, warpedImage, warpedDepth, warpedMask);

--- a/modules/rgbd/src/odometry.cpp
+++ b/modules/rgbd/src/odometry.cpp
@@ -954,8 +954,8 @@ warpFrameImpl(const InputArray _image, const InputArray _depth, const InputArray
     projectPoints(transformedCloud.reshape(3, 1), Mat::eye(3, 3, CV_64FC1), Mat::zeros(3, 1, CV_64FC1), cameraMatrix,
                 distCoeff, points2d);
 
-	_warpedImage.create(_image.getMat().size(), _image.getMat().type(), 0);
-	Mat warpedImage = _warpedImage.getMat();
+    _warpedImage.create(_image.getMat().size(), _image.getMat().type(), 0);
+    Mat warpedImage = _warpedImage.getMat();
 
     Mat zBuffer(_image.getMat().size(), CV_32FC1, std::numeric_limits<float>::max());
     const Rect rect = Rect(0, 0, _image.getMat().cols, _image.getMat().rows);
@@ -979,15 +979,15 @@ warpFrameImpl(const InputArray _image, const InputArray _depth, const InputArray
         }
     }
 
-	if (_warpedMask.needed())
-	{
-		Mat(zBuffer != std::numeric_limits<float>::max()).copyTo(_warpedMask);
-	}
+    if (_warpedMask.needed())
+    {
+        Mat(zBuffer != std::numeric_limits<float>::max()).copyTo(_warpedMask);
+    }
 
     if(_warpedDepth.needed())
     {
         zBuffer.setTo(std::numeric_limits<float>::quiet_NaN(), zBuffer == std::numeric_limits<float>::max());
-		zBuffer.copyTo(_warpedDepth);
+        zBuffer.copyTo(_warpedDepth);
     }
 }
 

--- a/modules/rgbd/src/plane.cpp
+++ b/modules/rgbd/src/plane.cpp
@@ -524,11 +524,24 @@ private:
   unsigned char plane_index_;
   /** THe block size as defined in the main algorithm */
   int block_size_;
-  
+
   const InlierFinder & operator = (const InlierFinder &);
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  void
+  RgbdPlane::find(InputArray points3d_in, OutputArray mask_out, OutputArray plane_coefficients)
+  {
+    this->operator()(points3d_in, mask_out, plane_coefficients);
+  }
+
+  void
+  RgbdPlane::find(InputArray points3d_in, InputArray normals_in, OutputArray mask_out,
+                        OutputArray plane_coefficients_out)
+  {
+      this->operator()(points3d_in, normals_in, mask_out, plane_coefficients_out);
+  }
 
   void
   RgbdPlane::operator()(InputArray points3d_in, OutputArray mask_out, OutputArray plane_coefficients)
@@ -582,7 +595,7 @@ private:
         plane = Ptr<PlaneBase>(new Plane(plane_grid.m_(y, x), n, (int)index_plane));
       else
         plane = Ptr<PlaneBase>(new PlaneABC(plane_grid.m_(y, x), n, (int)index_plane,
-			(float)sensor_error_a_, (float)sensor_error_b_, (float)sensor_error_c_));
+            (float)sensor_error_a_, (float)sensor_error_b_, (float)sensor_error_c_));
 
       Mat_<unsigned char> plane_mask = Mat_<unsigned char>::zeros(points3d.rows / block_size_,
                                                                           points3d.cols / block_size_);

--- a/modules/rgbd/src/utils.cpp
+++ b/modules/rgbd/src/utils.cpp
@@ -41,7 +41,7 @@
 namespace cv
 {
 namespace rgbd
-{    
+{
   /** If the input image is of type CV_16UC1 (like the Kinect one), the image is converted to floats, divided
    * by 1000 to get a depth in meters, and the values 0 are converted to std::numeric_limits<float>::quiet_NaN()
    * Otherwise, the image is simply converted to floats

--- a/modules/rgbd/test/test_normal.cpp
+++ b/modules/rgbd/test/test_normal.cpp
@@ -42,7 +42,7 @@ namespace cv
 namespace rgbd
 {
 
-class CV_EXPORTS TickMeter
+class CV_EXPORTS_W TickMeter
 {
 public:
     TickMeter();

--- a/modules/rgbd/test/test_normal.cpp
+++ b/modules/rgbd/test/test_normal.cpp
@@ -248,26 +248,23 @@ protected:
     try
     {
       Mat_<unsigned char> plane_mask;
-      for (unsigned char i = 0; i < 3; ++i)
+      for (int method = 0; method < 3; ++method)
       {
-        RgbdNormals::RGBD_NORMALS_METHOD method;
         // inner vector: whether it's 1 plane or 3 planes
         // outer vector: float or double
         std::vector<std::vector<float> > errors(2);
         errors[0].resize(4);
         errors[1].resize(4);
-        switch (i)
+        switch (method)
         {
-          case 0:
-            method = RgbdNormals::RGBD_NORMALS_METHOD_FALS;
+          case (RgbdNormals::RGBD_NORMALS_METHOD_FALS):
             std::cout << std::endl << "*** FALS" << std::endl;
             errors[0][0] = 0.006f;
             errors[0][1] = 0.03f;
             errors[1][0] = 0.00008f;
             errors[1][1] = 0.02f;
             break;
-          case 1:
-            method = RgbdNormals::RGBD_NORMALS_METHOD_LINEMOD;
+          case (RgbdNormals::RGBD_NORMALS_METHOD_LINEMOD):
             std::cout << std::endl << "*** LINEMOD" << std::endl;
             errors[0][0] = 0.04f;
             errors[0][1] = 0.07f;
@@ -279,8 +276,7 @@ protected:
             errors[1][2] = 0.05f; // depth 16U 1 plane
             errors[1][3] = 0.08f; // depth 16U 3 planes
             break;
-          case 2:
-            method = RgbdNormals::RGBD_NORMALS_METHOD_SRI;
+          case (RgbdNormals::RGBD_NORMALS_METHOD_SRI):
             std::cout << std::endl << "*** SRI" << std::endl;
             errors[0][0] = 0.02f;
             errors[0][1] = 0.04f;
@@ -288,7 +284,6 @@ protected:
             errors[1][1] = 0.04f;
             break;
           default:
-            method = (RgbdNormals::RGBD_NORMALS_METHOD)-1;
             CV_Error(0, "");
         }
 

--- a/modules/surface_matching/include/opencv2/surface_matching/icp.hpp
+++ b/modules/surface_matching/include/opencv2/surface_matching/icp.hpp
@@ -136,7 +136,7 @@ public:
      *
      *  \details It is assumed that the model is registered on the scene. Scene remains static, while the model transforms. The output poses transform the models onto the scene. Because of the point to plane minimization, the scene is expected to have the normals available. Expected to have the normals (Nx6).
      */
-  CV_WRAP int registerModelToScene(const Mat& srcPC, const Mat& dstPC, double& residual, double pose[16]);
+  CV_WRAP int registerModelToScene(const Mat& srcPC, const Mat& dstPC, double& residual, std::vector<double>& pose);
 
   /**
      *  \brief Perform registration with multiple initial poses

--- a/modules/surface_matching/include/opencv2/surface_matching/icp.hpp
+++ b/modules/surface_matching/include/opencv2/surface_matching/icp.hpp
@@ -136,7 +136,7 @@ public:
      *
      *  \details It is assumed that the model is registered on the scene. Scene remains static, while the model transforms. The output poses transform the models onto the scene. Because of the point to plane minimization, the scene is expected to have the normals available. Expected to have the normals (Nx6).
      */
-  CV_WRAP int registerModelToScene(const Mat& srcPC, const Mat& dstPC, double& residual, std::vector<double>& pose);
+  CV_WRAP int registerModelToScene(const Mat& srcPC, const Mat& dstPC, CV_OUT double& residual, CV_OUT std::vector<double>& pose);
 
   /**
      *  \brief Perform registration with multiple initial poses

--- a/modules/surface_matching/include/opencv2/surface_matching/icp.hpp
+++ b/modules/surface_matching/include/opencv2/surface_matching/icp.hpp
@@ -77,17 +77,17 @@ namespace ppf_match_3d
 * 5. Linearization of Point-to-Plane metric by Kok Lim Low:
 * https://www.comp.nus.edu.sg/~lowkl/publications/lowk_point-to-plane_icp_techrep.pdf
 */
-class CV_EXPORTS ICP
+class CV_EXPORTS_W ICP
 {
 public:
 
-  enum ICP_SAMPLING_TYPE
+  CV_WRAP enum
   {
     ICP_SAMPLING_TYPE_UNIFORM,
     ICP_SAMPLING_TYPE_GELFAND
   };
 
-  ICP()
+  CV_WRAP ICP()
   {
     m_tolerance = 0.005f;
     m_rejectionScale = 2.5f;
@@ -97,7 +97,7 @@ public:
     m_numNeighborsCorr = 1;
   }
 
-  virtual ~ICP() { }
+  CV_WRAP virtual ~ICP() { }
 
   /**
      *  \brief ICP constructor with default arguments.
@@ -114,7 +114,7 @@ public:
             applied. Leave it as 0.
      *  @param [in] numMaxCorr Currently this parameter is ignored and only PickyICP is applied. Leave it as 1.
      */
-  ICP(const int iterations, const float tolerence=0.05, const float rejectionScale=2.5, const int numLevels=6, const ICP_SAMPLING_TYPE sampleType = ICP_SAMPLING_TYPE_UNIFORM, const int numMaxCorr=1)
+  CV_WRAP ICP(const int iterations, const float tolerence=0.05, const float rejectionScale=2.5, const int numLevels=6, const int sampleType = ICP::ICP_SAMPLING_TYPE_UNIFORM, const int numMaxCorr=1)
   {
     m_tolerance = tolerence;
     m_numNeighborsCorr = numMaxCorr;
@@ -136,7 +136,7 @@ public:
      *
      *  \details It is assumed that the model is registered on the scene. Scene remains static, while the model transforms. The output poses transform the models onto the scene. Because of the point to plane minimization, the scene is expected to have the normals available. Expected to have the normals (Nx6).
      */
-  int registerModelToScene(const Mat& srcPC, const Mat& dstPC, double& residual, double pose[16]);
+  CV_WRAP int registerModelToScene(const Mat& srcPC, const Mat& dstPC, double& residual, double pose[16]);
 
   /**
      *  \brief Perform registration with multiple initial poses
@@ -149,7 +149,7 @@ public:
      *
      *  \details It is assumed that the model is registered on the scene. Scene remains static, while the model transforms. The output poses transform the models onto the scene. Because of the point to plane minimization, the scene is expected to have the normals available. Expected to have the normals (Nx6).
      */
-  int registerModelToScene(const Mat& srcPC, const Mat& dstPC, std::vector<Pose3DPtr>& poses);
+  CV_WRAP int registerModelToScene(const Mat& srcPC, const Mat& dstPC, std::vector<Pose3DPtr>& poses);
 
 private:
   float m_tolerance;

--- a/modules/surface_matching/include/opencv2/surface_matching/icp.hpp
+++ b/modules/surface_matching/include/opencv2/surface_matching/icp.hpp
@@ -149,7 +149,7 @@ public:
      *
      *  \details It is assumed that the model is registered on the scene. Scene remains static, while the model transforms. The output poses transform the models onto the scene. Because of the point to plane minimization, the scene is expected to have the normals available. Expected to have the normals (Nx6).
      */
-  CV_WRAP int registerModelToScene(const Mat& srcPC, const Mat& dstPC, std::vector<Pose3DPtr>& poses);
+  CV_WRAP int registerModelToScene(const Mat& srcPC, const Mat& dstPC, CV_IN_OUT std::vector<Pose3DPtr>& poses);
 
 private:
   float m_tolerance;

--- a/modules/surface_matching/include/opencv2/surface_matching/icp.hpp
+++ b/modules/surface_matching/include/opencv2/surface_matching/icp.hpp
@@ -114,7 +114,7 @@ public:
             applied. Leave it as 0.
      *  @param [in] numMaxCorr Currently this parameter is ignored and only PickyICP is applied. Leave it as 1.
      */
-  CV_WRAP ICP(const int iterations, const float tolerence=0.05, const float rejectionScale=2.5, const int numLevels=6, const int sampleType = ICP::ICP_SAMPLING_TYPE_UNIFORM, const int numMaxCorr=1)
+  CV_WRAP ICP(const int iterations, const float tolerence=0.05f, const float rejectionScale=2.5f, const int numLevels=6, const int sampleType = ICP::ICP_SAMPLING_TYPE_UNIFORM, const int numMaxCorr=1)
   {
     m_tolerance = tolerence;
     m_numNeighborsCorr = numMaxCorr;

--- a/modules/surface_matching/include/opencv2/surface_matching/icp.hpp
+++ b/modules/surface_matching/include/opencv2/surface_matching/icp.hpp
@@ -83,8 +83,8 @@ public:
 
   CV_WRAP enum
   {
-    ICP_SAMPLING_TYPE_UNIFORM,
-    ICP_SAMPLING_TYPE_GELFAND
+    ICP_SAMPLING_TYPE_UNIFORM = 0,
+    ICP_SAMPLING_TYPE_GELFAND = 1,
   };
 
   CV_WRAP ICP()
@@ -93,7 +93,7 @@ public:
     m_rejectionScale = 2.5f;
     m_maxIterations = 250;
     m_numLevels = 6;
-    m_sampleType = ICP_SAMPLING_TYPE_UNIFORM;
+    m_sampleType = ICP::ICP_SAMPLING_TYPE_UNIFORM;
     m_numNeighborsCorr = 1;
   }
 

--- a/modules/surface_matching/include/opencv2/surface_matching/pose_3d.hpp
+++ b/modules/surface_matching/include/opencv2/surface_matching/pose_3d.hpp
@@ -77,8 +77,8 @@ public:
     numVotes=0;
     residual = 0;
 
-    for (int i=0; i<16; i++)
-      pose[i]=0;
+    pose.resize(16);
+    std::fill(pose.begin(), pose.end(), 0);
   }
 
   CV_WRAP Pose3D(double Alpha, uint ModelIndex=0, uint NumVotes=0)
@@ -88,8 +88,8 @@ public:
     numVotes = NumVotes;
     residual=0;
 
-    for (int i=0; i<16; i++)
-      pose[i]=0;
+    pose.resize(16);
+    std::fill(pose.begin(), pose.end(), 0);
   }
 
   /**
@@ -127,7 +127,7 @@ public:
   double alpha, residual;
   uint modelIndex;
   uint numVotes;
-  double pose[16];
+  CV_PROP std::vector<double> pose;
   double angle;
   double t[3];
   double q[4];

--- a/modules/surface_matching/include/opencv2/surface_matching/pose_3d.hpp
+++ b/modules/surface_matching/include/opencv2/surface_matching/pose_3d.hpp
@@ -112,7 +112,7 @@ public:
    *  \brief Left multiplies the existing pose in order to update the transformation
    *  \param [in] IncrementalPose New pose to apply
    */
-  CV_WRAP void appendPose(double IncrementalPose[16]);
+  CV_WRAP void appendPose(const double IncrementalPose[16]);
   CV_WRAP void printPose();
 
   CV_WRAP Pose3DPtr clone();
@@ -127,7 +127,7 @@ public:
   double alpha, residual;
   uint modelIndex;
   uint numVotes;
-  CV_PROP std::vector<double> pose;
+  CV_PROP_RW std::vector<double> pose;
   double angle;
   double t[3];
   double q[4];

--- a/modules/surface_matching/include/opencv2/surface_matching/pose_3d.hpp
+++ b/modules/surface_matching/include/opencv2/surface_matching/pose_3d.hpp
@@ -67,10 +67,10 @@ typedef Ptr<PoseCluster3D> PoseCluster3DPtr;
 * various helper methods to work with poses
 *
 */
-class CV_EXPORTS Pose3D
+class CV_EXPORTS_W Pose3D
 {
 public:
-  Pose3D()
+  CV_WRAP Pose3D()
   {
     alpha=0;
     modelIndex=0;
@@ -81,7 +81,7 @@ public:
       pose[i]=0;
   }
 
-  Pose3D(double Alpha, unsigned int ModelIndex=0, unsigned int NumVotes=0)
+  CV_WRAP Pose3D(double Alpha, uint ModelIndex=0, uint NumVotes=0)
   {
     alpha = Alpha;
     modelIndex = ModelIndex;
@@ -96,55 +96,58 @@ public:
    *  \brief Updates the pose with the new one
    *  \param [in] NewPose New pose to overwrite
    */
-  void updatePose(double NewPose[16]);
+  CV_WRAP void updatePose(double NewPose[16]);
 
   /**
    *  \brief Updates the pose with the new one
    */
-  void updatePose(double NewR[9], double NewT[3]);
+  CV_WRAP void updatePose(double NewR[9], double NewT[3]);
 
   /**
    *  \brief Updates the pose with the new one, but this time using quaternions to represent rotation
    */
-  void updatePoseQuat(double Q[4], double NewT[3]);
+  CV_WRAP void updatePoseQuat(double Q[4], double NewT[3]);
 
   /**
    *  \brief Left multiplies the existing pose in order to update the transformation
    *  \param [in] IncrementalPose New pose to apply
    */
-  void appendPose(double IncrementalPose[16]);
-  void printPose();
+  CV_WRAP void appendPose(double IncrementalPose[16]);
+  CV_WRAP void printPose();
 
-  Pose3DPtr clone();
+  CV_WRAP Pose3DPtr clone();
 
   int writePose(FILE* f);
   int readPose(FILE* f);
   int writePose(const std::string& FileName);
   int readPose(const std::string& FileName);
 
-  virtual ~Pose3D() {}
+  CV_WRAP virtual ~Pose3D() {}
 
   double alpha, residual;
-  unsigned int modelIndex;
-  unsigned int numVotes;
-  double pose[16], angle, t[3], q[4];
+  uint modelIndex;
+  uint numVotes;
+  double pose[16];
+  double angle;
+  double t[3];
+  double q[4];
 };
 
 /**
-* @brief When multiple poses (see Pose3D) are grouped together (contribute to the same transformation) 
+* @brief When multiple poses (see Pose3D) are grouped together (contribute to the same transformation)
 * pose clusters occur. This class is a general container for such groups of poses. It is possible to store,
 * load and perform IO on these poses.
 */
-class CV_EXPORTS PoseCluster3D
+class CV_EXPORTS_W PoseCluster3D
 {
 public:
-  PoseCluster3D()
+  CV_WRAP PoseCluster3D()
   {
     numVotes=0;
     id=0;
   }
 
-  PoseCluster3D(Pose3DPtr newPose)
+  CV_WRAP PoseCluster3D(Pose3DPtr newPose)
   {
     poseList.clear();
     poseList.push_back(newPose);
@@ -152,14 +155,14 @@ public:
     id=0;
   }
 
-  PoseCluster3D(Pose3DPtr newPose, int newId)
+  CV_WRAP PoseCluster3D(Pose3DPtr newPose, int newId)
   {
     poseList.push_back(newPose);
     this->numVotes = newPose->numVotes;
     this->id = newId;
   }
 
-  virtual ~PoseCluster3D()
+  CV_WRAP virtual ~PoseCluster3D()
   {}
 
   /**
@@ -167,7 +170,7 @@ public:
    *  in order to preserve the consistency
    *  \param [in] newPose Pose to add to the cluster
    */
-  void addPose(Pose3DPtr newPose);
+  CV_WRAP void addPose(Pose3DPtr newPose);
 
   int writePoseCluster(FILE* f);
   int readPoseCluster(FILE* f);

--- a/modules/surface_matching/include/opencv2/surface_matching/ppf_helpers.hpp
+++ b/modules/surface_matching/include/opencv2/surface_matching/ppf_helpers.hpp
@@ -125,7 +125,7 @@ CV_EXPORTS_W Mat transPCCoeff(Mat pc, float scale, float Cx, float Cy, float Cz,
  *  @param [in] Pose 4x4 pose matrix, but linearized in row-major form.
  *  @return Transformed point cloud
 */
-CV_EXPORTS_W Mat transformPCPose(Mat pc, double Pose[16]);
+CV_EXPORTS_W Mat transformPCPose(Mat pc, const std::vector<double>& Pose);
 
 /**
  *  Generate a random 4x4 pose matrix
@@ -153,7 +153,7 @@ CV_EXPORTS_W Mat addNoisePC(Mat pc, double scale);
  *  @param [in] FlipViewpoint Should normals be flipped to a viewing direction?
  *  @param [in] viewpoint
  */
-CV_EXPORTS_W void computeNormalsPC3d(InputArray PC, OutputArray PCNormals, const int NumNeighbors, const bool FlipViewpoint, const std::vector<double> viewpoint);
+CV_EXPORTS_W void computeNormalsPC3d(InputArray PC, OutputArray PCNormals, const int NumNeighbors, const bool FlipViewpoint, const std::vector<double>& viewpoint);
 
 //! @}
 

--- a/modules/surface_matching/include/opencv2/surface_matching/ppf_helpers.hpp
+++ b/modules/surface_matching/include/opencv2/surface_matching/ppf_helpers.hpp
@@ -148,13 +148,12 @@ CV_EXPORTS_W Mat addNoisePC(Mat pc, double scale);
  *  If PCNormals is provided to be an Nx6 matrix, then no new allocation
  *  is made, instead the existing memory is overwritten.
  *  @param [in] PC Input point cloud to compute the normals for.
- *  @param [in] PCNormals Output point cloud
+ *  @param [out] PCNormals point cloud
  *  @param [in] NumNeighbors Number of neighbors to take into account in a local region
  *  @param [in] FlipViewpoint Should normals be flipped to a viewing direction?
  *  @param [in] viewpoint
- *  @return Returns 0 on success
  */
-CV_EXPORTS_W int computeNormalsPC3d(const Mat& PC, Mat& PCNormals, const int NumNeighbors, const bool FlipViewpoint, const double viewpoint[3]);
+CV_EXPORTS_W void computeNormalsPC3d(InputArray PC, OutputArray PCNormals, const int NumNeighbors, const bool FlipViewpoint, const std::vector<double> viewpoint);
 
 //! @}
 

--- a/modules/surface_matching/include/opencv2/surface_matching/ppf_helpers.hpp
+++ b/modules/surface_matching/include/opencv2/surface_matching/ppf_helpers.hpp
@@ -61,14 +61,14 @@ namespace ppf_match_3d
  *  and whether it should be loaded or not
  *  @return Returns the matrix on successfull load
  */
-CV_EXPORTS Mat loadPLYSimple(const char* fileName, int withNormals);
+CV_EXPORTS_W Mat loadPLYSimple(const char* fileName, int withNormals);
 
 /**
  *  @brief Write a point cloud to PLY file
  *  @param [in] PC Input point cloud
  *  @param [in] fileName The PLY model file to write
 */
-CV_EXPORTS void writePLY(Mat PC, const char* fileName);
+CV_EXPORTS_W void writePLY(Mat PC, const char* fileName);
 
 /**
 *  @brief Used for debbuging pruposes, writes a point cloud to a PLY file with the tip
@@ -76,10 +76,10 @@ CV_EXPORTS void writePLY(Mat PC, const char* fileName);
 *  @param [in] PC Input point cloud
 *  @param [in] fileName The PLY model file to write
 */
-CV_EXPORTS void writePLYVisibleNormals(Mat PC, const char* fileName);
+CV_EXPORTS_W void writePLYVisibleNormals(Mat PC, const char* fileName);
 
-Mat samplePCUniform(Mat PC, int sampleStep);
-Mat samplePCUniformInd(Mat PC, int sampleStep, std::vector<int>& indices);
+CV_EXPORTS_W Mat samplePCUniform(Mat PC, int sampleStep);
+CV_EXPORTS_W Mat samplePCUniformInd(Mat PC, int sampleStep, std::vector<int>& indices);
 
 /**
  *  Sample a point cloud using uniform steps
@@ -89,14 +89,14 @@ Mat samplePCUniformInd(Mat PC, int sampleStep, std::vector<int>& indices);
  *  @param [in] zrange Z components (min and max) of the bounding box of the model
  *  @param [in] sample_step_relative The point cloud is sampled such that all points
  *  have a certain minimum distance. This minimum distance is determined relatively using
- *  the parameter sample_step_relative. 
+ *  the parameter sample_step_relative.
  *  @param [in] weightByCenter The contribution of the quantized data points can be weighted
  *  by the distance to the origin. This parameter enables/disables the use of weighting.
  *  @return Sampled point cloud
 */
-CV_EXPORTS Mat samplePCByQuantization(Mat pc, float xrange[2], float yrange[2], float zrange[2], float sample_step_relative, int weightByCenter=0);
+CV_EXPORTS_W Mat samplePCByQuantization(Mat pc, float xrange[2], float yrange[2], float zrange[2], float sample_step_relative, int weightByCenter=0);
 
-void computeBboxStd(Mat pc, float xRange[2], float yRange[2], float zRange[2]);
+CV_EXPORTS_W void computeBboxStd(Mat pc, float xRange[2], float yRange[2], float zRange[2]);
 
 void* indexPCFlann(Mat pc);
 void destroyFlann(void* flannIndex);
@@ -114,8 +114,8 @@ void queryPCFlann(void* flannIndex, Mat& pc, Mat& indices, Mat& distances, const
 */
 CV_EXPORTS Mat normalize_pc(Mat pc, float scale);
 
-Mat normalizePCCoeff(Mat pc, float scale, float* Cx, float* Cy, float* Cz, float* MinVal, float* MaxVal);
-Mat transPCCoeff(Mat pc, float scale, float Cx, float Cy, float Cz, float MinVal, float MaxVal);
+CV_EXPORTS_W Mat normalizePCCoeff(Mat pc, float scale, float* Cx, float* Cy, float* Cz, float* MinVal, float* MaxVal);
+CV_EXPORTS_W Mat transPCCoeff(Mat pc, float scale, float Cx, float Cy, float Cz, float MinVal, float MaxVal);
 
 /**
  *  Transforms the point cloud with a given a homogeneous 4x4 pose matrix (in double precision)
@@ -125,20 +125,20 @@ Mat transPCCoeff(Mat pc, float scale, float Cx, float Cy, float Cz, float MinVal
  *  @param [in] Pose 4x4 pose matrix, but linearized in row-major form.
  *  @return Transformed point cloud
 */
-CV_EXPORTS Mat transformPCPose(Mat pc, double Pose[16]);
+CV_EXPORTS_W Mat transformPCPose(Mat pc, double Pose[16]);
 
 /**
  *  Generate a random 4x4 pose matrix
  *  @param [out] Pose The random pose
 */
-CV_EXPORTS void getRandomPose(double Pose[16]);
+CV_EXPORTS_W void getRandomPose(double Pose[16]);
 
 /**
  *  Adds a uniform noise in the given scale to the input point cloud
- *  @param [in] pc Input point cloud (CV_32F family). 
+ *  @param [in] pc Input point cloud (CV_32F family).
  *  @param [in] scale Input scale of the noise. The larger the scale, the more noisy the output
 */
-CV_EXPORTS Mat addNoisePC(Mat pc, double scale);
+CV_EXPORTS_W Mat addNoisePC(Mat pc, double scale);
 
 /**
  *  @brief Compute the normals of an arbitrary point cloud
@@ -154,7 +154,7 @@ CV_EXPORTS Mat addNoisePC(Mat pc, double scale);
  *  @param [in] viewpoint
  *  @return Returns 0 on success
  */
-CV_EXPORTS int computeNormalsPC3d(const Mat& PC, Mat& PCNormals, const int NumNeighbors, const bool FlipViewpoint, const double viewpoint[3]);
+CV_EXPORTS_W int computeNormalsPC3d(const Mat& PC, Mat& PCNormals, const int NumNeighbors, const bool FlipViewpoint, const double viewpoint[3]);
 
 //! @}
 

--- a/modules/surface_matching/include/opencv2/surface_matching/ppf_match_3d.hpp
+++ b/modules/surface_matching/include/opencv2/surface_matching/ppf_match_3d.hpp
@@ -148,7 +148,7 @@ protected:
   double angle_step, angle_step_radians, distance_step;
   double sampling_step_relative, angle_step_relative, distance_step_relative;
   Mat sampled_pc, ppf;
-  int num_ref_points, ppf_step;
+  int num_ref_points;
   hashtable_int* hash_table;
   THash* hash_nodes;
 

--- a/modules/surface_matching/include/opencv2/surface_matching/ppf_match_3d.hpp
+++ b/modules/surface_matching/include/opencv2/surface_matching/ppf_match_3d.hpp
@@ -94,14 +94,14 @@ typedef struct THash
   * detector.match(pcTest, results, 1.0/5.0,0.05);
   * @endcode
   */
-class CV_EXPORTS PPF3DDetector
+class CV_EXPORTS_W PPF3DDetector
 {
 public:
 
   /**
    * \brief Empty constructor. Sets default arguments
    */
-  PPF3DDetector();
+  CV_WRAP PPF3DDetector();
 
   /**
     * Constructor with arguments
@@ -109,9 +109,9 @@ public:
     * @param [in] relativeDistanceStep The discretization distance of the point pair distance relative to the model's diameter. This value has a direct impact on the hashtable. Using small values would lead to too fine discretization, and thus ambiguity in the bins of hashtable. Too large values would lead to no discrimination over the feature vectors and different point pair features would be assigned to the same bin. This argument defaults to the value of RelativeSamplingStep. For noisy scenes, the value can be increased to improve the robustness of the matching against noisy points.
     * @param [in] numAngles Set the discretization of the point pair orientation as the number of subdivisions of the angle. This value is the equivalent of RelativeDistanceStep for the orientations. Increasing the value increases the precision of the matching but decreases the robustness against incorrect normal directions. Decreasing the value decreases the precision of the matching but increases the robustness against incorrect normal directions. For very noisy scenes where the normal directions can not be computed accurately, the value can be set to 25 or 20.
     */
-  PPF3DDetector(const double relativeSamplingStep, const double relativeDistanceStep=0.05, const double numAngles=30);
+  CV_WRAP PPF3DDetector(const double relativeSamplingStep, const double relativeDistanceStep=0.05, const double numAngles=30);
 
-  virtual ~PPF3DDetector();
+  CV_WRAP virtual ~PPF3DDetector();
 
   /**
     *  Set the parameters for the search
@@ -119,7 +119,7 @@ public:
     *  @param [in] rotationThreshold Position threshold controlling the similarity of rotations. This parameter can be perceived as a threshold over the difference of angles
     *  @param [in] useWeightedClustering The algorithm by default clusters the poses without weighting. A non-zero value would indicate that the pose clustering should take into account the number of votes as the weights and perform a weighted averaging instead of a simple one.
     */
-  void setSearchParams(const double positionThreshold=-1, const double rotationThreshold=-1, const bool useWeightedClustering=false);
+  CV_WRAP void setSearchParams(const double positionThreshold=-1, const double rotationThreshold=-1, const bool useWeightedClustering=false);
 
   /**
     *  \brief Trains a new model.
@@ -128,7 +128,7 @@ public:
     *
     *  \details Uses the parameters set in the constructor to downsample and learn a new model. When the model is learnt, the instance gets ready for calling "match".
     */
-  void trainModel(const Mat& Model);
+  CV_WRAP void trainModel(const Mat& Model);
 
   /**
     *  \brief Matches a trained model across a provided scene.
@@ -138,7 +138,7 @@ public:
     *  @param [in] relativeSceneSampleStep The ratio of scene points to be used for the matching after sampling with relativeSceneDistance. For example, if this value is set to 1.0/5.0, every 5th point from the scene is used for pose estimation. This parameter allows an easy trade-off between speed and accuracy of the matching. Increasing the value leads to less points being used and in turn to a faster but less accurate pose computation. Decreasing the value has the inverse effect.
     *  @param [in] relativeSceneDistance Set the distance threshold relative to the diameter of the model. This parameter is equivalent to relativeSamplingStep in the training stage. This parameter acts like a prior sampling with the relativeSceneSampleStep parameter.
     */
-  void match(const Mat& scene, std::vector<Pose3DPtr> &results, const double relativeSceneSampleStep=1.0/5.0, const double relativeSceneDistance=0.03);
+  CV_WRAP void match(const Mat& scene, std::vector<Pose3DPtr> &results, const double relativeSceneSampleStep=1.0/5.0, const double relativeSceneDistance=0.03);
 
   void read(const FileNode& fn);
   void write(FileStorage& fs) const;

--- a/modules/surface_matching/include/opencv2/surface_matching/ppf_match_3d.hpp
+++ b/modules/surface_matching/include/opencv2/surface_matching/ppf_match_3d.hpp
@@ -138,7 +138,7 @@ public:
     *  @param [in] relativeSceneSampleStep The ratio of scene points to be used for the matching after sampling with relativeSceneDistance. For example, if this value is set to 1.0/5.0, every 5th point from the scene is used for pose estimation. This parameter allows an easy trade-off between speed and accuracy of the matching. Increasing the value leads to less points being used and in turn to a faster but less accurate pose computation. Decreasing the value has the inverse effect.
     *  @param [in] relativeSceneDistance Set the distance threshold relative to the diameter of the model. This parameter is equivalent to relativeSamplingStep in the training stage. This parameter acts like a prior sampling with the relativeSceneSampleStep parameter.
     */
-  CV_WRAP void match(const Mat& scene, std::vector<Pose3DPtr> &results, const double relativeSceneSampleStep=1.0/5.0, const double relativeSceneDistance=0.03);
+  CV_WRAP void match(const Mat& scene, CV_OUT std::vector<Pose3DPtr> &results, const double relativeSceneSampleStep=1.0/5.0, const double relativeSceneDistance=0.03);
 
   void read(const FileNode& fn);
   void write(FileStorage& fs) const;

--- a/modules/surface_matching/misc/python/pyopencv_ppf.hpp
+++ b/modules/surface_matching/misc/python/pyopencv_ppf.hpp
@@ -3,7 +3,10 @@ typedef std::vector<ppf_match_3d::Pose3DPtr> vector_Pose3DPtr;
 typedef std::string string;
 
 template<>
-bool pyopencv_to(PyObject *o, ppf_match_3d::Pose3DPtr &pose, const char *name);
+bool pyopencv_to(PyObject *o, ppf_match_3d::Pose3DPtr &poses, const char *name);
+
+template<>
+bool pyopencv_to(PyObject *o, std::vector<double> &pose, const char *name);
 
 template<> struct pyopencvVecConverter<ppf_match_3d::Pose3DPtr>
 {
@@ -24,10 +27,35 @@ template<> struct pyopencvVecConverter<ppf_match_3d::Pose3DPtr>
     }
 };
 
+template<> struct pyopencvVecConverter<double>
+{
+	static bool to(PyObject* obj, std::vector<double>& value, const ArgInfo info)
+	{
+		if (PyArray_Check(obj))
+		{
+			value.resize(1);
+			return pyopencv_to(obj, value[0], info.name);
+		}
+
+		return pyopencv_to_generic_vec(obj, value, info);
+	}
+
+	static PyObject* from(const std::vector<double>& value)
+	{
+		return pyopencv_from_generic_vec(value);
+	}
+};
+
 template<>
 bool pyopencv_to(PyObject *o, std::vector<ppf_match_3d::Pose3DPtr> &poses, const char *name)
 {
     return pyopencvVecConverter<ppf_match_3d::Pose3DPtr>::to(o, poses, ArgInfo(name, false));
+}
+
+template<>
+bool pyopencv_to(PyObject *o, std::vector<double> &pose, const char *name)
+{
+	return pyopencvVecConverter<double>::to(o, pose, ArgInfo(name, false));
 }
 
 #endif

--- a/modules/surface_matching/misc/python/pyopencv_ppf.hpp
+++ b/modules/surface_matching/misc/python/pyopencv_ppf.hpp
@@ -1,0 +1,33 @@
+#ifdef HAVE_OPENCV_SURFACE_MATCHING
+typedef std::vector<ppf_match_3d::Pose3DPtr> vector_Pose3DPtr;
+typedef std::string string;
+
+template<>
+bool pyopencv_to(PyObject *o, ppf_match_3d::Pose3DPtr &pose, const char *name);
+
+template<> struct pyopencvVecConverter<ppf_match_3d::Pose3DPtr>
+{
+    static bool to(PyObject* obj, std::vector<ppf_match_3d::Pose3DPtr>& value, const ArgInfo info)
+    {
+        if (PyArray_Check(obj))
+        {
+            value.resize(1);
+            return pyopencv_to(obj, value[0], info.name);
+        }
+
+        return pyopencv_to_generic_vec(obj, value, info);
+    }
+
+    static PyObject* from(const std::vector<ppf_match_3d::Pose3DPtr>& value)
+    {
+        return pyopencv_from_generic_vec(value);
+    }
+};
+
+template<>
+bool pyopencv_to(PyObject *o, std::vector<ppf_match_3d::Pose3DPtr> &poses, const char *name)
+{
+    return pyopencvVecConverter<ppf_match_3d::Pose3DPtr>::to(o, poses, ArgInfo(name, false));
+}
+
+#endif

--- a/modules/surface_matching/samples/ppf_load_match.cpp
+++ b/modules/surface_matching/samples/ppf_load_match.cpp
@@ -65,30 +65,30 @@ int main(int argc, char** argv)
              " input scene. The detected poses are further refined by ICP\n* and printed to the "
              " standard output." << endl;
     cout << "****************************************************" << endl;
-    
+
     if (argc < 3)
     {
         help("Not enough input arguments");
         exit(1);
     }
-    
+
 #if (defined __x86_64__ || defined _M_X64)
     cout << "Running on 64 bits" << endl;
 #else
     cout << "Running on 32 bits" << endl;
 #endif
-    
+
 #ifdef _OPENMP
     cout << "Running with OpenMP" << endl;
 #else
     cout << "Running without OpenMP and without TBB" << endl;
 #endif
-    
+
     string modelFileName = (string)argv[1];
     string sceneFileName = (string)argv[2];
-    
+
     Mat pc = loadPLYSimple(modelFileName.c_str(), 1);
-    
+
     // Now train the model
     cout << "Training..." << endl;
     int64 tick1 = cv::getTickCount();
@@ -98,10 +98,10 @@ int main(int argc, char** argv)
     cout << endl << "Training complete in "
          << (double)(tick2-tick1)/ cv::getTickFrequency()
          << " sec" << endl << "Loading model..." << endl;
-         
+
     // Read the scene
     Mat pcTest = loadPLYSimple(sceneFileName.c_str(), 1);
-    
+
     // Match the model to the scene and get the pose
     cout << endl << "Starting matching..." << endl;
     vector<Pose3DPtr> results;
@@ -127,19 +127,19 @@ int main(int argc, char** argv)
         N = results_size;
     }
     vector<Pose3DPtr> resultsSub(results.begin(),results.begin()+N);
-    
+
     // Create an instance of ICP
     ICP icp(100, 0.005f, 2.5f, 8);
     int64 t1 = cv::getTickCount();
-    
+
     // Register for all selected poses
     cout << endl << "Performing ICP on " << N << " poses..." << endl;
     icp.registerModelToScene(pc, pcTest, resultsSub);
     int64 t2 = cv::getTickCount();
-    
+
     cout << endl << "ICP Elapsed Time " <<
          (t2-t1)/cv::getTickFrequency() << " sec" << endl;
-         
+
     cout << "Poses: " << endl;
     // debug first five poses
     for (size_t i=0; i<resultsSub.size(); i++)
@@ -153,7 +153,7 @@ int main(int argc, char** argv)
             writePLY(pct, "para6700PCTrans.ply");
         }
     }
-    
+
     return 0;
-    
+
 }

--- a/modules/surface_matching/samples/ppf_normal_computation.cpp
+++ b/modules/surface_matching/samples/ppf_normal_computation.cpp
@@ -65,7 +65,9 @@ int main(int argc, char** argv)
   cv::ppf_match_3d::loadPLYSimple(modelFileName.c_str(), 1).copyTo(points);
 
   cout << "Computing normals\n";
-  double viewpoint[3] = { 0.0, 0.0, 0.0 };
+  std::vector<double> viewpoint;
+  viewpoint.resize(3);
+  std::fill(viewpoint.begin(), viewpoint.end(), 0);
   cv::ppf_match_3d::computeNormalsPC3d(points, pointsAndNormals, 6, false, viewpoint);
 
   std::cout << "Writing points\n";

--- a/modules/surface_matching/samples/python/ppf_load_match.py
+++ b/modules/surface_matching/samples/python/ppf_load_match.py
@@ -1,0 +1,130 @@
+#
+#  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
+#
+#  By downloading, copying, installing or using the software you agree to this license.
+#  If you do not agree to this license, do not download, install,
+#  copy or use the software.
+#
+#
+#                          License Agreement
+#                For Open Source Computer Vision Library
+#
+# Copyright (C) 2014, OpenCV Foundation, all rights reserved.
+# Third party copyrights are property of their respective owners.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#   * Redistribution's of source code must retain the above copyright notice,
+#     this list of conditions and the following disclaimer.
+#
+#   * Redistribution's in binary form must reproduce the above copyright notice,
+#     this list of conditions and the following disclaimer in the documentation
+#     and/or other materials provided with the distribution.
+#
+#   * The name of the copyright holders may not be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+# This software is provided by the copyright holders and contributors "as is" and
+# any express or implied warranties, including, but not limited to, the implied
+# warranties of merchantability and fitness for a particular purpose are disclaimed.
+# In no event shall the Intel Corporation or contributors be liable for any direct,
+# indirect, incidental, special, exemplary, or consequential damages
+# (including, but not limited to, procurement of substitute goods or services;
+# loss of use, data, or profits; or business interruption) however caused
+# and on any theory of liability, whether in contract, strict liability,
+# or tort (including negligence or otherwise) arising in any way out of
+# the use of this software, even if advised of the possibility of such damage.
+#
+# PPF Author: Tolga Birdal <tbirdal AT gmail.com>
+# Python wrapper by: Hamdi Sahloul <hamdisahloul AT hotmail.com>
+#
+# Known issues:
+#   `Pose3D.appendPose()` resets the pose instead of incrementing it [called inside `icp.registerModelToScene()`].
+#   `ppf_match_3d.transformPCPose()` not functional yet
+
+import cv2;
+import sys;
+
+def help(errorMessage):
+    print("Program init error : %s" % errorMessage);
+    print("\nUsage : ppf_matching [input model file] [input scene file]");
+    print("\nPlease start again with new parameters");
+
+if __name__ == "__main__":
+    # welcome message
+    print("****************************************************");
+    print("* Surface Matching demonstration : demonstrates the use of surface matching"
+          " using point pair features.");
+    print("* The sample loads a model and a scene, where the model lies in a different"
+          " pose than the training.\n* It then trains the model and searches for it in the"
+          " input scene. The detected poses are further refined by ICP\n* and printed to the "
+          " standard output.");
+    print("****************************************************");
+
+    if len(sys.argv) < 3:
+        help("Not enough input arguments");
+        sys.exit(1);
+
+    modelFileName = sys.argv[1];
+    sceneFileName = sys.argv[2];
+
+    pc = cv2.ppf_match_3d.loadPLYSimple(modelFileName, 1);
+
+    # Now train the model
+    print("Training...");
+    tick1 = cv2.getTickCount();
+    detector = cv2.ppf_match_3d.PPF3DDetector(0.025, 0.05);
+    detector.trainModel(pc);
+    tick2 = cv2.getTickCount();
+    print("\nTraining complete in %f sec\nLoading model..." %
+        (float(tick2-tick1)/ cv2.getTickFrequency()));
+
+    # Read the scene
+    pcTest = cv2.ppf_match_3d.loadPLYSimple(sceneFileName, 1);
+
+    # Match the model to the scene and get the pose
+    print("\nStarting matching...");
+    tick1 = cv2.getTickCount();
+    results = detector.match(pcTest, 1.0/40.0, 0.05);
+    tick2 = cv2.getTickCount();
+    print("\nPPF Elapsed Time %f sec" %
+         (float(tick2-tick1)/cv2.getTickFrequency()));
+
+    #check results size from match call above
+    results_size = len(results);
+    print("Number of matching poses: %u" % results_size);
+    if results_size == 0:
+        print("\nNo matching poses found. Exiting.");
+        sys.exit(0);
+
+    # Get only first N results - but adjust to results size if num of results are less than that specified by N
+    N = 2;
+    if results_size < N:
+        print("\nReducing matching poses to be reported (as specified in code): "
+              "%u to the number of matches found: %u"
+              % (N, results_size));
+        N = results_size;
+    resultsSub = results[0:N];
+
+    # Create an instance of ICP
+    icp = cv2.ppf_match_3d.ICP(100, 0.005, 2.5, 8);
+    t1 = cv2.getTickCount();
+
+    # Register for all selected poses
+    print("\nPerforming ICP on %u poses..." % N);
+    icp.registerModelToScene(pc, pcTest, resultsSub);
+    t2 = cv2.getTickCount();
+
+    print("\nICP Elapsed Time %f sec" %
+         (float(t2-t1)/cv2.getTickFrequency()));
+
+    print("Poses: ");
+    # debug first five poses
+    for i in range(0, len(resultsSub)):
+        result = resultsSub[i];
+        print("Pose Result %u" % i);
+        result.printPose();
+        if i == 0:
+            pct = cv2.ppf_match_3d.transformPCPose(pc, result.pose);
+            cv2.ppf_match_3d.writePLY(pct, "para6700PCTrans.ply");

--- a/modules/surface_matching/samples/python/ppf_load_match.py
+++ b/modules/surface_matching/samples/python/ppf_load_match.py
@@ -38,10 +38,6 @@
 #
 # PPF Author: Tolga Birdal <tbirdal AT gmail.com>
 # Python wrapper by: Hamdi Sahloul <hamdisahloul AT hotmail.com>
-#
-# Known issues:
-#   `Pose3D.appendPose()` resets the pose instead of incrementing it [called inside `icp.registerModelToScene()`].
-#   `ppf_match_3d.transformPCPose()` not functional yet
 
 import cv2;
 import sys;

--- a/modules/surface_matching/samples/python/ppf_normal_computation.py
+++ b/modules/surface_matching/samples/python/ppf_normal_computation.py
@@ -1,0 +1,70 @@
+#
+#  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
+#
+#  By downloading, copying, installing or using the software you agree to this license.
+#  If you do not agree to this license, do not download, install,
+#  copy or use the software.
+#
+#
+#                          License Agreement
+#                For Open Source Computer Vision Library
+#
+# Copyright (C) 2014, OpenCV Foundation, all rights reserved.
+# Third party copyrights are property of their respective owners.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#   * Redistribution's of source code must retain the above copyright notice,
+#     this list of conditions and the following disclaimer.
+#
+#   * Redistribution's in binary form must reproduce the above copyright notice,
+#     this list of conditions and the following disclaimer in the documentation
+#     and/or other materials provided with the distribution.
+#
+#   * The name of the copyright holders may not be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+# This software is provided by the copyright holders and contributors "as is" and
+# any express or implied warranties, including, but not limited to, the implied
+# warranties of merchantability and fitness for a particular purpose are disclaimed.
+# In no event shall the Intel Corporation or contributors be liable for any direct,
+# indirect, incidental, special, exemplary, or consequential damages
+# (including, but not limited to, procurement of substitute goods or services;
+# loss of use, data, or profits; or business interruption) however caused
+# and on any theory of liability, whether in contract, strict liability,
+# or tort (including negligence or otherwise) arising in any way out of
+# the use of this software, even if advised of the possibility of such damage.
+#
+# PPF Author: Tolga Birdal <tbirdal AT gmail.com>
+# Python wrapper by: Hamdi Sahloul <hamdisahloul AT hotmail.com>
+
+import cv2;
+import sys;
+
+def help(errorMessage):
+  print("Program init error : %s" % errorMessage);
+  print("\nUsage : ppf_normal_computation [input model file] [output model file]");
+  print("\nPlease start again with new parameters");
+
+if __name__ == "__main__":
+  if len(sys.argv) < 3:
+    help("Not enough input arguments");
+    sys.exit(1);
+
+  modelFileName = sys.argv[1];
+  outputFileName = sys.argv[2];
+
+  print("Loading points");
+  points = cv2.ppf_match_3d.loadPLYSimple(modelFileName, 1);
+
+  print("Computing normals");
+  viewpoint = [0.0, 0.0, 0.0];
+  pointsAndNormals = cv2.ppf_match_3d.computeNormalsPC3d(points, 6, False, viewpoint);
+
+  print("Writing points");
+  cv2.ppf_match_3d.writePLY(pointsAndNormals, outputFileName);
+  #the following function can also be used for debugging purposes
+  #cv2.ppf_match_3d.writePLYVisibleNormals(pointsAndNormals, outputFileName);
+
+  print("Done");

--- a/modules/surface_matching/src/c_utils.hpp
+++ b/modules/surface_matching/src/c_utils.hpp
@@ -60,7 +60,7 @@ static inline double TNorm3(const double v[])
   return (sqrt(v[0]*v[0]+v[1]*v[1]+v[2]*v[2]));
 }
 
-static inline void TNormalize3(double v[])
+static inline void TNormalize3(CV_OUT double v[])
 {
   double normTemp=TNorm3(v);
   if (normTemp>0)
@@ -76,7 +76,7 @@ static inline double TDot3(const double a[3], const double b[3])
   return  ((a[0])*(b[0])+(a[1])*(b[1])+(a[2])*(b[2]));
 }
 
-static inline void TCross(const double a[], const double b[], double c[])
+static inline void TCross(const double a[], const double b[], CV_OUT double c[])
 {
   c[0] = (a[1])*(b[2])-(a[2])*(b[1]);
   c[1] = (a[2])*(b[0])-(a[0])*(b[2]);
@@ -90,7 +90,7 @@ static inline double TAngle3(const double a[3], const double b[3])
   return (atan2(TNorm3(c), TDot3(a, b)));
 }
 
-static inline void matrixProduct33(double *A, double *B, double *R)
+static inline void matrixProduct33(const double *A, const double *B, CV_OUT double *R)
 {
   R[0] = A[0] * B[0] + A[1] * B[3] + A[2] * B[6];
   R[1] = A[0] * B[1] + A[1] * B[4] + A[2] * B[7];
@@ -106,21 +106,21 @@ static inline void matrixProduct33(double *A, double *B, double *R)
 }
 
 // A is a vector
-static inline void matrixProduct133(double *A, double *B, double *R)
+static inline void matrixProduct133(const double *A, const double *B, CV_OUT double *R)
 {
   R[0] = A[0] * B[0] + A[1] * B[3] + A[2] * B[6];
   R[1] = A[0] * B[1] + A[1] * B[4] + A[2] * B[7];
   R[2] = A[0] * B[2] + A[1] * B[5] + A[2] * B[8];
 }
 
-static inline void matrixProduct331(const double A[9], const double b[3], double r[3])
+static inline void matrixProduct331(const double A[9], const double b[3], CV_OUT double r[3])
 {
   r[0] = A[0] * b[0] + A[1] * b[1] + A[2] * b[2];
   r[1] = A[3] * b[0] + A[4] * b[1] + A[5] * b[2];
   r[2] = A[6] * b[0] + A[7] * b[1] + A[8] * b[2];
 }
 
-static inline void matrixTranspose33(double *A, double *At)
+static inline void matrixTranspose33(const double *A, CV_OUT double *At)
 {
   At[0] = A[0];
   At[4] = A[4];
@@ -133,7 +133,7 @@ static inline void matrixTranspose33(double *A, double *At)
   At[7] = A[5];
 }
 
-static inline void matrixProduct44(const double A[16], const double B[16], double R[16])
+static inline void matrixProduct44(const double A[16], const double B[16], CV_OUT double R[16])
 {
   R[0] = A[0] * B[0] + A[1] * B[4] + A[2] * B[8] + A[3] * B[12];
   R[1] = A[0] * B[1] + A[1] * B[5] + A[2] * B[9] + A[3] * B[13];
@@ -156,7 +156,7 @@ static inline void matrixProduct44(const double A[16], const double B[16], doubl
   R[15] = A[12] * B[3] + A[13] * B[7] + A[14] * B[11] + A[15] * B[15];
 }
 
-static inline void matrixProduct441(const double A[16], const double B[4], double R[4])
+static inline void matrixProduct441(const double A[16], const double B[4], CV_OUT double R[4])
 {
   R[0] = A[0] * B[0] + A[1] * B[1] + A[2] * B[2] + A[3] * B[3];
   R[1] = A[4] * B[0] + A[5] * B[1] + A[6] * B[2] + A[7] * B[3];
@@ -164,7 +164,7 @@ static inline void matrixProduct441(const double A[16], const double B[4], doubl
   R[3] = A[12] * B[0] + A[13] * B[1] + A[14] * B[2] + A[15] * B[3];
 }
 
-static inline void matrixPrint(double *A, int m, int n)
+static inline void matrixPrint(const double *A, int m, int n)
 {
   int i, j;
 
@@ -179,7 +179,7 @@ static inline void matrixPrint(double *A, int m, int n)
   }
 }
 
-static inline void matrixIdentity(int n, double *A)
+static inline void matrixIdentity(int n, CV_OUT double *A)
 {
   int i;
 
@@ -194,7 +194,7 @@ static inline void matrixIdentity(int n, double *A)
   }
 }
 
-static inline void rtToPose(const double R[9], const double t[3], double Pose[16])
+static inline void rtToPose(const double R[9], const double t[3], CV_OUT double Pose[16])
 {
   Pose[0]=R[0];
   Pose[1]=R[1];
@@ -230,7 +230,7 @@ static inline void poseToRT(const double Pose[16], double R[9], double t[3])
   t[2]=Pose[11];
 }
 
-static inline void poseToR(const double Pose[16], double R[9])
+static inline void poseToR(const double Pose[16], CV_OUT double R[9])
 {
   R[0] = Pose[0];
   R[1] = Pose[1];
@@ -246,7 +246,7 @@ static inline void poseToR(const double Pose[16], double R[9])
 /**
  *  \brief Axis angle to rotation but only compute y and z components
  */
-static inline void aaToRyz(double angle, const double r[3], double row2[3], double row3[3])
+static inline void aaToRyz(double angle, const double r[3], CV_OUT double row2[3], CV_OUT double row3[3])
 {
   const double sinA=sin(angle);
   const double cosA=cos(angle);
@@ -275,7 +275,7 @@ static inline void aaToRyz(double angle, const double r[3], double row2[3], doub
 /**
  *  \brief Axis angle to rotation
  */
-static inline void aaToR(double angle, const double r[3], double R[9])
+static inline void aaToR(const double angle, const double r[3], CV_OUT double R[9])
 {
   const double sinA=sin(angle);
   const double cosA=cos(angle);
@@ -315,7 +315,7 @@ static inline void aaToR(double angle, const double r[3], double R[9])
 /**
  *  \brief Compute a rotation in order to rotate around X direction
  */
-static inline void getUnitXRotation(double angle, double R[9])
+static inline void getUnitXRotation(const double angle, CV_OUT double R[9])
 {
   const double sinA=sin(angle);
   const double cosA=cos(angle);
@@ -336,7 +336,7 @@ static inline void getUnitXRotation(double angle, double R[9])
 /**
  *  \brief Compute a transformation in order to rotate around X direction
  */
-static inline void getUnitXRotation_44(double angle, double T[16])
+static inline void getUnitXRotation_44(const double angle, CV_OUT double T[16])
 {
   const double sinA=sin(angle);
   const double cosA=cos(angle);
@@ -366,7 +366,7 @@ static inline void getUnitXRotation_44(double angle, double T[16])
 /**
  *  \brief Compute the yz components of the transformation needed to rotate n1 onto x axis and p1 to origin
  */
-static inline void computeTransformRTyz(const double p1[4], const double n1[4], double row2[3], double row3[3], double t[3])
+static inline void computeTransformRTyz(const double p1[4], const double n1[4], CV_OUT double row2[3], CV_OUT double row3[3], CV_OUT double t[3])
 {
   // dot product with x axis
   double angle=acos( n1[0] );
@@ -401,7 +401,7 @@ static inline void computeTransformRTyz(const double p1[4], const double n1[4], 
 /**
  *  \brief Compute the transformation needed to rotate n1 onto x axis and p1 to origin
  */
-static inline void computeTransformRT(const double p1[4], const double n1[4], double R[9], double t[3])
+static inline void computeTransformRT(const double p1[4], const double n1[4], CV_OUT double R[9], CV_OUT double t[3])
 {
   // dot product with x axis
   double angle=acos( n1[0] );
@@ -572,7 +572,7 @@ static inline void aaToDCM(double *axis, double angle, double *R)
  *  \param [in] R Rotation Matrix
  *  \param [in] q Quaternion
  */
-static inline void dcmToQuat(double *R, double *q)
+static inline void dcmToQuat(const double *R, CV_OUT double *q)
 {
   double n4; // the norm of quaternion multiplied by 4
   double tr = R[0] + R[4] + R[8]; // trace of martix

--- a/modules/surface_matching/src/icp.cpp
+++ b/modules/surface_matching/src/icp.cpp
@@ -382,13 +382,13 @@ int ICP::registerModelToScene(const Mat& srcPC, const Mat& dstPC, double& residu
 
     while ( (!(fval_perc<(1+TolP) && fval_perc>(1-TolP))) && i<MaxIterationsPyr)
     {
-      size_t di=0, selInd = 0;
+      int di = 0, selInd = 0;
 
       queryPCFlann(flann, Src_Moved, Indices, Distances);
 
       for (di=0; di<numElSrc; di++)
       {
-        newI[di] = (int)di;
+        newI[di] = di;
         newJ[di] = indices[di];
       }
 
@@ -455,8 +455,8 @@ int ICP::registerModelToScene(const Mat& srcPC, const Mat& dstPC, double& residu
       if (selInd)
       {
 
-        Mat Src_Match = Mat((int)selInd, srcPCT.cols, CV_64F);
-        Mat Dst_Match = Mat((int)selInd, srcPCT.cols, CV_64F);
+        Mat Src_Match = Mat(selInd, srcPCT.cols, CV_64F);
+        Mat Dst_Match = Mat(selInd, srcPCT.cols, CV_64F);
 
         for (di=0; di<selInd; di++)
         {

--- a/modules/surface_matching/src/icp.cpp
+++ b/modules/surface_matching/src/icp.cpp
@@ -320,6 +320,7 @@ int ICP::registerModelToScene(const Mat& srcPC, const Mat& dstPC, double& residu
   Mat dstPC0 = dstTemp;
 
   // initialize pose
+  pose.resize(16);
   matrixIdentity(4, &(pose[0]));
 
   void* flann = indexPCFlann(dstPC0);

--- a/modules/surface_matching/src/icp.cpp
+++ b/modules/surface_matching/src/icp.cpp
@@ -50,7 +50,7 @@ static void subtractColumns(Mat srcPC, double mean[3])
 
   for (int i=0; i<height; i++)
   {
-    float *row = (float*)(&srcPC.data[i*srcPC.step]);
+    float *row = srcPC.ptr<float>(i);
     {
       row[0]-=(float)mean[0];
       row[1]-=(float)mean[1];
@@ -68,7 +68,7 @@ static void computeMeanCols(Mat srcPC, double mean[3])
 
   for (int i=0; i<height; i++)
   {
-    const float *row = (float*)(&srcPC.data[i*srcPC.step]);
+    const float *row = srcPC.ptr<float>(i);
     {
       mean1 += (double)row[0];
       mean2 += (double)row[1];
@@ -100,7 +100,7 @@ static double computeDistToOrigin(Mat srcPC)
 
   for (int i=0; i<height; i++)
   {
-    const float *row = (float*)(&srcPC.data[i*srcPC.step]);
+    const float *row = srcPC.ptr<float>(i);
     dist += sqrt(row[0]*row[0]+row[1]*row[1]+row[2]*row[2]);
   }
 
@@ -203,11 +203,11 @@ static void minimizePointToPlaneMetric(Mat Src, Mat Dst, Mat& X)
 #endif
   for (int i=0; i<Src.rows; i++)
   {
-    const double *srcPt = (double*)&Src.data[i*Src.step];
-    const double *dstPt = (double*)&Dst.data[i*Dst.step];
+    const double *srcPt = Src.ptr<double>(i);
+    const double *dstPt = Dst.ptr<double>(i);
     const double *normals = &dstPt[3];
-    double *bVal = (double*)&b.data[i*b.step];
-    double *aRow = (double*)&A.data[i*A.step];
+    double *bVal = b.ptr<double>(i);
+    double *aRow = A.ptr<double>(i);
 
     const double sub[3]={dstPt[0]-srcPt[0], dstPt[1]-srcPt[1], dstPt[2]-srcPt[2]};
 
@@ -462,10 +462,10 @@ int ICP::registerModelToScene(const Mat& srcPC, const Mat& dstPC, double& residu
         {
           const int indModel = indicesModel[di];
           const int indScene = indicesScene[di];
-          const float *srcPt = (float*)&srcPCT.data[indModel*srcPCT.step];
-          const float *dstPt = (float*)&dstPC0.data[indScene*dstPC0.step];
-          double *srcMatchPt = (double*)&Src_Match.data[di*Src_Match.step];
-          double *dstMatchPt = (double*)&Dst_Match.data[di*Dst_Match.step];
+          const float *srcPt = srcPCT.ptr<float>(indModel);
+          const float *dstPt = dstPC0.ptr<float>(indScene);
+          double *srcMatchPt = Src_Match.ptr<double>(di);
+          double *dstMatchPt = Dst_Match.ptr<double>(di);
           int ci=0;
 
           for (ci=0; ci<srcPCT.cols; ci++)

--- a/modules/surface_matching/src/icp.cpp
+++ b/modules/surface_matching/src/icp.cpp
@@ -382,13 +382,13 @@ int ICP::registerModelToScene(const Mat& srcPC, const Mat& dstPC, double& residu
 
     while ( (!(fval_perc<(1+TolP) && fval_perc>(1-TolP))) && i<MaxIterationsPyr)
     {
-      int di = 0, selInd = 0;
+      size_t di=0, selInd = 0;
 
       queryPCFlann(flann, Src_Moved, Indices, Distances);
 
       for (di=0; di<numElSrc; di++)
       {
-        newI[di] = di;
+        newI[di] = (int)di;
         newJ[di] = indices[di];
       }
 
@@ -455,8 +455,8 @@ int ICP::registerModelToScene(const Mat& srcPC, const Mat& dstPC, double& residu
       if (selInd)
       {
 
-        Mat Src_Match = Mat(selInd, srcPCT.cols, CV_64F);
-        Mat Dst_Match = Mat(selInd, srcPCT.cols, CV_64F);
+        Mat Src_Match = Mat((int)selInd, srcPCT.cols, CV_64F);
+        Mat Dst_Match = Mat((int)selInd, srcPCT.cols, CV_64F);
 
         for (di=0; di<selInd; di++)
         {

--- a/modules/surface_matching/src/icp.cpp
+++ b/modules/surface_matching/src/icp.cpp
@@ -464,8 +464,8 @@ int ICP::registerModelToScene(const Mat& srcPC, const Mat& dstPC, double& residu
           const int indScene = indicesScene[di];
           const float *srcPt = srcPCT.ptr<float>(indModel);
           const float *dstPt = dstPC0.ptr<float>(indScene);
-          double *srcMatchPt = Src_Match.ptr<double>(di);
-          double *dstMatchPt = Dst_Match.ptr<double>(di);
+          double *srcMatchPt = Src_Match.ptr<double>((int)di);
+          double *dstMatchPt = Dst_Match.ptr<double>((int)di);
           int ci=0;
 
           for (ci=0; ci<srcPCT.cols; ci++)

--- a/modules/surface_matching/src/icp.cpp
+++ b/modules/surface_matching/src/icp.cpp
@@ -543,7 +543,7 @@ int ICP::registerModelToScene(const Mat& srcPC, const Mat& dstPC, std::vector<Po
   for (size_t i=0; i<poses.size(); i++)
   {
     double poseICP[16]={0};
-    Mat srcTemp = transformPCPose(srcPC, poses[i]->pose);
+    Mat srcTemp = transformPCPose(srcPC, &(poses[i]->pose[0]));
     registerModelToScene(srcTemp, dstPC, poses[i]->residual, poseICP);
     poses[i]->appendPose(poseICP);
   }

--- a/modules/surface_matching/src/pose_3d.cpp
+++ b/modules/surface_matching/src/pose_3d.cpp
@@ -179,7 +179,7 @@ void Pose3D::appendPose(double IncrementalPose[16])
 {
   double R[9], PoseFull[16]={0};
 
-  matrixProduct44(IncrementalPose, this->pose, PoseFull);
+  matrixProduct44(IncrementalPose, &(this->pose[0]), PoseFull);
 
   R[0] = PoseFull[0];
   R[1] = PoseFull[1];
@@ -260,7 +260,7 @@ int Pose3D::writePose(FILE* f)
   fwrite(&angle, sizeof(double), 1, f);
   fwrite(&numVotes, sizeof(int), 1, f);
   fwrite(&modelIndex, sizeof(int), 1, f);
-  fwrite(pose, sizeof(double)*16, 1, f);
+  fwrite(&(pose[0]), sizeof(double)*16, 1, f);
   fwrite(t, sizeof(double)*3, 1, f);
   fwrite(q, sizeof(double)*4, 1, f);
   fwrite(&residual, sizeof(double), 1, f);
@@ -277,7 +277,7 @@ int Pose3D::readPose(FILE* f)
     status = fread(&angle, sizeof(double), 1, f);
     status = fread(&numVotes, sizeof(int), 1, f);
     status = fread(&modelIndex, sizeof(int), 1, f);
-    status = fread(pose, sizeof(double)*16, 1, f);
+    status = fread(&(pose[0]), sizeof(double)*16, 1, f);
     status = fread(t, sizeof(double)*3, 1, f);
     status = fread(q, sizeof(double)*4, 1, f);
     status = fread(&residual, sizeof(double), 1, f);

--- a/modules/surface_matching/src/pose_3d.cpp
+++ b/modules/surface_matching/src/pose_3d.cpp
@@ -175,7 +175,7 @@ void Pose3D::updatePoseQuat(double Q[4], double NewT[3])
 }
 
 
-void Pose3D::appendPose(double IncrementalPose[16])
+void Pose3D::appendPose(const double IncrementalPose[16])
 {
   double R[9], PoseFull[16]={0};
 

--- a/modules/surface_matching/src/ppf_helpers.cpp
+++ b/modules/surface_matching/src/ppf_helpers.cpp
@@ -530,12 +530,12 @@ Mat transPCCoeff(Mat pc, float scale, float Cx, float Cy, float Cz, float MinVal
   return pcn;
 }
 
-Mat transformPCPose(Mat pc, double Pose[16])
+Mat transformPCPose(Mat pc, const std::vector<double>& Pose)
 {
   Mat pct = Mat(pc.rows, pc.cols, CV_32F);
 
   double R[9], t[3];
-  poseToRT(Pose, R, t);
+  poseToRT(&(Pose[0]), R, t);
 
 #if defined _OPENMP
 #pragma omp parallel for
@@ -550,7 +550,7 @@ Mat transformPCPose(Mat pc, double Pose[16])
     double p[4] = {(double)pcData[0], (double)pcData[1], (double)pcData[2], 1};
     double p2[4];
 
-    matrixProduct441(Pose, p, p2);
+    matrixProduct441(&(Pose[0]), p, p2);
 
     // p2[3] should normally be 1
     if (fabs(p2[3])>EPS)
@@ -720,7 +720,7 @@ void meanCovLocalPCInd(const float* pc, const int* Indices, const int ws, const 
 
 }
 
-CV_EXPORTS_W void computeNormalsPC3d(InputArray PC_, OutputArray PCNormals_, const int NumNeighbors, const bool FlipViewpoint, const std::vector<double> viewpoint)
+CV_EXPORTS_W void computeNormalsPC3d(InputArray PC_, OutputArray PCNormals_, const int NumNeighbors, const bool FlipViewpoint, const std::vector<double>& viewpoint)
 {
   int i;
   Mat PC = PC_.getMat();

--- a/modules/surface_matching/src/ppf_helpers.cpp
+++ b/modules/surface_matching/src/ppf_helpers.cpp
@@ -86,7 +86,7 @@ Mat loadPLYSimple(const char* fileName, int withNormals)
 
   for (int i = 0; i < numVertices; i++)
   {
-    float* data = (float*)(&cloud.data[i*cloud.step[0]]);
+    float* data = cloud.ptr<float>(i);
     if (withNormals)
     {
       ifs >> data[0] >> data[1] >> data[2] >> data[3] >> data[4] >> data[5];
@@ -148,7 +148,7 @@ void writePLY(Mat PC, const char* FileName)
 
   for ( int pi = 0; pi < pointNum; ++pi )
   {
-    const float* point = (float*)(&PC.data[ pi*PC.step ]);
+    const float* point = PC.ptr<float>(pi);
 
     outFile << point[0] << " "<<point[1]<<" "<<point[2];
 
@@ -202,7 +202,7 @@ void writePLYVisibleNormals(Mat PC, const char* FileName)
 
   for (int pi = 0; pi < pointNum; ++pi)
   {
-    const float* point = (float*)(&PC.data[pi*PC.step]);
+    const float* point = PC.ptr<float>(pi);
 
     outFile << point[0] << " " << point[1] << " " << point[2];
 
@@ -295,7 +295,7 @@ Mat samplePCByQuantization(Mat pc, float xrange[2], float yrange[2], float zrang
   //#pragma omp parallel for
   for (int i=0; i<pc.rows; i++)
   {
-    const float* point = (float*)(&pc.data[i * pc.step]);
+    const float* point = pc.ptr<float>(i);
 
     // quantize a point
     const int xCell =(int) ((float)numSamplesDim*(point[0]-xrange[0])/xr);
@@ -342,7 +342,7 @@ Mat samplePCByQuantization(Mat pc, float xrange[2], float yrange[2], float zrang
         for (int j=0; j<cn; j++)
         {
           const int ptInd = curCell[j];
-          float* point = (float*)(&pc.data[ptInd * pc.step]);
+          float* point = pc.ptr<float>(ptInd);
           const double dx = point[0]-xc;
           const double dy = point[1]-yc;
           const double dz = point[2]-zc;
@@ -380,7 +380,7 @@ Mat samplePCByQuantization(Mat pc, float xrange[2], float yrange[2], float zrang
         for (int j=0; j<cn; j++)
         {
           const int ptInd = curCell[j];
-          float* point = (float*)(&pc.data[ptInd * pc.step]);
+          float* point = pc.ptr<float>(ptInd);
 
           px += (double)point[0];
           py += (double)point[1];
@@ -399,7 +399,7 @@ Mat samplePCByQuantization(Mat pc, float xrange[2], float yrange[2], float zrang
 
       }
 
-      float *pcData = (float*)(&pcSampled.data[c*pcSampled.step[0]]);
+      float *pcData = pcSampled.ptr<float>(c);
       pcData[0]=(float)px;
       pcData[1]=(float)py;
       pcData[2]=(float)pz;
@@ -453,7 +453,7 @@ void computeBboxStd(Mat pc, float xRange[2], float yRange[2], float zRange[2])
 
   for  ( int  ind = 0; ind < num; ind++ )
   {
-    const float* row = (float*)(pcPts.data + (ind * pcPts.step));
+    const float* row = pcPts.ptr<float>(ind);
     const float x = row[0];
     const float y = row[1];
     const float z = row[2];
@@ -542,8 +542,8 @@ Mat transformPCPose(Mat pc, double Pose[16])
 #endif
   for (int i=0; i<pc.rows; i++)
   {
-    const float *pcData = (float*)(&pc.data[i*pc.step]);
-    float *pcDataT = (float*)(&pct.data[i*pct.step]);
+    const float *pcData = pc.ptr<float>(i);
+    float *pcDataT = pct.ptr<float>(i);
     const float *n1 = &pcData[3];
     float *nT = &pcDataT[3];
 
@@ -738,7 +738,7 @@ CV_EXPORTS_W int computeNormalsPC3d(const Mat& PC, Mat& PCNormals, const int Num
 
   for (i=0; i<PC.rows; i++)
   {
-    const float* src = (float*)(&PC.data[i*PC.step]);
+    const float* src = PC.ptr<float>(i);
     float* dst = (float*)(&dataset[i*3]);
 
     dst[0] = src[0];
@@ -763,7 +763,7 @@ CV_EXPORTS_W int computeNormalsPC3d(const Mat& PC, Mat& PCNormals, const int Num
   {
     double C[3][3], mu[4];
     const float* pci = &dataset[i*3];
-    float* pcr = (float*)(&PCNormals.data[i*PCNormals.step]);
+    float* pcr = PCNormals.ptr<float>(i);
     double nr[3];
 
     int* indLocal = &indices[i*NumNeighbors];

--- a/modules/surface_matching/src/ppf_helpers.cpp
+++ b/modules/surface_matching/src/ppf_helpers.cpp
@@ -720,13 +720,13 @@ void meanCovLocalPCInd(const float* pc, const int* Indices, const int ws, const 
 
 }
 
-CV_EXPORTS_W int computeNormalsPC3d(const Mat& PC, Mat& PCNormals, const int NumNeighbors, const bool FlipViewpoint, const double viewpoint[3])
+CV_EXPORTS_W void computeNormalsPC3d(InputArray PC_, OutputArray PCNormals_, const int NumNeighbors, const bool FlipViewpoint, const std::vector<double> viewpoint)
 {
   int i;
+  Mat PC = PC_.getMat();
 
   if (PC.cols!=3 && PC.cols!=6) // 3d data is expected
   {
-    //return -1;
     CV_Error(cv::Error::BadImageSize, "PC should have 3 or 6 elements in its columns");
   }
 
@@ -757,7 +757,7 @@ CV_EXPORTS_W int computeNormalsPC3d(const Mat& PC, Mat& PCNormals, const int Num
   destroyFlann(flannIndex);
   flannIndex = 0;
 
-  PCNormals = Mat(PC.rows, 6, CV_32F);
+  Mat PCNormals(PC.rows, 6, CV_32F);
 
   for (i=0; i<PC.rows; i++)
   {
@@ -806,11 +806,12 @@ CV_EXPORTS_W int computeNormalsPC3d(const Mat& PC, Mat& PCNormals, const int Num
     pcr[5] = (float)nr[2];
   }
 
+  PCNormals.copyTo(PCNormals_);
+
   delete[] indices;
   delete[] distances;
   delete[] dataset;
 
-  return 1;
 }
 
 } // namespace ppf_match_3d

--- a/modules/surface_matching/src/ppf_helpers.cpp
+++ b/modules/surface_matching/src/ppf_helpers.cpp
@@ -720,7 +720,7 @@ void meanCovLocalPCInd(const float* pc, const int* Indices, const int ws, const 
 
 }
 
-CV_EXPORTS int computeNormalsPC3d(const Mat& PC, Mat& PCNormals, const int NumNeighbors, const bool FlipViewpoint, const double viewpoint[3])
+CV_EXPORTS_W int computeNormalsPC3d(const Mat& PC, Mat& PCNormals, const int NumNeighbors, const bool FlipViewpoint, const double viewpoint[3])
 {
   int i;
 

--- a/modules/surface_matching/src/ppf_match_3d.cpp
+++ b/modules/surface_matching/src/ppf_match_3d.cpp
@@ -252,8 +252,6 @@ void PPF3DDetector::trainModel(const Mat &PC)
 
   int numPPF = sampled.rows*sampled.rows;
   ppf = Mat(numPPF, PPF_LENGTH, CV_32FC1);
-  int ppfStep = (int)ppf.step;
-  int sampledStep = (int)sampled.step;
 
   // TODO: Maybe I could sample 1/5th of them here. Check the performance later.
   int numRefPoints = sampled.rows;
@@ -268,7 +266,7 @@ void PPF3DDetector::trainModel(const Mat &PC)
   // since this is just a training part.
   for (int i=0; i<numRefPoints; i++)
   {
-    float* f1 = (float*)(&sampled.data[i * sampledStep]);
+    float* f1 = sampled.ptr<float>(i);
     const double p1[4] = {f1[0], f1[1], f1[2], 0};
     const double n1[4] = {f1[3], f1[4], f1[5], 0};
 
@@ -278,7 +276,7 @@ void PPF3DDetector::trainModel(const Mat &PC)
       // cannnot compute the ppf with myself
       if (i!=j)
       {
-        float* f2 = (float*)(&sampled.data[j * sampledStep]);
+        float* f2 = sampled.ptr<float>(j);
         const double p2[4] = {f2[0], f2[1], f2[2], 0};
         const double n2[4] = {f2[3], f2[4], f2[5], 0};
 
@@ -286,8 +284,7 @@ void PPF3DDetector::trainModel(const Mat &PC)
         computePPFFeatures(p1, n1, p2, n2, f);
         KeyType hashValue = hashPPF(f, angle_step_radians, distanceStep);
         double alpha = computeAlpha(p1, n1, p2);
-        unsigned int corrInd = i*numRefPoints+j;
-        unsigned int ppfInd = corrInd*ppfStep;
+        unsigned int ppfInd = i*numRefPoints+j;
 
         THash* hashNode = &hash_nodes[i*numRefPoints+j];
         hashNode->id = hashValue;
@@ -296,7 +293,7 @@ void PPF3DDetector::trainModel(const Mat &PC)
 
         hashtableInsertHashed(hashTable, hashValue, (void*)hashNode);
 
-        float* ppfRow = (float*)(&(ppf.data[ ppfInd ]));
+        float* ppfRow = ppf.ptr<float>(ppfInd);
         ppfRow[0] = (float)f[0];
         ppfRow[1] = (float)f[1];
         ppfRow[2] = (float)f[2];
@@ -309,7 +306,6 @@ void PPF3DDetector::trainModel(const Mat &PC)
   angle_step = angle_step_radians;
   distance_step = distanceStep;
   hash_table = hashTable;
-  ppf_step = ppfStep;
   num_ref_points = numRefPoints;
   sampled_pc = sampled;
   trained = true;
@@ -513,7 +509,7 @@ void PPF3DDetector::match(const Mat& pc, std::vector<Pose3DPtr>& results, const 
     unsigned int refIndMax = 0, alphaIndMax = 0;
     unsigned int maxVotes = 0;
 
-    float* f1 = (float*)(&sampled.data[i * sampled.step]);
+    float* f1 = sampled.ptr<float>(i);
     const double p1[4] = {f1[0], f1[1], f1[2], 0};
     const double n1[4] = {f1[3], f1[4], f1[5], 0};
     double *row2, *row3, tsg[3]={0}, Rsg[9]={0}, RInv[9]={0};
@@ -532,7 +528,7 @@ void PPF3DDetector::match(const Mat& pc, std::vector<Pose3DPtr>& results, const 
     {
       if (i!=j)
       {
-        float* f2 = (float*)(&sampled.data[j * sampled.step]);
+        float* f2 = sampled.ptr<float>(j);
         const double p2[4] = {f2[0], f2[1], f2[2], 0};
         const double n2[4] = {f2[3], f2[4], f2[5], 0};
         double p2t[4], alpha_scene;
@@ -565,7 +561,7 @@ void PPF3DDetector::match(const Mat& pc, std::vector<Pose3DPtr>& results, const 
           THash* tData = (THash*) node->data;
           int corrI = (int)tData->i;
           int ppfInd = (int)tData->ppfInd;
-          float* ppfCorrScene = (float*)(&ppf.data[ppfInd]);
+          float* ppfCorrScene = ppf.ptr<float>(ppfInd);
           double alpha_model = (double)ppfCorrScene[PPF_LENGTH-1];
           double alpha = alpha_model - alpha_scene;
 
@@ -620,7 +616,7 @@ void PPF3DDetector::match(const Mat& pc, std::vector<Pose3DPtr>& results, const 
                         };
 
     // TODO : Compute pose
-    const float* fMax = (float*)(&sampled_pc.data[refIndMax * sampled_pc.step]);
+    const float* fMax = sampled_pc.ptr<float>(refIndMax);
     const double pMax[4] = {fMax[0], fMax[1], fMax[2], 1};
     const double nMax[4] = {fMax[3], fMax[4], fMax[5], 1};
 


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

- Adds a Python wrapper for both RGBD and Surface Matching modules
  - Replaces `(*T)(&mat.data[i * mat.step])` into `mat.ptr<T>(i)` for wrappers compatibility.
  - Replaces two-words types with one-word (e.g. `unsigned int` into `uint`) for wrappers compatibility.
  - Removes some `enum` names for wrappers compatibility.
  - Replaces some `Mat` types with appropriate `InputArray ` or `OutputArray` types.
  - Converts some pointers into vectors.
  - Adds `const` modifier where necessary.
- Provides sample python scripts for testing the wrappers.
- Supports OpenNI2 in the original `pyopencv_rgbd` sample code.