### PR TITLE
`VGG::compute()` header is unnecessary and problematic for Python binder

### DIFF
--- a/modules/xfeatures2d/include/opencv2/xfeatures2d.hpp
+++ b/modules/xfeatures2d/include/opencv2/xfeatures2d.hpp
@@ -311,13 +311,6 @@ public:
     CV_WRAP static Ptr<VGG> create( int desc = VGG::VGG_120, float isigma = 1.4f,
                                     bool img_normalize = true, bool use_scale_orientation = true,
                                     float scale_factor = 6.25f, bool dsc_normalize = false );
-    /**
-     * @param image image to extract descriptors
-     * @param keypoints of interest within image
-     * @param descriptors resulted descriptors array
-     */
-    CV_WRAP virtual void compute( InputArray image, std::vector<KeyPoint>& keypoints, OutputArray descriptors ) = 0;
-
 };
 
 /** @brief Class implementing BoostDesc (Learning Image Descriptors with Boosting), described in


### PR DESCRIPTION
resolves #1509

### This pullrequest changes
- Removes the unnecessary and problematic headers of `VGG::compute()`