### PR TITLE
Fix the test case for hdf.

### DIFF
--- a/modules/hdf/test/test_hdf5.cpp
+++ b/modules/hdf/test/test_hdf5.cpp
@@ -350,7 +350,7 @@ TEST_F(HDF5_Test, test_attribute_InutArray_OutputArray_2d)
         double diff = norm(attr_value - expected_attr_value);
         EXPECT_NEAR(diff, 0, 1e-6);
 
-        EXPECT_EQ(attr_value.size(), expected_attr_value.size());
+        EXPECT_EQ(attr_value.size, expected_attr_value.size);
         EXPECT_EQ(attr_value.type(), expected_attr_value.type());
     }
 


### PR DESCRIPTION
[MatSize::operator()()][1] supports only 2-d matrices.

[1]: https://github.com/opencv/opencv/blob/master/modules/core/include/opencv2/core/mat.inl.hpp#L1407

See http://pullrequest.opencv.org/buildbot/builders/precommit-contrib_linux64_no_opt/builds/10065/steps/test_hdf/logs/stdio

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->


<!-- Please describe what your pullrequest is changing -->

  