### PR TITLE
Shadow masks changed to single channel

### DIFF
--- a/modules/structured_light/src/graycodepattern.cpp
+++ b/modules/structured_light/src/graycodepattern.cpp
@@ -367,8 +367,8 @@ void GrayCodePattern_Impl::getImagesForShadowMasks( InputOutputArray blackImage,
   Mat& blackImage_ = *( Mat* ) blackImage.getObj();
   Mat& whiteImage_ = *( Mat* ) whiteImage.getObj();
 
-  blackImage_ = Mat( params.height, params.width, CV_8UC3, Scalar( 0, 0, 0 ) );
-  whiteImage_ = Mat( params.height, params.width, CV_8UC3, Scalar( 255, 255, 255 ) );
+  blackImage_ = Mat( params.height, params.width, CV_8U, Scalar( 0 ) );
+  whiteImage_ = Mat( params.height, params.width, CV_8U, Scalar( 255 ) );
 }
 
 // For a (x,y) pixel of the camera returns the corresponding projector's pixel


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes
Changed masks from 3-channel RGB to grayscale. Since rest of the gray code patterns are single channel, the masks should be as well to make it simple to handle. 

For instance, if user adds the mask to the pattern vector as shown in [this](http://docs.opencv.org/3.2.0/db/d56/tutorial_capture_graycode_pattern.html) examples, there could be an issue if you try to run ```cv::cvtColor``` since you'll have to treat the masks individually since they are RGBs
