### PR TITLE
Re-write surface matching using vectors and matrices

### DIFF
--- a/modules/surface_matching/include/opencv2/surface_matching/pose_3d.hpp
+++ b/modules/surface_matching/include/opencv2/surface_matching/pose_3d.hpp
@@ -77,42 +77,40 @@ public:
     numVotes=0;
     residual = 0;
 
-    for (int i=0; i<16; i++)
-      pose[i]=0;
+    pose = Matx44d::all(0);
   }
 
-  Pose3D(double Alpha, unsigned int ModelIndex=0, unsigned int NumVotes=0)
+  Pose3D(double Alpha, size_t ModelIndex=0, size_t NumVotes=0)
   {
     alpha = Alpha;
     modelIndex = ModelIndex;
     numVotes = NumVotes;
     residual=0;
 
-    for (int i=0; i<16; i++)
-      pose[i]=0;
+    pose = Matx44d::all(0);
   }
 
   /**
    *  \brief Updates the pose with the new one
    *  \param [in] NewPose New pose to overwrite
    */
-  void updatePose(double NewPose[16]);
+  void updatePose(Matx44d& NewPose);
 
   /**
    *  \brief Updates the pose with the new one
    */
-  void updatePose(double NewR[9], double NewT[3]);
+  void updatePose(Matx33d& NewR, Vec3d& NewT);
 
   /**
    *  \brief Updates the pose with the new one, but this time using quaternions to represent rotation
    */
-  void updatePoseQuat(double Q[4], double NewT[3]);
+  void updatePoseQuat(Vec4d& Q, Vec3d& NewT);
 
   /**
    *  \brief Left multiplies the existing pose in order to update the transformation
    *  \param [in] IncrementalPose New pose to apply
    */
-  void appendPose(double IncrementalPose[16]);
+  void appendPose(Matx44d& IncrementalPose);
   void printPose();
 
   Pose3DPtr clone();
@@ -125,17 +123,19 @@ public:
   virtual ~Pose3D() {}
 
   double alpha, residual;
-  unsigned int modelIndex;
-  unsigned int numVotes;
-  double pose[16], angle, t[3], q[4];
+  size_t modelIndex, numVotes;
+  Matx44d pose;
+  double angle;
+  Vec3d t;
+  Vec4d q;
 };
 
 /**
-* @brief When multiple poses (see Pose3D) are grouped together (contribute to the same transformation) 
+* @brief When multiple poses (see Pose3D) are grouped together (contribute to the same transformation)
 * pose clusters occur. This class is a general container for such groups of poses. It is possible to store,
 * load and perform IO on these poses.
 */
-class CV_EXPORTS PoseCluster3D
+class CV_EXPORTS_W PoseCluster3D
 {
 public:
   PoseCluster3D()
@@ -175,7 +175,7 @@ public:
   int readPoseCluster(const std::string& FileName);
 
   std::vector<Pose3DPtr> poseList;
-  int numVotes;
+  size_t numVotes;
   int id;
 };
 

--- a/modules/surface_matching/include/opencv2/surface_matching/ppf_helpers.hpp
+++ b/modules/surface_matching/include/opencv2/surface_matching/ppf_helpers.hpp
@@ -61,14 +61,14 @@ namespace ppf_match_3d
  *  and whether it should be loaded or not
  *  @return Returns the matrix on successfull load
  */
-CV_EXPORTS Mat loadPLYSimple(const char* fileName, int withNormals = 0);
+CV_EXPORTS_W Mat loadPLYSimple(const char* fileName, int withNormals = 0);
 
 /**
  *  @brief Write a point cloud to PLY file
  *  @param [in] PC Input point cloud
  *  @param [in] fileName The PLY model file to write
 */
-CV_EXPORTS void writePLY(Mat PC, const char* fileName);
+CV_EXPORTS_W void writePLY(Mat PC, const char* fileName);
 
 /**
 *  @brief Used for debbuging pruposes, writes a point cloud to a PLY file with the tip
@@ -76,7 +76,7 @@ CV_EXPORTS void writePLY(Mat PC, const char* fileName);
 *  @param [in] PC Input point cloud
 *  @param [in] fileName The PLY model file to write
 */
