### PR TITLE
making minRepDistance not quadratically dependent on the image size

### DIFF
--- a/modules/aruco/src/charuco.cpp
+++ b/modules/aruco/src/charuco.cpp
@@ -738,7 +738,7 @@ void detectCharucoDiamond(InputArray _image, InputArrayOfArrays _markerCorners,
 
     CV_Assert(_markerIds.total() > 0 && _markerIds.total() == _markerCorners.total());
 
-    const float minRepDistanceRate = 0.12f;
+    const float minRepDistanceRate = 1.302455f;
 
     // create Charuco board layout for diamond (3x3 layout)
     Ptr<Dictionary> dict = getPredefinedDictionary(PREDEFINED_DICTIONARY_NAME(0));
@@ -771,7 +771,7 @@ void detectCharucoDiamond(InputArray _image, InputArrayOfArrays _markerCorners,
           perimeterSq += edge.x*edge.x + edge.y*edge.y;
         }
         // maximum reprojection error relative to perimeter
-        float minRepDistance = perimeterSq * minRepDistanceRate * minRepDistanceRate;
+        float minRepDistance = sqrt(perimeterSq) * minRepDistanceRate;
 
         int currentId = _markerIds.getMat().at< int >(i);
 


### PR DESCRIPTION

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest resolves #1331

<!-- Please describe what your pullrequest is changing -->

### System information (version)

OpenCV => 3.3
Operating System / Platform => Any
Compiler => Any
Detailed description

CharUco Diamond detection detects too many false positives when the image resolution is high.

The reason is that a variable is that ```minRepDistance``` inside ```detectCharucoDiamond``` is growing in squared proportion to the image width, and then its value is squared again for the thresholding using ```closestCandidateDistance``` inside of ```refineDetectedMarkers```.


The images for testing this problem and the corresponding calibration files can be found in: 

https://github.com/opencv/opencv_contrib/issues/1331



