### PR TITLE
DNN errors have URL to submit an issue.

### DIFF
--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -53,6 +53,12 @@ namespace dnn //! This namespace is used for dnn module functionlaity.
 //! @addtogroup dnn
 //! @{
 
+    /*
+     * @brief Throws error with a generated GitHub issue link.
+     * @see submitError
+     */
+    #define CV_dnn_Error(code, msg) cv::dnn::submitError(code, msg, CV_Func, __FILE__, __LINE__)
+
     typedef std::vector<int> MatShape;
 
     /** @brief Initialize dnn module and built-in layers.
@@ -448,6 +454,22 @@ namespace dnn //! This namespace is used for dnn module functionlaity.
 
     CV_EXPORTS Mat blobFromImage(const Mat& image, double scalefactor=1.0, bool swapRB=true);
     CV_EXPORTS Mat blobFromImages(const std::vector<Mat>& image, double scalefactor=1.0, bool swapRB=true);
+
+   /**
+    * @brief Throws cv::error with generated link to GitHub issue.
+    * @param[in] code cv::Error::Code value.
+    * @param[in] msg  Default error message that will be shown.
+    * @param[in] func Function name where exceprion have thrown.
+    * @param[in] file Path to file where exceprion have thrown.
+    * @param[in] line Line number where exceprion have thrown.
+    *
+    * This method appends link to submit an issue to OpenCV's GitHub.
+    * It involves body with OpenCV version, operation system and
+    * exception location. However it has only basic information and user should
+    * provide more ditailed description i.e. neural network configuration/source.
+    */
+    CV_EXPORTS void submitError(int code, std::string msg, const char* func,
+                                const char* file, int line);
 
 //! @}
 }

--- a/modules/dnn/src/caffe/caffe_importer.cpp
+++ b/modules/dnn/src/caffe/caffe_importer.cpp
@@ -149,7 +149,7 @@ public:
             }
             break;
         default:
-            CV_Error(Error::StsError, "Unknown type \"" + String(field->type_name()) + "\" in prototxt");
+            CV_dnn_Error(Error::StsError, "Unknown type \"" + String(field->type_name()) + "\" in prototxt");
             break;
         }
     }
@@ -210,7 +210,7 @@ public:
                 shape.push_back((int)_shape.dim(i));
         }
         else
-            CV_Error(Error::StsError, "Unknown shape of input blob");
+            CV_dnn_Error(Error::StsError, "Unknown shape of input blob");
     }
 
     void blobFromProto(const caffe::BlobProto &pbBlob, cv::Mat &dstBlob)
@@ -324,7 +324,7 @@ public:
         {
             bool isInplace = layer.bottom_size() > outNum && layer.bottom(outNum) == name;
             if (!isInplace)
-                CV_Error(Error::StsBadArg, "Duplicate blobs produced by multiple sources");
+                CV_dnn_Error(Error::StsBadArg, "Duplicate blobs produced by multiple sources");
         }
 
         addedBlobs.push_back(BlobNote(name, layerId, outNum));
@@ -341,7 +341,7 @@ public:
 
         if (idx < 0)
         {
-            CV_Error(Error::StsObjectNotFound, "Can't find output blob \"" + name + "\"");
+            CV_dnn_Error(Error::StsObjectNotFound, "Can't find output blob \"" + name + "\"");
             return;
         }
 

--- a/modules/dnn/src/layers/lrn_layer.cpp
+++ b/modules/dnn/src/layers/lrn_layer.cpp
@@ -94,7 +94,7 @@ public:
                     spatialNormalization(src, dst);
                     break;
                 default:
-                    CV_Error(Error::StsNotImplemented, "Unimplemented mode of LRN layer");
+                    CV_dnn_Error(Error::StsNotImplemented, "Unimplemented mode of LRN layer");
                     break;
             }
         }

--- a/modules/dnn/src/layers/padding_layer.cpp
+++ b/modules/dnn/src/layers/padding_layer.cpp
@@ -30,7 +30,7 @@ public:
         paddingValue = params.get<double>("value", 0);
 
         if(paddingDim < 0 || padding < 0)
