### PR TITLE
xfeatures2d(test): disable tests with required non-free code

### DIFF
--- a/modules/xfeatures2d/perf/perf_latch.cpp
+++ b/modules/xfeatures2d/perf/perf_latch.cpp
@@ -11,6 +11,7 @@ typedef perf::TestBaseWithParam<std::string> latch;
     "cv/detectors_descriptors_evaluation/images_datasets/leuven/img1.png",\
     "stitching/a3.png"
 
+#ifdef OPENCV_ENABLE_NONFREE
 PERF_TEST_P(latch, extract, testing::Values(LATCH_IMAGES))
 {
     string filename = getDataPath(GetParam());
@@ -30,5 +31,6 @@ PERF_TEST_P(latch, extract, testing::Values(LATCH_IMAGES))
 
     SANITY_CHECK_NOTHING();
 }
+#endif // NONFREE
 
 }} // namespace

--- a/modules/xfeatures2d/perf/perf_surf.cpp
+++ b/modules/xfeatures2d/perf/perf_surf.cpp
@@ -3,6 +3,7 @@
 // of this distribution and at http://opencv.org/license.html.
 #include "perf_precomp.hpp"
 
+#ifdef OPENCV_ENABLE_NONFREE
 namespace opencv_test { namespace {
 
 typedef perf::TestBaseWithParam<std::string> surf;
@@ -64,3 +65,4 @@ PERF_TEST_P(surf, full, testing::Values(SURF_IMAGES))
 }
 
 }} // namespace
+#endif // NONFREE

--- a/modules/xfeatures2d/perf/perf_surf.cuda.cpp
+++ b/modules/xfeatures2d/perf/perf_surf.cuda.cpp
@@ -42,7 +42,7 @@
 
 #include "perf_precomp.hpp"
 
-#ifdef HAVE_CUDA
+#if defined(HAVE_CUDA) && defined(OPENCV_ENABLE_NONFREE)
 
 #include "opencv2/ts/cuda_perf.hpp"
 
@@ -99,4 +99,4 @@ PERF_TEST_P(Image, CUDA_SURF,
 #endif // HAVE_OPENCV_CUDAARITHM
 
 }} // namespace
-#endif // HAVE_CUDA
+#endif // HAVE_CUDA && OPENCV_ENABLE_NONFREE

--- a/modules/xfeatures2d/perf/perf_surf.ocl.cpp
+++ b/modules/xfeatures2d/perf/perf_surf.ocl.cpp
@@ -45,7 +45,7 @@
 
 #include "perf_precomp.hpp"
 
