### PR TITLE
Updated xobjdetect module CMakeLists.txt

### DIFF
--- a/modules/xobjdetect/CMakeLists.txt
+++ b/modules/xobjdetect/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(the_description "Object detection algorithms")
 ocv_define_module(xobjdetect opencv_core opencv_imgproc opencv_highgui opencv_objdetect WRAP python)
-if (NOT APPLE_FRAMEWORK)
+if (BUILD_opencv_apps AND NOT APPLE_FRAMEWORK)
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tools ${CMAKE_CURRENT_BINARY_DIR}/tools)
 endif()


### PR DESCRIPTION
Currently if you are building OpenCV with contrib under ios, not as framework, that can leads to errors in config station of cmake.
I suppose it would be better if xobjdetect module tool will be optional with the BUILD_opencv_apps just like others tools in OpenCV

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

CMakeLists.txt in xobjdetect module. Add option not to build tool at xobjdetect module

<!-- Please describe what your pullrequest is changing -->
