### PR TITLE
Added USING_STD_NAMESPACE macro to text module

### DIFF
--- a/modules/text/src/precomp.hpp
+++ b/modules/text/src/precomp.hpp
@@ -48,6 +48,9 @@
 #include "text_config.hpp"
 
 #ifdef HAVE_TESSERACT
+#if !defined(USE_STD_NAMESPACE)
+#define USE_STD_NAMESPACE
+#endif
 #include <tesseract/baseapi.h>
 #include <tesseract/resultiterator.h>
 #endif


### PR DESCRIPTION
resolves #1324

Added USING_STD_NAMESPACE macro since "-DUSING_STD_NAMESPACE is now needed for all of the tesseract library, not just for training."