### PR TITLE
tracking:fix rounding and grayscale for KCF

### DIFF
--- a/modules/tracking/src/trackerKCF.cpp
+++ b/modules/tracking/src/trackerKCF.cpp
@@ -212,7 +212,10 @@ namespace cv{
    */
   bool TrackerKCFImpl::initImpl( const Mat& image, const Rect2d& boundingBox ){
     frame=0;
-    roi = boundingBox;
+    roi.x = cvRound(boundingBox.x);
+    roi.y = cvRound(boundingBox.y);
+    roi.width = cvRound(boundingBox.width);
+    roi.height = cvRound(boundingBox.height);
 
     //calclulate output sigma
     output_sigma=std::sqrt(static_cast<float>(roi.width*roi.height))*params.output_sigma_factor;
@@ -242,8 +245,8 @@ namespace cv{
 
     // create gaussian response
     y=Mat::zeros((int)roi.height,(int)roi.width,CV_32F);
-    for(int i=0;i<roi.height;i++){
-      for(int j=0;j<roi.width;j++){
+    for(int i=0;i<int(roi.height);i++){
+      for(int j=0;j<int(roi.width);j++){
         y.at<float>(i,j) =
                 static_cast<float>((i-roi.height/2+1)*(i-roi.height/2+1)+(j-roi.width/2+1)*(j-roi.width/2+1));
       }
@@ -255,6 +258,10 @@ namespace cv{
     // perform fourier transfor to the gaussian response
     fft2(y,yf);
 
+    if (image.channels() == 1) { // disable CN for grayscale images
+      params.desc_pca &= ~(CN);
+      params.desc_npca &= ~(CN);
+    }
     model=Ptr<TrackerKCFModel>(new TrackerKCFModel(params));
 
     // record the non-compressed descriptors

--- a/modules/tracking/tutorials/tutorial_introduction_to_tracker.markdown
+++ b/modules/tracking/tutorials/tutorial_introduction_to_tracker.markdown
@@ -44,12 +44,14 @@ Explanation
 
     @snippet tracking/samples/tutorial_introduction_to_tracker.cpp create
 
-    There are at least 5 types of tracker algorithms that can be used:
+    There are at least 7 types of tracker algorithms that can be used:
     + MIL
     + BOOSTING
     + MEDIANFLOW
     + TLD
     + KCF
+    + GOTURN
+    + MOSSE
 
     Each tracker algorithm has their own advantages and disadvantages, please refer the documentation of @ref cv::Tracker for more detailed information.
 
@@ -64,8 +66,8 @@ Explanation
 
     @snippet tracking/samples/tutorial_introduction_to_tracker.cpp init
 
-    Tracker algorithm should be initialized with the provided image data as well as the bounding box of the tracked object.
-    Make sure that the bounding box is not valid (size more than zero) to avoid the initialization process failed.
+    Any tracker algorithm should be initialized with the provided image data, and an initial bounding box of the tracked object.
+    Make sure that the bounding box is valid (size more than zero) to avoid failure of the initialization process.
 
 -#  **Update**
 


### PR DESCRIPTION
resolves #1472

* round the input bounding box to integer values
* override params in case of grayscale images (disable colornames feature)
* unrelated to the issue, but docs needed some correction