-CV_EXPORTS void writePLYVisibleNormals(Mat PC, const char* fileName);
+CV_EXPORTS_W void writePLYVisibleNormals(Mat PC, const char* fileName);
 
 Mat samplePCUniform(Mat PC, int sampleStep);
 Mat samplePCUniformInd(Mat PC, int sampleStep, std::vector<int>& indices);
@@ -94,25 +94,14 @@ Mat samplePCUniformInd(Mat PC, int sampleStep, std::vector<int>& indices);
  *  by the distance to the origin. This parameter enables/disables the use of weighting.
  *  @return Sampled point cloud
 */
-CV_EXPORTS Mat samplePCByQuantization(Mat pc, float xrange[2], float yrange[2], float zrange[2], float sample_step_relative, int weightByCenter=0);
+CV_EXPORTS_W Mat samplePCByQuantization(Mat pc, Vec2f& xrange, Vec2f& yrange, Vec2f& zrange, float sample_step_relative, int weightByCenter=0);
 
-void computeBboxStd(Mat pc, float xRange[2], float yRange[2], float zRange[2]);
+void computeBboxStd(Mat pc, Vec2f& xRange, Vec2f& yRange, Vec2f& zRange);
 
 void* indexPCFlann(Mat pc);
 void destroyFlann(void* flannIndex);
 void queryPCFlann(void* flannIndex, Mat& pc, Mat& indices, Mat& distances);
 void queryPCFlann(void* flannIndex, Mat& pc, Mat& indices, Mat& distances, const int numNeighbors);
-
-/**
- *  Mostly for visualization purposes. Normalizes the point cloud in a Hartley-Zissermann
- *  fashion. In other words, the point cloud is centered, and scaled such that the largest
- *  distance from the origin is sqrt(2). Finally a rescaling is applied.
- *  @param [in] pc Input point cloud (CV_32F family). Point clouds with 3 or 6 elements per
- *  row are expected.
- *  @param [in] scale The scale after normalization. Default to 1.
- *  @return Normalized point cloud
-*/
-CV_EXPORTS Mat normalize_pc(Mat pc, float scale);
 
 Mat normalizePCCoeff(Mat pc, float scale, float* Cx, float* Cy, float* Cz, float* MinVal, float* MaxVal);
 Mat transPCCoeff(Mat pc, float scale, float Cx, float Cy, float Cz, float MinVal, float MaxVal);
