### PR TITLE
Fixed a buffer overflow which occurs when setImage is called with dif…

### DIFF
--- a/modules/ximgproc/src/selectivesearchsegmentation.cpp
+++ b/modules/ximgproc/src/selectivesearchsegmentation.cpp
@@ -142,7 +142,7 @@ namespace cv {
                 Mat regions = regions_.getMat();
                 sizes = sizes_.getMat();
 
-                if (image_id != -1 && last_image_id != image_id) {
+                if (image_id == -1 || last_image_id != image_id) {
 
                     std::vector<Mat> img_planes;
                     split(img, img_planes);
@@ -507,7 +507,7 @@ namespace cv {
                 Mat regions = regions_.getMat();
                 sizes = sizes_.getMat();
 
-                if (image_id != -1 && last_image_id != image_id) {
+                if (image_id == -1 || last_image_id != image_id) {
 
                     std::vector<Mat> img_planes;
                     split(img, img_planes);


### PR DESCRIPTION
…ferent images and default image_id.

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

Modified a conflict between comments ("If the image_id is not equal to -1 and the same as the previous call for setImage, computations are used again") and codes.
I believe the comment is correct because of a buffer overflow problem.