### PR TITLE
Reverted calls back to linear resize for floating point matrices

### DIFF
--- a/modules/ccalib/src/randpattern.cpp
+++ b/modules/ccalib/src/randpattern.cpp
@@ -371,7 +371,7 @@ void RandomPatternGenerator::generatePattern()
 
         Mat r = Mat(n, m, CV_32F);
         cv::randn(r, Scalar::all(0), Scalar::all(1));
-        cv::resize(r, r, Size(_imageWidth ,_imageHeight), 0, 0, INTER_LINEAR_EXACT);
+        cv::resize(r, r, Size(_imageWidth ,_imageHeight));
         double min_r, max_r;
         minMaxLoc(r, &min_r, &max_r);
 

--- a/modules/dpm/src/dpm_feature.cpp
+++ b/modules/dpm/src/dpm_feature.cpp
@@ -87,7 +87,7 @@ void Feature::computeFeaturePyramid(const Mat &imageM, vector< Mat > &pyramid)
     {
         const double scale = (double)(1.0f/pow(params.sfactor, i));
         Mat imScaled;
-        resize(imageM, imScaled, imSize * scale, 0, 0, INTER_LINEAR_EXACT);
+        resize(imageM, imScaled, imSize * scale);
         // First octave at twice the image resolution
         computeHOG32D(imScaled, pyramid[i], params.binSize/2,
                 params.padx + 1, params.pady + 1);
@@ -106,7 +106,7 @@ void Feature::computeFeaturePyramid(const Mat &imageM, vector< Mat > &pyramid)
         {
             Mat imScaled2;
             Size_<double> imScaledSize = imScaled.size();
-            resize(imScaled, imScaled2, imScaledSize*0.5, 0, 0, INTER_LINEAR_EXACT);
+            resize(imScaled, imScaled2, imScaledSize*0.5);
             imScaled = imScaled2;
             computeHOG32D(imScaled2, pyramid[j+params.interval],
                     params.binSize, params.padx + 1, params.pady + 1);


### PR DESCRIPTION
resolves #1490
### This pullrequest changes
Reverted calls back to linear resize for floating point matrices