-            CV_Error(cv::Error::StsNotImplemented, "Negative padding and dim aren't supported");
+            CV_dnn_Error(cv::Error::StsNotImplemented, "Negative padding and dim aren't supported");
     }
 
     bool getMemoryShapes(const std::vector<MatShape> &inputs,

--- a/modules/dnn/src/layers/pooling_layer.cpp
+++ b/modules/dnn/src/layers/pooling_layer.cpp
@@ -105,7 +105,7 @@ public:
                     avePooling(*inputs[ii], outputs[ii]);
                     break;
                 default:
-                    CV_Error(Error::StsNotImplemented, "Not implemented");
+                    CV_dnn_Error(Error::StsNotImplemented, "Not implemented");
                     break;
             }
         }

--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -65,7 +65,7 @@ void blobShapeFromTensor(const tensorflow::TensorProto &tensor, MatShape& shape)
     }
     else
     {
-        CV_Error(Error::StsError, "Unknown shape of input tensor");
+        CV_dnn_Error(Error::StsError, "Unknown shape of input tensor");
     }
 }
 
@@ -126,8 +126,12 @@ void blobFromTensor(const tensorflow::TensorProto &tensor, Mat &dstBlob)
             parseTensor<double>(tensor, dstBlob);
             break;
         default:
-            CV_Error(Error::StsError, "Tensor's data type is not supported");
+        {
+            std::ostringstream ss;
+            ss << "Tensor's data type " << tensor.dtype() << " is not supported";
+            CV_dnn_Error(Error::StsError, ss.str());
             break;
+        }
     }
 }
 
@@ -178,8 +182,13 @@ void printTensor(const tensorflow::TensorProto &tensor)
             break;
         }
     default:
-        CV_Error(Error::StsError, "Tensor type is not supported");
-        break;
+        {
+            std::ostringstream ss;
+            ss << "Tensor type " << tensor.dtype() << " is not supported";
+            CV_dnn_Error(Error::StsError, ss.str());
+            break;
+
+        }
     }
 }
 
@@ -439,7 +448,7 @@ void TFImporter::connect(const std::map<String, int>& layers_name_id_map, Net& n
 {
     std::map<String, int>::const_iterator it = layers_name_id_map.find(outPin.name);
     if (it == layers_name_id_map.end())
-        CV_Error(Error::StsError, "Input layer not found: " + outPin.name);
+        CV_dnn_Error(Error::StsError, "Input layer not found: " + outPin.name);
     network.connect(it->second, outPin.blobIndex, input_layer_id, input_blob_id);
 }
 
@@ -457,7 +466,7 @@ const tensorflow::TensorProto& TFImporter::getConstBlob(const tensorflow::NodeDe
             Pin input = parsePin(layer.input(i));
             if (const_layers.find(input.name) != const_layers.end()) {
                 if (input_blob_index != -1)
-                    CV_Error(Error::StsError, "More than one input is Const op");
+                    CV_dnn_Error(Error::StsError, "More than one input is Const op");
 
                 input_blob_index = i;
             }
@@ -663,7 +672,7 @@ void TFImporter::populateNet(Net dstNet)
             {
                 Pin inp = parsePin(layer.input(ii));
                 if (layer_id.find(inp.name) == layer_id.end())
-                    CV_Error(Error::StsError, "Input layer not found: " + inp.name);
+                    CV_dnn_Error(Error::StsError, "Input layer not found: " + inp.name);
                 dstNet.connect(layer_id.at(inp.name), inp.blobIndex, id, ii - 1);
             }
         }
@@ -729,7 +738,9 @@ void TFImporter::populateNet(Net dstNet)
         else
         {
             printLayerAttr(layer);
-            CV_Error_(Error::StsError, ("Unknown layer type %s in op %s", type.c_str(), name.c_str()));
+            std::ostringstream ss;
+            ss << "Unknown layer type " << type.c_str() << " in op " << name.c_str();
+            CV_dnn_Error(cv::Error::StsNotImplemented, ss.str());
         }
     }
 }

