### PR TITLE
Add getter and setter for VGG and Boost descriptors

### DIFF
--- a/modules/xfeatures2d/include/opencv2/xfeatures2d.hpp
+++ b/modules/xfeatures2d/include/opencv2/xfeatures2d.hpp
@@ -312,6 +312,21 @@ public:
     CV_WRAP static Ptr<VGG> create( int desc = VGG::VGG_120, float isigma = 1.4f,
                                     bool img_normalize = true, bool use_scale_orientation = true,
                                     float scale_factor = 6.25f, bool dsc_normalize = false );
+
+    CV_WRAP virtual void setSigma(const float isigma) = 0;
+    CV_WRAP virtual float getSigma() const = 0;
+
+    CV_WRAP virtual void setUseNormalizeImage(const bool img_normalize) = 0;
+    CV_WRAP virtual bool getUseNormalizeImage() const = 0;
+
+    CV_WRAP virtual void setUseScaleOrientation(const bool use_scale_orientation) = 0;
+    CV_WRAP virtual bool getUseScaleOrientation() const = 0;
+
+    CV_WRAP virtual void setScaleFactor(const float scale_factor) = 0;
+    CV_WRAP virtual float getScaleFactor() const = 0;
+
+    CV_WRAP virtual void setUseNormalizeDescriptor(const bool dsc_normalize) = 0;
+    CV_WRAP virtual bool getUseNormalizeDescriptor() const = 0;
 };
 
 /** @brief Class implementing BoostDesc (Learning Image Descriptors with Boosting), described in
@@ -353,6 +368,12 @@ public:
 
     CV_WRAP static Ptr<BoostDesc> create( int desc = BoostDesc::BINBOOST_256,
                     bool use_scale_orientation = true, float scale_factor = 6.25f );
+
+    CV_WRAP virtual void setUseScaleOrientation(const bool use_scale_orientation) = 0;
+    CV_WRAP virtual bool getUseScaleOrientation() const = 0;
+
+    CV_WRAP virtual void setScaleFactor(const float scale_factor) = 0;
+    CV_WRAP virtual float getScaleFactor() const = 0;
 };
 
 

--- a/modules/xfeatures2d/src/boostdesc.cpp
+++ b/modules/xfeatures2d/src/boostdesc.cpp
@@ -93,6 +93,13 @@ public:
     // compute descriptors given keypoints
     virtual void compute( InputArray image, vector<KeyPoint>& keypoints, OutputArray descriptors );
 
+    // getter / setter
+    virtual void setUseScaleOrientation(const bool use_scale_orientation) { m_use_scale_orientation = use_scale_orientation; }
+    virtual bool getUseScaleOrientation() const { return m_use_scale_orientation; }
+
+    virtual void setScaleFactor(const float scale_factor) { m_scale_factor = scale_factor; }
+    virtual float getScaleFactor() const { return m_scale_factor; }
+
 protected:
 
     /*

--- a/modules/xfeatures2d/src/vgg.cpp
+++ b/modules/xfeatures2d/src/vgg.cpp
@@ -83,7 +83,7 @@ public:
     virtual ~VGG_Impl();
 
     // returns the descriptor length in bytes
-    virtual int descriptorSize() const { return m_descriptor_size; };
+    virtual int descriptorSize() const { return m_descriptor_size; }
 
     // returns the descriptor type
     virtual int descriptorType() const { return CV_32F; }
@@ -93,6 +93,22 @@ public:
 
     // compute descriptors given keypoints
     virtual void compute( InputArray image, vector<KeyPoint>& keypoints, OutputArray descriptors );
+
+    // getter / setter
+    virtual void setSigma(const float isigma) { m_isigma = isigma; }
+    virtual float getSigma() const { return m_isigma; }
+
+    virtual void setUseNormalizeImage(const bool img_normalize) { m_img_normalize = img_normalize; }
+    virtual bool getUseNormalizeImage() const { return m_img_normalize; }
+
+    virtual void setUseScaleOrientation(const bool use_scale_orientation) { m_use_scale_orientation = use_scale_orientation; }
+    virtual bool getUseScaleOrientation() const { return m_use_scale_orientation; }
+
+    virtual void setScaleFactor(const float scale_factor) { m_scale_factor = scale_factor; }
+    virtual float getScaleFactor() const { return m_scale_factor; }
+
+    virtual void setUseNormalizeDescriptor(const bool dsc_normalize) { m_dsc_normalize = dsc_normalize; }
+    virtual bool getUseNormalizeDescriptor() const { return m_dsc_normalize; }
 
 protected:
 


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
For most of the features, default parameters are ok but VGG and Boost descriptor require to change the `scale_factor` according to the type of the feature used for the keypoints detection.

This allow to keep the compatibility with some code I have where a class wraps the feature that will be created by using the feature name:
```
cv::Ptr<cv::Feature2D> m_detector;
if (detectorName == "SIFT") {
  m_detector = cv::xfeatures2d::SIFT::create();
} else if (detectorName == "SURF") {
  m_detector  = cv::xfeatures2d::SURF::create();
} else if (detectorName == "VGG") {
  m_detector = cv::xfeatures2d::VGG::create();
} //etc.
```
