### PR TITLE
Thread-safe vector insertion while using OpenMP

### DIFF
--- a/modules/surface_matching/src/ppf_match_3d.cpp
+++ b/modules/surface_matching/src/ppf_match_3d.cpp
@@ -645,7 +645,12 @@ void PPF3DDetector::match(const Mat& pc, std::vector<Pose3DPtr>& results, const 
 
     Pose3DPtr pose(new Pose3D(alpha, refIndMax, maxVotes));
     pose->updatePose(rawPose);
-    poseList.push_back(pose);
+    #if defined (_OPENMP)
+    #pragma omp critical
+    #endif
+    {
+      poseList.push_back(pose);
+    }
 
 #if defined (_OPENMP)
     free(accumulator);


### PR DESCRIPTION
### This pullrequest changes
Fixes thread-unsafe insertion of raw poses