### PR TITLE
ximgproc: eliminate per-pixel manual loop

### DIFF
--- a/modules/ximgproc/src/selectivesearchsegmentation.cpp
+++ b/modules/ximgproc/src/selectivesearchsegmentation.cpp
@@ -163,14 +163,7 @@ namespace cv {
                     for (int r = 0; r < nb_segs; r++) {
 
                         // Generate mask
-                        Mat mask = Mat(img.rows, img.cols, CV_8UC1);
-
-                        int* regions_data = (int*)regions.data;
-                        char* mask_data = (char*)mask.data;
-
-                        for (unsigned int x = 0; x < regions.total(); x++) {
-                            mask_data[x] = regions_data[x] == r ? 255 : 0;
-                        }
+                        Mat mask = regions == r;
 
                         // Compute histogram for each channels
                         float tt = 0;


### PR DESCRIPTION
fixes warning on MacOSX