### PR TITLE
ovis: add setCompositors method

### DIFF
--- a/modules/ovis/include/opencv2/ovis.hpp
+++ b/modules/ovis/include/opencv2/ovis.hpp
@@ -63,6 +63,16 @@ public:
     CV_WRAP_AS(setBackgroundColor) virtual void setBackground(const Scalar& color) = 0;
 
     /**
+     * enable an ordered chain of full-screen post processing effects
+     *
+     * this way you can add distortion or SSAO effects.
+     * The effects themselves must be defined inside Ogre .compositor scripts.
+     * @see addResourceLocation
+     * @param names compositor names that will be applied in order of appearance
+     */
+    CV_WRAP virtual void setCompositors(const std::vector<String>& names) = 0;
+
+    /**
      * place an entity of an mesh in the scene
      *
      * the mesh needs to be created beforehand. Either programmatically

--- a/modules/ovis/src/ovis.cpp
+++ b/modules/ovis/src/ovis.cpp
@@ -7,6 +7,7 @@
 #include <OgreApplicationContext.h>
 #include <OgreCameraMan.h>
 #include <OgreRectangle2D.h>
+#include <OgreCompositorManager.h>
 
 #include <opencv2/calib3d.hpp>
 
@@ -337,6 +338,23 @@ public:
 
         // ensure bgplane is visible
         bgplane->setVisible(true);
+    }
+
+    void setCompositors(const std::vector<String>& names)
+    {
+        Viewport* vp = frameSrc->getViewport(0);
+        CompositorManager& cm = CompositorManager::getSingleton();
+
+        cm.removeCompositorChain(vp); // remove previous configuration
+
+        for(size_t i = 0; i < names.size(); i++)
+        {
+            if (!cm.addCompositor(vp, names[i])) {
+                LogManager::getSingleton().logError("Failed to add compositor: " + names[i]);
+                continue;
+            }
+            cm.setCompositorEnabled(vp, names[i], true);
+        }
     }
 
     void setBackground(const Scalar& color)


### PR DESCRIPTION
enables an ordered chain of full-screen post processing effects