### PR TITLE
Fixed while loop in buildPyramid in deepflow.cpp

### DIFF
--- a/modules/optflow/src/deepflow.cpp
+++ b/modules/optflow/src/deepflow.cpp
@@ -97,8 +97,7 @@ std::vector<Mat> OpticalFlowDeepFlow::buildPyramid( const Mat& src )
     std::vector<Mat> pyramid;
     pyramid.push_back(src);
     Mat prev = pyramid[0];
-    int i = 0;
-    while ( i < this->maxLayers )
+    for( int i = 0; i < this->maxLayers; ++i)
     {
         Mat next; //TODO: filtering at each level?
         Size nextSize((int) (prev.cols * downscaleFactor + 0.5f),


### PR DESCRIPTION
resolves #1218 

### This pullrequest changes:
The while loop in member function buildPyramid in deepflow.cpp terminated as a result of the break statement and never as a result of the termination criteria because the "i" variable in the while loop was never incremented.  The proposed change is to simply add a line that increments "i". Also, this is the first time I submit a pull request :).