### PR TITLE
dnn_modern: include protubuf headers in cmake

### DIFF
--- a/modules/dnn_modern/CMakeLists.txt
+++ b/modules/dnn_modern/CMakeLists.txt
@@ -93,6 +93,7 @@ else()
 endif()
 
 list(APPEND REQUIRED_LIBRARIES ${PROTOBUF_LIBRARIES})
+include_directories(SYSTEM ${PROTOBUF_INCLUDE_DIRS})
 
 ####
 # Setup the compiler options


### PR DESCRIPTION
Probably fixes #1129 