### PR TITLE
xfeatures2d: throw CV_Error if not built with OPENCV_ENABLE_NONFREE

### DIFF
--- a/modules/xfeatures2d/include/opencv2/xfeatures2d.hpp
+++ b/modules/xfeatures2d/include/opencv2/xfeatures2d.hpp
@@ -51,7 +51,7 @@ This section describes experimental algorithms for 2d feature detection.
     @defgroup xfeatures2d_nonfree Non-free 2D Features Algorithms
 
 This section describes two popular algorithms for 2d feature detection, SIFT and SURF, that are
-known to be patented. Use them at your own risk.
+known to be patented. You need to set the OPENCV_ENABLE_NONFREE option in cmake to use those. Use them at your own risk.
 
     @defgroup xfeatures2d_match Experimental 2D Features Matching Algorithm
 

--- a/modules/xfeatures2d/src/sift.cpp
+++ b/modules/xfeatures2d/src/sift.cpp
@@ -112,6 +112,8 @@ namespace cv
 namespace xfeatures2d
 {
 
+#ifdef OPENCV_ENABLE_NONFREE
+
 /*!
  SIFT implementation.
 
@@ -1196,6 +1198,15 @@ void SIFT_Impl::detectAndCompute(InputArray _image, InputArray _mask,
         //printf("descriptor extraction time: %g\n", t*1000./tf);
     }
 }
+
+#else // ! #ifdef OPENCV_ENABLE_NONFREE
+Ptr<SIFT> SIFT::create( int, int, double, double, double )
+{
+    CV_Error(Error::StsNotImplemented,
+        "This algorithm is patented and is excluded in this configuration; "
+        "Set OPENCV_ENABLE_NONFREE CMake option and rebuild the library");
+}
+#endif
 
 }
 }

--- a/modules/xfeatures2d/src/surf.cpp
+++ b/modules/xfeatures2d/src/surf.cpp
@@ -115,6 +115,8 @@ namespace cv
 namespace xfeatures2d
 {
 
+#ifdef OPENCV_ENABLE_NONFREE
+
 static const int   SURF_ORI_SEARCH_INC = 5;
 static const float SURF_ORI_SIGMA      = 2.5f;
 static const float SURF_DESC_SIGMA     = 3.3f;
@@ -1004,6 +1006,16 @@ Ptr<SURF> SURF::create(double _threshold, int _nOctaves, int _nOctaveLayers, boo
 {
     return makePtr<SURF_Impl>(_threshold, _nOctaves, _nOctaveLayers, _extended, _upright);
 }
+
+
+#else // ! #ifdef OPENCV_ENABLE_NONFREE
+Ptr<SURF> SURF::create(double, int, int, bool, bool)
+{
+    CV_Error(Error::StsNotImplemented,
+        "This algorithm is patented and is excluded in this configuration; "
+        "Set OPENCV_ENABLE_NONFREE CMake option and rebuild the library");
+}
+#endif
 
 }
 }

--- a/modules/xfeatures2d/src/surf.cuda.cpp
+++ b/modules/xfeatures2d/src/surf.cuda.cpp
@@ -64,6 +64,26 @@ void cv::cuda::SURF_CUDA::releaseMemory() { throw_no_cuda(); }
 
 #else // !defined (HAVE_CUDA)
 
+#if (!defined (OPENCV_ENABLE_NONFREE))
+#define throw_no_nonfree     CV_Error(Error::StsNotImplemented, \
+        "This algorithm is patented and is excluded in this configuration; " \
+        "Set OPENCV_ENABLE_NONFREE CMake option and rebuild the library");
+
+cv::cuda::SURF_CUDA::SURF_CUDA() { throw_no_nonfree }
+cv::cuda::SURF_CUDA::SURF_CUDA(double, int, int, bool, float, bool) { throw_no_nonfree }
+int cv::cuda::SURF_CUDA::descriptorSize() const { throw_no_nonfree }
+void cv::cuda::SURF_CUDA::uploadKeypoints(const std::vector<KeyPoint>&, GpuMat&) { throw_no_nonfree }
+void cv::cuda::SURF_CUDA::downloadKeypoints(const GpuMat&, std::vector<KeyPoint>&) { throw_no_nonfree }
+void cv::cuda::SURF_CUDA::downloadDescriptors(const GpuMat&, std::vector<float>&) { throw_no_nonfree }
+void cv::cuda::SURF_CUDA::operator()(const GpuMat&, const GpuMat&, GpuMat&) { throw_no_nonfree }
+void cv::cuda::SURF_CUDA::operator()(const GpuMat&, const GpuMat&, GpuMat&, GpuMat&, bool) { throw_no_nonfree }
+void cv::cuda::SURF_CUDA::operator()(const GpuMat&, const GpuMat&, std::vector<KeyPoint>&) { throw_no_nonfree }
+void cv::cuda::SURF_CUDA::operator()(const GpuMat&, const GpuMat&, std::vector<KeyPoint>&, GpuMat&, bool) { throw_no_nonfree }
+void cv::cuda::SURF_CUDA::operator()(const GpuMat&, const GpuMat&, std::vector<KeyPoint>&, std::vector<float>&, bool) { throw_no_nonfree }
+void cv::cuda::SURF_CUDA::releaseMemory() { throw_no_nonfree }
+
+#else // OPENCV_ENABLE_NONFREE
+
 namespace cv { namespace cuda { namespace device
 {
     namespace surf
@@ -431,5 +451,6 @@ void cv::cuda::SURF_CUDA::releaseMemory()
 }
 
 #endif // !defined (HAVE_CUDA)
+#endif // !defined (OPENCV_ENABLE_NONFREE)
 #endif
 

--- a/modules/xfeatures2d/src/surf.ocl.cpp
+++ b/modules/xfeatures2d/src/surf.ocl.cpp
@@ -57,6 +57,8 @@ namespace cv
 namespace xfeatures2d
 {
 
+#ifdef OPENCV_ENABLE_NONFREE
+
 enum { ORI_SEARCH_INC=5, ORI_LOCAL_SIZE=(360 / ORI_SEARCH_INC) };
 
 static inline int calcSize(int octave, int layer)
@@ -462,6 +464,8 @@ bool SURF_OCL::calcOrientation(UMat &keypoints)
     size_t globalThreads[3] = {nFeatures * localThreads[0], 1};
     return kerOri.run(2, globalThreads, localThreads, true);
 }
+
+#endif // ! #ifdef OPENCV_ENABLE_NONFREE
 
 }
 }


### PR DESCRIPTION
resolves #1668

unless opencv was built with OPENCV_ENABLE_NONFREE, 
the following algorithms are disabled (throw a runtime error):

* SIFT
* SURF
* SURF_OCL
* SURF / CUDA

* xphoto/bm3d_image_denoising (this already existed)