### PR TITLE
ovis: fixed OGRE search in Ubuntu

### DIFF
--- a/modules/ovis/CMakeLists.txt
+++ b/modules/ovis/CMakeLists.txt
@@ -3,8 +3,11 @@ set(the_description "OGRE 3D Visualiser.")
 find_package(OGRE 1.10 QUIET)
 
 if(NOT OGRE_FOUND)
-message(STATUS "Module opencv_ovis disabled because OGRE3D was not found.")
-ocv_module_disable(ovis)
+  message(STATUS "Module opencv_ovis disabled because OGRE3D was not found")
+  ocv_module_disable(ovis)
+elseif(OGRE_VERSION VERSION_LESS 1.10)
+  message(STATUS "Module opencv_ovis disabled because OGRE3D version is less than 1.10 (${OGRE_VERSION})")
+  ocv_module_disable(ovis)
 endif()
 
 include_directories(${OGRE_INCLUDE_DIRS}})


### PR DESCRIPTION
### This pullrequest changes

Ubuntu 17.10 has OGRE 1.9 [package](https://packages.ubuntu.com/artful/libogre-1.9-dev) which is found by cmake but is not compatible with current module state.
I.e. it is a workaround to a problem with _FindOGRE.cmake_ script [provided](https://packages.ubuntu.com/artful/amd64/libogre-1.9-dev/filelist) in Ubuntu 17.10: the script does not check requested version.