### PR TITLE
Compacted `(type)&var.data[i*step]` code into `var.ptr<type>(i)`

### DIFF
--- a/modules/surface_matching/include/opencv2/surface_matching/ppf_match_3d.hpp
+++ b/modules/surface_matching/include/opencv2/surface_matching/ppf_match_3d.hpp
@@ -148,7 +148,7 @@ protected:
   double angle_step, angle_step_radians, distance_step;
   double sampling_step_relative, angle_step_relative, distance_step_relative;
   Mat sampled_pc, ppf;
-  int num_ref_points, ppf_step;
+  int num_ref_points;
   hashtable_int* hash_table;
   THash* hash_nodes;
 

--- a/modules/surface_matching/src/icp.cpp
+++ b/modules/surface_matching/src/icp.cpp
@@ -50,7 +50,7 @@ static void subtractColumns(Mat srcPC, double mean[3])
 
   for (int i=0; i<height; i++)
   {
-    float *row = (float*)(&srcPC.data[i*srcPC.step]);
+    float *row = srcPC.ptr<float>(i);
     {
       row[0]-=(float)mean[0];
       row[1]-=(float)mean[1];
@@ -68,7 +68,7 @@ static void computeMeanCols(Mat srcPC, double mean[3])
 
   for (int i=0; i<height; i++)
   {
-    const float *row = (float*)(&srcPC.data[i*srcPC.step]);
+    const float *row = srcPC.ptr<float>(i);
     {
       mean1 += (double)row[0];
       mean2 += (double)row[1];
@@ -100,7 +100,7 @@ static double computeDistToOrigin(Mat srcPC)
 
   for (int i=0; i<height; i++)
   {
-    const float *row = (float*)(&srcPC.data[i*srcPC.step]);
+    const float *row = srcPC.ptr<float>(i);
     dist += sqrt(row[0]*row[0]+row[1]*row[1]+row[2]*row[2]);
   }
 
@@ -203,11 +203,11 @@ static void minimizePointToPlaneMetric(Mat Src, Mat Dst, Mat& X)
 #endif
   for (int i=0; i<Src.rows; i++)
   {
-    const double *srcPt = (double*)&Src.data[i*Src.step];
-    const double *dstPt = (double*)&Dst.data[i*Dst.step];
+    const double *srcPt = Src.ptr<double>(i);
+    const double *dstPt = Dst.ptr<double>(i);
     const double *normals = &dstPt[3];
-    double *bVal = (double*)&b.data[i*b.step];
-    double *aRow = (double*)&A.data[i*A.step];
+    double *bVal = b.ptr<double>(i);
+    double *aRow = A.ptr<double>(i);
 
     const double sub[3]={dstPt[0]-srcPt[0], dstPt[1]-srcPt[1], dstPt[2]-srcPt[2]};
 
@@ -382,13 +382,13 @@ int ICP::registerModelToScene(const Mat& srcPC, const Mat& dstPC, double& residu
 
     while ( (!(fval_perc<(1+TolP) && fval_perc>(1-TolP))) && i<MaxIterationsPyr)
     {
-      size_t di=0, selInd = 0;
+      uint di=0, selInd = 0;
 
       queryPCFlann(flann, Src_Moved, Indices, Distances);
 
       for (di=0; di<numElSrc; di++)
       {
-        newI[di] = (int)di;
+        newI[di] = di;
         newJ[di] = indices[di];
       }
 
@@ -455,17 +455,17 @@ int ICP::registerModelToScene(const Mat& srcPC, const Mat& dstPC, double& residu
       if (selInd)
       {
 
-        Mat Src_Match = Mat((int)selInd, srcPCT.cols, CV_64F);
-        Mat Dst_Match = Mat((int)selInd, srcPCT.cols, CV_64F);
+        Mat Src_Match = Mat(selInd, srcPCT.cols, CV_64F);
+        Mat Dst_Match = Mat(selInd, srcPCT.cols, CV_64F);
 
         for (di=0; di<selInd; di++)
         {
           const int indModel = indicesModel[di];
           const int indScene = indicesScene[di];
-          const float *srcPt = (float*)&srcPCT.data[indModel*srcPCT.step];
-          const float *dstPt = (float*)&dstPC0.data[indScene*dstPC0.step];
-          double *srcMatchPt = (double*)&Src_Match.data[di*Src_Match.step];
-          double *dstMatchPt = (double*)&Dst_Match.data[di*Dst_Match.step];
+          const float *srcPt = srcPCT.ptr<float>(indModel);
+          const float *dstPt = dstPC0.ptr<float>(indScene);
+          double *srcMatchPt = Src_Match.ptr<double>(di);
+          double *dstMatchPt = Dst_Match.ptr<double>(di);
           int ci=0;
 
           for (ci=0; ci<srcPCT.cols; ci++)

--- a/modules/surface_matching/src/ppf_helpers.cpp
+++ b/modules/surface_matching/src/ppf_helpers.cpp
@@ -86,7 +86,7 @@ Mat loadPLYSimple(const char* fileName, int withNormals)
 
   for (int i = 0; i < numVertices; i++)
   {
-    float* data = (float*)(&cloud.data[i*cloud.step[0]]);
+    float* data = cloud.ptr<float>(i);
     if (withNormals)
     {
       ifs >> data[0] >> data[1] >> data[2] >> data[3] >> data[4] >> data[5];
@@ -148,7 +148,7 @@ void writePLY(Mat PC, const char* FileName)
 
   for ( int pi = 0; pi < pointNum; ++pi )
   {
-    const float* point = (float*)(&PC.data[ pi*PC.step ]);
+    const float* point = PC.ptr<float>(pi);
 
     outFile << point[0] << " "<<point[1]<<" "<<point[2];
 
@@ -202,7 +202,7 @@ void writePLYVisibleNormals(Mat PC, const char* FileName)
 
   for (int pi = 0; pi < pointNum; ++pi)
   {
-    const float* point = (float*)(&PC.data[pi*PC.step]);
+    const float* point = PC.ptr<float>(pi);
 
     outFile << point[0] << " " << point[1] << " " << point[2];
 
@@ -295,7 +295,7 @@ Mat samplePCByQuantization(Mat pc, float xrange[2], float yrange[2], float zrang
   //#pragma omp parallel for
   for (int i=0; i<pc.rows; i++)
   {
-    const float* point = (float*)(&pc.data[i * pc.step]);
+    const float* point = pc.ptr<float>(i);
 
     // quantize a point
     const int xCell =(int) ((float)numSamplesDim*(point[0]-xrange[0])/xr);
@@ -342,7 +342,7 @@ Mat samplePCByQuantization(Mat pc, float xrange[2], float yrange[2], float zrang
         for (int j=0; j<cn; j++)
         {
           const int ptInd = curCell[j];
-          float* point = (float*)(&pc.data[ptInd * pc.step]);
+          float* point = pc.ptr<float>(ptInd);
           const double dx = point[0]-xc;
           const double dy = point[1]-yc;
           const double dz = point[2]-zc;
@@ -380,7 +380,7 @@ Mat samplePCByQuantization(Mat pc, float xrange[2], float yrange[2], float zrang
         for (int j=0; j<cn; j++)
         {
           const int ptInd = curCell[j];
-          float* point = (float*)(&pc.data[ptInd * pc.step]);
+          float* point = pc.ptr<float>(ptInd);
 
           px += (double)point[0];
           py += (double)point[1];
@@ -399,7 +399,7 @@ Mat samplePCByQuantization(Mat pc, float xrange[2], float yrange[2], float zrang
 
       }
 
-      float *pcData = (float*)(&pcSampled.data[c*pcSampled.step[0]]);
+      float *pcData = pcSampled.ptr<float>(c);
       pcData[0]=(float)px;
       pcData[1]=(float)py;
       pcData[2]=(float)pz;
@@ -542,8 +542,8 @@ Mat transformPCPose(Mat pc, double Pose[16])
 #endif
   for (int i=0; i<pc.rows; i++)
   {
-    const float *pcData = (float*)(&pc.data[i*pc.step]);
-    float *pcDataT = (float*)(&pct.data[i*pct.step]);
+    const float *pcData = pc.ptr<float>(i);
+    float *pcDataT = pct.ptr<float>(i);
     const float *n1 = &pcData[3];
     float *nT = &pcDataT[3];
 
@@ -738,7 +738,7 @@ CV_EXPORTS int computeNormalsPC3d(const Mat& PC, Mat& PCNormals, const int NumNe
 
   for (i=0; i<PC.rows; i++)
   {
-    const float* src = (float*)(&PC.data[i*PC.step]);
+    const float* src = PC.ptr<float>(i);
     float* dst = (float*)(&dataset[i*3]);
 
     dst[0] = src[0];
@@ -763,7 +763,7 @@ CV_EXPORTS int computeNormalsPC3d(const Mat& PC, Mat& PCNormals, const int NumNe
   {
     double C[3][3], mu[4];
     const float* pci = &dataset[i*3];
-    float* pcr = (float*)(&PCNormals.data[i*PCNormals.step]);
+    float* pcr = PCNormals.ptr<float>(i);
     double nr[3];
 
     int* indLocal = &indices[i*NumNeighbors];


### PR DESCRIPTION
### This pullrequest changes
Seems like some variable is being casted at some point, but its step is used at another place without considering the cast. While C++ did not complain, Numpy had some issues with it. Perhaps around this line:
```.cpp
unsigned int ppfInd = corrInd*ppfStep;
```
Anyhow, it is always great to compact the code! And both Numpy and C++ are happy with this PR..