### PR TITLE
MSLIC: fix uninitialized iteration variable

### DIFF
--- a/modules/ximgproc/src/slic.cpp
+++ b/modules/ximgproc/src/slic.cpp
@@ -278,6 +278,9 @@ void SuperpixelSLICImpl::initialize()
 
 void SuperpixelSLICImpl::iterate( int num_iterations )
 {
+    // store total iterations
+    m_iterations = num_iterations;
+
     if( m_algorithm == SLICO )
       PerformSLICO( num_iterations );
     else if( m_algorithm == SLIC )

--- a/modules/ximgproc/src/slic.cpp
+++ b/modules/ximgproc/src/slic.cpp
@@ -1375,10 +1375,6 @@ inline void SuperpixelSLICImpl::PerformMSLIC( const int&  itrnum )
     for( int b = 0; b < m_nr_channels; b++ )
       sigma[b].resize(m_numlabels, 0);
 
-    vector<float> sigmax(m_numlabels, 0);
-    vector<float> sigmay(m_numlabels, 0);
-    vector<int> clustersize(m_numlabels, 0);
-
     Mat distvec( m_height, m_width, CV_32F );
 
     const float xywt = (m_region_size/m_ruler)*(m_region_size/m_ruler);


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

resolves #1109 

### This pullrequest changes

The variable `m_iterations` is never initialized. This probably leads to the undeterministic behaviour as described in #1109. Maybe @cbalint13 can confirm that `itrnum` is the correct value for `m_iterations`.
