### PR TITLE
Make getProjPixel output value available in python bindings

### DIFF
--- a/modules/structured_light/include/opencv2/structured_light/graycodepattern.hpp
+++ b/modules/structured_light/include/opencv2/structured_light/graycodepattern.hpp
@@ -140,7 +140,7 @@ class CV_EXPORTS_W GrayCodePattern : public StructuredLightPattern
    *  @param projPix Projector's pixel corresponding to the camera's pixel: projPix.x and projPix.y are the image coordinates of the projector's pixel corresponding to the pixel being decoded in a camera.
    */
   CV_WRAP
-  virtual bool getProjPixel( InputArrayOfArrays patternImages, int x, int y, Point &projPix ) const = 0;
+  virtual bool getProjPixel( InputArrayOfArrays patternImages, int x, int y, CV_OUT Point &projPix ) const = 0;
 };
 
 //! @}

--- a/modules/structured_light/src/graycodepattern.cpp
+++ b/modules/structured_light/src/graycodepattern.cpp
@@ -72,7 +72,7 @@ class CV_EXPORTS_W GrayCodePattern_Impl CV_FINAL : public GrayCodePattern
   void getImagesForShadowMasks( InputOutputArray blackImage, InputOutputArray whiteImage ) const CV_OVERRIDE;
 
   // For a (x,y) pixel of the camera returns the corresponding projector pixel
-  bool getProjPixel(InputArrayOfArrays patternImages, int x, int y, Point &projPix) const CV_OVERRIDE;
+  bool getProjPixel(InputArrayOfArrays patternImages, int x, int y, CV_OUT Point &projPix) const CV_OVERRIDE;
 
  private:
   // Parameters


### PR DESCRIPTION
resolves #1601
### This pullrequest changes
Mark projPix as output value for python bindings