### PR TITLE
Fix memory leak when using CORNER_REFINE_APRILTAG and ArUco

### DIFF
--- a/modules/aruco/src/aruco.cpp
+++ b/modules/aruco/src/aruco.cpp
@@ -1094,6 +1094,8 @@ static void _apriltag(Mat im_orig, const Ptr<DetectorParameters> & _params, std:
 
         candidates.push_back(corners);
     }
+
+    _zarray_destroy(quads);
 }
 
 


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
Destroy `quads` to avoid a small memory leak when using `CORNER_REFINE_APRILTAG` with ArUco tag detection.