--- a/modules/dnn/src/torch/torch_importer.cpp
+++ b/modules/dnn/src/torch/torch_importer.cpp
@@ -210,7 +210,7 @@ struct TorchImporter : public ::cv::dnn::Importer
            else if (typeStr == "Long") //Carefully! CV_64S type coded as CV_USRTYPE1
                return CV_USRTYPE1;
            else
-               CV_Error(Error::StsNotImplemented, "Unknown type \"" + typeStr + "\" of torch class \"" + str + "\"");
+               CV_dnn_Error(Error::StsNotImplemented, "Unknown type \"" + typeStr + "\" of torch class \"" + str + "\"");
         }
 
         return -1;
@@ -383,7 +383,7 @@ struct TorchImporter : public ::cv::dnn::Importer
         size_t requireElems = (size_t)offset + (size_t)steps[0] * (size_t)sizes[0];
         size_t storageElems = storages[indexStorage].total();
         if (requireElems > storageElems)
-            CV_Error(Error::StsBadSize, "Storage has insufficent number of elemements for requested Tensor");
+            CV_dnn_Error(Error::StsBadSize, "Storage has insufficent number of elemements for requested Tensor");
 
         //convert sizes
         AutoBuffer<int, 4> isizes(ndims);
@@ -743,12 +743,12 @@ struct TorchImporter : public ::cv::dnn::Importer
             }
             else
             {
-                CV_Error(Error::StsNotImplemented, "Unknown nn class \"" + className + "\"");
+                CV_dnn_Error(Error::StsNotImplemented, "Unknown nn class \"" + className + "\"");
             }
         }
         else
         {
-            CV_Error(Error::StsNotImplemented, "Unsupported Torch class \"" + className + "\"");
+            CV_dnn_Error(Error::StsNotImplemented, "Unsupported Torch class \"" + className + "\"");
         }
 
         readedIndexes.insert(index);
@@ -775,7 +775,11 @@ struct TorchImporter : public ::cv::dnn::Importer
         else if (typeidx == TYPE_TABLE)
             readTable();
         else
-            CV_Error(Error::StsNotImplemented, "Unsupported Lua type");
+        {
+            std::ostringstream type;
+            type << typeidx;
+            CV_dnn_Error(Error::StsNotImplemented, "Unsupported Lua type: " + type.str());
+        }
     }
 
     inline String generateLayerName(const String &label = String())
@@ -935,7 +939,7 @@ struct TorchImporter : public ::cv::dnn::Importer
             }
         }
 
-        CV_Error(Error::StsInternal, "Unexpected torch container: " + module->thName);
+        CV_dnn_Error(Error::StsInternal, "Unexpected torch container: " + module->thName);
         return -1;
     }
 


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
Append URL with template GitHub issue to some exception massages from DNN. It includes OpenCV/contrib versions, OS. 
Example with exception with unknown `nn.SoftMax` Torch layer (resolves in #1212):

OpenCV Error: The function/feature is not implemented (Unknown nn class "nn.SoftMax". To submit an issue follow link and add details: https://github.com/opencv/opencv_contrib/issues/new?&body=OpenCV%3a%203%2e1%2e0%2d2747%2dg06a2587%0AOpenCV%28contrib%29%3a%203%2e2%2e0%2d284%2dge36af42%0AOperating%20System%3a%20Linux%204%2e8%2e0%2d34%2dgeneric%20x86%5f64%0A%0AException%20at%20%2fhome%2fdkurtaev%2fopencv%5fcontrib%2fmodules%2fdnn%2fsrc%2ftorch%2ftorch%5fimporter%2ecpp%3a746%0AUnknown%20nn%20class%20%22nn%2eSoftMax%22) in readTorchObject, file /home/dkurtaev/opencv_contrib/modules/dnn/src/torch/torch_importer.cpp, line 746

The main problem is URL length. Especially because of non-alphanumeric characters.