### PR TITLE
Fix Opencv3.2 freetype module build failed in macOS10.12 #919

### DIFF
--- a/modules/freetype/CMakeLists.txt
+++ b/modules/freetype/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 
 
 if( FREETYPE_FOUND AND HARFBUZZ_FOUND )
-  ocv_define_module(freetype opencv_core opencv_imgproc PRIVATE_REQUIRED ${freetype2_LIBRARIES} ${harfbuzz_LIBRARIES} WRAP python)
+  ocv_define_module(freetype opencv_core opencv_imgproc PRIVATE_REQUIRED ${FREETYPE_LIBRARIES} ${HARFBUZZ_LIBRARIES} WRAP python)
   ocv_include_directories( ${FREETYPE_INCLUDE_DIRS} ${HARFBUZZ_INCLUDE_DIRS} )
 else()
   ocv_module_disable(freetype)


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->
resolves #919 

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
Change CMakeFile.txt to use ${FREETYPE_LIBRARIES} ${HARFBUZZ_LIBRARIES} 