-#ifdef HAVE_OPENCV_OCL
+#if defined(HAVE_OPENCV_OCL) && defined(OPENCV_ENABLE_NONFREE)
 
 namespace opencv_test { namespace {
 
@@ -105,4 +105,4 @@ PERF_TEST_P(OCL_SURF, DISABLED_without_data_transfer, testing::Values(SURF_IMAGE
 }
 
 }} // namespace
-#endif // HAVE_OPENCV_OCL
+#endif // HAVE_OPENCV_OCL && OPENCV_ENABLE_NONFREE

--- a/modules/xfeatures2d/test/test_detectors.cpp
+++ b/modules/xfeatures2d/test/test_detectors.cpp
@@ -278,12 +278,15 @@ void CV_DetectorsTest::run( int /*start_from*/ )
     GaussianBlur(to_test, to_test, Size(3, 3), 1.5);
 
     vector<KeyPoint> exp;
+
+#ifdef OPENCV_ENABLE_NONFREE
     LoadExpected(string(ts->get_data_path()) + "detectors/surf.xml", exp);
     if (exp.empty())
         return;
 
     if (!testDetector(to_test, SURF::create(1536+512+512, 2, 2, true, false), exp))
         return;
+#endif
 
     LoadExpected(string(ts->get_data_path()) + "detectors/star.xml", exp);
     if (exp.empty())

--- a/modules/xfeatures2d/test/test_features2d.cpp
+++ b/modules/xfeatures2d/test/test_features2d.cpp
@@ -987,7 +987,7 @@ void CV_DescriptorMatcherTest::run( int )
  * Detectors
  */
 
-
+#ifdef OPENCV_ENABLE_NONFREE
 TEST( Features2d_Detector_SIFT, regression )
 {
     CV_FeatureDetectorTest test( "detector-sift", SIFT::create() );
@@ -999,6 +999,7 @@ TEST( Features2d_Detector_SURF, regression )
     CV_FeatureDetectorTest test( "detector-surf", SURF::create() );
     test.safe_run();
 }
+#endif
 
 TEST( Features2d_Detector_STAR, regression )
 {
@@ -1027,6 +1028,7 @@ TEST( Features2d_Detector_Harris_Laplace_Affine, regression )
 /*
  * Descriptors
  */
+#ifdef OPENCV_ENABLE_NONFREE
 TEST( Features2d_DescriptorExtractor_SIFT, regression )
 {
     CV_DescriptorExtractorTest<L1<float> > test( "descriptor-sift", 1.0f,
@@ -1064,6 +1066,7 @@ TEST( Features2d_DescriptorExtractor_SURF_OCL, regression )
     cv::ocl::setUseOpenCL(useOCL);
 }
 #endif
+#endif // NONFREE
 
 TEST( Features2d_DescriptorExtractor_DAISY, regression )
 {
@@ -1204,7 +1207,7 @@ TEST( Features2d_DescriptorExtractor_Calonder_float, regression )
     test.safe_run();
 }
 #endif*/ // CV_SSE2
-
+#ifdef OPENCV_ENABLE_NONFREE
 TEST(Features2d_BruteForceDescriptorMatcher_knnMatch, regression)
 {
     const int sz = 100;
@@ -1254,6 +1257,7 @@ TEST(Features2d_BruteForceDescriptorMatcher_knnMatch, regression)
         }
     }
 }
+#endif
 
 /*TEST(Features2d_DescriptorExtractorParamTest, regression)
 {
@@ -1330,8 +1334,10 @@ protected:
     Ptr<Feature2D> f2d;
 };
 
+#ifdef OPENCV_ENABLE_NONFREE
 TEST(Features2d_SIFTHomographyTest, regression) { CV_DetectPlanarTest test("SIFT", 80, SIFT::create()); test.safe_run(); }
 TEST(Features2d_SURFHomographyTest, regression) { CV_DetectPlanarTest test("SURF", 80, SURF::create()); test.safe_run(); }
+#endif
 
 class FeatureDetectorUsingMaskTest : public cvtest::BaseTest
 {
@@ -1394,6 +1400,7 @@ protected:
     Ptr<FeatureDetector> featureDetector_;
 };
 
+#ifdef OPENCV_ENABLE_NONFREE
 TEST(Features2d_SIFT_using_mask, regression)
 {
     FeatureDetectorUsingMaskTest test(SIFT::create());
@@ -1433,5 +1440,6 @@ TEST( XFeatures2d_DescriptorExtractor, batch )
         EXPECT_GT(descriptors[i].rows, 100);
     }
 }
+#endif // NONFREE
 
 }} // namespace

--- a/modules/xfeatures2d/test/test_keypoints.cpp
+++ b/modules/xfeatures2d/test/test_keypoints.cpp
@@ -115,7 +115,7 @@ protected:
 
 
 // Registration of tests
-
+#ifdef OPENCV_ENABLE_NONFREE
 TEST(Features2d_Detector_Keypoints_SURF, validation)
 {
     CV_FeatureDetectorKeypointsTest test(xfeatures2d::SURF::create());
@@ -127,6 +127,8 @@ TEST(Features2d_Detector_Keypoints_SIFT, validation)
     CV_FeatureDetectorKeypointsTest test(xfeatures2d::SIFT::create());
     test.safe_run();
 }
+#endif // NONFREE
+
 
 TEST(Features2d_Detector_Keypoints_Star, validation)
 {

--- a/modules/xfeatures2d/test/test_rotation_and_scale_invariance.cpp
+++ b/modules/xfeatures2d/test/test_rotation_and_scale_invariance.cpp
@@ -610,6 +610,7 @@ protected:
 /*
  * Detector's rotation invariance check
  */
+#ifdef OPENCV_ENABLE_NONFREE
 TEST(Features2d_RotationInvariance_Detector_SURF, regression)
 {
     DetectorRotationInvarianceTest test(SURF::create(),
@@ -655,6 +656,7 @@ TEST(Features2d_RotationInvariance_Descriptor_LATCH, regression)
                                           0.9999f);
     test.safe_run();
 }
+#endif // NONFREE
 
 TEST(DISABLED_Features2d_RotationInvariance_Descriptor_DAISY, regression)
 {
@@ -701,6 +703,7 @@ TEST(Features2d_RotationInvariance_Descriptor_VGG48, regression)
     test.safe_run();
 }
 
+#ifdef OPENCV_ENABLE_NONFREE
 TEST(Features2d_RotationInvariance_Descriptor_BRIEF_64, regression)
 {
     DescriptorRotationInvarianceTest test(SURF::create(),
@@ -870,6 +873,8 @@ TEST(Features2d_RotationInvariance2_Detector_SURF, regression)
     }
 }
 
+#endif // NONFREE
+
 TEST(DISABLED_Features2d_ScaleInvariance_Descriptor_DAISY, regression)
 {
     DescriptorScaleInvarianceTest test(BRISK::create(),
@@ -915,6 +920,7 @@ TEST(Features2d_ScaleInvariance_Descriptor_VGG48, regression)
     test.safe_run();
 }
 
+#ifdef OPENCV_ENABLE_NONFREE
 TEST(Features2d_ScaleInvariance_Descriptor_BoostDesc_BGM, regression)
 {
     DescriptorScaleInvarianceTest test(SURF::create(),
@@ -977,5 +983,6 @@ TEST(Features2d_ScaleInvariance_Descriptor_BoostDesc_BINBOOST_256, regression)
                                        0.98f);
     test.safe_run();
 }
+#endif // NONFREE
 
 }} // namespace

