### PR TITLE
fix missing include that causes compilation fail in windows

### DIFF
--- a/modules/cvv/src/view/dual_filter_view.hpp
+++ b/modules/cvv/src/view/dual_filter_view.hpp
@@ -2,6 +2,7 @@
 #define CVVISUAL_DUAL_FILTER_VIEW_HPP
 
 // STD
+#include <array>
 #include <string>
 #include <unordered_map>
 // OpenCV


### PR DESCRIPTION
`std::array` is used in `dual_filter_view.hpp` but the header `array` wasn't included. This still compiles on linux because it somehow includes it implicitly, however this will cause compilation fail on windows. This PR fixes it.