### PR TITLE
issue_1100 dnn and xfeatures2d cmake ocv_download needs PACKAGE instead of FILENAME

### DIFF
--- a/modules/dnn/cmake/OpenCVFindLibProtobuf.cmake
+++ b/modules/dnn/cmake/OpenCVFindLibProtobuf.cmake
@@ -29,7 +29,7 @@ if(PROTOBUF_FOUND)
 else()
   set(PROTOBUF_CPP_PATH "${OpenCV_BINARY_DIR}/3rdparty/protobuf")
   set(PROTOBUF_CPP_ROOT "${PROTOBUF_CPP_PATH}/protobuf-3.1.0")
-  ocv_download(FILENAME "protobuf-cpp-3.1.0.tar.gz"
+  ocv_download(PACKAGE "protobuf-cpp-3.1.0.tar.gz"
                HASH "bd5e3eed635a8d32e2b99658633815ef"
                URL
                  "${OPENCV_PROTOBUF_URL}"

--- a/modules/xfeatures2d/cmake/download_boostdesc.cmake
+++ b/modules/xfeatures2d/cmake/download_boostdesc.cmake
@@ -19,7 +19,7 @@ function(download_boost_descriptors dst_dir status_var)
 
   set(${status_var} TRUE PARENT_SCOPE)
   foreach(id ${ids})
-    ocv_download(FILENAME ${name_${id}}
+    ocv_download(PACKAGE ${name_${id}}
                  HASH ${hash_${id}}
                  URL
                    "${OPENCV_BOOSTDESC_URL}"

--- a/modules/xfeatures2d/cmake/download_vgg.cmake
+++ b/modules/xfeatures2d/cmake/download_vgg.cmake
@@ -13,7 +13,7 @@ function(download_vgg_descriptors dst_dir status_var)
 
   set(${status_var} TRUE PARENT_SCOPE)
   foreach(id ${ids})
-    ocv_download(FILENAME ${name_${id}}
+    ocv_download(PACKAGE ${name_${id}}
                  HASH ${hash_${id}}
                  URL
                    "${OPENCV_VGGDESC_URL}"


### PR DESCRIPTION
Update the dnn and xfeatures2d cmake files to use PACKAGE instead of
FILENAME when invoking opencv’s ocv_download function in
opencv-3.2.0/cmake/OpenCVUtils.cmake