### PR TITLE
Fix the runtime bug again.

### DIFF
--- a/modules/tracking/samples/multitracker.cpp
+++ b/modules/tracking/samples/multitracker.cpp
@@ -90,7 +90,7 @@ int main( int argc, char** argv ){
   selectROIs("tracker",frame,ROIs);
 
   //quit when the tracked object(s) is not provided
-  if(objects.size()<1)
+  if(ROIs.size()<1)
     return 0;
 
   std::vector<Ptr<Tracker> > algorithms;


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

Some time ago, I provided a [PR](https://github.com/opencv/opencv_contrib/pull/1370/files) for fixing the runtime bug. But I unintentionally found the bug had not been solved thoroughly, the commited codes changed maybe when merged. I don't know why it happened. Could someone explain it? Thanks in advance.
<!-- Please describe what your pullrequest is changing -->
