### PR TITLE
stereo: fix crash

### DIFF
--- a/modules/stereo/include/opencv2/stereo/matching.hpp
+++ b/modules/stereo/include/opencv2/stereo/matching.hpp
@@ -366,13 +366,12 @@ namespace cv
             };
         protected:
             //arrays used in the region removal
-            Mat speckleY;
-            Mat speckleX;
-            Mat puss;
+            Mat_<int> speckleY;
+            Mat_<int> speckleX;
+            Mat_<int> puss;
             //int *specklePointX;
             //int *specklePointY;
             //long long *pus;
-            int previous_size;
             //!method for setting the maximum disparity
             void setMaxDisparity(int val)
             {
@@ -480,10 +479,10 @@ namespace cv
                 CV_Assert(currentMap.cols == out.cols);
                 CV_Assert(currentMap.rows == out.rows);
                 CV_Assert(t >= 0);
-                int *pus = (int *)puss.data;
+                CV_Assert(!puss.empty());
                 int *specklePointX = (int *)speckleX.data;
                 int *specklePointY = (int *)speckleY.data;
-                memset(pus, 0, previous_size * sizeof(pus[0]));
+                puss.setTo(Scalar::all(0));
                 T *map = (T *)currentMap.data;
                 T *outputMap = (T *)out.data;
                 int height = currentMap.rows;
@@ -511,7 +510,7 @@ namespace cv
                             speckle_size = dr;
                             specklePointX[dr] = i;
                             specklePointY[dr] = j;
-                            pus[i * width + j] = 1;
+                            puss(i, j) = 1;
                             dr++;
                             map[iw + j] = k;
                             while (st < dr)
@@ -522,7 +521,7 @@ namespace cv
                                 for (int d = 0; d < 8; d++)
                                 {//if insisde
                                     if (ii + di[d] >= 0 && ii + di[d] < height && jj + dj[d] >= 0 && jj + dj[d] < width &&
-                                        pus[(ii + di[d]) * width + jj + dj[d]] == 0)
+                                        puss(ii + di[d], jj + dj[d]) == 0)
                                     {
                                         T val = map[(ii + di[d]) * width + jj + dj[d]];
                                         if (val == 0)
@@ -531,7 +530,7 @@ namespace cv
                                             specklePointX[dr] = (ii + di[d]);
                                             specklePointY[dr] = (jj + dj[d]);
                                             dr++;
-                                            pus[(ii + di[d]) * width + jj + dj[d]] = 1;
+                                            puss(ii + di[d], jj + dj[d]) = 1;
                                         }//this means that my point is a good point to be used in computing the final filling value
                                         else if (val >= 1 && val < 250)
                                         {

--- a/modules/stereo/src/stereo_binary_bm.cpp
+++ b/modules/stereo/src/stereo_binary_bm.cpp
@@ -275,7 +275,6 @@ namespace cv
             StereoBinaryBMImpl(int _numDisparities, int _kernelSize) : Matching(_numDisparities)
             {
                 params = StereoBinaryBMParams(_numDisparities, _kernelSize);
-                previous_size = 0;
             }
 
             void compute(InputArray leftarr, InputArray rightarr, OutputArray disparr)
@@ -322,12 +321,11 @@ namespace cv
 
                 int width = left0.cols;
                 int height = left0.rows;
-                if(previous_size != width * height)
+                if (puss.total() != (size_t)width * height)
                 {
-                    previous_size = width * height;
-                    speckleX.create(height,width,CV_32SC4);
-                    speckleY.create(height,width,CV_32SC4);
-                    puss.create(height,width,CV_32SC4);
+                    speckleX.create(height, width);
+                    speckleY.create(height, width);
+                    puss.create(height, width);
 
                     censusImage[0].create(left0.rows,left0.cols,CV_32SC4);
                     censusImage[1].create(left0.rows,left0.cols,CV_32SC4);

--- a/modules/stereo/src/stereo_binary_sgbm.cpp
+++ b/modules/stereo/src/stereo_binary_sgbm.cpp
@@ -248,7 +248,7 @@ namespace cv
                             CostType* hsumAdd = hsumBuf + (std::min(k, height-1) % hsumBufNRows)*costBufSize;
                             if( k < height )
                             {
-                                for(int ii = 0; ii <= ww; ii++)
+                                for(int ii = 0; ii < ww; ii++)
                                 {
                                     for(int dd = 0; dd <= params.numDisparities; dd++)
                                     {

--- a/modules/stereo/src/stereo_binary_sgbm.cpp
+++ b/modules/stereo/src/stereo_binary_sgbm.cpp
@@ -692,12 +692,11 @@ namespace cv
                 {
                     int width = left.cols;
                     int height = left.rows;
-                    if(previous_size != width * height)
+                    if (puss.total() != (size_t)width * height)
                     {
-                        previous_size = width * height;
-                        speckleX.create(height,width,CV_32SC4);
-                        speckleY.create(height,width,CV_32SC4);
-                        puss.create(height,width,CV_32SC4);
+                        speckleX.create(height, width);
+                        speckleY.create(height, width);
+                        puss.create(height, width);
                     }
                     Mat aux;
                     aux.create(height,width,CV_16S);


### PR DESCRIPTION
- uninitialized variable 'previous_size'
- incorrect Mat element access pattern via address arithmetic
- invalid 'for' range