### PR TITLE
Enabled FastHoughTransform export to python.

### DIFF
--- a/modules/ximgproc/include/opencv2/ximgproc/fast_hough_transform.hpp
+++ b/modules/ximgproc/include/opencv2/ximgproc/fast_hough_transform.hpp
@@ -130,12 +130,12 @@ typedef enum {
 * The function calculates the fast Hough transform for full, half or quarter
 * range of angles.
 */
-CV_EXPORTS void FastHoughTransform( InputArray  src,
-                                    OutputArray dst,
-                                    int         dstMatDepth,
-                                    int         angleRange = ARO_315_135,
-                                    int         op = FHT_ADD,
-                                    int         makeSkew = HDO_DESKEW );
+CV_EXPORTS_W void FastHoughTransform( InputArray  src,
+                                      OutputArray dst,
+                                      int         dstMatDepth,
+                                      int         angleRange = ARO_315_135,
+                                      int         op = FHT_ADD,
+                                      int         makeSkew = HDO_DESKEW );
 
 /**
 * @brief   Calculates coordinates of line segment corresponded by point in Hough space.
@@ -152,6 +152,7 @@ CV_EXPORTS void FastHoughTransform( InputArray  src,
 *
 * The function calculates coordinates of line segment corresponded by point in Hough space.
 */
+// TODO cannot be exported yet; conversion from/to Vec4i is not wrapped in core
 CV_EXPORTS Vec4i HoughPoint2Line(const Point &houghPoint,
                                  InputArray  srcImgInfo,
                                  int         angleRange = ARO_315_135,

--- a/modules/ximgproc/include/opencv2/ximgproc/fast_hough_transform.hpp
+++ b/modules/ximgproc/include/opencv2/ximgproc/fast_hough_transform.hpp
@@ -152,7 +152,6 @@ CV_EXPORTS_W void FastHoughTransform( InputArray  src,
 *
 * The function calculates coordinates of line segment corresponded by point in Hough space.
 */
-// TODO cannot be exported yet; conversion from/to Vec4i is not wrapped in core
 CV_EXPORTS_W Vec4i HoughPoint2Line(const Point &houghPoint,
                                  InputArray  srcImgInfo,
                                  int         angleRange = ARO_315_135,

--- a/modules/ximgproc/include/opencv2/ximgproc/fast_hough_transform.hpp
+++ b/modules/ximgproc/include/opencv2/ximgproc/fast_hough_transform.hpp
@@ -153,7 +153,7 @@ CV_EXPORTS_W void FastHoughTransform( InputArray  src,
 * The function calculates coordinates of line segment corresponded by point in Hough space.
 */
 // TODO cannot be exported yet; conversion from/to Vec4i is not wrapped in core
-CV_EXPORTS Vec4i HoughPoint2Line(const Point &houghPoint,
+CV_EXPORTS_W Vec4i HoughPoint2Line(const Point &houghPoint,
                                  InputArray  srcImgInfo,
                                  int         angleRange = ARO_315_135,
                                  int         makeSkew = HDO_DESKEW,

--- a/modules/ximgproc/include/opencv2/ximgproc/fast_hough_transform.hpp
+++ b/modules/ximgproc/include/opencv2/ximgproc/fast_hough_transform.hpp
@@ -153,10 +153,10 @@ CV_EXPORTS_W void FastHoughTransform( InputArray  src,
 * The function calculates coordinates of line segment corresponded by point in Hough space.
 */
 CV_EXPORTS_W Vec4i HoughPoint2Line(const Point &houghPoint,
-                                 InputArray  srcImgInfo,
-                                 int         angleRange = ARO_315_135,
-                                 int         makeSkew = HDO_DESKEW,
-                                 int         rules = RO_IGNORE_BORDERS );
+                                   InputArray  srcImgInfo,
+                                   int         angleRange = ARO_315_135,
+                                   int         makeSkew = HDO_DESKEW,
+                                   int         rules = RO_IGNORE_BORDERS );
 
 } }// namespace cv::ximgproc
 


### PR DESCRIPTION
### This pullrequest changes

Enabled export of `FastHoughTransform` and `HoughPoint2Line` to `opencv-contrib-python`.
