### PR TITLE
fix java wrappers for ERFilter, OCRHMMDecoder, OCRBeamSearchDecoder

### DIFF
--- a/modules/text/include/opencv2/text/erfilter.hpp
+++ b/modules/text/include/opencv2/text/erfilter.hpp
@@ -373,20 +373,21 @@ CV_EXPORTS_W void detectRegions(InputArray image, const Ptr<ERFilter>& er_filter
 
 
 /** @brief Extracts text regions from image.
- *
- * @param image Source image where text blocks needs to be extracted from.  Should be CV_8UC3 (color).
- * @param er_filter1 Extremal Region Filter for the 1st stage classifier of N&M algorithm [Neumann12]
- * @param er_filter2 Extremal Region Filter for the 2nd stage classifier of N&M algorithm [Neumann12]
- * @param groups_rects Output list of rectangle blocks with text
- * @param method Grouping method (see text::erGrouping_Modes). Can be one of ERGROUPING_ORIENTATION_HORIZ, ERGROUPING_ORIENTATION_ANY.
- * @param filename The XML or YAML file with the classifier model (e.g. samples/trained_classifier_erGrouping.xml). Only to use when grouping method is ERGROUPING_ORIENTATION_ANY.
- * @param minProbability The minimum probability for accepting a group. Only to use when grouping method is ERGROUPING_ORIENTATION_ANY.
- *
+
+@param image Source image where text blocks needs to be extracted from.  Should be CV_8UC3 (color).
+@param er_filter1 Extremal Region Filter for the 1st stage classifier of N&M algorithm [Neumann12]
+@param er_filter2 Extremal Region Filter for the 2nd stage classifier of N&M algorithm [Neumann12]
+@param groups_rects Output list of rectangle blocks with text
+@param method Grouping method (see text::erGrouping_Modes). Can be one of ERGROUPING_ORIENTATION_HORIZ, ERGROUPING_ORIENTATION_ANY.
+@param filename The XML or YAML file with the classifier model (e.g. samples/trained_classifier_erGrouping.xml). Only to use when grouping method is ERGROUPING_ORIENTATION_ANY.
+@param minProbability The minimum probability for accepting a group. Only to use when grouping method is ERGROUPING_ORIENTATION_ANY.
+
+
  */
 CV_EXPORTS_W void detectRegions(InputArray image, const Ptr<ERFilter>& er_filter1, const Ptr<ERFilter>& er_filter2, CV_OUT std::vector<Rect> &groups_rects,
                                            int method = ERGROUPING_ORIENTATION_HORIZ,
                                            const String& filename = String(),
-                                           float minProbablity = (float)0.5);
+                                           float minProbability = (float)0.5);
 
 //! @}
 

--- a/modules/text/include/opencv2/text/erfilter.hpp
+++ b/modules/text/include/opencv2/text/erfilter.hpp
@@ -371,6 +371,23 @@ CV_EXPORTS void MSERsToERStats(InputArray image, std::vector<std::vector<Point> 
 // Utility funtion for scripting
 CV_EXPORTS_W void detectRegions(InputArray image, const Ptr<ERFilter>& er_filter1, const Ptr<ERFilter>& er_filter2, CV_OUT std::vector< std::vector<Point> >& regions);
 
+
+/** @brief Extracts text regions from image.
+ *
+ * @param image Source image where text blocks needs to be extracted from.  Should be CV_8UC3 (color).
+ * @param er_filter1 Extremal Region Filter for the 1st stage classifier of N&M algorithm [Neumann12]
+ * @param er_filter2 Extremal Region Filter for the 2nd stage classifier of N&M algorithm [Neumann12]
+ * @param groups_rects Output list of rectangle blocks with text
+ * @param method Grouping method (see text::erGrouping_Modes). Can be one of ERGROUPING_ORIENTATION_HORIZ, ERGROUPING_ORIENTATION_ANY.
+ * @param filename The XML or YAML file with the classifier model (e.g. samples/trained_classifier_erGrouping.xml). Only to use when grouping method is ERGROUPING_ORIENTATION_ANY.
+ * @param minProbability The minimum probability for accepting a group. Only to use when grouping method is ERGROUPING_ORIENTATION_ANY.
+ *
+ */
+CV_EXPORTS_W void detectRegions(InputArray image, const Ptr<ERFilter>& er_filter1, const Ptr<ERFilter>& er_filter2, CV_OUT std::vector<Rect> &groups_rects,
+                                           int method = ERGROUPING_ORIENTATION_HORIZ,
+                                           const String& filename = String(),
+                                           float minProbablity = (float)0.5);
+
 //! @}
 
 }

