### PR TITLE
Import SoftMax & LogSoftMax layers from Torch

### DIFF
--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -251,6 +251,8 @@ namespace dnn
     class CV_EXPORTS SoftmaxLayer : public Layer
     {
     public:
+        bool logSoftMax;
+
         static Ptr<SoftmaxLayer> create(const LayerParams& params);
     };
 

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -436,6 +436,7 @@ namespace dnn //! This namespace is used for dnn module functionlaity.
      * - nn.SpatialMaxPooling, nn.SpatialAveragePooling
      * - nn.ReLU, nn.TanH, nn.Sigmoid
      * - nn.Reshape
+     * - nn.SoftMax, nn.LogSoftMax
      *
      * Also some equivalents of these classes from cunn, cudnn, and fbcunn may be successfully imported.
      */

--- a/modules/dnn/src/layers/softmax_layer.cpp
+++ b/modules/dnn/src/layers/softmax_layer.cpp
@@ -57,6 +57,7 @@ public:
     SoftMaxLayerImpl(const LayerParams& params)
     {
         axisRaw = params.get<int>("axis", 1);
+        logSoftMax = params.get<int>("log_softmax", false);
         setParamsFrom(params);
     }
 
@@ -142,6 +143,14 @@ public:
             {
                 for (size_t i = 0; i < innerSize; i++)
                     dstPtr[srcOffset + cnDim * cnStep + i] /= bufPtr[bufOffset + i];
+            }
+            if (logSoftMax)
+            {
+                for (size_t cnDim = 0; cnDim < channels; cnDim++)
+                {
+                    for (size_t i = 0; i < innerSize; i++)
+                        dstPtr[srcOffset + cnDim * cnStep + i] = log(dstPtr[srcOffset + cnDim * cnStep + i]);
+                }
             }
         }
     }

--- a/modules/dnn/src/torch/torch_importer.cpp
+++ b/modules/dnn/src/torch/torch_importer.cpp
@@ -741,6 +741,17 @@ struct TorchImporter : public ::cv::dnn::Importer
                 layerParams.set("indices_blob_id", tensorParams["indices"].first);
                 curModule->modules.push_back(newModule);
             }
+            else if (nnName == "SoftMax")
+            {
+                newModule->apiType = "SoftMax";
+                curModule->modules.push_back(newModule);
+            }
+            else if (nnName == "LogSoftMax")
+            {
+                newModule->apiType = "SoftMax";
+                layerParams.set("log_softmax", true);
+                curModule->modules.push_back(newModule);
+            }
             else
             {
                 CV_Error(Error::StsNotImplemented, "Unknown nn class \"" + className + "\"");

--- a/modules/dnn/test/test_torch_importer.cpp
+++ b/modules/dnn/test/test_torch_importer.cpp
@@ -159,6 +159,18 @@ TEST(Torch_Importer, net_cadd_table)
     runTorchNet("net_cadd_table");
 }
 
+TEST(Torch_Importer, net_softmax)
+{
+    runTorchNet("net_softmax");
+    runTorchNet("net_softmax_spatial");
+}
+
+TEST(Torch_Importer, net_logsoftmax)
+{
+    runTorchNet("net_logsoftmax");
+    runTorchNet("net_logsoftmax_spatial");
+}
+
 TEST(Torch_Importer, ENet_accuracy)
 {
     Net net;


### PR DESCRIPTION
**Merge with**: https://github.com/opencv/opencv_extra/pull/341

### This pullrequest changes
Classification networks trained in Torch use criterion that expected output from `SoftMax` and espetially from `LogSoftMax`: https://github.com/torch/nn/blob/master/doc/criterion.md.
From my point of view, the most popular criterion for multi-class training is a [ClassNLLCriterion](https://github.com/torch/nn/blob/master/doc/criterion.md#classnllcriterion).
SoftMax and LogSoftMax are monotonic functions that means predicted class (maximum of output) is the same if we exclude these computations. Thanks for Torch framework it's so simple doing by [replace layer to nn.Identity](https://github.com/torch/nn/blob/master/doc/module.md#replacefunction) or [remove it at all](https://github.com/torch/nn/blob/65f42723f51d13683a431329452e5f385988e984/doc/containers.md#removeindex).
Currently DNN's torch importer doesn't import SoftMax and LogSoftMax layers. Despite it's not so critical for model deployment, we'd better to cover it.
