### PR TITLE
update structured_edge_detection

### DIFF
--- a/modules/ximgproc/src/structured_edge_detection.cpp
+++ b/modules/ximgproc/src/structured_edge_detection.cpp
@@ -801,9 +801,11 @@ protected:
                 {// for j,k in [0;width)x[0;nTreesEval)
 
                     int currentNode = pIndex[j*nTreesEval + k];
+                    
+                    const int nBnds = (__rf.edgeBoundaries.size() - 1) / (nTreesNodes * nTrees);
 
-                    int start  = __rf.edgeBoundaries[currentNode];
-                    int finish = __rf.edgeBoundaries[currentNode + 1];
+                    int start = __rf.edgeBoundaries[currentNode * nBnds];
+                    int finish = __rf.edgeBoundaries[currentNode * nBnds + 1];
 
                     if (start == finish)
                         continue;

--- a/modules/ximgproc/src/structured_edge_detection.cpp
+++ b/modules/ximgproc/src/structured_edge_detection.cpp
@@ -801,7 +801,9 @@ protected:
                 {// for j,k in [0;width)x[0;nTreesEval)
 
                     int currentNode = pIndex[j*nTreesEval + k];
-                    const int nBnds = (__rf.edgeBoundaries.size() - 1) / (nTreesNodes * nTrees);
+                    size_t sizeBoundaries = __rf.edgeBoundaries.size();
+                    int convertedBoundaries = static_cast<int>(sizeBoundaries);
+                    int nBnds = (convertedBoundaries - 1) / (nTreesNodes * nTrees);
                     int start = __rf.edgeBoundaries[currentNode * nBnds];
                     int finish = __rf.edgeBoundaries[currentNode * nBnds + 1];
 

--- a/modules/ximgproc/src/structured_edge_detection.cpp
+++ b/modules/ximgproc/src/structured_edge_detection.cpp
@@ -801,9 +801,7 @@ protected:
                 {// for j,k in [0;width)x[0;nTreesEval)
 
                     int currentNode = pIndex[j*nTreesEval + k];
-                    
                     const int nBnds = (__rf.edgeBoundaries.size() - 1) / (nTreesNodes * nTrees);
-
                     int start = __rf.edgeBoundaries[currentNode * nBnds];
                     int finish = __rf.edgeBoundaries[currentNode * nBnds + 1];
 


### PR DESCRIPTION
update structured_edge_detection to read models from updated p. dollar toolbox

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
current version returns blurry edge map with "new" models from updated p. dollar toolbox
the solution can be to set sharpen parameter from the models to 0 and update the structured_edge_detection.cpp file as suggested here : http://answers.opencv.org/question/72962/trained-model-for-opencv-structured-edge-detection/?answer=95989#post-id-95989