### PR TITLE
Fixed gflags search in Ubuntu

### DIFF
--- a/modules/sfm/cmake/FindGflags.cmake
+++ b/modules/sfm/cmake/FindGflags.cmake
@@ -418,7 +418,7 @@ function(__find_exported_gflags)
         "version: ${gflags_VERSION} exported here: ${gflags_DIR} using CMake.")
     endif (NOT GFLAGS_NAMESPACE)
   else (FOUND_INSTALLED_GFLAGS_CMAKE_CONFIGURATION)
-    message(STATUS "Failed to find an installed/exported CMake configuration "
+    gflags_report_not_found("Failed to find an installed/exported CMake configuration "
       "for gflags, will perform search for installed gflags components.")
   endif (FOUND_INSTALLED_GFLAGS_CMAKE_CONFIGURATION)
 


### PR DESCRIPTION
resolves https://github.com/opencv/opencv/issues/8536

`set(... PARENT_SCOPE)` block at the end of the function *__find_exported_gflags* should not be executed in case of failure. Otherwise, following calls to `find_path(GFLAGS_INCLUDE_DIR ...)` will not work.