### PR TITLE
Blobs reuse improvement

### DIFF
--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -369,6 +369,21 @@ namespace dnn //! This namespace is used for dnn module functionlaity.
          CV_WRAP void getMemoryConsumption(const int layerId,
                                            const MatShape& netInputShape,
                                            size_t& weights, size_t& blobs) const;
+
+         /** @brief Computes bytes number which are requered to store
+          * all weights and intermediate blobs for each layer.
+          * @param netInputShapes vector of shapes for all net inputs.
+          * @param layerIds output vector to save layer IDs.
+          * @param weights output parameter to store resulting bytes for weights.
+          * @param blobs output parameter to store resulting bytes for intermediate blobs.
+          */
+         CV_WRAP void getMemoryConsumption(const std::vector<MatShape>& netInputShapes,
+                                           std::vector<int>& layerIds, std::vector<size_t>& weights,
+                                           std::vector<size_t>& blobs) const;
+         /** @overload */
+         CV_WRAP void getMemoryConsumption(const MatShape& netInputShape,
+                                           std::vector<int>& layerIds, std::vector<size_t>& weights,
+                                           std::vector<size_t>& blobs) const;
     private:
 
         struct Impl;

--- a/modules/dnn/misc/python/pyopencv_dnn.hpp
+++ b/modules/dnn/misc/python/pyopencv_dnn.hpp
@@ -2,6 +2,7 @@
 typedef dnn::DictValue LayerId;
 typedef std::vector<dnn::MatShape> vector_MatShape;
 typedef std::vector<std::vector<dnn::MatShape> > vector_vector_MatShape;
+typedef std::vector<size_t> vector_size_t;
 
 template<>
 bool pyopencv_to(PyObject *o, dnn::DictValue &dv, const char *name)

--- a/modules/dnn/src/dnn.cpp
+++ b/modules/dnn/src/dnn.cpp
@@ -55,6 +55,22 @@ using std::map;
 using std::make_pair;
 using std::set;
 
+namespace
+{
+    typedef std::vector<MatShape> ShapesVec;
+
+    struct LayerShapes
+    {
+        ShapesVec in, out, internal;
+        // No guarantees that layer which support in-place computations
+        // will be computed in-place (input.data_ptr == output.data_ptr).
+        // If layer said that it could work in-place and layers after it
+        // no longer use input blob, we'll set output = input.
+        bool supportInPlace;
+        LayerShapes() {supportInPlace = false;}
+    };
+}
+
 namespace cv
 {
 namespace dnn
@@ -237,6 +253,14 @@ public:
             it->second += 1;
     }
 
+    void addReferences(const std::vector<LayerPin>& pins)
+    {
+        for (int i = 0; i < pins.size(); i++)
+        {
+            addReference(pins[i]);
+        }
+    }
+
     // Returns number of references to allocated memory that used in specific
     // layer blob.
     int numReferences(const LayerPin& lp)
@@ -282,6 +306,14 @@ public:
         refIt->second -= 1;
     }
 
+    void releaseReferences(const std::vector<LayerPin>& pins)
+    {
+        for (int i = 0; i < pins.size(); i++)
+        {
+            releaseReference(pins[i]);
+        }
+    }
+
     void reuseOrCreate(const MatShape& shape, const LayerPin& lp, Mat& dst)
     {
         std::map<LayerPin, Mat>::iterator hostIt;
@@ -320,6 +352,84 @@ public:
         }
     }
 
