### PR TITLE
Removed an extra reallocation of networks every setBlob call.

### DIFF
--- a/modules/dnn/src/dnn.cpp
+++ b/modules/dnn/src/dnn.cpp
@@ -604,10 +604,10 @@ void Net::setBlob(String outputName, const Mat &blob_)
 
     LayerData &ld = impl->layers[pin.lid];
     ld.outputBlobs.resize( std::max(pin.oid+1, (int)ld.requiredOutputs.size()) );
-    MatSize prevShape = ld.outputBlobs[pin.oid].size;
+    bool oldShape = ld.outputBlobs[pin.oid].size == blob_.size;
     ld.outputBlobs[pin.oid] = blob_.clone();
 
-    impl->netWasAllocated = impl->netWasAllocated && prevShape == blob_.size;
+    impl->netWasAllocated = impl->netWasAllocated && oldShape;
 }
 
 Mat Net::getBlob(String outputName)


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
Before PR changes, every `setBlob` call reallocated network. Despite the same shapes.