### PR TITLE
aruco: make public the getBoardObjectAndImagePoints function

### DIFF
--- a/modules/aruco/include/opencv2/aruco.hpp
+++ b/modules/aruco/include/opencv2/aruco.hpp
@@ -545,7 +545,7 @@ CV_EXPORTS_W double calibrateCameraAruco(
  * @param objPoints Vector of vectors of board marker points in the board coordinate space.
  * @param imgPoints Vector of vectors of the projections of board marker corner points.
 */
-void getBoardObjectAndImagePoints(const Ptr<Board> &board, InputArrayOfArrays detectedCorners,
+CV_EXPORTS_W void getBoardObjectAndImagePoints(const Ptr<Board> &board, InputArrayOfArrays detectedCorners,
   InputArray detectedIds, OutputArray objPoints, OutputArray imgPoints);
 
 

--- a/modules/aruco/include/opencv2/aruco.hpp
+++ b/modules/aruco/include/opencv2/aruco.hpp
@@ -535,6 +535,20 @@ CV_EXPORTS_W double calibrateCameraAruco(
   TermCriteria criteria = TermCriteria(TermCriteria::COUNT + TermCriteria::EPS, 30, DBL_EPSILON));
 
 
+/**
+ * @brief Given a board configuration and a set of detected markers, returns the corresponding
+ * image points and object points to call solvePnP
+ *
+ * @param board Marker board layout.
+ * @param detectedIds List of identifiers for each marker.
+ * @param detectedCorners List of detected marker corners of the board.
+ * @param imgPoints Vector of vectors of the projections of board marker corner points.
+ * @param objPoints Vector of vectors of board marker points in the board coordinate space.
+*/
+void getBoardObjectAndImagePoints(const Ptr<Board> &board, InputArray detectedIds,
+    InputArrayOfArrays detectedCorners, OutputArray imgPoints, OutputArray objPoints);
+
+
 //! @}
 }
 }

