### PR TITLE
fixed bug when norm less than eps where float array elements were left uninitialized

### DIFF
--- a/modules/surface_matching/src/ppf_helpers.cpp
+++ b/modules/surface_matching/src/ppf_helpers.cpp
@@ -444,9 +444,9 @@ Mat samplePCByQuantization(Mat pc, Vec2f& xrange, Vec2f& yrange, Vec2f& zrange, 
       }
       else
       {
-        pcData[3]=nx;
-        pcData[4]=ny;
-        pcData[5]=nz;
+        pcData[3]=(float)nx;
+        pcData[4]=(float)ny;
+        pcData[5]=(float)nz;
       }
       //#pragma omp atomic
       c++;

--- a/modules/surface_matching/src/ppf_helpers.cpp
+++ b/modules/surface_matching/src/ppf_helpers.cpp
@@ -442,6 +442,12 @@ Mat samplePCByQuantization(Mat pc, Vec2f& xrange, Vec2f& yrange, Vec2f& zrange, 
         pcData[4]=(float)(ny/norm);
         pcData[5]=(float)(nz/norm);
       }
+      else
+      {
+        pcData[3]=nx;
+        pcData[4]=ny;
+        pcData[5]=nz;
+      }
       //#pragma omp atomic
       c++;
 

--- a/modules/surface_matching/src/ppf_helpers.cpp
+++ b/modules/surface_matching/src/ppf_helpers.cpp
@@ -444,9 +444,9 @@ Mat samplePCByQuantization(Mat pc, Vec2f& xrange, Vec2f& yrange, Vec2f& zrange, 
       }
       else
       {
-        pcData[3]=(float)nx;
-        pcData[4]=(float)ny;
-        pcData[5]=(float)nz;
+        pcData[3]=0.0f;
+        pcData[4]=0.0f;
+        pcData[5]=0.0f;
       }
       //#pragma omp atomic
       c++;


### PR DESCRIPTION
### This pullrequest changes ppf_helpers.cpp
 In method "samplePCByQuantization" segmentation fault occurred using v3.4.1, in cases where input norm of some points was 0, elements 3,4,5 of the float array were left uninitialized leading to garbage variables which are used later to compute the ppf features and later giving incorrect hash values causing segmentation fault and the whole application crashes.
