### PR TITLE
Fix reallocation issue of raw poses vector

### DIFF
--- a/modules/surface_matching/include/opencv2/surface_matching/ppf_match_3d.hpp
+++ b/modules/surface_matching/include/opencv2/surface_matching/ppf_match_3d.hpp
@@ -166,7 +166,7 @@ private:
 
   bool matchPose(const Pose3D& sourcePose, const Pose3D& targetPose);
 
-  void clusterPoses(std::vector<Pose3DPtr> poseList, int numPoses, std::vector<Pose3DPtr> &finalPoses);
+  void clusterPoses(std::vector<Pose3DPtr>& poseList, int numPoses, std::vector<Pose3DPtr> &finalPoses);
 
   bool trained;
 };

--- a/modules/surface_matching/src/ppf_match_3d.cpp
+++ b/modules/surface_matching/src/ppf_match_3d.cpp
@@ -327,7 +327,7 @@ bool PPF3DDetector::matchPose(const Pose3D& sourcePose, const Pose3D& targetPose
   return (phi<this->rotation_threshold && dNorm < this->position_threshold);
 }
 
-void PPF3DDetector::clusterPoses(std::vector<Pose3DPtr> poseList, int numPoses, std::vector<Pose3DPtr> &finalPoses)
+void PPF3DDetector::clusterPoses(std::vector<Pose3DPtr>& poseList, int numPoses, std::vector<Pose3DPtr> &finalPoses)
 {
   std::vector<PoseCluster3DPtr> poseClusters;
 


### PR DESCRIPTION
### This pullrequest changes
Fixes a reallocation issue that causes crashes rarely in Python wrapper (and possibly in C++ apps as well).

Edit: Seems the crashes were caused by OpenMP as in #1055, however, fixing the reallocation is still recommended.