### PR TITLE
Cleanup old TBB-related guards

### DIFF
--- a/modules/dpm/CMakeLists.txt
+++ b/modules/dpm/CMakeLists.txt
@@ -1,8 +1,5 @@
 set(the_description "Object Detection")
 
-#uncomment the following line to enable parallel computing
-#add_definitions(-DHAVE_TBB)
-
 ocv_define_module(dpm opencv_core opencv_imgproc opencv_objdetect OPTIONAL opencv_highgui WRAP python)
 
 ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4512) # disable warning on Win64

--- a/modules/dpm/samples/cascade_detect_camera.cpp
+++ b/modules/dpm/samples/cascade_detect_camera.cpp
@@ -97,16 +97,6 @@ int main( int argc, char** argv )
         return -1;
     }
 
-#ifdef HAVE_TBB
-    cout << "Running with TBB" << endl;
-#else
-#ifdef _OPENMP
-    cout << "Running with OpenMP" << endl;
-#else
-    cout << "Running without OpenMP and without TBB" << endl;
-#endif
-#endif
-
     Mat frame;
     namedWindow("DPM Cascade Detection", 1);
     // the color of the rectangle

--- a/modules/dpm/samples/cascade_detect_sequence.cpp
+++ b/modules/dpm/samples/cascade_detect_sequence.cpp
@@ -113,16 +113,6 @@ int main( int argc, char** argv )
     if ( !readImageLists(image_list, imgFileList) )
         return -1;
 
-#ifdef HAVE_TBB
-    cout << "Running with TBB" << endl;
-#else
-#ifdef _OPENMP
-    cout << "Running with OpenMP" << endl;
-#else
-    cout << "Running without OpenMP and without TBB" << endl;
-#endif
-#endif
-
     cv::Ptr<DPMDetector> detector = \
     DPMDetector::create(vector<string>(1, model_path));
 

--- a/modules/dpm/src/dpm_cascade.hpp
+++ b/modules/dpm/src/dpm_cascade.hpp
@@ -128,7 +128,6 @@ class DPMCascade
         std::vector< std::vector<double> > detect(Mat &image);
 };
 
-#ifdef HAVE_TBB
 /** @brief This class convolves root PCA feature pyramid
  * and root PCA filters in parallel using Intel Threading
  * Building Blocks (TBB)
@@ -151,7 +150,6 @@ class ParalComputeRootPCAScores : public ParallelLoopBody
         int pcaDim;
         std::vector< Mat > &scores;
 };
-#endif
 } // namespace dpm
 } // namespace cv
 

--- a/modules/dpm/src/dpm_feature.hpp
+++ b/modules/dpm/src/dpm_feature.hpp
@@ -137,7 +137,6 @@ class Feature
 
 };
 
-#ifdef HAVE_TBB
 /** @brief This class computes feature pyramid in parallel
  * using Intel Threading Building Blocks (TBB)
  */
@@ -165,7 +164,6 @@ class ParalComputePyramid : public ParallelLoopBody
         // pyramid parameters
         PyramidParameter &params;
 };
-#endif
 
 } // namespace dpm
 } // namespace cv


### PR DESCRIPTION
Coupled with opencv/opencv#11253

### This pullrequest changes

Some of functions in _dpm_ module can be optimized for parallel execution even if TBB is not available by using _cv::parallel_for_.
