### PR TITLE
matlab: disable module by default

### DIFF
--- a/modules/matlab/CMakeLists.txt
+++ b/modules/matlab/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(BUILD_opencv_matlab_INIT OFF)  # Matlab module is broken
+
 # ----------------------------------------------------------------------------
 #  CMake file for Matlab/Octave support
 #


### PR DESCRIPTION
- broken bindings generator
- broken conversion functions (uses non-supported cv::Mat types)
- other problems like missing/invalid conversion functions for Moments and other structs

related #1376