### PR TITLE
Build SFM with C++11 if Ceres was built with C++11

### DIFF
--- a/modules/sfm/CMakeLists.txt
+++ b/modules/sfm/CMakeLists.txt
@@ -63,6 +63,15 @@ else()
   message(STATUS "CERES support is disabled. Ceres Solver for reconstruction API is required.")
 endif()
 
+### COMPILE WITH C++11 IF CERES WAS COMPILED WITH C++11
+
+if(Ceres_FOUND)
+  list (FIND CERES_COMPILED_COMPONENTS "C++11" _index)
+  if (${_index} GREATER -1)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+  endif()
+endif()
+
 ### DEFINE OPENCV SFM MODULE DEPENDENCIES ###
 
 ### CREATE OPENCV SFM MODULE ###


### PR DESCRIPTION
resolves #1122

### This pull request changes the CMake for the SFM module

If Ceres was built using `C++11`, then its headers contain `C++11` features, which breaks the `sfm` build if the features are not enabled in the compiler options.

### Notes

(1) `CERES_WAS_COMPILED_WITH_CXX11` appears in the Ceres source code, but isn't set for my version of Ceres (1.13.0), so I've used `CERES_COMPILED_COMPONENTS`.