### PR TITLE
Comment out direct print statements during tesseract run invocations

### DIFF
--- a/modules/text/src/ocr_tesseract.cpp
+++ b/modules/text/src/ocr_tesseract.cpp
@@ -116,7 +116,7 @@ CV_WRAP String OCRTesseract::run(InputArray image, InputArray mask, int min_conf
     run(image_m, mask_m, output1, NULL, &component_texts, &component_confidences, component_level);
     for(unsigned int i = 0; i < component_texts.size(); i++)
     {
-        cout << "confidence: " << component_confidences[i] << " text:" << component_texts[i] << endl;
+        // cout << "confidence: " << component_confidences[i] << " text:" << component_texts[i] << endl;
 
         if(component_confidences[i] > min_confidence)
         {


### PR DESCRIPTION
This statement interferes with regular logging on the client side
where the OpenCV library's outputs cannot be managed by the user
and forcefully print out in the client code. For instance, this
is observed when OpenCV is used as a python library where it is
expected to provide optional loggers instead of direct writes to
stdout.

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
