### PR TITLE
Fixed PCT Signature typos.

### DIFF
--- a/modules/xfeatures2d/include/opencv2/xfeatures2d.hpp
+++ b/modules/xfeatures2d/include/opencv2/xfeatures2d.hpp
@@ -605,7 +605,7 @@ public:
     * @brief Weights (multiplicative constants) that linearly stretch individual axes of the feature space
     *       (x,y = position; L,a,b = color in CIE Lab space; c = contrast. e = entropy)
     */
-    CV_WRAP virtual float getWeightConstrast() const = 0;
+    CV_WRAP virtual float getWeightContrast() const = 0;
     /**
     * @brief Weights (multiplicative constants) that linearly stretch individual axes of the feature space
     *       (x,y = position; L,a,b = color in CIE Lab space; c = contrast. e = entropy)

--- a/modules/xfeatures2d/src/pct_signatures.cpp
+++ b/modules/xfeatures2d/src/pct_signatures.cpp
@@ -137,7 +137,7 @@ namespace cv
                 float getWeightL() const                        { return mSampler->getWeightL(); }
                 float getWeightA() const                        { return mSampler->getWeightA(); }
                 float getWeightB() const                        { return mSampler->getWeightB(); }
-                float getWeightConstrast() const                { return mSampler->getWeightConstrast(); }
+                float getWeightContrast() const                 { return mSampler->getWeightContrast(); }
                 float getWeightEntropy() const                  { return mSampler->getWeightEntropy(); }
 
                 std::vector<Point2f> getSamplingPoints() const  { return mSampler->getSamplingPoints(); }

--- a/modules/xfeatures2d/src/pct_signatures/pct_sampler.cpp
+++ b/modules/xfeatures2d/src/pct_signatures/pct_sampler.cpp
@@ -128,7 +128,7 @@ namespace cv
                 float getWeightL() const               { return mWeights[L_IDX]; }
                 float getWeightA() const               { return mWeights[A_IDX]; }
                 float getWeightB() const               { return mWeights[B_IDX]; }
-                float getWeightConstrast() const       { return mWeights[CONTRAST_IDX]; }
+                float getWeightContrast() const        { return mWeights[CONTRAST_IDX]; }
                 float getWeightEntropy() const         { return mWeights[ENTROPY_IDX]; }
 
                 std::vector<Point2f> getSamplingPoints() const

--- a/modules/xfeatures2d/src/pct_signatures/pct_sampler.hpp
+++ b/modules/xfeatures2d/src/pct_signatures/pct_sampler.hpp
@@ -103,7 +103,7 @@ namespace cv
                 virtual float getWeightL() const = 0;
                 virtual float getWeightA() const = 0;
                 virtual float getWeightB() const = 0;
-                virtual float getWeightConstrast() const = 0;
+                virtual float getWeightContrast() const = 0;
                 virtual float getWeightEntropy() const = 0;
 
                 virtual std::vector<Point2f> getSamplingPoints() const = 0;

--- a/modules/xfeatures2d/src/pct_signatures/similarity.hpp
+++ b/modules/xfeatures2d/src/pct_signatures/similarity.hpp
@@ -89,7 +89,7 @@ namespace cv
                 const Mat& points2, int idx2)
             {
                 float distance = computeDistance(distancefunction, points1, idx1, points2, idx2);
-                return exp(-alpha + distance * distance);
+                return exp(-alpha * distance * distance);
             }
 
 


### PR DESCRIPTION
### This pullrequest fixes some typos in PCTSignatures

Typos in a property accessor caused incorrect exporting of the property in EmguCV (an OpenCV .NET wrapper).

Moreover, a similarity function typo has been fixed.

