### PR TITLE
Framework for a viable way to add some more binarization algorithms, …

### DIFF
--- a/modules/ximgproc/doc/ximgproc.bib
+++ b/modules/ximgproc/doc/ximgproc.bib
@@ -222,3 +222,40 @@
   pages={191--196},
   year={1997}
 }
+
+@book{Niblack1985,
+  title={An introduction to digital image processing},
+  author={Niblack, Wayne},
+  year={1985},
+  publisher={Strandberg Publishing Company}
+}
+
+@inproceedings{Sauvola1997,
+  title={Adaptive document binarization},
+  author={Sauvola, Jaakko and Seppanen, Tapio and Haapakoski, Sami and Pietikainen, Matti},
+  booktitle={Document Analysis and Recognition, 1997., Proceedings of the Fourth International Conference on},
+  volume={1},
+  pages={147--152},
+  year={1997},
+  organization={IEEE}
+}
+
+@article{Wolf2004,
+  title={Extraction and recognition of artificial text in multimedia documents},
+  author={Wolf, Christian and Jolion, J-M},
+  journal={Pattern Analysis \& Applications},
+  volume={6},
+  number={4},
+  pages={309--326},
+  year={2004},
+  publisher={Springer}
+}
+
+@inproceedings{Khurshid2009,
+  title={Comparison of Niblack inspired Binarization methods for ancient documents},
+  author={Khurshid, Khurram and Siddiqi, Imran and Faure, Claudie and Vincent, Nicole},
+  booktitle={IS\&T/SPIE Electronic Imaging},
+  pages={72470U--72470U},
+  year={2009},
+  organization={International Society for Optics and Photonics}
+}

--- a/modules/ximgproc/include/opencv2/ximgproc.hpp
+++ b/modules/ximgproc/include/opencv2/ximgproc.hpp
@@ -79,10 +79,21 @@ enum ThinningTypes{
     THINNING_GUOHALL      = 1  // Thinning technique of Guo-Hall
 };
 
+/**
+* @brief Specifies the binarization method to use in cv::ximgproc::niBlackThreshold
+*/
+enum LocalBinarizationMethods{
+	BINARIZATION_NIBLACK = 0, //!< Classic Niblack binarization. See @cite Niblack1985 .
+	BINARIZATION_SAUVOLA = 1, //!< Sauvola's technique. See @cite Sauvola1997 .
+	BINARIZATION_WOLF = 2,    //!< Wolf's technique. See @cite Wolf2004 .
+	BINARIZATION_NICK = 3     //!< NICK technique. See @cite Khurshid2009 .
+};
+
 //! @addtogroup ximgproc
 //! @{
 
