### PR TITLE
Fix SFM compilation problem with Windows not finding libmv directory

### DIFF
--- a/modules/sfm/CMakeLists.txt
+++ b/modules/sfm/CMakeLists.txt
@@ -1,3 +1,4 @@
+set(OPENCV_MODULE_IS_PART_OF_WORLD FALSE)
 set(the_description "SFM algorithms")
 
 
@@ -113,7 +114,7 @@ if(NOT CMAKE_VERSION VERSION_LESS 2.8.11) # See ocv_target_include_directories()
   endif()
 endif()
 include_directories(${OCV_TARGET_INCLUDE_DIRS_${the_module}})
-add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/src/libmv_light)
+add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/src/libmv_light" "${CMAKE_CURRENT_BINARY_DIR}/src/libmv")
 
 ocv_target_link_libraries(${the_module} ${LIBMV_LIGHT_LIBS})
 

--- a/modules/sfm/CMakeLists.txt
+++ b/modules/sfm/CMakeLists.txt
@@ -113,7 +113,7 @@ if(NOT CMAKE_VERSION VERSION_LESS 2.8.11) # See ocv_target_include_directories()
   endif()
 endif()
 include_directories(${OCV_TARGET_INCLUDE_DIRS_${the_module}})
-add_subdirectory(src/libmv_light)
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/src/libmv_light)
 
 ocv_target_link_libraries(${the_module} ${LIBMV_LIGHT_LIBS})
 

--- a/modules/sfm/CMakeLists.txt
+++ b/modules/sfm/CMakeLists.txt
@@ -39,7 +39,7 @@ endif()
 ### LIBMV LIGHT DEFINITIONS ###
 
 set(LIBMV_LIGHT_INCLUDES
-  src/libmv_light
+  "${CMAKE_CURRENT_LIST_DIR}/src/libmv_light"
   "${OpenCV_SOURCE_DIR}/include/opencv"
   "${GLOG_INCLUDE_DIRS}"
   "${GFLAGS_INCLUDE_DIRS}"


### PR DESCRIPTION
resolves #1353 

### This pullrequest changes

Adds required cmake path prefix to allow compilation under Windows MSVC (tested VS2017).
(resolves issue #1353 "sfm is disabled because subdirectory libmv not found")
