### PR TITLE
Fix changes with allocating memory outside layers.

### DIFF
--- a/modules/dnn/src/layers/blank_layer.cpp
+++ b/modules/dnn/src/layers/blank_layer.cpp
@@ -49,18 +49,16 @@ class BlankLayerImpl : public BlankLayer
 public:
     BlankLayerImpl(const LayerParams&) {}
 
-    void allocate(const std::vector<Mat*> &inputs, std::vector<Mat> &outputs)
+    bool getMemoryShapes(const std::vector<MatShape> &inputs,
+                         const int requiredOutputs,
+                         std::vector<MatShape> &outputs,
+                         std::vector<MatShape> &internals) const
     {
-        outputs.resize(inputs.size());
-        for (size_t i = 0; i < inputs.size(); i++)
-            outputs[i] = *inputs[i];
+        Layer::getMemoryShapes(inputs, requiredOutputs, outputs, internals);
+        return true;
     }
 
-    void forward(std::vector<Mat*> &inputs, std::vector<Mat> &outputs, std::vector<Mat> &internals)
-    {
-        for (size_t i = 0; i < inputs.size(); i++)
-            outputs[i] = *inputs[i];
-    }
+    void forward(std::vector<Mat*> &inputs, std::vector<Mat> &outputs, std::vector<Mat> &internals) {}
 };
 
 Ptr<BlankLayer> BlankLayer::create(const LayerParams& params)

--- a/modules/dnn/src/layers/elementwise_layers.cpp
+++ b/modules/dnn/src/layers/elementwise_layers.cpp
@@ -37,9 +37,9 @@ public:
     ElementWiseLayer(bool run_parallel_=false, const Func &f=Func()) : func(f), run_parallel(run_parallel_) {}
 
     bool getMemoryShapes(const std::vector<MatShape> &inputs,
-                                         const int requiredOutputs,
-                                         std::vector<MatShape> &outputs,
-                                         std::vector<MatShape> &internals) const
+                         const int requiredOutputs,
+                         std::vector<MatShape> &outputs,
+                         std::vector<MatShape> &internals) const
     {
         Layer::getMemoryShapes(inputs, requiredOutputs, outputs, internals);
         return true;

--- a/modules/dnn/src/layers/pooling_layer.cpp
+++ b/modules/dnn/src/layers/pooling_layer.cpp
@@ -203,7 +203,13 @@ public:
         CV_Assert(inputs.size() != 0);
         Size in(inputs[0][3], inputs[0][2]), out;
 
-        if (padMode.empty()) {
+        if (globalPooling)
+        {
+            out.height = 1;
+            out.width = 1;
+        }
+        else if (padMode.empty())
+        {
             //Yeah, something strange Caffe scheme-)
             out.height = static_cast<int>(ceil(static_cast<float>(in.height + 2 * pad.height -
                                                                   kernel.height) / stride.height)) + 1;


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
* Removed `allocate` method from Blank layer.
* Correct global average pooling output shape computation (in case of global pooling kernel size initializes properly in `finalize` that calls after all allocations).
* Removed a temporal Mat allocation from Reshape layer.