@@ -125,20 +114,20 @@ Mat transPCCoeff(Mat pc, float scale, float Cx, float Cy, float Cz, float MinVal
  *  @param [in] Pose 4x4 pose matrix, but linearized in row-major form.
  *  @return Transformed point cloud
 */
-CV_EXPORTS Mat transformPCPose(Mat pc, const double Pose[16]);
+CV_EXPORTS_W Mat transformPCPose(Mat pc, const Matx44d& Pose);
 
 /**
  *  Generate a random 4x4 pose matrix
  *  @param [out] Pose The random pose
 */
-CV_EXPORTS void getRandomPose(double Pose[16]);
+CV_EXPORTS_W void getRandomPose(Matx44d& Pose);
 
 /**
  *  Adds a uniform noise in the given scale to the input point cloud
  *  @param [in] pc Input point cloud (CV_32F family).
  *  @param [in] scale Input scale of the noise. The larger the scale, the more noisy the output
 */
-CV_EXPORTS Mat addNoisePC(Mat pc, double scale);
+CV_EXPORTS_W Mat addNoisePC(Mat pc, double scale);
 
 /**
  *  @brief Compute the normals of an arbitrary point cloud
@@ -154,7 +143,7 @@ CV_EXPORTS Mat addNoisePC(Mat pc, double scale);
  *  @param [in] viewpoint
  *  @return Returns 0 on success
  */
-CV_EXPORTS_W int computeNormalsPC3d(const Mat& PC, CV_OUT Mat& PCNormals, const int NumNeighbors, const bool FlipViewpoint, const Vec3d& viewpoint);
+CV_EXPORTS_W int computeNormalsPC3d(const Mat& PC, CV_OUT Mat& PCNormals, const int NumNeighbors, const bool FlipViewpoint, const Vec3f& viewpoint);
 
 //! @}
 

--- a/modules/surface_matching/include/opencv2/surface_matching/ppf_match_3d.hpp
+++ b/modules/surface_matching/include/opencv2/surface_matching/ppf_match_3d.hpp
@@ -94,7 +94,7 @@ typedef struct THash
   * detector.match(pcTest, results, 1.0/5.0,0.05);
   * @endcode
   */
-class CV_EXPORTS PPF3DDetector
+class CV_EXPORTS_W PPF3DDetector
 {
 public:
 
@@ -160,9 +160,9 @@ protected:
   void clearTrainingModels();
 
 private:
-  void computePPFFeatures(const double p1[4], const double n1[4],
-                          const double p2[4], const double n2[4],
-                          double f[4]);
+  void computePPFFeatures(const Vec3d& p1, const Vec3d& n1,
+                          const Vec3d& p2, const Vec3d& n2,
+                          Vec4d& f);
 
   bool matchPose(const Pose3D& sourcePose, const Pose3D& targetPose);
 

--- a/modules/surface_matching/include/opencv2/surface_matching/t_hash_int.hpp
+++ b/modules/surface_matching/include/opencv2/surface_matching/t_hash_int.hpp
@@ -55,7 +55,7 @@ namespace ppf_match_3d
 //! @addtogroup surface_matching
 //! @{
 
-typedef unsigned int KeyType;
+typedef uint KeyType;
 
 typedef struct hashnode_i
 {
@@ -68,7 +68,7 @@ typedef struct HSHTBL_i
 {
   size_t size;
   struct hashnode_i **nodes;
-  size_t (*hashfunc)(unsigned int);
+  size_t (*hashfunc)(uint);
 } hashtable_int;
 
 
@@ -76,7 +76,7 @@ typedef struct HSHTBL_i
 
 from http://www-graphics.stanford.edu/~seander/bithacks.html
 */
-inline static unsigned int next_power_of_two(unsigned int value)
+inline static uint next_power_of_two(uint value)
 {
 
   --value;
@@ -90,7 +90,7 @@ inline static unsigned int next_power_of_two(unsigned int value)
   return value;
 }
 
-hashtable_int *hashtableCreate(size_t size, size_t (*hashfunc)(unsigned int));
+hashtable_int *hashtableCreate(size_t size, size_t (*hashfunc)(uint));
 void hashtableDestroy(hashtable_int *hashtbl);
 int hashtableInsert(hashtable_int *hashtbl, KeyType key, void *data);
 int hashtableInsertHashed(hashtable_int *hashtbl, KeyType key, void *data);

--- a/modules/surface_matching/src/hash_murmur64.hpp
+++ b/modules/surface_matching/src/hash_murmur64.hpp
@@ -26,7 +26,7 @@ THE SOFTWARE.
 // Block read - if your platform needs to do endian-swapping or can only
 // handle aligned reads, do the conversion here
 
-FORCE_INLINE unsigned int getblock ( const unsigned int * p, int i )
+FORCE_INLINE uint getblock ( const uint * p, int i )
 {
   return p[i];
 }
@@ -36,7 +36,7 @@ FORCE_INLINE unsigned int getblock ( const unsigned int * p, int i )
 
 // avalanches all bits to within 0.25% bias
 
-FORCE_INLINE unsigned int fmix32 ( unsigned int h )
+FORCE_INLINE uint fmix32 ( uint h )
 {
   h ^= h >> 16;
   h *= 0x85ebca6b;
@@ -49,7 +49,7 @@ FORCE_INLINE unsigned int fmix32 ( unsigned int h )
 
 //-----------------------------------------------------------------------------
 
-FORCE_INLINE void bmix32 ( unsigned int & h1, unsigned int & k1, unsigned int & c1, unsigned int & c2 )
+FORCE_INLINE void bmix32 ( uint & h1, uint & k1, uint & c1, uint & c2 )
 {
   k1 *= c1;
   k1  = ROTL32(k1,11);
@@ -64,7 +64,7 @@ FORCE_INLINE void bmix32 ( unsigned int & h1, unsigned int & k1, unsigned int & 
 
 //-----------------------------------------------------------------------------
 
-FORCE_INLINE void bmix32 ( unsigned int & h1, unsigned int & h2, unsigned int & k1, unsigned int & k2, unsigned int & c1, unsigned int & c2 )
+FORCE_INLINE void bmix32 ( uint & h1, uint & h2, uint & k1, uint & k2, uint & c1, uint & c2 )
 {
   k1 *= c1;
   k1  = ROTL32(k1,11);
@@ -89,26 +89,26 @@ FORCE_INLINE void bmix32 ( unsigned int & h1, unsigned int & h2, unsigned int & 
 
 //----------
 
-FORCE_INLINE void hashMurmurx64 ( const void * key, const int len, const unsigned int seed, void * out )
+FORCE_INLINE void hashMurmurx64 ( const void * key, const int len, const uint seed, void * out )
 {
-  const unsigned char * data = (const unsigned char*)key;
+  const uchar * data = (const uchar*)key;
   const int nblocks = len / 8;
 
-  unsigned int h1 = 0x8de1c3ac ^ seed;
-  unsigned int h2 = 0xbab98226 ^ seed;
+  uint h1 = 0x8de1c3ac ^ seed;
+  uint h2 = 0xbab98226 ^ seed;
 
-  unsigned int c1 = 0x95543787;
-  unsigned int c2 = 0x2ad7eb25;
+  uint c1 = 0x95543787;
+  uint c2 = 0x2ad7eb25;
 
   //----------
   // body
 
-  const unsigned int * blocks = (const unsigned int *)(data + nblocks*8);
+  const uint * blocks = (const uint *)(data + nblocks*8);
 
   for (int i = -nblocks; i; i++)
   {
-    unsigned int k1 = getblock(blocks,i*2+0);
-    unsigned int k2 = getblock(blocks,i*2+1);
+    uint k1 = getblock(blocks,i*2+0);
+    uint k2 = getblock(blocks,i*2+1);
 
     bmix32(h1,h2,k1,k2,c1,c2);
   }
@@ -116,10 +116,10 @@ FORCE_INLINE void hashMurmurx64 ( const void * key, const int len, const unsigne
   //----------
   // tail
 
-  const unsigned char * tail = (const unsigned char*)(data + nblocks*8);
+  const uchar * tail = (const uchar*)(data + nblocks*8);
 
-  unsigned int k1 = 0;
-  unsigned int k2 = 0;
+  uint k1 = 0;
+  uint k2 = 0;
 
   switch (len & 7)
   {
@@ -154,8 +154,8 @@ FORCE_INLINE void hashMurmurx64 ( const void * key, const int len, const unsigne
   h1 += h2;
   h2 += h1;
 
-  ((unsigned int*)out)[0] = h1;
-  ((unsigned int*)out)[1] = h2;
+  ((uint*)out)[0] = h1;
+  ((uint*)out)[1] = h2;
 }
 
 

--- a/modules/surface_matching/src/t_hash_int.cpp
+++ b/modules/surface_matching/src/t_hash_int.cpp
@@ -47,10 +47,10 @@ namespace ppf_match_3d
 // This magic value is just
 #define T_HASH_MAGIC 427462442
 
-size_t hash( unsigned int a);
+size_t hash( uint a);
 
 // default hash function
-size_t hash( unsigned int a)
+size_t hash( uint a)
 {
     a = (a+0x7ed55d16) + (a<<12);
     a = (a^0xc761c23c) ^ (a>>19);
@@ -61,37 +61,37 @@ size_t hash( unsigned int a)
     return a;
 }
 
-hashtable_int *hashtableCreate(size_t size, size_t (*hashfunc)(unsigned int))
+hashtable_int *hashtableCreate(size_t size, size_t (*hashfunc)(uint))
 {
     hashtable_int *hashtbl;
-    
+
     if (size < 16)
     {
         size = 16;
     }
     else
     {
-        size = (size_t)next_power_of_two((unsigned int)size);
+        size = (size_t)next_power_of_two((uint)size);
     }
-    
-	hashtbl=(hashtable_int*)malloc(sizeof(hashtable_int));
+
+    hashtbl=(hashtable_int*)malloc(sizeof(hashtable_int));
     if (!hashtbl)
         return NULL;
-        
-	hashtbl->nodes=(hashnode_i**)calloc(size, sizeof(struct hashnode_i*));
+
+    hashtbl->nodes=(hashnode_i**)calloc(size, sizeof(struct hashnode_i*));
     if (!hashtbl->nodes)
     {
         free(hashtbl);
         return NULL;
     }
-    
+
     hashtbl->size=size;
-    
+
     if (hashfunc)
         hashtbl->hashfunc=hashfunc;
     else
         hashtbl->hashfunc=hash;
-        
+
     return hashtbl;
 }
 
@@ -100,7 +100,7 @@ void hashtableDestroy(hashtable_int *hashtbl)
 {
     size_t n;
     struct hashnode_i *node, *oldnode;
-    
+
     for (n=0; n<hashtbl->size; ++n)
     {
         node=hashtbl->nodes[n];
@@ -120,10 +120,10 @@ int hashtableInsert(hashtable_int *hashtbl, KeyType key, void *data)
 {
     struct hashnode_i *node;
     size_t hash=hashtbl->hashfunc(key)%hashtbl->size;
-    
-    
+
+
     /* fpruintf(stderr, "hashtbl_insert() key=%s, hash=%d, data=%s\n", key, hash, (char*)data);*/
-    
+
     node=hashtbl->nodes[hash];
     while (node)
     {
@@ -134,18 +134,18 @@ int hashtableInsert(hashtable_int *hashtbl, KeyType key, void *data)
         }
         node=node->next;
     }
-    
-    
-	node=(hashnode_i*)malloc(sizeof(struct hashnode_i));
+
+
+    node=(hashnode_i*)malloc(sizeof(struct hashnode_i));
     if (!node)
         return -1;
     node->key=key;
-    
+
     node->data=data;
     node->next=hashtbl->nodes[hash];
     hashtbl->nodes[hash]=node;
-    
-    
+
+
     return 0;
 }
 
@@ -153,10 +153,10 @@ int hashtableInsertHashed(hashtable_int *hashtbl, KeyType key, void *data)
 {
     struct hashnode_i *node;
     size_t hash = key % hashtbl->size;
-    
-    
+
+
     /* fpruintf(stderr, "hashtbl_insert() key=%s, hash=%d, data=%s\n", key, hash, (char*)data);*/
-    
+
     node=hashtbl->nodes[hash];
     while (node)
     {
@@ -167,18 +167,18 @@ int hashtableInsertHashed(hashtable_int *hashtbl, KeyType key, void *data)
         }
         node=node->next;
     }
-    
-	node=(hashnode_i*)malloc(sizeof(struct hashnode_i));
+
+    node=(hashnode_i*)malloc(sizeof(struct hashnode_i));
     if (!node)
         return -1;
-		
+
     node->key=key;
-    
+
     node->data=data;
     node->next=hashtbl->nodes[hash];
     hashtbl->nodes[hash]=node;
-    
-    
+
+
     return 0;
 }
 
@@ -187,7 +187,7 @@ int hashtableRemove(hashtable_int *hashtbl, KeyType key)
 {
     struct hashnode_i *node, *prevnode=NULL;
     size_t hash=hashtbl->hashfunc(key)%hashtbl->size;
-    
+
     node=hashtbl->nodes[hash];
     while (node)
     {
@@ -203,7 +203,7 @@ int hashtableRemove(hashtable_int *hashtbl, KeyType key)
         prevnode=node;
         node=node->next;
     }
-    
+
     return -1;
 }
 
@@ -212,9 +212,9 @@ void *hashtableGet(hashtable_int *hashtbl, KeyType key)
 {
     struct hashnode_i *node;
     size_t hash=hashtbl->hashfunc(key)%hashtbl->size;
-    
+
     /* fprintf(stderr, "hashtbl_get() key=%s, hash=%d\n", key, hash);*/
-    
+
     node=hashtbl->nodes[hash];
     while (node)
     {
@@ -222,14 +222,14 @@ void *hashtableGet(hashtable_int *hashtbl, KeyType key)
             return node->data;
         node=node->next;
     }
-    
+
     return NULL;
 }
 
 hashnode_i* hashtableGetBucketHashed(hashtable_int *hashtbl, KeyType key)
 {
     size_t hash = key % hashtbl->size;
-    
+
     return hashtbl->nodes[hash];
 }
 
@@ -238,14 +238,14 @@ int hashtableResize(hashtable_int *hashtbl, size_t size)
     hashtable_int newtbl;
     size_t n;
     struct hashnode_i *node,*next;
-    
+
     newtbl.size=size;
     newtbl.hashfunc=hashtbl->hashfunc;
-    
-	newtbl.nodes=(hashnode_i**)calloc(size, sizeof(struct hashnode_i*));
+
+    newtbl.nodes=(hashnode_i**)calloc(size, sizeof(struct hashnode_i*));
     if (!newtbl.nodes)
         return -1;
-        
+
     for (n=0; n<hashtbl->size; ++n)
     {
         for (node=hashtbl->nodes[n]; node; node=next)
@@ -253,14 +253,14 @@ int hashtableResize(hashtable_int *hashtbl, size_t size)
             next = node->next;
             hashtableInsert(&newtbl, node->key, node->data);
             hashtableRemove(hashtbl, node->key);
-            
+
         }
     }
-    
+
     free(hashtbl->nodes);
     hashtbl->size=newtbl.size;
     hashtbl->nodes=newtbl.nodes;
-    
+
     return 0;
 }
 
@@ -270,24 +270,24 @@ int hashtableWrite(const hashtable_int * hashtbl, const size_t dataSize, FILE* f
     size_t hashMagic=T_HASH_MAGIC;
     size_t n=hashtbl->size;
     size_t i;
-    
+
     fwrite(&hashMagic, sizeof(size_t),1, f);
     fwrite(&n, sizeof(size_t),1, f);
     fwrite(&dataSize, sizeof(size_t),1, f);
-    
+
     for (i=0; i<hashtbl->size; i++)
     {
         struct hashnode_i* node=hashtbl->nodes[i];
         size_t noEl=0;
-        
+
         while (node)
         {
             noEl++;
             node=node->next;
         }
-        
+
         fwrite(&noEl, sizeof(size_t),1, f);
-        
+
         node=hashtbl->nodes[i];
         while (node)
         {
@@ -296,7 +296,7 @@ int hashtableWrite(const hashtable_int * hashtbl, const size_t dataSize, FILE* f
             node=node->next;
         }
     }
-    
+
     return 1;
 }
 
@@ -305,13 +305,13 @@ void hashtablePrint(hashtable_int *hashtbl)
 {
     size_t n;
     struct hashnode_i *node,*next;
-    
+
     for (n=0; n<hashtbl->size; ++n)
     {
         for (node=hashtbl->nodes[n]; node; node=next)
         {
             next = node->next;
-			std::cout<<"Key : "<<node->key<<", Data : "<<node->data<<std::endl;
+            std::cout<<"Key : "<<node->key<<", Data : "<<node->data<<std::endl;
         }
     }
 }
@@ -321,7 +321,7 @@ hashtable_int *hashtableRead(FILE* f)
     size_t hashMagic = 0;
     size_t n = 0, status;
     hashtable_int *hashtbl = 0;
-    
+
     status = fread(&hashMagic, sizeof(size_t),1, f);
     if (status && hashMagic==T_HASH_MAGIC)
     {
@@ -329,20 +329,20 @@ hashtable_int *hashtableRead(FILE* f)
         size_t dataSize;
         status = fread(&n, sizeof(size_t),1, f);
         status = fread(&dataSize, sizeof(size_t),1, f);
-        
+
         hashtbl=hashtableCreate(n, hash);
-        
+
         for (i=0; i<hashtbl->size; i++)
         {
             size_t j=0;
             status = fread(&n, sizeof(size_t),1, f);
-            
+
             for (j=0; j<n; j++)
             {
                 int key=0;
                 void* data=0;
                 status = fread(&key, sizeof(KeyType), 1, f);
-                
+
                 if (dataSize>sizeof(void*))
                 {
                     data=malloc(dataSize);
@@ -355,7 +355,7 @@ hashtable_int *hashtableRead(FILE* f)
                 }
                 else
                     status = fread(&data, dataSize, 1, f);
-                    
+
                 hashtableInsert(hashtbl, key, data);
                 //free(key);
             }
@@ -363,7 +363,7 @@ hashtable_int *hashtableRead(FILE* f)
     }
     else
         return 0;
-        
+
     return hashtbl;
 }
 


### PR DESCRIPTION
Recreated #1023 by @Sahloul:

Code rebased to latest master to handle merge conflicts

Original PR description

This is supposed to increase efficiency, readability, maintainability, and support Python bindings.

### This pullrequest changes
- Rewrites the surface matching module using `cv::Matx` and `cv::Vec`
- Utilize the OpenCV utilities to reduce the code size
- All `unsigned type` have been rewritten to `utype`
- Some complex expressions or resource intense functions are simplified

During the reduction process, no functionality was harmed, and all samples have been tested.