### PR TITLE
Add CV_OVERRIDE

### DIFF
--- a/modules/face/src/facemarkAAM.cpp
+++ b/modules/face/src/facemarkAAM.cpp
@@ -103,11 +103,11 @@ public:
 
     bool getData(void * items) CV_OVERRIDE;
 
-    bool fitConfig( InputArray image, InputArray roi, OutputArrayOfArrays _landmarks, const std::vector<Config> &runtime_params );
+    bool fitConfig( InputArray image, InputArray roi, OutputArrayOfArrays _landmarks, const std::vector<Config> &runtime_params ) CV_OVERRIDE;
 
 protected:
 
-    bool fit( InputArray image, InputArray faces, OutputArrayOfArrays landmarks );
+    bool fit( InputArray image, InputArray faces, OutputArrayOfArrays landmarks ) CV_OVERRIDE;
     //bool fit( InputArray image, InputArray faces, InputOutputArray landmarks, void * runtime_params);//!< from many ROIs
     bool fitImpl( const Mat image, std::vector<Point2f>& landmarks,const  Mat R,const  Point2f T,const  float scale, const int sclIdx=0 );
 

--- a/modules/face/src/facemarkLBF.cpp
+++ b/modules/face/src/facemarkLBF.cpp
@@ -115,7 +115,7 @@ public:
 
 protected:
 
-    bool fit( InputArray image, InputArray faces, OutputArrayOfArrays landmarks );//!< from many ROIs
+    bool fit( InputArray image, InputArray faces, OutputArrayOfArrays landmarks ) CV_OVERRIDE;//!< from many ROIs
     bool fitImpl( const Mat image, std::vector<Point2f> & landmarks );//!< from a face
 
     bool addTrainingSample(InputArray image, InputArray landmarks) CV_OVERRIDE;


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

```
/build/precommit_opencl_linux/opencv_contrib/modules/face/src/facemarkAAM.cpp:106:10: warning: 'virtual bool cv::face::FacemarkAAMImpl::fitConfig(cv::InputArray, cv::InputArray, cv::OutputArrayOfArrays, const std::vector<cv::face::FacemarkAAM::Config>&)' can be marked override [-Wsuggest-override]
/build/precommit_opencl_linux/opencv_contrib/modules/face/src/facemarkAAM.cpp:110:10: warning: 'virtual bool cv::face::FacemarkAAMImpl::fit(cv::InputArray, cv::InputArray, cv::OutputArrayOfArrays)' can be marked override [-Wsuggest-override]
/build/precommit_opencl_linux/opencv_contrib/modules/face/src/facemarkLBF.cpp:118:10: warning: 'virtual bool cv::face::FacemarkLBFImpl::fit(cv::InputArray, cv::InputArray, cv::OutputArrayOfArrays)' can be marked override [-Wsuggest-override]
```