### PR TITLE
Stop ICP iterations before solver crashes due to underdetermined system

### DIFF
--- a/modules/surface_matching/src/icp.cpp
+++ b/modules/surface_matching/src/icp.cpp
@@ -452,7 +452,7 @@ int ICP::registerModelToScene(const Mat& srcPC, const Mat& dstPC, double& residu
 
       hashtableDestroy(duplicateTable);
 
-      if (selInd)
+      if (selInd >= 6)
       {
 
         Mat Src_Match = Mat(selInd, srcPCT.cols, CV_64F);


### PR DESCRIPTION
The `minimizePointToPlaneMetric()` calls `cv::solve()` to solve a linear system consisting of six compoenents:
- Euler angles (3 components: roll, pitch, yaw) 
- Translation (three components: X, Y, Z)

In order to solve such linear system, there should be at least six points corresponding between the model and scene clouds. However, current implementation constrain minimal limit to only one point, which may cause crashes.

### This pullrequest changes
Sets a minimum limit of six-points correspondance in order to iterate ICP further