### PR TITLE
Updated Halide pipelines

### DIFF
--- a/modules/dnn/perf/perf_halide_net.cpp
+++ b/modules/dnn/perf/perf_halide_net.cpp
@@ -39,7 +39,7 @@ static void loadNet(std::string weights, std::string proto, std::string schedule
     else
         CV_Error(Error::StsNotImplemented, "Unknown framework " + framework);
 
-    net->setInput(blobFromImage(input, 1.0, false));
+    net->setInput(blobFromImage(input, 1.0, Size(), Scalar(), false));
     net->setPreferableBackend(DNN_BACKEND_HALIDE);
     net->setPreferableTarget(targetId);
     net->setHalideScheduler(scheduler);
@@ -52,7 +52,7 @@ static void loadNet(std::string weights, std::string proto, std::string schedule
 PERF_TEST(GoogLeNet, HalidePerfTest)
 {
     Net net;
-    loadNet("dnn/bvlc_googlenet2.caffemodel", "dnn/bvlc_googlenet.prototxt",
+    loadNet("dnn/bvlc_googlenet.caffemodel", "dnn/bvlc_googlenet.prototxt",
             "", 227, 227, "prob", "caffe", DNN_TARGET_CPU, &net);
     TEST_CYCLE() net.forward();
     SANITY_CHECK_NOTHING();

--- a/modules/dnn/src/layers/convolution_layer.cpp
+++ b/modules/dnn/src/layers/convolution_layer.cpp
@@ -625,7 +625,7 @@ public:
         {
             // prepare weightsMat where each row is aligned and has enough zero padding on the right to
             // use vectorized (i.e. with intrinsics) loops without tail processing
-            Mat wm = blobs[0].reshape(1, outCn);
+            Mat wm = blobs[0].reshape(1, outCn).clone();
             if( wm.step1() % VEC_ALIGN != 0 )
             {
                 int newcols = (int)alignSize(wm.step1(), VEC_ALIGN);


### PR DESCRIPTION
### This pullrequest changes
* Replaced `blobFromImage` in Halide tests.
* Removed Halide buffer allocation in Batch norm layer.
* Create fused weights in convolutional layer separately from origin weights. In example, deconvolution's `weightsMat` creates by `transpose` with data copying. So, in this PR added `clone` call in convolution layer in the same way.