### PR TITLE
Visibility of layer options

### DIFF
--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -329,6 +329,8 @@ namespace dnn
     class CV_EXPORTS ReLULayer : public Layer
     {
     public:
+        float negativeSlope;
+
         static Ptr<ReLULayer> create(const LayerParams &params);
     };
 
@@ -365,6 +367,8 @@ namespace dnn
     class CV_EXPORTS PowerLayer : public Layer
     {
     public:
+        float power, scale, shift;
+
         static Ptr<PowerLayer> create(const LayerParams &params);
     };
 
@@ -395,18 +399,27 @@ namespace dnn
     class CV_EXPORTS BatchNormLayer : public Layer
     {
     public:
+        bool hasWeights, hasBias;
+        float epsilon;
+
         static Ptr<BatchNormLayer> create(const LayerParams &params);
     };
 
     class CV_EXPORTS MaxUnpoolLayer : public Layer
     {
     public:
+        Size poolKernel;
+        Size poolPad;
+        Size poolStride;
+
         static Ptr<MaxUnpoolLayer> create(const LayerParams &params);
     };
 
     class CV_EXPORTS ScaleLayer : public Layer
     {
     public:
+        bool hasBias;
+
         static Ptr<ScaleLayer> create(const LayerParams& params);
     };
 

--- a/modules/dnn/src/layers/batch_norm_layer.cpp
+++ b/modules/dnn/src/layers/batch_norm_layer.cpp
@@ -91,9 +91,6 @@ public:
         }
         return flops;
     }
-
-    bool hasWeights, hasBias;
-    float epsilon;
 };
 
 Ptr<BatchNormLayer> BatchNormLayer::create(const LayerParams& params)

--- a/modules/dnn/src/layers/blank_layer.cpp
+++ b/modules/dnn/src/layers/blank_layer.cpp
@@ -47,7 +47,10 @@ namespace dnn
 class BlankLayerImpl : public BlankLayer
 {
 public:
-    BlankLayerImpl(const LayerParams&) {}
+    BlankLayerImpl(const LayerParams& params)
+    {
+        setParamsFrom(params);
+    }
 
     void allocate(const std::vector<Mat*> &inputs, std::vector<Mat> &outputs)
     {

--- a/modules/dnn/src/layers/elementwise_layers.cpp
+++ b/modules/dnn/src/layers/elementwise_layers.cpp
@@ -261,6 +261,7 @@ Ptr<ReLULayer> ReLULayer::create(const LayerParams& params)
     float negativeSlope = params.get<float>("negative_slope", 0.f);
     Ptr<ReLULayer> l(new ElementWiseLayer<ReLUFunctor>(true, ReLUFunctor(negativeSlope)));
     l->setParamsFrom(params);
+    l->negativeSlope = negativeSlope;
 
     return l;
 }
@@ -306,6 +307,9 @@ Ptr<PowerLayer> PowerLayer::create(const LayerParams& params)
                       (PowerLayer*)(new ElementWiseLayer<PowerFunctor1>(false, PowerFunctor1(scale, shift))) :
                       (PowerLayer*)(new ElementWiseLayer<PowerFunctor>(true, PowerFunctor(power, scale, shift))));
     l->setParamsFrom(params);
+    l->power = power;
+    l->scale = scale;
+    l->shift = shift;
 
     return l;
 }

--- a/modules/dnn/src/layers/max_unpooling_layer.cpp
+++ b/modules/dnn/src/layers/max_unpooling_layer.cpp
@@ -81,10 +81,6 @@ public:
             }
         }
     }
-
-    Size poolKernel;
-    Size poolPad;
-    Size poolStride;
 };
 
 Ptr<MaxUnpoolLayer> MaxUnpoolLayer::create(const LayerParams& params)

--- a/modules/dnn/src/layers/scale_layer.cpp
+++ b/modules/dnn/src/layers/scale_layer.cpp
@@ -67,8 +67,6 @@ public:
         }
         return flops;
     }
-
-    bool hasBias;
 };
 
 


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
BatchNorm, Scale, ReLU, Power and MaxUnpool layers parameters and flags are public. Motivated by another layers (Pooling, Conv, etc.).
Added initialization of names of Blank layers (Dropout, Identity).
