### PR TITLE
minor fix to allow learn_color_balance.py to work with python 3+

### DIFF
--- a/modules/xphoto/samples/learn_color_balance.py
+++ b/modules/xphoto/samples/learn_color_balance.py
@@ -221,7 +221,7 @@ if __name__ == '__main__':
                                                  "specify the -g parameter"))
         sys.exit(1)
 
-    img_range = map(int,parse_sequence(args.range))
+    img_range = list(map(int,parse_sequence(args.range)))
     if len(img_range)!=2:
         print("Error: Please specify the -r parameter in form <first_image_index>,<last_image_index>")
         sys.exit(1)


### PR DESCRIPTION

resolves #1647

### This pull request changes
changed line 224 of learn_color_balance.py  to explicitly return a list, 
map() object returns an iterator, not a list, in python 3.
the fix,  list(map()) is still compatible with python 2

