### PR TITLE
face: fix dependancies

### DIFF
--- a/modules/face/CMakeLists.txt
+++ b/modules/face/CMakeLists.txt
@@ -2,8 +2,8 @@ set(the_description "Face recognition etc")
 ocv_define_module(face opencv_core
     opencv_imgproc
     opencv_objdetect
-    opencv_tracking     # estimateRigidTransform()
-    opencv_photo        # samples
+    opencv_video     # estimateRigidTransform() (trainFacemark)
+    opencv_photo     # seamlessClone() (face_swap sample)
     WRAP python java
 )
 # NOTE: objdetect module is needed for one of the samples


### PR DESCRIPTION
### This pullrequest changes

swap opencv_tracking dependancy for opencv_video.

the Kazemi FaceMark training code uses `estimateRigidTransform()`, which is from opencv_video, not opencv_tracking.
this also removes the further dependancies on datasets, plot, dnn, flann, ml  for the face module.