### PR TITLE
Reuse DNN outputs

### DIFF
--- a/modules/dnn/src/layers/batch_norm_layer.cpp
+++ b/modules/dnn/src/layers/batch_norm_layer.cpp
@@ -30,6 +30,15 @@ public:
         epsilon = params.get<float>("eps", 1E-5);
     }
 
+    bool getMemoryShapes(const std::vector<MatShape> &inputs,
+                         const int requiredOutputs,
+                         std::vector<MatShape> &outputs,
+                         std::vector<MatShape> &internals) const
+    {
+        Layer::getMemoryShapes(inputs, requiredOutputs, outputs, internals);
+        return true;
+    }
+
     void forward(std::vector<Mat*> &inputs, std::vector<Mat> &outputs, std::vector<Mat> &internals)
     {
         CV_Assert(blobs.size() >= 2);

--- a/modules/dnn/src/layers/blank_layer.cpp
+++ b/modules/dnn/src/layers/blank_layer.cpp
@@ -61,7 +61,12 @@ public:
         return true;
     }
 
-    void forward(std::vector<Mat*> &inputs, std::vector<Mat> &outputs, std::vector<Mat> &internals) {}
+    void forward(std::vector<Mat*> &inputs, std::vector<Mat> &outputs, std::vector<Mat> &internals)
+    {
+        for (int i = 0, n = outputs.size(); i < n; ++i)
+            if (outputs[i].data != inputs[i]->data)
+                inputs[i]->copyTo(outputs[i]);
+    }
 };
 
 Ptr<BlankLayer> BlankLayer::create(const LayerParams& params)

--- a/modules/dnn/src/layers/reshape_layer.cpp
+++ b/modules/dnn/src/layers/reshape_layer.cpp
@@ -178,7 +178,7 @@ public:
         for (size_t i = 0; i < inputs.size(); i++)
         {
             Mat srcBlob = *inputs[i];
-            MatShape inputShape = shape(srcBlob);
+            MatShape inputShape = shape(srcBlob), outShape = shape(outputs[i]);
 
             if (performReordering)
             {
@@ -203,6 +203,11 @@ public:
                     }
                 }
                 internals[i].copyTo(outputs[i]);
+            }
+            else
+            {
+                if (outputs[i].data != srcBlob.data)
+                    srcBlob.reshape(1, outShape).copyTo(outputs[i]);
             }
         }
     }

--- a/modules/dnn/src/layers/scale_layer.cpp
+++ b/modules/dnn/src/layers/scale_layer.cpp
@@ -27,6 +27,15 @@ public:
         hasBias = params.get<bool>("bias_term", false);
     }
 
+    bool getMemoryShapes(const std::vector<MatShape> &inputs,
+                         const int requiredOutputs,
+                         std::vector<MatShape> &outputs,
+                         std::vector<MatShape> &internals) const
+    {
+        Layer::getMemoryShapes(inputs, requiredOutputs, outputs, internals);
+        return true;
+    }
+
     void forward(std::vector<Mat*> &inputs, std::vector<Mat> &outputs, std::vector<Mat> &internals)
     {
         CV_Assert(blobs.size() == 1 + hasBias);

--- a/modules/dnn/src/layers/split_layer.cpp
+++ b/modules/dnn/src/layers/split_layer.cpp
@@ -72,17 +72,17 @@ public:
     {
         CV_Assert(inputs.size() == 1);
 
-        outputs.resize(outputsCount >= 0 ? outputsCount : requiredOutputs,
-                       inputs[0]);
-
-        return false;
+        Layer::getMemoryShapes(inputs, outputsCount >= 0 ? outputsCount : requiredOutputs,
+                               outputs, internals);
+        return true;
     }
 
     void forward(std::vector<Mat*> &inputs, std::vector<Mat> &outputs, std::vector<Mat> &internals)
     {
         for (size_t i = 0; i < outputs.size(); i++)
         {
-            inputs[0]->copyTo(outputs[i]);
+            if (outputs[i].data != inputs[0]->data)
+                inputs[0]->copyTo(outputs[i]);
         }
     }
 };

--- a/modules/dnn/test/test_caffe_importer.cpp
+++ b/modules/dnn/test/test_caffe_importer.cpp
@@ -102,7 +102,7 @@ TEST(Reproducibility_AlexNet, Accuracy)
     normAssert(ref, out);
 }
 
-#if !defined(_WIN32) || defined(_WIN64)
+#if !defined(_WIN32)
 TEST(Reproducibility_FCN, Accuracy)
 {
     Net net;


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
Proposed manager for reusing allocated blobs for layers' outputs and internals.
Enabled FCN-8s test for Win64.
Now layers just tell us that they could work in-place. But their implementation should be independent of it.
Split, batch normalization and scale layers now could work in-place. 

Note: in-place layers are only layers with single input blob (number of output blobs might be more than one).


**Measurements:**
Load model, allocate and do single forward pass.

| Model | Maximum resident memory (based on /usr/bin/time --verbore) |
|--------|------|
| ENet, 512x512x3 input image | from 828MB to 190MB (x4.36) |
|ResNet-50, 224x224x3 | from 343MB to 212MB (x1.62) |
|FCN-8s, 500x500x3 | from 4.5GB to 2.78GB (x1.62) |