+    void allocateBlobsForLayer(LayerData &ld, const LayerShapes& layerShapes,
+                               std::vector<LayerPin>& pinsForInternalBlobs)
+    {
+        pinsForInternalBlobs.clear();
+
+        std::vector<Mat>& outputBlobs = ld.outputBlobs,
+                &internalBlobs = ld.internals;
+
+        const ShapesVec& outShapes = layerShapes.out,
+                internalShapes = layerShapes.internal;
+
+        outputBlobs.resize(std::max((size_t)1, outShapes.size())); //layer produce at least one output blob
+        internalBlobs.resize(internalShapes.size());
+
+        CV_Assert(ld.requiredOutputs.size() <= outShapes.size());
+
+        // Check that layer could work in-place.
+        bool inPlace = false;
+        if (layerShapes.supportInPlace)
+        {
+            if (ld.inputBlobs.size() == 1)
+            {
+                // Get number of references to the input memory.
+                int numRef = numReferences(ld.inputBlobsId[0]);
+                // If current layer is one and only customer of this blob.
+                inPlace = numRef == 1;
+            }
+        }
+
+        ShapesVec shapes(outShapes);
+        shapes.insert(shapes.end(), internalShapes.begin(), internalShapes.end());
+        std::vector<Mat*> blobs;
+        for(int i = 0; i < outputBlobs.size(); i++)
+        {
+            blobs.push_back(&outputBlobs[i]);
+        }
+
+        for(int i = 0; i < internalBlobs.size(); i++)
+        {
+            blobs.push_back(&internalBlobs[i]);
+            if (total(internalShapes[i]))
+            {
+                pinsForInternalBlobs.push_back(LayerPin(ld.id, ld.outputBlobs.size() + i));
+            }
+        }
+
+        addReferences(pinsForInternalBlobs);
+
+        std::map<int, std::vector<int> > idxSizes;
+        for(int i = 0; i < shapes.size(); i++)
+        {
+            idxSizes[total(shapes[i])].push_back(i);
+        }
+
+        std::map<int, std::vector<int> >::reverse_iterator it;
+        for(it = idxSizes.rbegin(); it != idxSizes.rend(); it++)
+        {
+            for(int j = 0; j < it->second.size(); j++)
+            {
+                int index = it->second[j];
+                if (total(shapes[index]))
+                {
+                    LayerPin blobPin(ld.id, index);
+                    if (index < outShapes.size() && inPlace)
+                    {
+                        CV_Assert(ld.inputBlobs[0]->total() == total(shapes[index]));
+                        ld.outputBlobs[index] = ld.inputBlobs[0]->reshape(1, shapes[index]);
+                        reuse(ld.inputBlobsId[0], blobPin);
+                    }
+                    else
+                    {
+                        reuseOrCreate(shapes[index], blobPin, *blobs[index]);
+                    }
+                }
+            }
+        }
+    }
+
     // Clear internal state. Calls before an every reallocation.
     void reset()
     {
@@ -346,18 +456,6 @@ private:
 
 struct Net::Impl
 {
-    typedef std::vector<MatShape> ShapesVec;
-    struct LayerShapes
-    {
-        ShapesVec in, out, internal;
-        // No guarantees that layer which support in-place computations
-        // will be computed in-place (input.data_ptr == output.data_ptr).
-        // If layer said that it could work in-place and layers after it
-        // no longer use input blob, we'll set output = input.
-        bool supportInPlace;
-        LayerShapes() {supportInPlace = false;}
-    };
-
     typedef std::map<int, LayerShapes> LayersShapesMap;
     typedef std::map<int, LayerData> MapIdToLayerData;
 
@@ -599,55 +697,11 @@ struct Net::Impl
         LayersShapesMap::const_iterator layerShapesIt = layersShapes.find(lid);
 
         CV_Assert(layerShapesIt != layersShapes.end());
-        const ShapesVec& outShapes = layerShapesIt->second.out;
-        CV_Assert(ld.requiredOutputs.size() <= outShapes.size());
 
-        ld.outputBlobs.resize(std::max((size_t)1, outShapes.size())); //layer produce at least one output blob
-
-        // Check that layer could work in-place.
-        bool inPlace = false;
-        if (layerShapesIt->second.supportInPlace)
-        {
-            if (ld.inputBlobs.size() == 1)
-            {
-                // Get number of references to the input memory.
-                int numRef = blobManager.numReferences(ld.inputBlobsId[0]);
-
-                // If current layer is one and only customer of this blob.
-                inPlace = numRef == 1;
-            }
-        }
-
-        for(int i = 0; i < outShapes.size(); i++)
-        {
-            LayerPin outputBlobPin(ld.id, i);
-            if (inPlace)
-            {
-                CV_Assert(ld.inputBlobs[0]->total() == total(outShapes[i]));
-                // Copy input blob data to every output.
-                ld.outputBlobs[i] = ld.inputBlobs[0]->reshape(1, outShapes[i]);
-                blobManager.reuse(ld.inputBlobsId[0], outputBlobPin);
-            }
-            else
-                blobManager.reuseOrCreate(outShapes[i], outputBlobPin, ld.outputBlobs[i]);
-        }
-
-        const ShapesVec& intShapes = layerShapesIt->second.internal;
-        ld.internals.resize(intShapes.size());
-        for(int i = 0; i < intShapes.size(); i++)
-        {
-            if (total(intShapes[i]))
-            {
-                LayerPin intBlobPin(ld.id, ld.outputBlobs.size() + i);
-                // Add reference to itself.
-                blobManager.addReference(intBlobPin);
-
-                blobManager.reuseOrCreate(intShapes[i], intBlobPin, ld.internals[i]);
-            }
-        }
+        std::vector<LayerPin> pinsForInternalBlobs;
+        blobManager.allocateBlobsForLayer(ld, layerShapesIt->second, pinsForInternalBlobs);
 
         Ptr<Layer> layerPtr = ld.getLayerInstance();
-        //try
         {
             layerPtr->finalize(ld.inputBlobs, ld.outputBlobs);
 #if 0
@@ -660,24 +714,10 @@ struct Net::Impl
             std::cout << "\n";
 #endif
         }
-        /*catch (const cv::Exception &err)
-        {
-            CV_RETHROW_ERROR(err, format("The following error occured while making allocate() for layer \"%s\": %s", ld.name.c_str(), err.err.c_str()));
-        }*/
 
         // After allocation of layer, we decrease counters to it's input blobs.
-        for (size_t i = 0; i < ld.inputBlobsId.size(); ++i)
-        {
-            blobManager.releaseReference(ld.inputBlobsId[i]);
-        }
-        for (size_t i = 0; i < ld.internals.size(); ++i)
-        {
-            if (total(intShapes[i]))
-            {
-                LayerPin intBlobPin(ld.id, ld.outputBlobs.size() + i);
-                blobManager.releaseReference(intBlobPin);
-            }
-        }
+        blobManager.releaseReferences(ld.inputBlobsId);
+        blobManager.releaseReferences(pinsForInternalBlobs);
 
         ld.flag = 1;
     }
@@ -702,8 +742,7 @@ struct Net::Impl
         for (it = layers.begin(); it != layers.end(); ++it)
         {
             const LayerData& ld = it->second;
-            for (int i = 0; i < ld.inputBlobsId.size(); ++i)
-                blobManager.addReference(ld.inputBlobsId[i]);
+            blobManager.addReferences(ld.inputBlobsId);
         }
 
         for (it = layers.begin(); it != layers.end(); it++)
@@ -1001,10 +1040,10 @@ std::vector<int> Net::getUnconnectedOutLayers() const
     return layersIds;
 }
 
