### PR TITLE
bgsegm: add java bindings

### DIFF
--- a/modules/bgsegm/CMakeLists.txt
+++ b/modules/bgsegm/CMakeLists.txt
@@ -1,2 +1,2 @@
 set(the_description "Background Segmentation Algorithms")
-ocv_define_module(bgsegm opencv_core opencv_imgproc opencv_video opencv_calib3d WRAP python)
+ocv_define_module(bgsegm opencv_core opencv_imgproc opencv_video opencv_calib3d WRAP python java)


### PR DESCRIPTION
resolves #1495
2nd attempt at #1496 

latest changes to java bindings  (great job !), allow to just add "java" to CMakeLists.txt now.

(the previously wrong inheritance got resolved) 

(couldn't re-use the old pr after closing & forced push)