### PR TITLE
one of the tracking files will not compile without an include from da…

### DIFF
--- a/modules/tracking/CMakeLists.txt
+++ b/modules/tracking/CMakeLists.txt
@@ -1,2 +1,2 @@
 set(the_description "Tracking API")
-ocv_define_module(tracking opencv_imgproc opencv_core opencv_video opencv_highgui opencv_dnn opencv_plot OPTIONAL opencv_datasets WRAP java python)
+ocv_define_module(tracking opencv_imgproc opencv_core opencv_video opencv_highgui opencv_dnn opencv_plot opencv_datasets WRAP java python)


### PR DESCRIPTION
Without this fix compilation of opencv_tracking will fail with:

In file included from /code/opencv_contrib/modules/tracking/src/gtrTracker.hpp:49:0,
                 from /code/opencv_contrib/modules/tracking/src/gtrTracker.cpp:42:
/code/opencv_contrib/modules/tracking/src/gtrUtils.hpp:7:43: fatal error: opencv2/datasets/track_alov.hpp: No such file or directory
compilation terminated.
