### PR TITLE
tracking:Disable all tests except kalman filter

### DIFF
--- a/modules/tracking/test/test_aukf.cpp
+++ b/modules/tracking/test/test_aukf.cpp
@@ -204,7 +204,7 @@ TEST(AUKF, br_landing_point)
     ASSERT_NEAR(landing_coordinate, landing_y, abs_error);
 }
 
-TEST(AUKF, br_mean_squared_error)
+TEST(DISABLED_AUKF, DISABLED_br_mean_squared_error)
 {
     const double velocity_treshold = 0.004;
     const double state_treshold = 0.04;
@@ -344,7 +344,7 @@ public:
     }
 };
 
-TEST(AUKF, ungm_mean_squared_error)
+TEST(AUKF, DISABLED_ungm_mean_squared_error)
 {
 
     const double alpha = 1.5;

--- a/modules/tracking/test/test_trackerOPE.cpp
+++ b/modules/tracking/test/test_trackerOPE.cpp
@@ -380,56 +380,56 @@ PARAM_TEST_CASE(OPE_Overlap, string, float)
   }
 };
 
-TEST_P(OPE_Distance, MIL)
+TEST_P(OPE_Distance, DISABLED_MIL)
 {
   TrackerOPETest test( Tracker::create( "MIL" ), TrackerOPETest::DISTANCE, dataset, threshold );
   test.run();
   RecordProperty( "ratioSuccess", test.getRatioSucc() );
 }
 
-TEST_P(OPE_Overlap, MIL)
+TEST_P(OPE_Overlap, DISABLED_MIL)
 {
   TrackerOPETest test( Tracker::create( "MIL" ), TrackerOPETest::OVERLAP, dataset, threshold );
   test.run();
   RecordProperty( "ratioSuccess", test.getRatioSucc() );
 }
 
-TEST_P(OPE_Distance, Boosting)
+TEST_P(OPE_Distance, DISABLED_Boosting)
 {
   TrackerOPETest test( Tracker::create( "BOOSTING" ), TrackerOPETest::DISTANCE, dataset, threshold );
   test.run();
   RecordProperty( "ratioSuccess", test.getRatioSucc() );
 }
 
-TEST_P(OPE_Overlap, Boosting)
+TEST_P(OPE_Overlap, DISABLED_Boosting)
 {
   TrackerOPETest test( Tracker::create( "BOOSTING" ), TrackerOPETest::OVERLAP, dataset, threshold );
   test.run();
   RecordProperty( "ratioSuccess", test.getRatioSucc() );
 }
 
-TEST_P(OPE_Distance, TLD)
+TEST_P(OPE_Distance, DISABLED_TLD)
 {
   TrackerOPETest test( Tracker::create( "TLD" ), TrackerOPETest::DISTANCE, dataset, threshold );
   test.run();
   RecordProperty( "ratioSuccess", test.getRatioSucc() );
 }
 
-TEST_P(OPE_Overlap, TLD)
+TEST_P(OPE_Overlap, DISABLED_TLD)
 {
   TrackerOPETest test( Tracker::create( "TLD" ), TrackerOPETest::OVERLAP, dataset, threshold );
   test.run();
   RecordProperty( "ratioSuccess", test.getRatioSucc() );
 }
 
-TEST_P(OPE_Distance, GOTURN)
+TEST_P(OPE_Distance, DISABLED_GOTURN)
 {
   TrackerOPETest test(Tracker::create("GOTURN"), TrackerOPETest::DISTANCE, dataset, threshold);
   test.run();
   RecordProperty("ratioSuccess", test.getRatioSucc());
 }
 
-TEST_P(OPE_Overlap, GOTURN)
+TEST_P(OPE_Overlap, DISABLED_GOTURN)
 {
   TrackerOPETest test(Tracker::create("GOTURN"), TrackerOPETest::OVERLAP, dataset, threshold);
   test.run();

--- a/modules/tracking/test/test_trackerSRE.cpp
+++ b/modules/tracking/test/test_trackerSRE.cpp
@@ -487,56 +487,56 @@ PARAM_TEST_CASE(SRE_Overlap, string, int, float)
   }
 };
 
-TEST_P(SRE_Distance, MIL)
+TEST_P(SRE_Distance, DISABLED_MIL)
 {
   TrackerSRETest test( Tracker::create( "MIL" ), TrackerSRETest::DISTANCE, dataset, shift, threshold );
   test.run();
   RecordProperty( "ratioSuccess", test.getRatioSucc() );
 }
 
-TEST_P(SRE_Overlap, MIL)
+TEST_P(SRE_Overlap, DISABLED_MIL)
 {
   TrackerSRETest test( Tracker::create( "MIL" ), TrackerSRETest::OVERLAP, dataset, shift, threshold );
   test.run();
   RecordProperty( "ratioSuccess", test.getRatioSucc() );
 }
 
-TEST_P(SRE_Distance, Boosting)
+TEST_P(SRE_Distance, DISABLED_Boosting)
 {
   TrackerSRETest test( Tracker::create( "BOOSTING" ), TrackerSRETest::DISTANCE, dataset, shift, threshold );
   test.run();
   RecordProperty( "ratioSuccess", test.getRatioSucc() );
 }
 
-TEST_P(SRE_Overlap, Boosting)
+TEST_P(SRE_Overlap, DISABLED_Boosting)
 {
   TrackerSRETest test( Tracker::create( "BOOSTING" ), TrackerSRETest::OVERLAP, dataset, shift, threshold );
   test.run();
   RecordProperty( "ratioSuccess", test.getRatioSucc() );
 }
 
