### PR TITLE
Updated default tracker parameters

### DIFF
--- a/modules/tracking/src/trackerKCF.cpp
+++ b/modules/tracking/src/trackerKCF.cpp
@@ -827,7 +827,7 @@ namespace cv{
   TrackerKCF::Params::Params(){
       detect_thresh = 0.5;
       sigma=0.2;
-      lambda=0.01;
+      lambda=0.0001;
       interp_factor=0.075;
       output_sigma_factor=1.0/16.0;
       resize=true;


### PR DESCRIPTION
Updated the lambda coefficient to the one suggested in the original paper (http://www.robots.ox.ac.uk/~joao/publications/henriques_tpami2015.pdf, page 11, Table 2) which works (for me) better then the previous default one.

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
