### PR TITLE
Bug fixes: using mask with BinaryDescriptor 

### DIFF
--- a/modules/line_descriptor/src/binary_descriptor.cpp
+++ b/modules/line_descriptor/src/binary_descriptor.cpp
@@ -1349,6 +1349,9 @@ int BinaryDescriptor::computeLBD( ScaleLines &keyLines, bool useDetectionData )
     for ( int g = 0; g < 32; g++ )
     {
       /* get LBD data */
+      if (keyLines[lineIDInScaleVec].empty()) {
+        continue;
+      }
       float* des_Vec = &keyLines[lineIDInScaleVec][0].descriptor.front();
       *pointerToRow = des_Vec[g];
       pointerToRow++;

--- a/modules/line_descriptor/src/binary_descriptor.cpp
+++ b/modules/line_descriptor/src/binary_descriptor.cpp
@@ -504,7 +504,7 @@ void BinaryDescriptor::detectImpl( const Mat& imageSrc, std::vector<KeyLine>& ke
   /* delete undesired KeyLines, according to input mask */
   if( !mask.empty() )
   {
-    for ( size_t keyCounter = 0; keyCounter < keylines.size(); keyCounter++ )
+    for ( size_t keyCounter = 0; keyCounter < keylines.size(); )
     {
       KeyLine& kl = keylines[keyCounter];
 
@@ -517,6 +517,8 @@ void BinaryDescriptor::detectImpl( const Mat& imageSrc, std::vector<KeyLine>& ke
 
       if( mask.at < uchar > ( (int) kl.startPointY, (int) kl.startPointX ) == 0 && mask.at < uchar > ( (int) kl.endPointY, (int) kl.endPointX ) == 0 )
         keylines.erase( keylines.begin() + keyCounter );
+      else
+        keyCounter++;
     }
   }
 

--- a/modules/line_descriptor/src/binary_descriptor.cpp
+++ b/modules/line_descriptor/src/binary_descriptor.cpp
@@ -1344,20 +1344,6 @@ int BinaryDescriptor::computeLBD( ScaleLines &keyLines, bool useDetectionData )
     }/* end for(short lineIDInSameLine = 0; lineIDInSameLine<sameLineSize;
      lineIDInSameLine++) */
 
-    cv::Mat appoggio = cv::Mat( 1, 32, CV_32FC1 );
-    float* pointerToRow = appoggio.ptr<float>( 0 );
-    for ( int g = 0; g < 32; g++ )
-    {
-      /* get LBD data */
-      if (keyLines[lineIDInScaleVec].empty()) {
-        continue;
-      }
-      float* des_Vec = &keyLines[lineIDInScaleVec][0].descriptor.front();
-      *pointerToRow = des_Vec[g];
-      pointerToRow++;
-
-    }
-
   }/* end for(short lineIDInScaleVec = 0;
    lineIDInScaleVec<numOfFinalLine; lineIDInScaleVec++) */
 


### PR DESCRIPTION
resolves #1437

Using mask with cv::line_descriptor::BinaryDescriptor to detect feature lines, will get wrong results.

```cpp
Ptr<BinaryDescriptor> bd = BinaryDescriptor::createBinaryDescriptor();
Mat mask = Mat::zeros(src.size(), CV_8UC1);  // With all 0 mask should get no line
vector<KeyLine> lines;
bd->detect(src, lines, mask);  // Still get some lines
Mat desc;
bd->compute(src, lines, desc);  // Get NULL pointer exception
```

### This pullrequest changes

* Change BinaryDescriptor::detectImpl method: erasing an element from std::vector in the loop, should not always move iterator forward, let `keyCounter++` only call on no-erasing. This change make `bd->detect(...)` get correct masked key lines.
* Change BinaryDescriptor::computeLBD method: `float* des_Vec = &keyLines[lineIDInScaleVec][0].descriptor.front();` get NULL exception when using mask, add a check to avoid


```
force_builders=linux,windows,macosx,docs
```