### PR TITLE
tracking: hide getModel() method in Tracker API

### DIFF
--- a/modules/tracking/include/opencv2/tracking/tracker.hpp
+++ b/modules/tracking/include/opencv2/tracking/tracker.hpp
@@ -565,11 +565,6 @@ class CV_EXPORTS_W Tracker : public virtual Algorithm
   virtual void read( const FileNode& fn )=0;
   virtual void write( FileStorage& fs ) const=0;
 
-  Ptr<TrackerModel> getModel()
-  {
-    return model;
-  }
-
  protected:
 
   virtual bool initImpl( const Mat& image, const Rect2d& boundingBox ) = 0;

--- a/modules/tracking/src/tldTracker.hpp
+++ b/modules/tracking/src/tldTracker.hpp
@@ -122,6 +122,11 @@ public:
 	void read(const FileNode& fn);
 	void write(FileStorage& fs) const;
 
+    Ptr<TrackerModel> getModel()
+    {
+      return model;
+    }
+
 	class Pexpert
 	{
 	public:


### PR DESCRIPTION
`TrackerModel` is private stuff, so it's better to hide it.
Related: https://github.com/opencv/opencv/issues/8451