-TEST_P(SRE_Distance, TLD)
+TEST_P(SRE_Distance, DISABLED_TLD)
 {
   TrackerSRETest test( Tracker::create( "TLD" ), TrackerSRETest::DISTANCE, dataset, shift, threshold );
   test.run();
   RecordProperty( "ratioSuccess", test.getRatioSucc() );
 }
 
-TEST_P(SRE_Overlap, TLD)
+TEST_P(SRE_Overlap, DISABLED_TLD)
 {
   TrackerSRETest test( Tracker::create( "TLD" ), TrackerSRETest::OVERLAP, dataset, shift, threshold );
   test.run();
   RecordProperty( "ratioSuccess", test.getRatioSucc() );
 }
 
-TEST_P(SRE_Distance, GOTURN)
+TEST_P(SRE_Distance, DISABLED_GOTURN)
 {
   TrackerSRETest test(Tracker::create("GOTURN"), TrackerSRETest::DISTANCE, dataset, shift, threshold);
   test.run();
   RecordProperty("ratioSuccess", test.getRatioSucc());
 }
 
-TEST_P(SRE_Overlap, GOTURN)
+TEST_P(SRE_Overlap, DISABLED_GOTURN)
 {
   TrackerSRETest test(Tracker::create("GOTURN"), TrackerSRETest::OVERLAP, dataset, shift, threshold);
   test.run();

--- a/modules/tracking/test/test_trackerTRE.cpp
+++ b/modules/tracking/test/test_trackerTRE.cpp
@@ -457,56 +457,56 @@ PARAM_TEST_CASE(TRE_Overlap, string, int, float)
   }
 };
 
-TEST_P(TRE_Distance, MIL)
+TEST_P(TRE_Distance, DISABLED_MIL)
 {
   TrackerTRETest test( Tracker::create( "MIL" ), TrackerTRETest::DISTANCE, dataset, threshold, segment );
   test.run();
   RecordProperty( "ratioSuccess", test.getRatioSucc() );
 }
 
-TEST_P(TRE_Overlap, MIL)
+TEST_P(TRE_Overlap, DISABLED_MIL)
 {
   TrackerTRETest test( Tracker::create( "MIL" ), TrackerTRETest::OVERLAP, dataset, threshold, segment );
   test.run();
   RecordProperty( "ratioSuccess", test.getRatioSucc() );
 }
 
-TEST_P(TRE_Distance, Boosting)
+TEST_P(TRE_Distance, DISABLED_Boosting)
 {
   TrackerTRETest test( Tracker::create( "BOOSTING" ), TrackerTRETest::DISTANCE, dataset, threshold, segment );
   test.run();
   RecordProperty( "ratioSuccess", test.getRatioSucc() );
 }
 
-TEST_P(TRE_Overlap, Boosting)
+TEST_P(TRE_Overlap, DISABLED_Boosting)
 {
   TrackerTRETest test( Tracker::create( "BOOSTING" ), TrackerTRETest::OVERLAP, dataset, threshold, segment );
   test.run();
   RecordProperty( "ratioSuccess", test.getRatioSucc() );
 }
 
-TEST_P(TRE_Distance, TLD)
+TEST_P(TRE_Distance, DISABLED_TLD)
 {
   TrackerTRETest test( Tracker::create( "TLD" ), TrackerTRETest::DISTANCE, dataset, threshold, segment );
   test.run();
   RecordProperty( "ratioSuccess", test.getRatioSucc() );
 }
 
-TEST_P(TRE_Overlap, TLD)
+TEST_P(TRE_Overlap, DISABLED_TLD)
 {
   TrackerTRETest test( Tracker::create( "TLD" ), TrackerTRETest::OVERLAP, dataset, threshold, segment );
   test.run();
   RecordProperty( "ratioSuccess", test.getRatioSucc() );
 }
 
-TEST_P(TRE_Distance, GOTURN)
+TEST_P(TRE_Distance, DISABLED_GOTURN)
 {
   TrackerTRETest test(Tracker::create("GOTURN"), TrackerTRETest::DISTANCE, dataset, threshold, segment);
   test.run();
   RecordProperty("ratioSuccess", test.getRatioSucc());
 }
 
-TEST_P(TRE_Overlap, GOTURN)
+TEST_P(TRE_Overlap, DISABLED_GOTURN)
 {
   TrackerTRETest test(Tracker::create("GOTURN"), TrackerTRETest::OVERLAP, dataset, threshold, segment);
   test.run();

--- a/modules/tracking/test/test_ukf.cpp
+++ b/modules/tracking/test/test_ukf.cpp
@@ -204,7 +204,7 @@ TEST(UKF, br_landing_point)
     ASSERT_NEAR(landing_coordinate, landing_y, abs_error);
 }
 
-TEST(UKF, br_mean_squared_error)
+TEST(UKF, DISABLED_br_mean_squared_error)
 {
     const double velocity_treshold = 0.09;
     const double state_treshold = 0.9;
@@ -343,7 +343,7 @@ public:
     }
 };
 
-TEST(UKF, ungm_mean_squared_error)
+TEST(UKF, DISABLED_ungm_mean_squared_error)
 {
     const double alpha = 1.5;
     const double beta = 2.0;


### PR DESCRIPTION
Tests was disabled because they are partially broken and take long time.