--- a/modules/text/include/opencv2/text/ocr.hpp
+++ b/modules/text/include/opencv2/text/ocr.hpp
@@ -172,6 +172,13 @@ enum decoder_mode
     OCR_DECODER_VITERBI = 0 // Other algorithms may be added
 };
 
+/* OCR classifier type*/
+enum classifier_type
+{
+    OCR_KNN_CLASSIFIER = 0,
+    OCR_CNN_CLASSIFIER = 1
+};
+
 /** @brief OCRHMMDecoder class provides an interface for OCR using Hidden Markov Models.
 
 @note
@@ -299,6 +306,21 @@ public:
                                                                                        //     cols == rows == vocabulari.size()
                                      int mode = OCR_DECODER_VITERBI);         // HMM Decoding algorithm (only Viterbi for the moment)
 
+    /** @brief Creates an instance of the OCRHMMDecoder class. Loads and initializes HMMDecoder from the specified path
+
+     @overload
+     */
+    CV_WRAP static Ptr<OCRHMMDecoder> create(const String& filename,
+
+                                     const String& vocabulary,                    // The language vocabulary (chars when ascii english text)
+                                                                                       //     size() must be equal to the number of classes
+                                     InputArray transition_probabilities_table,        // Table with transition probabilities between character pairs
+                                                                                       //     cols == rows == vocabulari.size()
+                                     InputArray emission_probabilities_table,          // Table with observation emission probabilities
+                                                                                       //     cols == rows == vocabulari.size()
+                                     int mode = OCR_DECODER_VITERBI,                    // HMM Decoding algorithm (only Viterbi for the moment)
+
+                                     int classifier = OCR_KNN_CLASSIFIER);              // The character classifier type
 protected:
 
     Ptr<OCRHMMDecoder::ClassifierCallback> classifier;
@@ -318,6 +340,8 @@ fixed size, while retaining the centroid and aspect ratio, in order to extract a
 based on gradient orientations along the chain-code of its perimeter. Then, the region is classified
 using a KNN model trained with synthetic data of rendered characters with different standard font
 types.
+
+@deprecated loadOCRHMMClassifier instead
  */
 
 CV_EXPORTS_W Ptr<OCRHMMDecoder::ClassifierCallback> loadOCRHMMClassifierNM(const String& filename);
@@ -330,9 +354,19 @@ The CNN default classifier is based in the scene text recognition method propose
 Andrew NG in [Coates11a]. The character classifier consists in a Single Layer Convolutional Neural Network and
 a linear classifier. It is applied to the input image in a sliding window fashion, providing a set of recognitions
 at each window location.
+
+@deprecated use loadOCRHMMClassifier instead
  */
 CV_EXPORTS_W Ptr<OCRHMMDecoder::ClassifierCallback> loadOCRHMMClassifierCNN(const String& filename);
 
