### PR TITLE
Create a float-type cloud when depth map is not double-type

### DIFF
--- a/modules/rgbd/src/depth_to_3d.cpp
+++ b/modules/rgbd/src/depth_to_3d.cpp
@@ -232,14 +232,8 @@ namespace rgbd
         depth.type() == CV_64FC1 || depth.type() == CV_32FC1 || depth.type() == CV_16UC1 || depth.type() == CV_16SC1);
     CV_Assert(mask.empty() || mask.channels() == 1);
 
-    // TODO figure out what to do when types are different: convert or reject ?
     cv::Mat K_new;
-    if ((depth.depth() == CV_32F || depth.depth() == CV_64F) && depth.depth() != K.depth())
-    {
-      K.convertTo(K_new, depth.depth());
-    }
-    else
-      K_new = K;
+    K.convertTo(K_new, depth.depth() == CV_64F ? CV_64F : CV_32F); // issue #1021
 
     // Create 3D points in one go.
     if (!mask.empty())


### PR DESCRIPTION
resolves #1021 

### This pullrequest changes
The current implementation of `cv::rgbd::depthTo3d` would return CV_64F cloud if camera matrix argument is of type CV_64F and the depth map is non-float type.

However, since `cv::rgbd::warpFrameImpl` uses `Point2f` type for its points internally, it always expects CV_32F clouds. This results in a crash when camera matrix passed to `cv::rgbd::warpFrame` is of type CV_64F (the default data type in numpy).

This PR resolves the above mentioned issue...

<!-- Please describe what your pullrequest is changing -->
