### PR TITLE
aruco::Board::create: fix debug assertion fail

### DIFF
--- a/modules/aruco/src/aruco.cpp
+++ b/modules/aruco/src/aruco.cpp
@@ -1284,14 +1284,11 @@ Ptr<Board> Board::create(InputArrayOfArrays objPoints, const Ptr<Dictionary> &di
     for (unsigned int i = 0; i < objPoints.total(); i++) {
         std::vector<Point3f> corners;
         Mat corners_mat = objPoints.getMat(i);
-        if(objPoints.type() == CV_32FC1)
-        {
-            CV_Assert(corners_mat.total() == 12);
-        }
-        else
-        {
-            CV_Assert(corners_mat.total() == 4);
-        }
+
+        if(corners_mat.type() == CV_32FC1)
+            corners_mat = corners_mat.reshape(3);
+        CV_Assert(corners_mat.total() == 4);
+
         for (int j = 0; j < 4; j++) {
             corners.push_back(corners_mat.at<Point3f>(j));
         }


### PR DESCRIPTION
If `corners_mat` has `CV_32FC1` type, debug assertion failure occurs in `corners_mat.at<Point3f>`.

resolves #963 