+/** @brief Allow to implicitly load the default character classifier when creating an OCRHMMDecoder object.
+
+ @param filename The XML or YAML file with the classifier model (e.g. OCRBeamSearch_CNN_model_data.xml.gz)
+
+ @param classifier Can be one of classifier_type enum values.
+
+ */
+CV_EXPORTS_W Ptr<OCRHMMDecoder::ClassifierCallback> loadOCRHMMClassifier(const String& filename, int classifier);
 //! @}
 
 /** @brief Utility function to create a tailored language model transitions table from a given list of words (lexicon).
@@ -466,6 +500,20 @@ public:
                                      int mode = OCR_DECODER_VITERBI,          // HMM Decoding algorithm (only Viterbi for the moment)
                                      int beam_size = 500);                              // Size of the beam in Beam Search algorithm
 
+    /** @brief Creates an instance of the OCRBeamSearchDecoder class. Initializes HMMDecoder from the specified path.
+
+    @overload
+
+     */
+    CV_WRAP static Ptr<OCRBeamSearchDecoder> create(const String& filename, // The character classifier file
+                                     const String& vocabulary,                    // The language vocabulary (chars when ascii english text)
+                                                                                       //     size() must be equal to the number of classes
+                                     InputArray transition_probabilities_table,        // Table with transition probabilities between character pairs
+                                                                                       //     cols == rows == vocabulari.size()
+                                     InputArray emission_probabilities_table,          // Table with observation emission probabilities
+                                                                                       //     cols == rows == vocabulari.size()
+                                     int mode = OCR_DECODER_VITERBI,          // HMM Decoding algorithm (only Viterbi for the moment)
+                                     int beam_size = 500);
 protected:
 
     Ptr<OCRBeamSearchDecoder::ClassifierCallback> classifier;

--- a/modules/text/src/ocr_beamsearch_decoder.cpp
+++ b/modules/text/src/ocr_beamsearch_decoder.cpp
@@ -499,7 +499,7 @@ Ptr<OCRBeamSearchDecoder> OCRBeamSearchDecoder::create( Ptr<OCRBeamSearchDecoder
     return makePtr<OCRBeamSearchDecoderImpl>(_classifier, _vocabulary, transition_p, emission_p, _mode, _beam_size);
 }
 