--- a/modules/aruco/include/opencv2/aruco.hpp
+++ b/modules/aruco/include/opencv2/aruco.hpp
@@ -540,13 +540,13 @@ CV_EXPORTS_W double calibrateCameraAruco(
  * image points and object points to call solvePnP
  *
  * @param board Marker board layout.
- * @param detectedIds List of identifiers for each marker.
  * @param detectedCorners List of detected marker corners of the board.
- * @param imgPoints Vector of vectors of the projections of board marker corner points.
+ * @param detectedIds List of identifiers for each marker.
  * @param objPoints Vector of vectors of board marker points in the board coordinate space.
+ * @param imgPoints Vector of vectors of the projections of board marker corner points.
 */
-void getBoardObjectAndImagePoints(const Ptr<Board> &board, InputArray detectedIds,
-    InputArrayOfArrays detectedCorners, OutputArray imgPoints, OutputArray objPoints);
+void getBoardObjectAndImagePoints(const Ptr<Board> &board, InputArrayOfArrays detectedCorners,
+  InputArray detectedIds, OutputArray objPoints, OutputArray imgPoints);
 
 
 //! @}

--- a/modules/aruco/src/aruco.cpp
+++ b/modules/aruco/src/aruco.cpp
@@ -887,9 +887,8 @@ void estimatePoseSingleMarkers(InputArrayOfArrays _corners, float markerLength,
 
 
 
-void getBoardObjectAndImagePoints(const Ptr<Board> &board, InputArray detectedIds,
-                                          InputArrayOfArrays detectedCorners,
-                                          OutputArray imgPoints, OutputArray objPoints) {
+void getBoardObjectAndImagePoints(const Ptr<Board> &board, InputArrayOfArrays detectedCorners,
+    InputArray detectedIds, OutputArray objPoints, OutputArray imgPoints) {
 
     CV_Assert(board->ids.size() == board->objPoints.size());
     CV_Assert(detectedIds.total() == detectedCorners.total());
@@ -1239,7 +1238,7 @@ int estimatePoseBoard(InputArrayOfArrays _corners, InputArray _ids, const Ptr<Bo
 
     // get object and image points for the solvePnP function
     Mat objPoints, imgPoints;
-    getBoardObjectAndImagePoints(board, _ids, _corners, imgPoints, objPoints);
+    getBoardObjectAndImagePoints(board, _corners, _ids, objPoints, imgPoints);
 
     CV_Assert(imgPoints.total() == objPoints.total());
 
@@ -1540,8 +1539,8 @@ double calibrateCameraAruco(InputArrayOfArrays _corners, InputArray _ids, InputA
         }
         markerCounter += nMarkersInThisFrame;
         Mat currentImgPoints, currentObjPoints;
-        getBoardObjectAndImagePoints(board, thisFrameIds, thisFrameCorners, currentImgPoints,
-                                      currentObjPoints);
+        getBoardObjectAndImagePoints(board, thisFrameCorners, thisFrameIds, currentObjPoints,
+            currentImgPoints);
         if(currentImgPoints.total() > 0 && currentObjPoints.total() > 0) {
             processedImagePoints.push_back(currentImgPoints);
             processedObjectPoints.push_back(currentObjPoints);

--- a/modules/aruco/src/aruco.cpp
+++ b/modules/aruco/src/aruco.cpp
@@ -887,18 +887,14 @@ void estimatePoseSingleMarkers(InputArrayOfArrays _corners, float markerLength,
 
 
 
-/**
-  * @brief Given a board configuration and a set of detected markers, returns the corresponding
-  * image points and object points to call solvePnP
-  */
-static void _getBoardObjectAndImagePoints(const Ptr<Board> &_board, InputArray _detectedIds,
-                                          InputArrayOfArrays _detectedCorners,
-                                          OutputArray _imgPoints, OutputArray _objPoints) {
+void getBoardObjectAndImagePoints(const Ptr<Board> &board, InputArray detectedIds,
+                                          InputArrayOfArrays detectedCorners,
+                                          OutputArray imgPoints, OutputArray objPoints) {
 
-    CV_Assert(_board->ids.size() == _board->objPoints.size());
-    CV_Assert(_detectedIds.total() == _detectedCorners.total());
+    CV_Assert(board->ids.size() == board->objPoints.size());
+    CV_Assert(detectedIds.total() == detectedCorners.total());
 
-    size_t nDetectedMarkers = _detectedIds.total();
+    size_t nDetectedMarkers = detectedIds.total();
 
     vector< Point3f > objPnts;
     objPnts.reserve(nDetectedMarkers);
@@ -908,20 +904,20 @@ static void _getBoardObjectAndImagePoints(const Ptr<Board> &_board, InputArray _
 
     // look for detected markers that belong to the board and get their information
     for(unsigned int i = 0; i < nDetectedMarkers; i++) {
-        int currentId = _detectedIds.getMat().ptr< int >(0)[i];
-        for(unsigned int j = 0; j < _board->ids.size(); j++) {
-            if(currentId == _board->ids[j]) {
+        int currentId = detectedIds.getMat().ptr< int >(0)[i];
+        for(unsigned int j = 0; j < board->ids.size(); j++) {
+            if(currentId == board->ids[j]) {
                 for(int p = 0; p < 4; p++) {
-                    objPnts.push_back(_board->objPoints[j][p]);
-                    imgPnts.push_back(_detectedCorners.getMat(i).ptr< Point2f >(0)[p]);
+                    objPnts.push_back(board->objPoints[j][p]);
+                    imgPnts.push_back(detectedCorners.getMat(i).ptr< Point2f >(0)[p]);
                 }
             }
         }
     }
 
     // create output
-    Mat(objPnts).copyTo(_objPoints);
-    Mat(imgPnts).copyTo(_imgPoints);
+    Mat(objPnts).copyTo(objPoints);
+    Mat(imgPnts).copyTo(imgPoints);
 }
 
 
@@ -1243,7 +1239,7 @@ int estimatePoseBoard(InputArrayOfArrays _corners, InputArray _ids, const Ptr<Bo
 
     // get object and image points for the solvePnP function
     Mat objPoints, imgPoints;
-    _getBoardObjectAndImagePoints(board, _ids, _corners, imgPoints, objPoints);
+    getBoardObjectAndImagePoints(board, _ids, _corners, imgPoints, objPoints);
 
     CV_Assert(imgPoints.total() == objPoints.total());
 
@@ -1544,7 +1540,7 @@ double calibrateCameraAruco(InputArrayOfArrays _corners, InputArray _ids, InputA
         }
         markerCounter += nMarkersInThisFrame;
         Mat currentImgPoints, currentObjPoints;
-        _getBoardObjectAndImagePoints(board, thisFrameIds, thisFrameCorners, currentImgPoints,
+        getBoardObjectAndImagePoints(board, thisFrameIds, thisFrameCorners, currentImgPoints,
                                       currentObjPoints);
         if(currentImgPoints.total() > 0 && currentObjPoints.total() > 0) {
             processedImagePoints.push_back(currentImgPoints);


### PR DESCRIPTION
The aruco module allows to calibrate a camera using aruco markers using the `cv::aruco::calibrateCameraAruco` function, but not to calibrate a fisheye camera, or a stereo camera. This function simply internally uses `cv::aruco::getBoardObjectAndImagePoints` to extract the object points of the used aruco board for the calibration, and the OpenCV calibration function `cv::aruco::calibrateCameraAruco`.

By making the `cv::aruco::getBoardObjectAndImagePoints` function public it allows to use it with the other OpenCV calibrations function for fisheye cameras and stereo cameras.

### This pullrequest changes

- The `cv::aruco::getBoardObjectAndImagePoints` function is now public
- The arguments of this function has been reordered for consistency with `cv::calibrateCamera` and `cv::aruco::calibrateCameraAruco` functions