-void Net::getLayersShapes(const Net::Impl::ShapesVec& netInputShapes,
+void Net::getLayersShapes(const ShapesVec& netInputShapes,
                           std::vector<int>* layersIds,
-                          std::vector<Net::Impl::ShapesVec>* inLayersShapes,
-                          std::vector<Net::Impl::ShapesVec>* outLayersShapes) const
+                          std::vector<ShapesVec>* inLayersShapes,
+                          std::vector<ShapesVec>* outLayersShapes) const
 {
     if ((layersIds || inLayersShapes || outLayersShapes) == false)
         return;
@@ -1030,29 +1069,29 @@ void Net::getLayersShapes(const Net::Impl::ShapesVec& netInputShapes,
 
 void Net::getLayersShapes(const MatShape& netInputShape,
                           std::vector<int>* layerIds,
-                          std::vector<Net::Impl::ShapesVec>* inLayersShapes,
-                          std::vector<Net::Impl::ShapesVec>* outLayersShapes) const
+                          std::vector<ShapesVec>* inLayersShapes,
+                          std::vector<ShapesVec>* outLayersShapes) const
 {
-    getLayersShapes(Net::Impl::ShapesVec(1, netInputShape),
+    getLayersShapes(ShapesVec(1, netInputShape),
                     layerIds, inLayersShapes, outLayersShapes);
 }
 
 void Net::getLayerShapes(const MatShape& netInputShape,
                          const int layerId,
-                         Net::Impl::ShapesVec* inLayerShapes,
-                         Net::Impl::ShapesVec* outLayerShapes) const
+                         ShapesVec* inLayerShapes,
+                         ShapesVec* outLayerShapes) const
 {
-    getLayerShapes(Net::Impl::ShapesVec(1, netInputShape),
+    getLayerShapes(ShapesVec(1, netInputShape),
                    layerId, inLayerShapes, outLayerShapes);
 
 }
 
-void Net::getLayerShapes(const Net::Impl::ShapesVec& netInputShapes,
+void Net::getLayerShapes(const ShapesVec& netInputShapes,
                     const int layerId,
-                    Net::Impl::ShapesVec* inLayerShapes,
-                    Net::Impl::ShapesVec* outLayerShapes) const
+                    ShapesVec* inLayerShapes,
+                    ShapesVec* outLayerShapes) const
 {
-    Impl::LayerShapes shapes;
+    LayerShapes shapes;
     impl->getLayerShapes(netInputShapes, layerId, shapes);
     if (inLayerShapes)
         *inLayerShapes = shapes.in;
@@ -1089,7 +1128,7 @@ int64 Net::getFLOPS(const int layerId,
     Impl::MapIdToLayerData::iterator layer = impl->layers.find(layerId);
     CV_Assert(layer != impl->layers.end());
 
-    Impl::LayerShapes shapes;
+    LayerShapes shapes;
     impl->getLayerShapes(netInputShapes, layerId, shapes);
 
     return layer->second.getLayerInstance()->getFLOPS(shapes.in, shapes.out);
@@ -1160,26 +1199,14 @@ void Net::getMemoryConsumption(const std::vector<MatShape>& netInputShapes,
                                size_t& weights, size_t& blobs) const
 {
     std::vector<int> layerIds;
-    std::vector<std::vector<MatShape> > outLayerShapes;
-
-    getLayersShapes(netInputShapes, &layerIds, 0, &outLayerShapes);
+    std::vector<size_t> w, b;
+    getMemoryConsumption(netInputShapes, layerIds, w, b);
 
     weights = blobs = 0;
     for(int i = 0; i < layerIds.size(); i++)
     {
-        Impl::MapIdToLayerData::iterator layer = impl->layers.find(layerIds[i]);
-        CV_Assert(layer != impl->layers.end());
-
-        for(int j = 0; j < layer->second.params.blobs.size(); j++)
-        {
-            const Mat& weightsBlob = layer->second.params.blobs[j];
-            weights += weightsBlob.total()*weightsBlob.elemSize();
-        }
-
-        for(int j = 0; j < outLayerShapes[i].size(); j++)
-        {
-            blobs += total(outLayerShapes[i][j]) * sizeof(float);
-        }
+        weights += w[i];
+        blobs += b[i];
     }
 }
 
@@ -1195,6 +1222,47 @@ void Net::getMemoryConsumption(const MatShape& netInputShape,
                                size_t& weights, size_t& blobs) const
 {
     getMemoryConsumption(std::vector<MatShape>(1, netInputShape),
+                         weights, blobs);
+}
+
+void Net::getMemoryConsumption(const std::vector<MatShape>& netInputShapes,
+                                  std::vector<int>& layerIds, std::vector<size_t>& weights,
+                                  std::vector<size_t>& blobs) const
+{
+    layerIds.clear();
+    weights.clear();
+    blobs.clear();
+
+    std::vector<std::vector<MatShape> > outLayerShapes;
+
+    getLayersShapes(netInputShapes, &layerIds, 0, &outLayerShapes);
+
+    for(int i = 0; i < layerIds.size(); i++)
+    {
+        int w = 0, b = 0;
+        Impl::MapIdToLayerData::iterator layer = impl->layers.find(layerIds[i]);
+        CV_Assert(layer != impl->layers.end());
+
+        for(int j = 0; j < layer->second.params.blobs.size(); j++)
+        {
+            const Mat& weightsBlob = layer->second.params.blobs[j];
+            w += weightsBlob.total()*weightsBlob.elemSize();
+        }
+
+        for(int j = 0; j < outLayerShapes[i].size(); j++)
+        {
+            b += total(outLayerShapes[i][j]) * sizeof(float);
+        }
+
+        weights.push_back(w);
+        blobs.push_back(b);
+    }
+}
+
+void Net::getMemoryConsumption(const MatShape& netInputShape, std::vector<int>& layerIds,
+                               std::vector<size_t>& weights, std::vector<size_t>& blobs) const
+{
+    getMemoryConsumption(std::vector<MatShape>(1, netInputShape), layerIds,
                          weights, blobs);
 }
 

--- a/modules/dnn/src/layers/batch_norm_layer.cpp
+++ b/modules/dnn/src/layers/batch_norm_layer.cpp
@@ -30,6 +30,15 @@ public:
         epsilon = params.get<float>("eps", 1E-5);
     }
 
+    bool getMemoryShapes(const std::vector<MatShape> &inputs,
+                         const int requiredOutputs,
+                         std::vector<MatShape> &outputs,
+                         std::vector<MatShape> &internals) const
+    {
+        Layer::getMemoryShapes(inputs, requiredOutputs, outputs, internals);
+        return true;
+    }
+
     void forward(std::vector<Mat*> &inputs, std::vector<Mat> &outputs, std::vector<Mat> &internals)
     {
         CV_Assert(blobs.size() >= 2);

--- a/modules/dnn/src/layers/blank_layer.cpp
+++ b/modules/dnn/src/layers/blank_layer.cpp
@@ -61,7 +61,12 @@ public:
         return true;
     }
 
-    void forward(std::vector<Mat*> &inputs, std::vector<Mat> &outputs, std::vector<Mat> &internals) {}
+    void forward(std::vector<Mat*> &inputs, std::vector<Mat> &outputs, std::vector<Mat> &internals)
+    {
+        for (int i = 0, n = outputs.size(); i < n; ++i)
+            if (outputs[i].data != inputs[i]->data)
+                inputs[i]->copyTo(outputs[i]);
+    }
 };
 
 Ptr<BlankLayer> BlankLayer::create(const LayerParams& params)

--- a/modules/dnn/src/layers/reshape_layer.cpp
+++ b/modules/dnn/src/layers/reshape_layer.cpp
@@ -178,7 +178,7 @@ public:
         for (size_t i = 0; i < inputs.size(); i++)
         {
             Mat srcBlob = *inputs[i];
-            MatShape inputShape = shape(srcBlob);
+            MatShape inputShape = shape(srcBlob), outShape = shape(outputs[i]);
 
             if (performReordering)
             {
@@ -203,6 +203,11 @@ public:
                     }
                 }
                 internals[i].copyTo(outputs[i]);
+            }
+            else
+            {
+                if (outputs[i].data != srcBlob.data)
+                    srcBlob.reshape(1, outShape).copyTo(outputs[i]);
             }
         }
     }

