### PR TITLE
Contrib.java.wrapper.fix.3.2

### DIFF
--- a/modules/text/CMakeLists.txt
+++ b/modules/text/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(the_description "Text Detection and Recognition")
-ocv_define_module(text opencv_ml opencv_imgproc opencv_core opencv_features2d OPTIONAL opencv_highgui WRAP python)
+ocv_define_module(text opencv_ml opencv_imgproc opencv_core opencv_features2d OPTIONAL opencv_highgui WRAP python java)
 
 if(NOT CMAKE_CROSSCOMPILING OR OPENCV_FIND_TESSERACT)
   set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)

--- a/modules/text/include/opencv2/text/erfilter.hpp
+++ b/modules/text/include/opencv2/text/erfilter.hpp
@@ -193,10 +193,10 @@ public:
 loadClassifierNM1, e.g. from file in samples/cpp/trained_classifierNM1.xml
 @param  thresholdDelta :   Threshold step in subsequent thresholds when extracting the component tree
 @param  minArea :   The minimum area (% of image size) allowed for retreived ER's
-@param  minArea :   The maximum area (% of image size) allowed for retreived ER's
+@param  maxArea :   The maximum area (% of image size) allowed for retreived ER's
 @param  minProbability :   The minimum probability P(er|character) allowed for retreived ER's
 @param  nonMaxSuppression :   Whenever non-maximum suppression is done over the branch probabilities
-@param  minProbability :   The minimum probability difference between local maxima and local minima ERs
+@param  minProbabilityDiff :   The minimum probability difference between local maxima and local minima ERs
 
 The component tree of the image is extracted by a threshold increased step by step from 0 to 255,
 incrementally computable descriptors (aspect_ratio, compactness, number of holes, and number of
@@ -227,6 +227,24 @@ features: hole area ratio, convex hull ratio, and number of outer inflexion poin
 CV_EXPORTS_W Ptr<ERFilter> createERFilterNM2(const Ptr<ERFilter::Callback>& cb,
                                                   float minProbability = (float)0.3);
 
+/** @brief Reads an Extremal Region Filter for the 1st stage classifier of N&M algorithm
+    from the provided path e.g. /path/to/cpp/trained_classifierNM1.xml
+
+@overload
+ */
+CV_EXPORTS_W  Ptr<ERFilter> createERFilterNM1(const String& filename,
+                                                  int thresholdDelta = 1, float minArea = (float)0.00025,
+                                                  float maxArea = (float)0.13, float minProbability = (float)0.4,
+                                                  bool nonMaxSuppression = true,
+                                                  float minProbabilityDiff = (float)0.1);
+
+/** @brief Reads an Extremal Region Filter for the 2nd stage classifier of N&M algorithm
+    from the provided path e.g. /path/to/cpp/trained_classifierNM2.xml
+
+@overload
+ */
+CV_EXPORTS_W Ptr<ERFilter> createERFilterNM2(const String& filename,
+                                                  float minProbability = (float)0.3);
 
 /** @brief Allow to implicitly load the default classifier when creating an ERFilter object.
 

--- a/modules/text/include/opencv2/text/ocr.hpp
+++ b/modules/text/include/opencv2/text/ocr.hpp
@@ -61,6 +61,31 @@ enum
     OCR_LEVEL_TEXTLINE
 };
 
+//! Tesseract.PageSegMode Enumeration
+enum page_seg_mode
+{
+    PSM_OSD_ONLY,
+    PSM_AUTO_OSD,
+    PSM_AUTO_ONLY,
+    PSM_AUTO,
+    PSM_SINGLE_COLUMN,
+    PSM_SINGLE_BLOCK_VERT_TEXT,
+    PSM_SINGLE_BLOCK,
+    PSM_SINGLE_LINE,
+    PSM_SINGLE_WORD,
+    PSM_CIRCLE_WORD,
+    PSM_SINGLE_CHAR
+};
+
+//! Tesseract.OcrEngineMode Enumeration
+enum ocr_engine_mode
+{
+    OEM_TESSERACT_ONLY,
+    OEM_CUBE_ONLY,
+    OEM_TESSERACT_CUBE_COMBINED,
+    OEM_DEFAULT
+};
+
 //base class BaseOCR declares a common API that would be used in a typical text recognition scenario
 class CV_EXPORTS_W BaseOCR
 {
@@ -136,7 +161,7 @@ public:
     possible values.
      */
     CV_WRAP static Ptr<OCRTesseract> create(const char* datapath=NULL, const char* language=NULL,
-                                    const char* char_whitelist=NULL, int oem=3, int psmode=3);
+                                    const char* char_whitelist=NULL, int oem=OEM_DEFAULT, int psmode=PSM_AUTO);
 };
 
 

--- a/modules/text/src/erfilter.cpp
+++ b/modules/text/src/erfilter.cpp
@@ -279,9 +279,9 @@ void ERFilterNM::er_tree_extract( InputArray image )
 
     // the quads for euler number calculation
     // quads[2][2] and quads[2][3] are never used.
-    // The four lowest bits in each quads[i][j] correspond to the 2x2 binary patterns 
-    // Q_1, Q_2, Q_3 in the Neumann and Matas CVPR 2012 paper 
-    // (see in page 4 at the end of first column). 
+    // The four lowest bits in each quads[i][j] correspond to the 2x2 binary patterns
+    // Q_1, Q_2, Q_3 in the Neumann and Matas CVPR 2012 paper
+    // (see in page 4 at the end of first column).
     // Q_1 and Q_2 have four patterns, while Q_3 has only two.
     const int quads[3][4] =
     {
@@ -1143,6 +1143,17 @@ Ptr<ERFilter> createERFilterNM2(const Ptr<ERFilter::Callback>& cb, float minProb
 
     filter->setMinProbability(minProbability);
     return (Ptr<ERFilter>)filter;
+}
+
+Ptr<ERFilter> createERFilterNM1(const String& filename, int _thresholdDelta,
+                                float _minArea, float _maxArea, float _minProbability,
+                                bool _nonMaxSuppression, float _minProbabilityDiff) {
+    return createERFilterNM1(loadClassifierNM1(filename), _thresholdDelta, _minArea, _maxArea, _minProbability, _nonMaxSuppression, _minProbabilityDiff);
+
+}
+
+Ptr<ERFilter> createERFilterNM2(const String& filename, float _minProbability) {
+    return createERFilterNM2(loadClassifierNM2(filename), _minProbability);
 }
 
 /*!


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
resolves #1188 

additional constructors were added to ERFilter class where the callback parameter has been replaced with the String designating the filename of the XML or YAML file with the classifier model (e.g. trained_classifierNM1.xml):

```
CV_EXPORTS_W  Ptr<ERFilter> createERFilterNM1(const String& filename,
                                                  int thresholdDelta = 1, float minArea = (float)0.00025,
                                                  float maxArea = (float)0.13, float minProbability = (float)0.4,
                                                  bool nonMaxSuppression = true,
                                                  float minProbabilityDiff = (float)0.1);
```

```
CV_EXPORTS_W Ptr<ERFilter> createERFilterNM2(const String& filename,
                                                  float minProbability = (float)0.3);

```

The example of calling these constructors from Java:

```
ERFilter erc1 = Text.createERFilterNM1(strClassifierNM1Path,16,0.00015f,0.13f,0.2f,true,0.1f);
ERFilter erc2 = Text.createERFilterNM2(strClassifierNM2Path, 0.5f); 
```