-CV_EXPORTS_W Ptr<OCRBeamSearchDecoder> OCRBeamSearchDecoder::create(Ptr<OCRBeamSearchDecoder::ClassifierCallback> _classifier,
+Ptr<OCRBeamSearchDecoder> OCRBeamSearchDecoder::create(Ptr<OCRBeamSearchDecoder::ClassifierCallback> _classifier,
                                                         const String& _vocabulary,
                                                         InputArray transition_p,
                                                         InputArray emission_p,
@@ -509,8 +509,17 @@ CV_EXPORTS_W Ptr<OCRBeamSearchDecoder> OCRBeamSearchDecoder::create(Ptr<OCRBeamS
     return makePtr<OCRBeamSearchDecoderImpl>(_classifier, _vocabulary, transition_p, emission_p, (decoder_mode)_mode, _beam_size);
 }
 
+Ptr<OCRBeamSearchDecoder> OCRBeamSearchDecoder::create(const String& _filename,
+                                                        const String& _vocabulary,
+                                                        InputArray transition_p,
+                                                        InputArray emission_p,
+                                                        int _mode,
+                                                        int _beam_size)
+{
+    return makePtr<OCRBeamSearchDecoderImpl>(loadOCRBeamSearchClassifierCNN(_filename), _vocabulary, transition_p, emission_p, (decoder_mode)_mode, _beam_size);
+}
 
-class CV_EXPORTS OCRBeamSearchClassifierCNN : public OCRBeamSearchDecoder::ClassifierCallback
+class OCRBeamSearchClassifierCNN : public OCRBeamSearchDecoder::ClassifierCallback
 {
 public:
     //constructor

--- a/modules/text/src/ocr_hmm_decoder.cpp
+++ b/modules/text/src/ocr_hmm_decoder.cpp
@@ -90,7 +90,7 @@ void OCRHMMDecoder::run(Mat& image, Mat& mask, string& output_text, vector<Rect>
         component_confidences->clear();
 }
 
-CV_WRAP String OCRHMMDecoder::run(InputArray image, int min_confidence, int component_level)
+String OCRHMMDecoder::run(InputArray image, int min_confidence, int component_level)
 {
     std::string output1;
     std::string output2;
@@ -109,7 +109,7 @@ CV_WRAP String OCRHMMDecoder::run(InputArray image, int min_confidence, int comp
     return String(output2);
 }
 
-CV_WRAP cv::String OCRHMMDecoder::run(InputArray image, InputArray mask, int min_confidence, int component_level)
+cv::String OCRHMMDecoder::run(InputArray image, InputArray mask, int min_confidence, int component_level)
 {
     std::string output1;
     std::string output2;
@@ -684,8 +684,17 @@ Ptr<OCRHMMDecoder> OCRHMMDecoder::create( Ptr<OCRHMMDecoder::ClassifierCallback>
     return makePtr<OCRHMMDecoderImpl>(_classifier, _vocabulary, transition_p, emission_p, (decoder_mode)_mode);
 }
 
+Ptr<OCRHMMDecoder> OCRHMMDecoder::create( const String& _filename,
+                                          const String& _vocabulary,
+                                          InputArray transition_p,
+                                          InputArray emission_p,
+                                          int _mode,
+                                          int _classifier)
+{
+    return makePtr<OCRHMMDecoderImpl>(loadOCRHMMClassifier(_filename, _classifier), _vocabulary, transition_p, emission_p, (decoder_mode)_mode);
+}
 
-class CV_EXPORTS OCRHMMClassifierKNN : public OCRHMMDecoder::ClassifierCallback
+class OCRHMMClassifierKNN : public OCRHMMDecoder::ClassifierCallback
 {
 public:
     //constructor
@@ -916,6 +925,22 @@ void OCRHMMClassifierKNN::eval( InputArray _mask, vector<int>& out_class, vector
 
 }
 
+Ptr<OCRHMMDecoder::ClassifierCallback> loadOCRHMMClassifier(const String& _filename, int _classifier)
+
+{
+    Ptr<OCRHMMDecoder::ClassifierCallback> pt;
+    switch(_classifier) {
+        case OCR_KNN_CLASSIFIER:
+            pt = loadOCRHMMClassifierNM(_filename);
+            break;
+        case OCR_CNN_CLASSIFIER:
+            pt = loadOCRHMMClassifierCNN(_filename);
+        default:
+            CV_Error(Error::StsBadArg, "Specified HMM classifier is not supported!");
+            break;
+    }
+    return pt;
+}
 
 Ptr<OCRHMMDecoder::ClassifierCallback> loadOCRHMMClassifierNM(const String& filename)
 
@@ -923,7 +948,7 @@ Ptr<OCRHMMDecoder::ClassifierCallback> loadOCRHMMClassifierNM(const String& file
     return makePtr<OCRHMMClassifierKNN>(std::string(filename));
 }
 
-class CV_EXPORTS OCRHMMClassifierCNN : public OCRHMMDecoder::ClassifierCallback
+class OCRHMMClassifierCNN : public OCRHMMDecoder::ClassifierCallback
 {
 public:
     //constructor


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->
resolves #1209 

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->

Overload methods added to ensure usable java wrappers for the following classes of Text module:

1. ERFilter
2. OCRHMMDecoder
3. OCRBeamSearchDecoder

### Details on added methods
#### ERFilter

```
void detectRegions(InputArray image, const Ptr<ERFilter>& er_filter1, const Ptr<ERFilter>& er_filter2, CV_OUT std::vector<Rect> &groups_rects,
                                           int method = ERGROUPING_ORIENTATION_HORIZ,
                                           const String& filename = String(),
                                           float minProbability = (float)0.5);
```

This method simplifies usage of ER method for text detection. Example of usage is below:

``` 
        ERFilter erc1 = Text.createERFilterNM1(getClass().getResource(DEFAULT_CLASSIFIER_NM1).getPath(),8,0.00015f,0.15f,0.2f,true,0.1f);
        ERFilter erc2 = Text.createERFilterNM2(getClass().getResource(DEFAULT_CLASSIFIER_NM2).getPath(), 0.5f);        
        

        MatOfRect mor = new MatOfRect();  // the output array of rectangles, which surround text areas
        Text.detectRegions(image, erc1, erc2, mor);

```
#### OCRHMMDecoder
#### OCRBeamSearchDecoder
as described in the issue #1209 
