### PR TITLE
saliency: improve BING handling

### DIFF
--- a/modules/saliency/include/opencv2/saliency/saliencySpecializedClasses.hpp
+++ b/modules/saliency/include/opencv2/saliency/saliencySpecializedClasses.hpp
@@ -464,7 +464,7 @@ private:
   void setColorSpace( int clr = MAXBGR );
 
 // Load trained model.
-  int loadTrainedModel( std::string modelName = "" );// Return -1, 0, or 1 if partial, none, or all loaded
+  int loadTrainedModel();// Return -1, 0, or 1 if partial, none, or all loaded
 
 // Get potential bounding boxes, each of which is represented by a Vec4i for (minX, minY, maxX, maxY).
 // The trained model should be prepared before calling this function: loadTrainedModel() or trainStageI() + trainStageII().

--- a/modules/saliency/src/BING/CmFile.cpp
+++ b/modules/saliency/src/BING/CmFile.cpp
@@ -76,7 +76,7 @@ bool CmFile::MkDir( std::string &_path )
       buffer[i] = '/';
     }
   }
-  mkdir( _path.c_str(), 0 );
+  mkdir( _path.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH );
   return true;
 #endif
 }

--- a/modules/saliency/src/BING/objectnessBING.cpp
+++ b/modules/saliency/src/BING/objectnessBING.cpp
@@ -95,16 +95,14 @@ void ObjectnessBING::setBBResDir(const String &resultsDir )
   _resultsDir = resultsDir;
 }
 
-int ObjectnessBING::loadTrainedModel( std::string modelName )  // Return -1, 0, or 1 if partial, none, or all loaded
+int ObjectnessBING::loadTrainedModel()  // Return -1, 0, or 1 if partial, none, or all loaded
 {
-  if( modelName.size() == 0 )
-    modelName = _modelName;
-  CStr s1 = modelName + ".wS1", s2 = modelName + ".wS2", sI = modelName + ".idx";
+  CStr s1 = _modelName + ".wS1", s2 = _modelName + ".wS2", sI = _modelName + ".idx";
   Mat filters1f, reW1f, idx1i, show3u;
 
   if( !matRead( s1, filters1f ) || !matRead( sI, idx1i ) )
   {
-    printf( "Can't load model: %s or %s\n", s1.c_str(), sI.c_str() );
+    printf( "Can't load model: %s or %s\r\n", s1.c_str(), sI.c_str() );
     return 0;
   }
 
@@ -384,7 +382,9 @@ void ObjectnessBING::getObjBndBoxesForSingleImage( Mat img, ValStructVec<float, 
   for ( int clr = MAXBGR; clr <= G; clr++ )
   {
     setColorSpace( clr );
-    loadTrainedModel();
+    if (!loadTrainedModel())
+      continue;
+
     CmTimer tm( "Predict" );
     tm.Start();
 
@@ -439,6 +439,9 @@ bool ObjectnessBING::matRead( const std::string& filename, Mat& _M )
   String filenamePlusExt( filename.c_str() );
   filenamePlusExt += ".yml.gz";
   FileStorage fs2( filenamePlusExt, FileStorage::READ );
+  if (! fs2.isOpened()) // wrong trainingPath
+    return false;
+
   Mat M;
   fs2[String( removeExtension( basename( filename ) ).c_str() )] >> M;
 


### PR DESCRIPTION
resolves #1411

### This pullrequest changes

* make the BING path fail better, if the pretrained models are not present or found
* fix some minor assumptions in the sample, like the default trainingpath
* add some visualization for BING to the sample. (bonus, prev. output went entirely unsused.)
* all result files are written to a local "Results" dir. let's assume, "trainingpath" is read-only