### PR TITLE
stereo: fix self-comparison warnings in test_block_matching.cpp

### DIFF
--- a/modules/stereo/test/test_block_matching.cpp
+++ b/modules/stereo/test/test_block_matching.cpp
@@ -97,7 +97,7 @@ void CV_BlockMatchingTest::run(int )
         ts->set_failed_test_info(cvtest::TS::FAIL_INVALID_TEST_DATA);
         return;
     }
-    if(image1.rows != image2.rows || image1.cols != image2.cols || gt.cols != gt.cols || gt.rows != gt.rows)
+    if(image1.rows != image2.rows || image1.cols != image2.cols || image1.cols != gt.cols || image1.rows != gt.rows)
     {
         ts->printf(cvtest::TS::LOG, "Wrong input / output dimension \n");
         ts->set_failed_test_info(cvtest::TS::FAIL_INVALID_TEST_DATA);
@@ -181,7 +181,7 @@ void CV_SGBlockMatchingTest::run(int )
         ts->set_failed_test_info(cvtest::TS::FAIL_INVALID_TEST_DATA);
         return;
     }
-    if(image1.rows != image2.rows || image1.cols != image2.cols || gt.cols != gt.cols || gt.rows != gt.rows)
+    if(image1.rows != image2.rows || image1.cols != image2.cols || image1.cols != gt.cols || image1.rows != gt.rows)
     {
         ts->printf(cvtest::TS::LOG, "Wrong input / output dimension \n");
         ts->set_failed_test_info(cvtest::TS::FAIL_INVALID_TEST_DATA);


### PR DESCRIPTION
resolves #1394

### This pullrequest changes

compare groundtruth image size to size of image1, not to itself

(all image1 image2 gt and test images need to be of the same size)