### PR TITLE
matlab: require installation of Jinja2 Python package

### DIFF
--- a/modules/matlab/CMakeLists.txt
+++ b/modules/matlab/CMakeLists.txt
@@ -26,14 +26,31 @@
 # ----------------------------------------------------------------------------
 #  Architecture checks
 # ----------------------------------------------------------------------------
-# make sure we're on a supported architecture with Matlab and python installed
+# make sure we're on a supported architecture with Matlab and Python (with jinja2) installed
 if(APPLE_FRAMEWORK OR ANDROID OR NOT MATLAB_FOUND)
     ocv_module_disable(matlab)
-    return()
-elseif (NOT PYTHON_DEFAULT_AVAILABLE)
+elseif(NOT PYTHON_DEFAULT_AVAILABLE)
     message(WARNING "A required dependency of the matlab module (Python) was not found. Disabling Matlab bindings...")
     ocv_module_disable(matlab)
-    return()
+endif()
+
+if(NOT DEFINED HAVE_PYTHON_JINJA2)
+  # Bindings generator requires Jinja2 python package
+  execute_process(COMMAND "${PYTHON_DEFAULT_EXECUTABLE}" -c "import jinja2; print(jinja2.__version__)"
+                  RESULT_VARIABLE _result
+                  OUTPUT_VARIABLE _jinja2_version
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  if(NOT _result EQUAL 0)
+    set(HAVE_PYTHON_JINJA2 0 CACHE INTERNAL "")
+  else()
+    message(STATUS "Python Jinja version: ${_jinja2_version}")
+    set(HAVE_PYTHON_JINJA2 1 CACHE INTERNAL "")
+  endif()
+endif()
+if(NOT HAVE_PYTHON_JINJA2)
+  message(WARNING "A required dependency of the matlab module (Python Jinja2 package) was not found (installation command: \"pip install jinja2\"). Disabling Matlab bindings...")
+  ocv_module_disable(matlab)
 endif()
 
 
@@ -93,7 +110,6 @@ ocv_add_module(matlab   BINDINGS
                                  opencv_calib opencv_calib3d
                                  opencv_stitching opencv_superres
                                  opencv_xfeatures2d
-                                 opencv_hal
 )
 
 # get the commit information
@@ -101,7 +117,6 @@ execute_process(COMMAND git log -1 --pretty=%H OUTPUT_VARIABLE GIT_COMMIT ERROR_
 string(REGEX REPLACE "(\r?\n)+$" "" GIT_COMMIT "${GIT_COMMIT}")
 
 # set the path to the C++ header and doc parser, and template engine
-set(JINJA2_PATH ${CMAKE_SOURCE_DIR}/3rdparty)
 set(HDR_PARSER_PATH ${CMAKE_SOURCE_DIR}/modules/python/src2)
 
 # set mex compiler options
@@ -157,7 +172,6 @@ if (NOT MEX_WORKS)
     execute_process(
         COMMAND ${PYTHON_DEFAULT_EXECUTABLE}
                 ${CMAKE_CURRENT_SOURCE_DIR}/generator/gen_matlab.py
-                --jinja2    ${JINJA2_PATH}
                 --hdrparser ${HDR_PARSER_PATH}
                 --extra     "test=${CMAKE_CURRENT_SOURCE_DIR}/test/test_generator.hpp"
                 --outdir    ${CMAKE_BINARY_DIR}/junk
@@ -216,7 +230,6 @@ add_custom_command(
     OUTPUT ${GENERATE_PROXY}
     COMMAND ${PYTHON_DEFAULT_EXECUTABLE}
             ${CMAKE_CURRENT_SOURCE_DIR}/generator/gen_matlab.py
-            --jinja2     ${JINJA2_PATH}
             --hdrparser  ${HDR_PARSER_PATH}
             --moduleroot ${CMAKE_SOURCE_DIR}/modules ${OPENCV_EXTRA_MODULES_PATH}
             --modules    ${opencv_modules}
@@ -224,7 +237,6 @@ add_custom_command(
             --outdir     ${CMAKE_CURRENT_BINARY_DIR}
     COMMAND ${PYTHON_DEFAULT_EXECUTABLE}
             ${CMAKE_CURRENT_SOURCE_DIR}/generator/build_info.py
-            --jinja2         ${JINJA2_PATH}
             --os             ${CMAKE_SYSTEM}
             --arch           ${ARCH} ${CMAKE_SYSTEM_PROCESSOR}
             --compiler       ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}
@@ -238,7 +250,6 @@ add_custom_command(
             --outdir         ${CMAKE_CURRENT_BINARY_DIR}
     COMMAND ${PYTHON_DEFAULT_EXECUTABLE}
             ${CMAKE_CURRENT_SOURCE_DIR}/generator/cvmex.py
-            --jinja2 ${JINJA2_PATH}
             --opts="${MEX_OPTS}"
             --include_dirs="${MEX_INCLUDE_DIRS}"
             --lib_dir="${MEX_LIB_DIR}"
@@ -301,7 +312,6 @@ install(CODE
     "execute_process(
     COMMAND ${PYTHON_DEFAULT_EXECUTABLE}
             ${CMAKE_CURRENT_SOURCE_DIR}/generator/cvmex.py
-            --jinja2 ${JINJA2_PATH}
             --opts=${MEX_OPTS}
             --include_dirs=-I${CMAKE_INSTALL_PREFIX}/${OPENCV_INCLUDE_INSTALL_PATH}
             --lib_dir=-L${CMAKE_INSTALL_PREFIX}/${OPENCV_LIB_INSTALL_PATH}

--- a/modules/matlab/generator/build_info.py
+++ b/modules/matlab/generator/build_info.py
@@ -25,7 +25,7 @@ def substitute(build, output_dir):
 
 if __name__ == "__main__":
     """
-    Usage: python build_info.py --jinja2 /path/to/jinja2/engine
+    Usage: python build_info.py
                                 --os os_version_string
                                 --arch [bitness processor]
                                 --compiler [id version]
@@ -50,7 +50,6 @@ if __name__ == "__main__":
     import sys, re, os, time
     from argparse import ArgumentParser
     parser = ArgumentParser()
-    parser.add_argument('--jinja2')
     parser.add_argument('--os')
     parser.add_argument('--arch', nargs=2)
     parser.add_argument('--compiler', nargs='+')
@@ -64,9 +63,6 @@ if __name__ == "__main__":
     parser.add_argument('--configuration')
     parser.add_argument('--outdir')
     build = parser.parse_args()
-
-    # add jinja to the path
-    sys.path.append(build.jinja2)
 
     from filters import *
     from jinja2 import Environment, FileSystemLoader

--- a/modules/matlab/generator/cvmex.py
+++ b/modules/matlab/generator/cvmex.py
@@ -26,7 +26,7 @@ def substitute(cv, output_dir):
 
 if __name__ == "__main__":
     """
-    Usage: python cvmex.py  --jinja2 /path/to/jinja2/engine
+    Usage: python cvmex.py
                             --opts [-list -of -opts]
                             --include_dirs [-list -of -opencv_include_directories]
                             --lib_dir opencv_lib_directory
@@ -44,7 +44,6 @@ if __name__ == "__main__":
     import sys, re, os, time
     from argparse import ArgumentParser
     parser = ArgumentParser()
-    parser.add_argument('--jinja2')
     parser.add_argument('--opts')
     parser.add_argument('--include_dirs')
     parser.add_argument('--lib_dir')
@@ -52,9 +51,6 @@ if __name__ == "__main__":
     parser.add_argument('--flags')
     parser.add_argument('--outdir')
     cv = parser.parse_args()
-
-    # add jinja to the path
-    sys.path.append(cv.jinja2)
 
     from filters import *
     from jinja2 import Environment, FileSystemLoader

--- a/modules/matlab/generator/gen_matlab.py
+++ b/modules/matlab/generator/gen_matlab.py
@@ -129,7 +129,7 @@ class MatlabWrapperGenerator(object):
 
 if __name__ == "__main__":
     """
-    Usage: python gen_matlab.py --jinja2 /path/to/jinja2/engine
+    Usage: python gen_matlab.py
                                 --hdrparser /path/to/hdr_parser/dir
                                 --moduleroot [ /path/to/opencv/modules /path/to/opencv_contrib/modules etc ]
                                 --modules [core imgproc objdetect etc]
@@ -145,8 +145,6 @@ if __name__ == "__main__":
          definitions
 
     gen_matlab.py requires the following inputs:
-    --jinja2       the path to the Jinja2 templating engine
-                   e.g. ${CMAKE_SOURCE_DIR}/3rdparty
     --hdrparser    the path to the header parser directory
                    (opencv/modules/python/src2)
     --moduleroot   (optional) paths to the opencv directories containing the modules
@@ -165,7 +163,6 @@ if __name__ == "__main__":
     # parse the input options
     from argparse import ArgumentParser
     parser = ArgumentParser()
-    parser.add_argument('--jinja2')
     parser.add_argument('--hdrparser')
     parser.add_argument('--moduleroot', nargs='*', default=[], required=False)
     parser.add_argument('--modules', nargs='*', default=[], required=False)
@@ -174,7 +171,6 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # add the hdr_parser module to the path
-    sys.path.append(args.jinja2)
     sys.path.append(args.hdrparser)
 
     # create the generator


### PR DESCRIPTION
CMake warning on missing Jinja2 package:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: No module named jinja2
CMake Warning at /home/alalek/projects/opencv/contrib/modules/matlab/CMakeLists.txt:52 (message):
  A required dependency of the matlab module (Python Jinja2 package) was not
  found (installation command: "pip install jinja2").  Disabling Matlab
  bindings...

```