### PR TITLE
renamed constants because they conflict with constants in Windows Kit

### DIFF
--- a/modules/face/src/mace.cpp
+++ b/modules/face/src/mace.cpp
@@ -208,8 +208,8 @@ struct MACEImpl : MACE {
         re -= m1;
         double value=0;
         double num=0;
-        int rad1=int(floor((double)(45.0/64.0)*(double)IMGSIZE));
-        int rad2=int(floor((double)(27.0/64.0)*(double)IMGSIZE));
+        int rad_1=int(floor((double)(45.0/64.0)*(double)IMGSIZE));
+        int rad_2=int(floor((double)(27.0/64.0)*(double)IMGSIZE));
         // cache a few pow's and sqrts
         std::vector<double> r2(IMGSIZE_2X);
         Mat_<double> radtab(IMGSIZE_2X,IMGSIZE_2X);
@@ -226,8 +226,8 @@ struct MACEImpl : MACE {
         for (int l=0; l<IMGSIZE_2X; l++) {
             for (int m=0; m<IMGSIZE_2X; m++) {
                 double rad = radtab(l,m);
-                if (rad < rad1) {
-                    if (rad > rad2) {
+                if (rad < rad_1) {
+                    if (rad > rad_2) {
                         value += re(l,m);
                         num++;
                     }
@@ -240,8 +240,8 @@ struct MACEImpl : MACE {
         for (int l=0; l<IMGSIZE_2X; l++) {
             for (int m=0; m<IMGSIZE_2X; m++) {
                 double rad = radtab(l,m);
-                if (rad < rad1) {
-                    if (rad > rad2) {
+                if (rad < rad_1) {
+                    if (rad > rad_2) {
                         double d = (value - re(l,m));
                         std2 += d * d;
                     }


### PR DESCRIPTION
resolves #1580 

### This pullrequest changes

The constants rad1 and rad2 used in mace.cpp are conflicting with constants used in Windows Kits. Seems they are getting from precompiled headers. I fixed it by renaming constants, but probably there is some other reason for this problem.