--- a/modules/dnn/src/layers/scale_layer.cpp
+++ b/modules/dnn/src/layers/scale_layer.cpp
@@ -27,6 +27,15 @@ public:
         hasBias = params.get<bool>("bias_term", false);
     }
 
+    bool getMemoryShapes(const std::vector<MatShape> &inputs,
+                         const int requiredOutputs,
+                         std::vector<MatShape> &outputs,
+                         std::vector<MatShape> &internals) const
+    {
+        Layer::getMemoryShapes(inputs, requiredOutputs, outputs, internals);
+        return true;
+    }
+
     void forward(std::vector<Mat*> &inputs, std::vector<Mat> &outputs, std::vector<Mat> &internals)
     {
         CV_Assert(blobs.size() == 1 + hasBias);

--- a/modules/dnn/src/layers/split_layer.cpp
+++ b/modules/dnn/src/layers/split_layer.cpp
@@ -72,17 +72,17 @@ public:
     {
         CV_Assert(inputs.size() == 1);
 
-        outputs.resize(outputsCount >= 0 ? outputsCount : requiredOutputs,
-                       inputs[0]);
-
-        return false;
+        Layer::getMemoryShapes(inputs, outputsCount >= 0 ? outputsCount : requiredOutputs,
+                               outputs, internals);
+        return true;
     }
 
     void forward(std::vector<Mat*> &inputs, std::vector<Mat> &outputs, std::vector<Mat> &internals)
     {
         for (size_t i = 0; i < outputs.size(); i++)
         {
-            inputs[0]->copyTo(outputs[i]);
+            if (outputs[i].data != inputs[0]->data)
+                inputs[0]->copyTo(outputs[i]);
         }
     }
 };

