### PR TITLE
LUCID - Support RGBA

### DIFF
--- a/modules/xfeatures2d/src/lucid.cpp
+++ b/modules/xfeatures2d/src/lucid.cpp
@@ -100,10 +100,15 @@ namespace cv {
         // gliese581h suggested filling a cv::Mat with descriptors to enable BFmatcher compatibility
         // speed-ups and enhancements by gliese581h
         void LUCIDImpl::compute(InputArray _src, std::vector<KeyPoint> &keypoints, OutputArray _desc) {
-            cv::Mat src_input = _src.getMat();
-            if (src_input.empty())
-                return;
-            CV_Assert(src_input.depth() == CV_8U && src_input.channels() == 3);
+            if (_src.empty()) return;
+            CV_Assert(_src.depth() == CV_8U);
+            cv::Mat src_input;
+            if (_src.channels() == 4)
+                cvtColor(_src, src_input, COLOR_BGRA2BGR);
+            else {
+                CV_Assert(_src.channels() == 3);
+                src_input = _src.getMat();
+            }
 
             Mat_<Vec3b> src;
 


### PR DESCRIPTION
RGBA are also colored images, but LUCID rejects them!

### This pullrequest changes
- Converts RGBA to RGB