-/** @brief Applies Niblack thresholding to input image.
+/** @brief Performs thresholding on input images using Niblack's technique or some of the
+popular variations it inspired.
 
 The function transforms a grayscale image to a binary image according to the formulae:
 -   **THRESH_BINARY**
@@ -91,8 +102,9 @@ The function transforms a grayscale image to a binary image according to the for
     \f[dst(x,y) =  \fork{0}{if \(src(x,y) > T(x,y)\)}{\texttt{maxValue}}{otherwise}\f]
 where \f$T(x,y)\f$ is a threshold calculated individually for each pixel.
 
-The threshold value \f$T(x, y)\f$ is the mean minus \f$ delta \f$ times standard deviation
-of \f$\texttt{blockSize} \times\texttt{blockSize}\f$ neighborhood of \f$(x, y)\f$.
+The threshold value \f$T(x, y)\f$ is determined based on the binarization method chosen. For
+classic Niblack, it is the mean minus \f$ k \f$ times standard deviation of
+\f$\texttt{blockSize} \times\texttt{blockSize}\f$ neighborhood of \f$(x, y)\f$.
 
 The function can't process the image in-place.
 
@@ -103,14 +115,17 @@ used with the THRESH_BINARY and THRESH_BINARY_INV thresholding types.
 @param type Thresholding type, see cv::ThresholdTypes.
 @param blockSize Size of a pixel neighborhood that is used to calculate a threshold value
 for the pixel: 3, 5, 7, and so on.
-@param delta Constant multiplied with the standard deviation and subtracted from the mean.
-Normally, it is taken to be a real number between 0 and 1.
+@param k The user-adjustable parameter used by Niblack and inspired techniques. For Niblack, this is
+normally a value between 0 and 1 that is multiplied with the standard deviation and subtracted from
+the mean.
+@param binarizationMethod Binarization method to use. By default, Niblack's technique is used.
+Other techniques can be specified, see cv::ximgproc::LocalBinarizationMethods.
 
 @sa  threshold, adaptiveThreshold
  */
 CV_EXPORTS_W void niBlackThreshold( InputArray _src, OutputArray _dst,
                                     double maxValue, int type,
-                                    int blockSize, double delta );
+                                    int blockSize, double k, int binarizationMethod = BINARIZATION_NIBLACK );
 
 /** @brief Applies a binary blob thinning operation, to achieve a skeletization of the input image.
 

--- a/modules/ximgproc/samples/niblack_thresholding.cpp
+++ b/modules/ximgproc/samples/niblack_thresholding.cpp
@@ -16,6 +16,7 @@ Mat_<uchar> src;
 int k_ = 8;
 int blockSize_ = 11;
 int type_ = THRESH_BINARY;
+int method_ = BINARIZATION_NIBLACK;
 
 void on_trackbar(int, void*);
 
@@ -34,6 +35,7 @@ int main(int argc, char** argv)
     namedWindow("Niblack", WINDOW_AUTOSIZE);
     createTrackbar("k", "Niblack", &k_, 20, on_trackbar);
     createTrackbar("blockSize", "Niblack", &blockSize_, 30, on_trackbar);
+    createTrackbar("method", "Niblack", &method_, 3, on_trackbar);
     createTrackbar("threshType", "Niblack", &type_, 4, on_trackbar);
     on_trackbar(0, 0);
     waitKey(0);
@@ -47,7 +49,8 @@ void on_trackbar(int, void*)
     int blockSize = 2*(blockSize_ >= 1 ? blockSize_ : 1) + 1; // 3,5,7,...,61
     int type = type_;  // THRESH_BINARY, THRESH_BINARY_INV,
                        // THRESH_TRUNC, THRESH_TOZERO, THRESH_TOZERO_INV
+    int method = method_; //BINARIZATION_NIBLACK, BINARIZATION_SAUVOLA, BINARIZATION_WOLF, BINARIZATION_NICK
     Mat dst;
-    niBlackThreshold(src, dst, 255, type, blockSize, k);
+    niBlackThreshold(src, dst, 255, type, blockSize, k, method);
     imshow("Niblack", dst);
 }


### PR DESCRIPTION
…by extending the current niBlackThreshold implementation






<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1138 
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->

Please see #1138 for context, where I proposed adding some more binarization algos.

This PR is a _draft_ of my proposed way to add some more Niblack inspired binarization algorithms to opencv_contrib. It is only a draft, I am looking for a first review.

Could I kindly get someone to review it and get an opinion on whether this is a way to go to add some more popular binarization algos? If this is the way to go, then I will gladly finish it off: tidying up source, update docs, etc...

3 major changes here to give the idea of what I propose:
1. Added enum to denote common NIblack inspired binarization algos.

2. Changed the current Niblack implementation (cv::ximgproc::niBlackThreshold)to handle multiple Niblack inspired algos including the original Niblack. I'm using the "delta" parameter of existing niBlackThreshold to pass values to algos' user-defined parameters. 

3. Changed the NIblack example to show that it works. Did some basic testing with DIBCO2009 and [DIBCO2016 dataset](https://vc.ee.duth.gr/h-dibco2016/benchmark/DIBCO2016_dataset-original.zip) and results seem reasonable. Use the "method" slider to switch between algos.