### PR TITLE
Fixed several warnings produced by clang

### DIFF
--- a/modules/cvv/src/controller/view_controller.cpp
+++ b/modules/cvv/src/controller/view_controller.cpp
@@ -64,21 +64,21 @@ void ViewController::addCallType(const QString typeName, TabFactory constr)
 	ViewController::callTabType[typeName] = constr;
 }
 
-std::unique_ptr<cvv::gui::FilterCallTab>
+static std::unique_ptr<cvv::gui::FilterCallTab>
 makeFilterCallTab(cvv::util::Reference<cvv::impl::Call> call)
 {
 	return cvv::util::make_unique<cvv::gui::FilterCallTab>(
 	    *call.castTo<cvv::impl::FilterCall>());
 }
 
-std::unique_ptr<cvv::gui::MatchCallTab>
+static std::unique_ptr<cvv::gui::MatchCallTab>
 makeMatchCallTab(cvv::util::Reference<cvv::impl::Call> call)
 {
 	return cvv::util::make_unique<cvv::gui::MatchCallTab>(
 	    *call.castTo<cvv::impl::MatchCall>());
 }
 
-std::unique_ptr<cvv::gui::ImageCallTab>
+static std::unique_ptr<cvv::gui::ImageCallTab>
 makeImageCallTab(cvv::util::Reference<cvv::impl::Call> call)
 {
 	return cvv::util::make_unique<cvv::gui::ImageCallTab>(

--- a/modules/cvv/src/qtutil/filter/changed_pixels_widget.cpp
+++ b/modules/cvv/src/qtutil/filter/changed_pixels_widget.cpp
@@ -14,7 +14,7 @@ void changedPixelImage(const cv::Mat& mat0, const cv::Mat& mat1, cv::Mat& out);
 template<int Depth, int Channels>
 void changedPixelImage(const cv::Mat& mat0, const cv::Mat& mat1, cv::Mat& out);
 
-void changedPixelImage(const cv::Mat& mat0, const cv::Mat& mat1, cv::Mat& out)
+static void changedPixelImage(const cv::Mat& mat0, const cv::Mat& mat1, cv::Mat& out)
 {
 	// need same size
 	if (mat0.size() != mat1.size())

--- a/modules/cvv/src/qtutil/matchview/keypointmanagement.cpp
+++ b/modules/cvv/src/qtutil/matchview/keypointmanagement.cpp
@@ -142,7 +142,7 @@ void KeyPointManagement::setSelection(
 
 void KeyPointManagement::addSetting()
 {
-	addSetting(std::move(util::make_unique<KeyPointSettingsSelector>(univers_)));
+    addSetting(util::make_unique<KeyPointSettingsSelector>(univers_));
 }
 
 
@@ -176,7 +176,7 @@ void KeyPointManagement::removeSetting(KeyPointSettingsSelector *setting)
 
 void KeyPointManagement::addSelection()
 {
-	addSelection(std::move(util::make_unique<KeyPointSelectionSelector>(univers_)));
+    addSelection(util::make_unique<KeyPointSelectionSelector>(univers_));
 }
 
 void KeyPointManagement::addSelection(std::unique_ptr<KeyPointSelectionSelector> selection)

--- a/modules/cvv/src/qtutil/matchview/matchmanagement.cpp
+++ b/modules/cvv/src/qtutil/matchview/matchmanagement.cpp
@@ -137,7 +137,7 @@ void MatchManagement::setSelection(
 
 void MatchManagement::addSetting()
 {
-	addSetting(std::move(util::make_unique<MatchSettingsSelector>(univers_)));
+    addSetting(util::make_unique<MatchSettingsSelector>(univers_));
 }
 
 
@@ -172,7 +172,7 @@ void MatchManagement::removeSetting(MatchSettingsSelector *setting)
 
 void MatchManagement::addSelection()
 {
-	addSelection(std::move(util::make_unique<MatchSelectionSelector>(univers_)));
+    addSelection(util::make_unique<MatchSelectionSelector>(univers_));
 }
 
 void MatchManagement::addSelection(std::unique_ptr<MatchSelectionSelector> selection)

--- a/modules/cvv/src/qtutil/matchview/matchscene.hpp
+++ b/modules/cvv/src/qtutil/matchview/matchscene.hpp
@@ -44,7 +44,7 @@ class MatchSceneGraphicsView : public QGraphicsView
 		emit signalResized();
 	}
 
-	virtual void contextMenuEvent(QContextMenuEvent *event)
+    virtual void contextMenuEvent(QContextMenuEvent *event) CV_OVERRIDE
 	{
 		emit signalContextMenu(event->globalPos());
 		//event->ignore();

--- a/modules/cvv/src/qtutil/util.cpp
+++ b/modules/cvv/src/qtutil/util.cpp
@@ -335,7 +335,7 @@ bool checkValueRange(const cv::Mat &mat, DepthType<depth> min,
  * @param res The error code.
  * @return The result.
  */
-std::pair<ImageConversionResult, QImage> errorResult(ImageConversionResult res,
+static std::pair<ImageConversionResult, QImage> errorResult(ImageConversionResult res,
 						     const cv::Mat &mat)
 {
 	switch (res)

--- a/modules/cvv/src/qtutil/zoomableimage.cpp
+++ b/modules/cvv/src/qtutil/zoomableimage.cpp
@@ -137,7 +137,7 @@ template <int depth> std::string printPixel(const cv::Mat &mat, int i, int j)
  * @return The channels of pixel mat,col from mat as a string. (or ">6
  * channels")
  */
-std::string printPixel(const cv::Mat &mat, int i, int j)
+static std::string printPixel(const cv::Mat &mat, int i, int j)
 {
 	if (i >= 0 && j >= 0)
 	{

--- a/modules/cvv/src/view/defaultfilterview.cpp
+++ b/modules/cvv/src/view/defaultfilterview.cpp
@@ -41,8 +41,7 @@ DefaultFilterView::DefaultFilterView(const std::vector<cv::Mat> &images,
 
 		accor->insert(
 		    QString("Image Information: ") + QString::number(count),
-		    std::move(
-			util::make_unique<qtutil::ZoomableOptPanel>(*zoomIm)));
+            util::make_unique<qtutil::ZoomableOptPanel>(*zoomIm));
 
 		zoomIm->setMat(image);
 
@@ -51,7 +50,7 @@ DefaultFilterView::DefaultFilterView(const std::vector<cv::Mat> &images,
 		histogram->setVisible(false);
 		connect(zoomIm.get(), SIGNAL(updateArea(QRectF, qreal)), histogram.get(), SLOT(setArea(QRectF, qreal)));
 
-		accor->insert(QString("Histogram: ") + QString::number(count), std::move(util::make_unique<qtutil::HistogramOptPanel>(*histogram)));
+        accor->insert(QString("Histogram: ") + QString::number(count), util::make_unique<qtutil::HistogramOptPanel>(*histogram));
 
 		imageLayout->addWidget(zoomIm.release(), 0, count);
     imageLayout->addWidget(histogram.release(), 1, count);

--- a/modules/cvv/src/view/dual_filter_view.cpp
+++ b/modules/cvv/src/view/dual_filter_view.cpp
@@ -69,8 +69,7 @@ DualFilterView::DualFilterView(std::array<cv::Mat, 2> images, QWidget *parent)
 
 		accor->insert(
 		    QString("Image Information: ") + QString::number(count),
-		    std::move(
-		        util::make_unique<qtutil::ZoomableOptPanel>(*zoomIm)));
+                util::make_unique<qtutil::ZoomableOptPanel>(*zoomIm));
 
 		if (count != 1)
 		{
@@ -99,7 +98,7 @@ DualFilterView::DualFilterView(std::array<cv::Mat, 2> images, QWidget *parent)
 	syncVec.push_back(lambda(rawImages_.at(1), 2));
 	
 	accor->insert("Zoom synchronization",
-		std::move(util::make_unique<qtutil::SyncZoomWidget>(syncVec)), true, 1);
+        util::make_unique<qtutil::SyncZoomWidget>(syncVec), true, 1);
 	
 	//ensure that all images have same width
 	imwid->setLayout(imageLayout.release());

--- a/modules/cvv/src/view/image_view.cpp
+++ b/modules/cvv/src/view/image_view.cpp
@@ -32,8 +32,7 @@ ImageView::ImageView(const cv::Mat &image, QWidget *parent)
 	accor->setMaximumWidth(300);
 
 	auto zoomim = util::make_unique<qtutil::ZoomableImage>();
-	accor->insert(QString("ImageInformation:"),
-		std::move(util::make_unique<qtutil::ZoomableOptPanel>(*zoomim,false)));
+    accor->insert(QString("ImageInformation:"), util::make_unique<qtutil::ZoomableOptPanel>(*zoomim,false));
 	zoomim->setMat(image);
 
 	auto histogram = util::make_unique<qtutil::Histogram>();
@@ -41,7 +40,7 @@ ImageView::ImageView(const cv::Mat &image, QWidget *parent)
 	histogram->setVisible(false);
 	connect(zoomim.get(), SIGNAL(updateArea(QRectF, qreal)), histogram.get(), SLOT(setArea(QRectF, qreal)));
 
-	accor->insert(QString("Histogram:"), std::move(util::make_unique<qtutil::HistogramOptPanel>(*histogram)));
+    accor->insert(QString("Histogram:"), util::make_unique<qtutil::HistogramOptPanel>(*histogram));
 
 	this->image = (*zoomim);
 	imageLayout->addWidget(zoomim.release(), 0, 0);

--- a/modules/cvv/src/view/linematchview.cpp
+++ b/modules/cvv/src/view/linematchview.cpp
@@ -66,18 +66,15 @@ LineMatchView::LineMatchView(std::vector<cv::KeyPoint> leftKeyPoints,
 	accor->insert("Match Settings", std::move(matchmnt));
 	accor->insert("KeyPoint Settings", std::move(keyPointmnt));
 	accor->insert("Show selection in rawview window",
-		      std::move(util::make_unique<qtutil::ShowInRawView>(leftKeyPoints,
+              util::make_unique<qtutil::ShowInRawView>(leftKeyPoints,
 								 rightKeyPoints,
 								 matches,
 								 matchManagment_,
-								 keyManagment_)));
+                                 keyManagment_));
 
-	accor->insert("Sync Zoom ",
-		      std::move(matchscene_ptr->getSyncZoomWidget()));
-	accor->insert("Left Image ",
-		      std::move(matchscene_ptr->getLeftMatInfoWidget()));
-	accor->insert("Right Image ",
-		      std::move(matchscene_ptr->getRightMatInfoWidget()));
+    accor->insert("Sync Zoom ", matchscene_ptr->getSyncZoomWidget());
+    accor->insert("Left Image ", matchscene_ptr->getLeftMatInfoWidget());
+    accor->insert("Right Image ", matchscene_ptr->getRightMatInfoWidget());
 
 	layout->addWidget(accor.release());
 	layout->addWidget(matchscene.release());

--- a/modules/cvv/src/view/linematchview.hpp
+++ b/modules/cvv/src/view/linematchview.hpp
@@ -56,19 +56,19 @@ class LineMatchView : public MatchView
 		return matchManagment_->getCurrentSelection();
 	}
 
-	virtual std::vector<cv::KeyPoint> getKeyPointSelection()
+    virtual std::vector<cv::KeyPoint> getKeyPointSelection() CV_OVERRIDE
 	{
 		return keyManagment_->getCurrentSelection();
 	}
 
 public slots:
 
-	virtual void setMatchSelection(std::vector<cv::DMatch> selection)
+    virtual void setMatchSelection(std::vector<cv::DMatch> selection) CV_OVERRIDE
 	{
 		matchManagment_->setSelection(selection);
 	}
 
-	virtual void setKeyPointSelection(std::vector<cv::KeyPoint> selection)
+    virtual void setKeyPointSelection(std::vector<cv::KeyPoint> selection) CV_OVERRIDE
 	{
 		keyManagment_->setSelection(selection);
 	}

--- a/modules/cvv/src/view/pointmatchview.cpp
+++ b/modules/cvv/src/view/pointmatchview.cpp
@@ -46,11 +46,11 @@ PointMatchView::PointMatchView(std::vector<cv::KeyPoint> leftKeyPoints,
 
 	accor->insert("Match Settings", std::move(matchmnt));
 	accor->insert("Sync Zoom ",
-		      std::move(matchscene_ptr->getSyncZoomWidget()));
+              matchscene_ptr->getSyncZoomWidget());
 	accor->insert("Left Image ",
-		      std::move(matchscene_ptr->getLeftMatInfoWidget()));
+              matchscene_ptr->getLeftMatInfoWidget());
 	accor->insert("Right Image ",
-		      std::move(matchscene_ptr->getRightMatInfoWidget()));
+              matchscene_ptr->getRightMatInfoWidget());
 
 	layout->addWidget(accor.release());
 	layout->addWidget(matchscene.release());

--- a/modules/cvv/src/view/pointmatchview.hpp
+++ b/modules/cvv/src/view/pointmatchview.hpp
@@ -58,7 +58,7 @@ class PointMatchView : public MatchView
 
 public slots:
 
-	virtual void setMatchSelection(std::vector<cv::DMatch> selection)
+    virtual void setMatchSelection(std::vector<cv::DMatch> selection) CV_OVERRIDE
 	{
 		matchManagment_->setSelection(selection);
 	}

--- a/modules/cvv/src/view/singlefilterview.cpp
+++ b/modules/cvv/src/view/singlefilterview.cpp
@@ -44,8 +44,7 @@ SingleFilterView::SingleFilterView(const std::vector<cv::Mat> &images,
 		auto originalZoomIm = util::make_unique<qtutil::ZoomableImage>(image);
 		accor->insert(
 		    QString("Info original image ") + QString::number(count),
-		    std::move(
-			util::make_unique<qtutil::ZoomableOptPanel>(*originalZoomIm)));
+            util::make_unique<qtutil::ZoomableOptPanel>(*originalZoomIm));
 		syncVec.push_back(originalZoomIm.get());
 
 
@@ -66,8 +65,7 @@ SingleFilterView::SingleFilterView(const std::vector<cv::Mat> &images,
 
 		accor->insert(
 		    QString("Info filtered image ") + QString::number(count),
-		    std::move(
-			util::make_unique<qtutil::ZoomableOptPanel>(*filterZoomIm)));
+            util::make_unique<qtutil::ZoomableOptPanel>(*filterZoomIm));
 
 		syncVec.push_back(filterZoomIm.get());
 
@@ -84,7 +82,7 @@ SingleFilterView::SingleFilterView(const std::vector<cv::Mat> &images,
 	imwid->setLayout(imageLayout.release());
 
 	accor->insert("Zoom synchronization",
-		std::move(util::make_unique<qtutil::SyncZoomWidget>(syncVec)), true, 1);
+        util::make_unique<qtutil::SyncZoomWidget>(syncVec), true, 1);
 
 	layout->addWidget(accor.release());
 	layout->addWidget(imwid.release());

--- a/modules/cvv/src/view/translationsmatchview.cpp
+++ b/modules/cvv/src/view/translationsmatchview.cpp
@@ -57,17 +57,17 @@ TranslationMatchView::TranslationMatchView(
 	accor->insert("Match Settings", std::move(matchmnt));
 	accor->insert("KeyPoint Settings", std::move(keyPointmnt));
 	accor->insert("Show selection in rawview window",
-		      std::move(util::make_unique<qtutil::ShowInRawView>(leftKeyPoints,
+              util::make_unique<qtutil::ShowInRawView>(leftKeyPoints,
 								 rightKeyPoints,
 								 matches,
 								 matchManagment_,
-								 keyManagment_)));
+                                 keyManagment_));
 	accor->insert("Sync Zoom ",
-		      std::move(matchscene_ptr->getSyncZoomWidget()));
+              matchscene_ptr->getSyncZoomWidget());
 	accor->insert("Left Image ",
-		      std::move(matchscene_ptr->getLeftMatInfoWidget()));
+              matchscene_ptr->getLeftMatInfoWidget());
 	accor->insert("Right Image ",
-		      std::move(matchscene_ptr->getRightMatInfoWidget()));
+              matchscene_ptr->getRightMatInfoWidget());
 
 	layout->addWidget(accor.release());
 	layout->addWidget(matchscene.release());

--- a/modules/cvv/src/view/translationsmatchview.hpp
+++ b/modules/cvv/src/view/translationsmatchview.hpp
@@ -60,19 +60,19 @@ class TranslationMatchView : public MatchView
 		return matchManagment_->getCurrentSelection();
 	}
 
-	virtual std::vector<cv::KeyPoint> getKeyPointSelection()
+    virtual std::vector<cv::KeyPoint> getKeyPointSelection() CV_OVERRIDE
 	{
 		return keyManagment_->getCurrentSelection();
 	}
 
 public slots:
 
-	virtual void setMatchSelection(std::vector<cv::DMatch> selection)
+    virtual void setMatchSelection(std::vector<cv::DMatch> selection) CV_OVERRIDE
 	{
 		matchManagment_->setSelection(selection);
 	}
 
-	virtual void setKeyPointSelection(std::vector<cv::KeyPoint> selection)
+    virtual void setKeyPointSelection(std::vector<cv::KeyPoint> selection) CV_OVERRIDE
 	{
 		keyManagment_->setSelection(selection);
 	}


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

_cvv_ module:
* override-related warnings
* local functions without declaration
* complains about move semantics (_std::move_ prevents copy elision, `-Wpessimizing-move`)