--- a/modules/xfeatures2d/test/test_surf.cuda.cpp
+++ b/modules/xfeatures2d/test/test_surf.cuda.cpp
@@ -42,7 +42,7 @@
 
 #include "test_precomp.hpp"
 
-#ifdef HAVE_CUDA
+#if defined(HAVE_CUDA) && defined(OPENCV_ENABLE_NONFREE)
 
 namespace opencv_test { namespace {
 
@@ -181,4 +181,4 @@ INSTANTIATE_TEST_CASE_P(CUDA_Features2D, SURF, testing::Combine(
 #endif // HAVE_OPENCV_CUDAARITHM
 
 }} // namespace
-#endif // HAVE_CUDA
+#endif // HAVE_CUDA && OPENCV_ENABLE_NONFREE

--- a/modules/xfeatures2d/test/test_surf.ocl.cpp
+++ b/modules/xfeatures2d/test/test_surf.ocl.cpp
@@ -45,7 +45,7 @@
 
 #include "test_precomp.hpp"
 
-#ifdef HAVE_OPENCL
+#if defined(HAVE_OPENCL) && defined(OPENCV_ENABLE_NONFREE)
 
 namespace opencv_test { namespace {
 
@@ -200,4 +200,4 @@ INSTANTIATE_TEST_CASE_P(OCL_Features2D, SURF, testing::Combine(
 
 }} // namespace
 
-#endif // HAVE_OPENCL
+#endif // HAVE_OPENCL && OPENCV_ENABLE_NONFREE


### PR DESCRIPTION
related #1682

[Failed nightly build](http://pullrequest.opencv.org/buildbot/builders/3_4-contrib_noOCL-lin64/builds/54).