### PR TITLE
Add readNetFromTensorflow

### DIFF
--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -306,7 +306,7 @@ namespace dnn //! This namespace is used for dnn module functionlaity.
     CV_EXPORTS Ptr<Importer> createTensorflowImporter(const String &model);
 
     /** @brief Reads a network model stored in TensorFlow model files.
-      * @details This is shortcut consisting from createTensorflowImporter and Net::populateNet calls.
+      * @details This is shortcut consisting from createTensorflowImporter and Importer::populateNet calls.
       */
     CV_EXPORTS_W Net readNetFromTensorflow(const String &model);
 

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -308,7 +308,7 @@ namespace dnn //! This namespace is used for dnn module functionlaity.
     /** @brief Reads a network model stored in TensorFlow model files.
       * @details This is shortcut consisting from createTensorflowImporter and Importer::populateNet calls.
       */
-    CV_EXPORTS_W Net readNetFromTensorflow(const String &model);
+    CV_EXPORTS_W Ptr<Net> readNetFromTensorflow(const String &model);
 
     /** @brief Creates the importer of <a href="http://torch.ch">Torch7</a> framework network.
      *  @param filename path to the file, dumped from Torch by using torch.save() function.

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -305,6 +305,11 @@ namespace dnn //! This namespace is used for dnn module functionlaity.
      */
     CV_EXPORTS Ptr<Importer> createTensorflowImporter(const String &model);
 
+    /** @brief Reads a network model stored in TensorFlow model files.
+      * @details This is shortcut consisting from createTensorflowImporter and Net::populateNet calls.
+      */
+    CV_EXPORTS_W Net readNetFromTensorflow(const String &model);
+
     /** @brief Creates the importer of <a href="http://torch.ch">Torch7</a> framework network.
      *  @param filename path to the file, dumped from Torch by using torch.save() function.
      *  @param isBinary specifies whether the network was serialized in ascii mode or binary.

--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -748,7 +748,7 @@ Ptr<Importer> cv::dnn::createTensorflowImporter(const String&)
 
 #endif //HAVE_PROTOBUF
 
-Net cv::dnn::readNetFromTensorflow(const String &model)
+Ptr<Net> cv::dnn::readNetFromTensorflow(const String &model)
 {
     Ptr<Importer> tensorflowImporter;
     try
@@ -764,5 +764,5 @@ Net cv::dnn::readNetFromTensorflow(const String &model)
     Net net;
     if (tensorflowImporter)
         tensorflowImporter->populateNet(net);
-    return net;
+    return makePtr<Net>(net);
 }

--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -747,3 +747,22 @@ Ptr<Importer> cv::dnn::createTensorflowImporter(const String&)
 }
 
 #endif //HAVE_PROTOBUF
+
+Net cv::dnn::readNetFromTensorflow(const String &model)
+{
+    Ptr<Importer> tensorflowImporter;
+    try
+    {
+        tensorflowImporter = createTensorflowImporter(model);
+    }
+    catch (cv::Exception& e)
+    {
+        std::cerr << "Exception: " << e.what() << std::endl;
+        return Net();
+    }
+
+    Net net;
+    if (tensorflowImporter)
+        tensorflowImporter->populateNet(net);
+    return net;
+}

--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -751,15 +751,7 @@ Ptr<Importer> cv::dnn::createTensorflowImporter(const String&)
 Ptr<Net> cv::dnn::readNetFromTensorflow(const String &model)
 {
     Ptr<Importer> tensorflowImporter;
-    try
-    {
-        tensorflowImporter = createTensorflowImporter(model);
-    }
-    catch (cv::Exception& e)
-    {
-        std::cerr << "Exception: " << e.what() << std::endl;
-        return Net();
-    }
+    tensorflowImporter = createTensorflowImporter(model);
 
     Net net;
     if (tensorflowImporter)


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes
<!-- Please describe what your pullrequest is changing -->
Add function that reads a network stored in TensorFlow graph files.
It provides a simple way to load a network like <code>cv::dnn::readNetFromCaffe()</code>.

```cpp
// cv::Ptr<cv::dnn::Importer> importer = cv::dnn::createTensorflowImporter( "graph.pb" );
// cv::dnn::Net net;
// importer->populateNet( net );
cv::Ptr<cv::dnn::Net> net = cv::dnn::readNetFromTensorflow( "graph.pb" );
```