### PR TITLE
ovis: remove superficial '}' from cmake

### DIFF
--- a/modules/ovis/CMakeLists.txt
+++ b/modules/ovis/CMakeLists.txt
@@ -16,7 +16,7 @@ elseif(OGRE_VERSION VERSION_GREATER 1.10) # we need C++11 for OGRE 1.11
   endif()
 endif()
 
-include_directories(${OGRE_INCLUDE_DIRS}})
+include_directories(${OGRE_INCLUDE_DIRS})
 link_directories(${OGRE_LIBRARY_DIRS})
 
 ocv_define_module(ovis opencv_core opencv_imgproc opencv_calib3d WRAP python)


### PR DESCRIPTION
with Ogre 1.11 OGRE_INCLUDE_DIRS has only one element and the '}'
corrupting the last include path becomes noticable.

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->


<!-- Please describe what your pullrequest is changing -->
