### PR TITLE
aurco: support custom dictionaries via python bindngs

### DIFF
--- a/modules/aruco/include/opencv2/aruco/dictionary.hpp
+++ b/modules/aruco/include/opencv2/aruco/dictionary.hpp
@@ -61,9 +61,9 @@ namespace aruco {
 class CV_EXPORTS_W Dictionary {
 
     public:
-    CV_PROP_RW Mat bytesList;      // marker code information
-    CV_PROP int markerSize;        // number of bits per dimension
-    CV_PROP int maxCorrectionBits; // maximum number of bits that can be corrected
+    CV_PROP_RW Mat bytesList;         // marker code information
+    CV_PROP_RW int markerSize;        // number of bits per dimension
+    CV_PROP_RW int maxCorrectionBits; // maximum number of bits that can be corrected
 
 
     /**

--- a/modules/aruco/include/opencv2/aruco/dictionary.hpp
+++ b/modules/aruco/include/opencv2/aruco/dictionary.hpp
@@ -61,7 +61,7 @@ namespace aruco {
 class CV_EXPORTS_W Dictionary {
 
     public:
-    CV_PROP Mat bytesList;         // marker code information
+    CV_PROP_RW Mat bytesList;      // marker code information
     CV_PROP int markerSize;        // number of bits per dimension
     CV_PROP int maxCorrectionBits; // maximum number of bits that can be corrected
 
@@ -120,13 +120,13 @@ class CV_EXPORTS_W Dictionary {
     /**
       * @brief Transform matrix of bits to list of bytes in the 4 rotations
       */
-    static Mat getByteListFromBits(const Mat &bits);
+    CV_WRAP static Mat getByteListFromBits(const Mat &bits);
 
 
     /**
       * @brief Transform list of bytes to matrix of bits
       */
-    static Mat getBitsFromByteList(const Mat &byteList, int markerSize);
+    CV_WRAP static Mat getBitsFromByteList(const Mat &byteList, int markerSize);
 };
 
 


### PR DESCRIPTION
### This pullrequest changes

As described in the documentation https://docs.opencv.org/3.4.0/d5/dae/tutorial_aruco_detection.html the way to manually create custom dictionaries is to edit the `bytesList` property of the Dictionary object, typically using matrices generated via the `Dictionary::getByteListFromBits()` function.  In the current python bindings `bytesList` is read-only and `Dictionary::getByteListFromBits()` is not exported.

This PR makes it possible to manually create custom dictionaries by making `bytesList`, `markerSize`, and `maxCorrectionBits` writable and exporting `Dictionary::getByteListFromBits()` and `Dictionary::getBitsFromByteList()`.

In python creating a custom dictionary can now be accomplished via this pattern
```python
import numpy as np
from cv2.aruco import custom_dictionary, Dictionary_getByteListFromBits

my_dict = custom_dictionary(2, 3)

bits_H = np.array([[1, 0, 1],
                   [1, 1, 1],
                   [1, 0, 1]],
                  dtype=np.uint8)
bits_I = np.array([[0, 1, 0],
                   [0, 1, 0],
                   [0, 1, 0]],
                  dtype=np.uint8)

my_dict.bytesList = np.array([Dictionary_getByteListFromBits(bits_H)[0],
                              Dictionary_getByteListFromBits(bits_I)[0]])
```

Tested with Python 2.7, here are the marker images drawn from this custom dictionary:
![hi_00](https://user-images.githubusercontent.com/8782818/34913025-e99c4f16-f8a5-11e7-9847-fb260a42529f.png) ![hi_01](https://user-images.githubusercontent.com/8782818/34913026-e9b63bec-f8a5-11e7-97c5-0ef6f27d02d9.png)
