### PR TITLE
Fix uninitialized LSC weights

### DIFF
--- a/modules/ximgproc/src/lsc.cpp
+++ b/modules/ximgproc/src/lsc.cpp
@@ -1165,7 +1165,7 @@ inline void SuperpixelLSCImpl::GetFeatureSpace()
     }
 
     // compute m_W normalization array
-    m_W = Mat( m_height, m_width, CV_32F );
+    m_W = Mat( m_height, m_width, CV_32F, 0.0f );
     parallel_for_( Range(0, m_width), FeatureSpaceWeights( m_chvec, &m_W,
                    sigmaX1, sigmaX2, sigmaY1, sigmaY2, sigmaC1, sigmaC2,
                    m_nr_channels, m_chvec_max, m_dist_coeff, m_color_coeff,


### PR DESCRIPTION
### This pullrequest changes

Valgrind complains about jumps depending on uninitialized memory originating from `m_W`. And indeed, when the weights are computed in `FeatureSpaceWeights`, they are not initialized but immediately updated (see https://github.com/opencv/opencv_contrib/blob/ab5f5d6ca20014d1a0200176d4e3dacfd6c8762a/modules/ximgproc/src/lsc.cpp#L1071-L1074). This may be fixed by explicitly setting the `m_W` `Mat` to zero.