### PR TITLE
fix cmake configuration error

### DIFF
--- a/modules/cnn_3dobj/CMakeLists.txt
+++ b/modules/cnn_3dobj/CMakeLists.txt
@@ -36,12 +36,12 @@ ocv_define_module(cnn_3dobj opencv_core opencv_imgproc ${Caffe_LIBS} ${Glog_LIBS
 ocv_add_testdata(testdata/cv contrib/cnn_3dobj)
 
 if(TARGET opencv_test_cnn_3dobj)
-  target_link_libraries(opencv_test_cnn_3dobj boost_system)
+  target_link_libraries(opencv_test_cnn_3dobj PUBLIC boost_system)
 endif()
 
 foreach(exe_TGT  classify video sphereview_data model_analysis)
     if(TARGET example_cnn_3dobj_${exe_TGT})
-      target_link_libraries(example_cnn_3dobj_${exe_TGT} boost_system)
+      target_link_libraries(example_cnn_3dobj_${exe_TGT} PUBLIC boost_system)
     endif()
 endforeach()
 endif()


### PR DESCRIPTION
WIthout this change, there will be the below cmake configuration error

``````
CMake Error at /home/ubuntu/ppa/opencv_contrib/modules/cnn_3dobj/CMakeLists.txt:39 (target_link_libraries):
  The keyword signature for target_link_libraries has already been used with
  the target "opencv_test_cnn_3dobj".  All uses of target_link_libraries with
  a target must be either all-keyword or all-plain.

  The uses of the keyword signature are here:

   * /home/ubuntu/ppa/opencv/cmake/OpenCVUtils.cmake:911 (target_link_libraries)
``````