### PR TITLE
Fix reshape layer

### DIFF
--- a/modules/dnn/test/test_torch_importer.cpp
+++ b/modules/dnn/test/test_torch_importer.cpp
@@ -122,6 +122,7 @@ TEST(Torch_Importer, run_reshape)
 {
     runTorchNet("net_reshape");
     runTorchNet("net_reshape_batch");
+    runTorchNet("net_reshape_single_sample");
 }
 
 TEST(Torch_Importer, run_linear)


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
Added more complicated tests for Torch reshape layer in https://github.com/opencv/opencv_extra/pull/340 .
Fixed layer more carefully process `batch_size = 1` and cases with reshape without batching.