--- a/modules/dnn/test/test_caffe_importer.cpp
+++ b/modules/dnn/test/test_caffe_importer.cpp
@@ -102,7 +102,7 @@ TEST(Reproducibility_AlexNet, Accuracy)
     normAssert(ref, out);
 }
 
-#if !defined(_WIN32) || defined(_WIN64)
+#if !defined(_WIN32)
 TEST(Reproducibility_FCN, Accuracy)
 {
     Net net;

--- a/modules/dnn/test/test_caffe_importer.cpp
+++ b/modules/dnn/test/test_caffe_importer.cpp
@@ -102,7 +102,7 @@ TEST(Reproducibility_AlexNet, Accuracy)
     normAssert(ref, out);
 }
 
-#if !defined(_WIN32)
+#if !defined(_WIN32) || defined(_WIN64)
 TEST(Reproducibility_FCN, Accuracy)
 {
     Net net;
@@ -120,6 +120,10 @@ TEST(Reproducibility_FCN, Accuracy)
     Size inputSize(500, 500);
     if (sample.size() != inputSize)
         resize(sample, sample, inputSize);
+
+    std::vector<int> layerIds;
+    std::vector<size_t> weights, blobs;
+    net.getMemoryConsumption(shape(1,3,227,227), layerIds, weights, blobs);
 
     net.setBlob(".data", blobFromImage(sample, 1.));
     net.forward();


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes
Changed order of choosing blobs. Refactored code.
Now, the largest blobs are fitted in first order.
Memory consumption:

| Model | Before commit| PR#1105 |Mine|
| ------------- | ------------- |------------- |------------- |
|FCN-8s, 500x500x3|4.5GB|2.78GB|2.36GB|

Other models are without changes in terms of memory consumption.
