### PR TITLE
Fixed several warnings produced by clang-6.0.0

### DIFF
--- a/modules/bioinspired/src/parvoretinafilter.hpp
+++ b/modules/bioinspired/src/parvoretinafilter.hpp
@@ -244,7 +244,7 @@ private:
         float *parvocellularOutputON_PTR= parvocellularOutputON+r.start;
         float *parvocellularOutputOFF_PTR= parvocellularOutputOFF+r.start;
 
-            for (register int IDpixel=r.start ; IDpixel!=r.end ; ++IDpixel)
+            for (int IDpixel=r.start ; IDpixel!=r.end ; ++IDpixel)
         {
         float pixelDifference = *(photoreceptorsOutput_PTR++) -*(horizontalCellsOutput_PTR++);
         // test condition to allow write pixelDifference in ON or OFF buffer and 0 in the over

--- a/modules/saliency/src/BING/kyheader.hpp
+++ b/modules/saliency/src/BING/kyheader.hpp
@@ -163,7 +163,7 @@ inline cv::Rect Vec4i2Rect( cv::Vec4i &v )
 # define POPCNT64(x) __builtin_popcountll(x)
 #endif
 
-inline int popcnt64( register uint64_t u )
+inline int popcnt64( uint64_t u )
 {
   u = ( u & 0x5555555555555555 ) + ( ( u >> 1 ) & 0x5555555555555555 );
   u = ( u & 0x3333333333333333 ) + ( ( u >> 2 ) & 0x3333333333333333 );
@@ -174,7 +174,7 @@ inline int popcnt64( register uint64_t u )
   return (int)u;
 }
 
-inline int popcnt( register uint32_t u )
+inline int popcnt( uint32_t u )
 {
   u = ( u & 0x55555555 ) + ( ( u >> 1 ) & 0x55555555 );
   u = ( u & 0x33333333 ) + ( ( u >> 2 ) & 0x33333333 );
@@ -184,7 +184,7 @@ inline int popcnt( register uint32_t u )
   return (int)u;
 }
 
-inline int popcnt64_nibble( register uint64_t u )
+inline int popcnt64_nibble( uint64_t u )
 {
   static const uint8_t Table[] =
   { 0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4 };
@@ -198,7 +198,7 @@ inline int popcnt64_nibble( register uint64_t u )
   return (int)c;
 }
 
-inline int popcnt_nibble( register uint32_t u )
+inline int popcnt_nibble( uint32_t u )
 {
   static const uint8_t Table[] =
   { 0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4 };
@@ -212,7 +212,7 @@ inline int popcnt_nibble( register uint32_t u )
   return (int)c;
 }
 
-inline int popcnt64_byte( register uint64_t u )
+inline int popcnt64_byte( uint64_t u )
 {
 #define B2(k) k, k+1, k+1, k+2
 #define B4(k) B2(k), B2(k+1), B2(k+1), B2(k+2)
@@ -232,7 +232,7 @@ inline int popcnt64_byte( register uint64_t u )
   return (int)c;
 }
 
-inline int popcnt_byte( register uint32_t u )
+inline int popcnt_byte( uint32_t u )
 {
 #define B2(k) k, k+1, k+1, k+2
 #define B4(k) B2(k), B2(k+1), B2(k+1), B2(k+2)

--- a/modules/sfm/src/io/io_bundler.h
+++ b/modules/sfm/src/io/io_bundler.h
@@ -47,7 +47,7 @@
 // towards the top of the image. Thus, (-w/2, -h/2) is the lower-left corner of
 // the image, and (w/2, h/2) is the top-right corner (where w and h are the
 // width and height of the image).
-bool readBundlerFile(const std::string &file,
+static bool readBundlerFile(const std::string &file,
                      std::vector<cv::Matx33d> &Rs,
                      std::vector<cv::Vec3d> &Ts,
                      std::vector<cv::Matx33d> &Ks,

--- a/modules/sfm/src/libmv_capi.h
+++ b/modules/sfm/src/libmv_capi.h
@@ -85,7 +85,7 @@ struct libmv_Reconstruction {
 // Based on 'libmv_capi' (blender API)
 /////////////////////////////////////
 
-void libmv_initLogging(const char* argv0) {
+static void libmv_initLogging(const char* argv0) {
   // Make it so FATAL messages are always print into console.
   char severity_fatal[32];
   static int initLog=0;
@@ -101,14 +101,14 @@ void libmv_initLogging(const char* argv0) {
   SetCommandLineOption("minloglevel", severity_fatal);
 }
 
-void libmv_startDebugLogging(void) {
+static void libmv_startDebugLogging(void) {
   SetCommandLineOption("logtostderr", "1");
   SetCommandLineOption("v", "2");
   SetCommandLineOption("stderrthreshold", "1");
   SetCommandLineOption("minloglevel", "0");
 }
 
-void libmv_setLoggingVerbosity(int verbosity) {
+static void libmv_setLoggingVerbosity(int verbosity) {
   char val[10];
   snprintf(val, sizeof(val), "%d", verbosity);
   SetCommandLineOption("v", val);
@@ -122,7 +122,7 @@ void libmv_setLoggingVerbosity(int verbosity) {
 /* Select the two keyframes that give a lower reprojection error
  */
 
-bool selectTwoKeyframesBasedOnGRICAndVariance(
+static bool selectTwoKeyframesBasedOnGRICAndVariance(
     Tracks& tracks,
     Tracks& normalized_tracks,
     CameraIntrinsics& camera_intrinsics,
@@ -252,7 +252,7 @@ static void libmv_cameraIntrinsicsFillFromOptions(
  * options values.
  */
 
-CameraIntrinsics* libmv_cameraIntrinsicsCreateFromOptions(
+static CameraIntrinsics* libmv_cameraIntrinsicsCreateFromOptions(
     const libmv_CameraIntrinsicsOptions* camera_intrinsics_options) {
   CameraIntrinsics *camera_intrinsics = NULL;
   switch (camera_intrinsics_options->distortion_model) {
@@ -278,7 +278,7 @@ CameraIntrinsics* libmv_cameraIntrinsicsCreateFromOptions(
 /* Normalizes the tracks given the camera intrinsics parameters
  */
 
-void
+static void
 libmv_getNormalizedTracks(const libmv::Tracks &tracks,
                           const libmv::CameraIntrinsics &camera_intrinsics,
                           libmv::Tracks *normalized_tracks) {
@@ -302,7 +302,7 @@ libmv_getNormalizedTracks(const libmv::Tracks &tracks,
 /* Refine the final solution using Bundle Adjustment
  */
 
-void libmv_solveRefineIntrinsics(
+static void libmv_solveRefineIntrinsics(
     const Tracks &tracks,
     const int refine_intrinsics,
     const int bundle_constraints,
@@ -339,7 +339,7 @@ void libmv_solveRefineIntrinsics(
 /* Finish the reconstrunction and computes the final reprojection error
  */
 
-void finishReconstruction(
+static void finishReconstruction(
     const Tracks &tracks,
     const CameraIntrinsics &camera_intrinsics,
     libmv_Reconstruction *libmv_reconstruction) {
@@ -361,7 +361,7 @@ void finishReconstruction(
 /* Perform the complete reconstruction process
  */
 
-libmv_Reconstruction *libmv_solveReconstruction(
+static libmv_Reconstruction *libmv_solveReconstruction(
     const Tracks &libmv_tracks,
     const libmv_CameraIntrinsicsOptions* libmv_camera_intrinsics_options,
     libmv_ReconstructionOptions* libmv_reconstruction_options) {

--- a/modules/sfm/src/libmv_light/libmv/multiview/projection.h
+++ b/modules/sfm/src/libmv_light/libmv/multiview/projection.h
@@ -122,7 +122,7 @@ inline void Project(const Mat34 &P, const Vec3 &X, Vec3 *x) {
 
 inline void Project(const Mat34 &P, const Vec3 &X, Vec2 *x) {
   Vec3 hx;
-  Project(P, X, x);
+  Project(P, X, &hx);
   *x = hx.head<2>() / hx(2);
 }
 

--- a/modules/sfm/src/projection.cpp
+++ b/modules/sfm/src/projection.cpp
@@ -75,7 +75,7 @@ homogeneousToEuclidean(const Mat & _X, Mat & _x)
 }
 
 void
-homogeneousToEuclidean(const InputArray _X, OutputArray _x)
+homogeneousToEuclidean(InputArray _X, OutputArray _x)
 {
   // src
   const Mat X = _X.getMat();
@@ -96,7 +96,7 @@ homogeneousToEuclidean(const InputArray _X, OutputArray _x)
 }
 
 void
-euclideanToHomogeneous(const InputArray _x, OutputArray _X)
+euclideanToHomogeneous(InputArray _x, OutputArray _X)
 {
   const Mat x = _x.getMat();
   const Mat last_row = Mat::ones(1, x.cols, x.type());

--- a/modules/sfm/src/simple_pipeline.cpp
+++ b/modules/sfm/src/simple_pipeline.cpp
@@ -52,7 +52,7 @@ namespace sfm
 /* Parses a given array of 2d points into the libmv tracks structure
  */
 
-void
+static void
 parser_2D_tracks( const std::vector<Mat> &points2d, libmv::Tracks &tracks )
 {
   const int nframes = static_cast<int>(points2d.size());
@@ -71,7 +71,7 @@ parser_2D_tracks( const std::vector<Mat> &points2d, libmv::Tracks &tracks )
 /* Parses a given set of matches into the libmv tracks structure
  */
 
-void
+static void
 parser_2D_tracks( const libmv::Matches &matches, libmv::Tracks &tracks )
 {
   std::set<Matches::ImageID>::const_iterator iter_image =
@@ -115,7 +115,7 @@ parser_2D_tracks( const libmv::Matches &matches, libmv::Tracks &tracks )
  * reconstruction pipeline.
  */
 
-libmv_Reconstruction *libmv_solveReconstructionImpl(
+static libmv_Reconstruction *libmv_solveReconstructionImpl(
   const std::vector<String> &images,
   const libmv_CameraIntrinsicsOptions* libmv_camera_intrinsics_options,
   libmv_ReconstructionOptions* libmv_reconstruction_options)

--- a/modules/sfm/src/triangulation.cpp
+++ b/modules/sfm/src/triangulation.cpp
@@ -64,7 +64,7 @@ namespace sfm
 
   Reference: @cite HartleyZ00 12.2 pag.312
  */
-void
+static void
 triangulateDLT( const Vec2d &xl, const Vec2d &xr,
                 const Matx34d &Pl, const Matx34d &Pr,
                 Vec3d &point3d )
@@ -92,7 +92,7 @@ triangulateDLT( const Vec2d &xl, const Vec2d &xr,
 
  * Reference: it is the standard DLT; for derivation see appendix of Keir's thesis
  */
-void
+static void
 triangulateNViews(const Mat_<double> &x, const std::vector<Matx34d> &Ps, Vec3d &X)
 {
     CV_Assert(x.rows == 2);

--- a/modules/sfm/test/scene.cpp
+++ b/modules/sfm/test/scene.cpp
@@ -38,8 +38,7 @@
 
 #include "test_precomp.hpp"
 
-cv::Matx33d
-randomK(bool is_projective)
+static cv::Matx33d randomK(bool is_projective)
 {
   static cv::RNG rng;
 

--- a/modules/tracking/src/trackerFeature.cpp
+++ b/modules/tracking/src/trackerFeature.cpp
@@ -250,7 +250,7 @@ class Parallel_compute : public cv::ParallelLoopBody
 
   virtual void operator()( const cv::Range &r ) const
   {
-    for ( register int jf = r.start; jf != r.end; ++jf )
+    for ( int jf = r.start; jf != r.end; ++jf )
     {
       int cols = images[jf].cols;
       int rows = images[jf].rows;

--- a/modules/ximgproc/src/edgeaware_filters_common.cpp
+++ b/modules/ximgproc/src/edgeaware_filters_common.cpp
@@ -2,26 +2,26 @@
  *  By downloading, copying, installing or using the software you agree to this license.
  *  If you do not agree to this license, do not download, install,
  *  copy or use the software.
- *  
- *  
+ *
+ *
  *  License Agreement
  *  For Open Source Computer Vision Library
  *  (3 - clause BSD License)
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without modification,
  *  are permitted provided that the following conditions are met :
- *  
+ *
  *  * Redistributions of source code must retain the above copyright notice,
  *  this list of conditions and the following disclaimer.
- *  
+ *
  *  * Redistributions in binary form must reproduce the above copyright notice,
  *  this list of conditions and the following disclaimer in the documentation
  *  and / or other materials provided with the distribution.
- *  
+ *
  *  * Neither the names of the copyright holders nor the names of the contributors
  *  may be used to endorse or promote products derived from this software
  *  without specific prior written permission.
- *  
+ *
  *  This software is provided by the copyright holders and contributors "as is" and
  *  any express or implied warranties, including, but not limited to, the implied
  *  warranties of merchantability and fitness for a particular purpose are disclaimed.
@@ -151,9 +151,9 @@ inline float getFloatSignBit()
     return signFloat;
 }
 
-void add_(register float *dst, register float *src1, int w)
+void add_(float *dst, float *src1, int w)
 {
-    register int j = 0;
+    int j = 0;
 #if CV_SSE
     if (CPU_SUPPORT_SSE1())
     {
@@ -171,9 +171,9 @@ void add_(register float *dst, register float *src1, int w)
         dst[j] += src1[j];
 }
 
-void mul(register float *dst, register float *src1, register float *src2, int w)
+void mul(float *dst, float *src1, float *src2, int w)
 {
-    register int j = 0;
+    int j = 0;
 #if CV_SSE
     if (CPU_SUPPORT_SSE1())
     {
@@ -191,9 +191,9 @@ void mul(register float *dst, register float *src1, register float *src2, int w)
         dst[j] = src1[j] * src2[j];
 }
 
-void mul(register float *dst, register float *src1, float src2, int w)
+void mul(float *dst, float *src1, float src2, int w)
 {
-    register int j = 0;
+    int j = 0;
 #if CV_SSE
     if (CPU_SUPPORT_SSE1())
     {
@@ -211,9 +211,9 @@ void mul(register float *dst, register float *src1, float src2, int w)
         dst[j] = src1[j]*src2;
 }
 
-void mad(register float *dst, register float *src1, float alpha, float beta, int w)
+void mad(float *dst, float *src1, float alpha, float beta, int w)
 {
-    register int j = 0;
+    int j = 0;
 #if CV_SSE
     if (CPU_SUPPORT_SSE1())
     {
@@ -233,9 +233,9 @@ void mad(register float *dst, register float *src1, float alpha, float beta, int
         dst[j] = alpha*src1[j] + beta;
 }
 
-void sqr_(register float *dst, register float *src1, int w)
+void sqr_(float *dst, float *src1, int w)
 {
-    register int j = 0;
+    int j = 0;
 #if CV_SSE
     if (CPU_SUPPORT_SSE1())
     {
@@ -252,9 +252,9 @@ void sqr_(register float *dst, register float *src1, int w)
         dst[j] = src1[j] * src1[j];
 }
 
-void sqr_dif(register float *dst, register float *src1, register float *src2, int w)
+void sqr_dif(float *dst, float *src1, float *src2, int w)
 {
-    register int j = 0;
+    int j = 0;
 #if CV_SSE
     if (CPU_SUPPORT_SSE1())
     {
@@ -271,9 +271,9 @@ void sqr_dif(register float *dst, register float *src1, register float *src2, in
         dst[j] = (src1[j] - src2[j])*(src1[j] - src2[j]);
 }
 
-void add_mul(register float *dst, register float *src1, register float *src2, int w)
+void add_mul(float *dst, float *src1, float *src2, int w)
 {
-    register int j = 0;
+    int j = 0;
 #if CV_SSE
     if (CPU_SUPPORT_SSE1())
     {
@@ -295,9 +295,9 @@ void add_mul(register float *dst, register float *src1, register float *src2, in
     }
 }
 
-void add_sqr(register float *dst, register float *src1, int w)
+void add_sqr(float *dst, float *src1, int w)
 {
-    register int j = 0;
+    int j = 0;
 #if CV_SSE
     if (CPU_SUPPORT_SSE1())
     {
@@ -318,9 +318,9 @@ void add_sqr(register float *dst, register float *src1, int w)
     }
 }
 
-void add_sqr_dif(register float *dst, register float *src1, register float *src2, int w)
+void add_sqr_dif(float *dst, float *src1, float *src2, int w)
 {
-    register int j = 0;
+    int j = 0;
 #if CV_SSE
     if (CPU_SUPPORT_SSE1())
     {
@@ -341,9 +341,9 @@ void add_sqr_dif(register float *dst, register float *src1, register float *src2
     }
 }
 
-void sub_mul(register float *dst, register float *src1, register float *src2, int w)
+void sub_mul(float *dst, float *src1, float *src2, int w)
 {
-    register int j = 0;
+    int j = 0;
 #if CV_SSE
     if (CPU_SUPPORT_SSE1())
     {
@@ -363,9 +363,9 @@ void sub_mul(register float *dst, register float *src1, register float *src2, in
         dst[j] -= src1[j] * src2[j];
 }
 
-void sub_mad(register float *dst, register float *src1, register float *src2, float c0, int w)
+void sub_mad(float *dst, float *src1, float *src2, float c0, int w)
 {
-    register int j = 0;
+    int j = 0;
 #if CV_SSE
     if (CPU_SUPPORT_SSE1())
     {
@@ -387,9 +387,9 @@ void sub_mad(register float *dst, register float *src1, register float *src2, fl
         dst[j] -= src1[j] * src2[j] + c0;
 }
 
-void det_2x2(register float *dst, register float *a00, register float *a01, register float *a10, register float *a11, int w)
+void det_2x2(float *dst, float *a00, float *a01, float *a10, float *a11, int w)
 {
-    register int j = 0;
+    int j = 0;
 #if CV_SSE
     if (CPU_SUPPORT_SSE1())
     {
@@ -407,9 +407,9 @@ void det_2x2(register float *dst, register float *a00, register float *a01, regi
         dst[j] = a00[j]*a11[j] - a01[j]*a10[j];
 }
 
-void div_det_2x2(register float *a00, register float *a01, register float *a11, int w)
+void div_det_2x2(float *a00, float *a01, float *a11, int w)
 {
-    register int j = 0;
+    int j = 0;
 #if CV_SSE
     if (CPU_SUPPORT_SSE1())
     {
@@ -425,13 +425,13 @@ void div_det_2x2(register float *a00, register float *a01, register float *a11, 
             _a01 = _mm_loadu_ps(a01 + j);
             _a01 = _mm_xor_ps(_a01, SIGN_MASK);
             b = _mm_mul_ps(_a01, _a01);
-            
+
             a = _mm_sub_ps(a, b);
-            
+
             _a01 = _mm_div_ps(_a01, a);
             _a00 = _mm_div_ps(_a00, a);
             _a11 = _mm_div_ps(_a11, a);
-            
+
             _mm_storeu_ps(a01 + j, _a01);
             _mm_storeu_ps(a00 + j, _a00);
             _mm_storeu_ps(a11 + j, _a11);
@@ -447,9 +447,9 @@ void div_det_2x2(register float *a00, register float *a01, register float *a11, 
     }
 }
 
-void div_1x(register float *a1, register float *b1, int w)
+void div_1x(float *a1, float *b1, int w)
 {
-    register int j = 0;
+    int j = 0;
 #if CV_SSE
     if (CPU_SUPPORT_SSE1())
     {
@@ -468,9 +468,9 @@ void div_1x(register float *a1, register float *b1, int w)
     }
 }
 
-void inv_self(register float *src, int w)
+void inv_self(float *src, int w)
 {
-    register int j = 0;
+    int j = 0;
 #if CV_SSE
     if (CPU_SUPPORT_SSE1())
     {
@@ -488,9 +488,9 @@ void inv_self(register float *src, int w)
     }
 }
 
-void sqrt_(register float *dst, register float *src, int w)
+void sqrt_(float *dst, float *src, int w)
 {
-    register int j = 0;
+    int j = 0;
 #if CV_SSE
     if (CPU_SUPPORT_SSE1())
     {
@@ -506,9 +506,9 @@ void sqrt_(register float *dst, register float *src, int w)
         dst[j] = sqrt(src[j]);
 }
 
-void min_(register float *dst, register float *src1, register float *src2, int w)
+void min_(float *dst, float *src1, float *src2, int w)
 {
-    register int j = 0;
+    int j = 0;
 #if CV_SSE
     if (CPU_SUPPORT_SSE1())
     {
@@ -527,9 +527,9 @@ void min_(register float *dst, register float *src1, register float *src2, int w
         dst[j] = std::min(src1[j], src2[j]);
 }
 
-void rf_vert_row_pass(register float *curRow, register float *prevRow, float alphaVal, int w)
+void rf_vert_row_pass(float *curRow, float *prevRow, float alphaVal, int w)
 {
-    register int j = 0;
+    int j = 0;
 #if CV_SSE
     if (CPU_SUPPORT_SSE1())
     {

--- a/modules/ximgproc/src/edgeaware_filters_common.hpp
+++ b/modules/ximgproc/src/edgeaware_filters_common.hpp
@@ -2,26 +2,26 @@
  *  By downloading, copying, installing or using the software you agree to this license.
  *  If you do not agree to this license, do not download, install,
  *  copy or use the software.
- *  
- *  
+ *
+ *
  *  License Agreement
  *  For Open Source Computer Vision Library
  *  (3 - clause BSD License)
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without modification,
  *  are permitted provided that the following conditions are met :
- *  
+ *
  *  * Redistributions of source code must retain the above copyright notice,
  *  this list of conditions and the following disclaimer.
- *  
+ *
  *  * Redistributions in binary form must reproduce the above copyright notice,
  *  this list of conditions and the following disclaimer in the documentation
  *  and / or other materials provided with the distribution.
- *  
+ *
  *  * Neither the names of the copyright holders nor the names of the contributors
  *  may be used to endorse or promote products derived from this software
  *  without specific prior written permission.
- *  
+ *
  *  This software is provided by the copyright holders and contributors "as is" and
  *  any express or implied warranties, including, but not limited to, the implied
  *  warranties of merchantability and fitness for a particular purpose are disclaimed.
@@ -50,44 +50,44 @@ int getTotalNumberOfChannels(InputArrayOfArrays src);
 void checkSameSizeAndDepth(InputArrayOfArrays src, Size &sz, int &depth);
 
 namespace intrinsics
-{  
-    void add_(register float *dst, register float *src1, int w);
+{
+    void add_(float *dst, float *src1, int w);
 
-    void mul(register float *dst, register float *src1, register float *src2, int w);
+    void mul(float *dst, float *src1, float *src2, int w);
 
-    void mul(register float *dst, register float *src1, float src2, int w);
+    void mul(float *dst, float *src1, float src2, int w);
 
     //dst = alpha*src + beta
-    void mad(register float *dst, register float *src1, float alpha, float beta, int w);
+    void mad(float *dst, float *src1, float alpha, float beta, int w);
 
-    void add_mul(register float *dst, register float *src1, register float *src2, int w);
+    void add_mul(float *dst, float *src1, float *src2, int w);
 
-    void sub_mul(register float *dst, register float *src1, register float *src2, int w);
+    void sub_mul(float *dst, float *src1, float *src2, int w);
 
-    void sub_mad(register float *dst, register float *src1, register float *src2, float c0, int w);
+    void sub_mad(float *dst, float *src1, float *src2, float c0, int w);
 
-    void det_2x2(register float *dst, register float *a00, register float *a01, register float *a10, register float *a11, int w);
+    void det_2x2(float *dst, float *a00, float *a01, float *a10, float *a11, int w);
 
-    void div_det_2x2(register float *a00, register float *a01, register float *a11, int w);
+    void div_det_2x2(float *a00, float *a01, float *a11, int w);
 
-    void div_1x(register float *a1, register float *b1, int w);
+    void div_1x(float *a1, float *b1, int w);
 
-    void inv_self(register float *src, int w);
+    void inv_self(float *src, int w);
 
-    
-    void sqr_(register float *dst, register float *src1, int w);
 
-    void sqrt_(register float *dst, register float *src, int w);
+    void sqr_(float *dst, float *src1, int w);
 
-    void sqr_dif(register float *dst, register float *src1, register float *src2, int w);
+    void sqrt_(float *dst, float *src, int w);
 
-    void add_sqr_dif(register float *dst, register float *src1, register float *src2, int w);
+    void sqr_dif(float *dst, float *src1, float *src2, int w);
 
-    void add_sqr(register float *dst, register float *src1, int w);
+    void add_sqr_dif(float *dst, float *src1, float *src2, int w);
 
-    void min_(register float *dst, register float *src1, register float *src2, int w);
+    void add_sqr(float *dst, float *src1, int w);
 
-    void rf_vert_row_pass(register float *curRow, register float *prevRow, float alphaVal, int w);
+    void min_(float *dst, float *src1, float *src2, int w);
+
+    void rf_vert_row_pass(float *curRow, float *prevRow, float alphaVal, int w);
 }
 
 }

--- a/modules/ximgproc/src/guided_filter.cpp
+++ b/modules/ximgproc/src/guided_filter.cpp
@@ -2,26 +2,26 @@
  *  By downloading, copying, installing or using the software you agree to this license.
  *  If you do not agree to this license, do not download, install,
  *  copy or use the software.
- *  
- *  
+ *
+ *
  *  License Agreement
  *  For Open Source Computer Vision Library
  *  (3 - clause BSD License)
- *  
+ *
  *  Redistribution and use in source and binary forms, with or without modification,
  *  are permitted provided that the following conditions are met :
- *  
+ *
  *  * Redistributions of source code must retain the above copyright notice,
  *  this list of conditions and the following disclaimer.
- *  
+ *
  *  * Redistributions in binary form must reproduce the above copyright notice,
  *  this list of conditions and the following disclaimer in the documentation
  *  and / or other materials provided with the distribution.
- *  
+ *
  *  * Neither the names of the copyright holders nor the names of the contributors
  *  may be used to endorse or promote products derived from this software
  *  without specific prior written permission.
- *  
+ *
  *  This software is provided by the copyright holders and contributors "as is" and
  *  any express or implied warranties, including, but not limited to, the implied
  *  warranties of merchantability and fitness for a particular purpose are disclaimed.
@@ -106,10 +106,10 @@ static void splitFirstNChannels(InputArrayOfArrays src, vector<XMat>& dst, int m
     {
         Size sz;
         int depth, totalCnNum;
-        
+
         checkSameSizeAndDepth(src, sz, depth);
         totalCnNum = std::min(maxDstCn, getTotalNumberOfChannels(src));
-        
+
         dst.resize(totalCnNum);
         vector<int> fromTo(2*totalCnNum);
         for (int i = 0; i < totalCnNum; i++)
@@ -127,7 +127,7 @@ static void splitFirstNChannels(InputArrayOfArrays src, vector<XMat>& dst, int m
 class GuidedFilterImpl : public GuidedFilter
 {
 public:
-    
+
     static Ptr<GuidedFilterImpl> create(InputArray guide, int radius, double eps);
 
     void filter(InputArray src, OutputArray dst, int dDepth = -1);
@@ -148,7 +148,7 @@ protected:
 protected:
 
     GuidedFilterImpl() {}
-    
+
     void init(InputArray guide, int radius, double eps);
 
     void computeCovGuide(SymArray2D<Mat>& covars);
@@ -168,7 +168,7 @@ protected:
     }
 
 private: /*Routines to parallelize boxFilter and convertTo*/
-    
+
     typedef void (GuidedFilterImpl::*TransformFunc)(Mat& src, Mat& dst);
 
     struct GFTransform_ParBody : public ParallelLoopBody
@@ -357,7 +357,7 @@ void GuidedFilterImpl::ComputeCovGuideFromChannelsMul_ParBody::operator()(const 
     }
 }
 
-GuidedFilterImpl::ComputeCovGuideInv_ParBody::ComputeCovGuideInv_ParBody(GuidedFilterImpl& gf_, SymArray2D<Mat>& covars_) 
+GuidedFilterImpl::ComputeCovGuideInv_ParBody::ComputeCovGuideInv_ParBody(GuidedFilterImpl& gf_, SymArray2D<Mat>& covars_)
     : gf(gf_), covars(covars_)
 {
     gf.covarsInv.create(gf.gCnNum);
@@ -415,8 +415,8 @@ void GuidedFilterImpl::ComputeCovGuideInv_ParBody::operator()(const Range& range
 
             for (int k = 0; k < 3; k++)
             {
-                register float *a = covars(k, 0).ptr<float>(i);
-                register float *ac = gf.covarsInv(k, 0).ptr<float>(i);
+                float *a = covars(k, 0).ptr<float>(i);
+                float *ac = gf.covarsInv(k, 0).ptr<float>(i);
 
                 if (k == 0)
                     mul(det, a, ac, gf.w);
@@ -503,7 +503,7 @@ void GuidedFilterImpl::ComputeCovFromSrcChannelsMul_ParBody::operator()(const Ra
             int start   = (si % 2) ? 0 : gf.gCnNum - 1;
             int end     = (si % 2) ? gf.gCnNum : -1;
 
-            register float *srcMeanLine = srcCnMean[si].ptr<float>(i);
+            float *srcMeanLine = srcCnMean[si].ptr<float>(i);
 
             for (int gi = start; gi != end; gi += step)
             {
@@ -658,7 +658,7 @@ void GuidedFilterImpl::getWalkPattern(int eid, int &cn1, int &cn2)
         0,  0,  1, -1, -1, -1,
         0,  1,  1, -1, -1, -1,
 
-        0,  0,  0,  2,  1,  1, 
+        0,  0,  0,  2,  1,  1,
         0,  1,  2,  2,  2,  1,
     };
 
@@ -689,7 +689,7 @@ void GuidedFilterImpl::init(InputArray guide, int radius_, double eps_)
     guideCnMean.resize(gCnNum);
     parConvertToWorkType(guideCn, guideCn);
     parMeanFilter(guideCn, guideCnMean);
-    
+
     SymArray2D<Mat> covars;
     computeCovGuide(covars);
     runParBody(ComputeCovGuideInv_ParBody(*this, covars));


### PR DESCRIPTION
### This pullrequest changes

- removed `register` specifier (deprecated in C++17)
- disabled _sfm_ module when configuring with cmake 2.x
- added `static` to several functions (_sfm_ module)
- infinite recursion in `Project` function (_sfm_ module)

