### PR TITLE
Update bgfg_gmg.cpp

### DIFF
--- a/modules/bgsegm/src/bgfg_gmg.cpp
+++ b/modules/bgsegm/src/bgfg_gmg.cpp
@@ -196,8 +196,6 @@ private:
     Mat_<int> nfeatures_;
     Mat_<int> colors_;
     Mat_<float> weights_;
-
-    Mat buf_;
 };
 
 
@@ -459,8 +457,7 @@ void BackgroundSubtractorGMGImpl::apply(InputArray _frame, OutputArray _fgmask, 
 
     if (smoothingRadius > 0)
     {
-        medianBlur(fgmask, buf_, smoothingRadius);
-        swap(fgmask, buf_);
+        medianBlur(fgmask, fgmask, smoothingRadius);
     }
 
     // keep track of how many frames we have processed
@@ -474,7 +471,6 @@ void BackgroundSubtractorGMGImpl::release()
     nfeatures_.release();
     colors_.release();
     weights_.release();
-    buf_.release();
 }
 
 


### PR DESCRIPTION
# Problem
## Real case

I used `GMG Background Subtractor`, there is my code:
```cpp
#include <opencv2/opencv.hpp>
#include <opencv2/bgsegm.hpp>

cv::Ptr<cv::BackgroundSubtractor> bg_model = cv::bgsegm::createBackgroundSubtractorGMG();

void process(const cv::Mat& frame)
{
    cv::Mat output;
    bg_model->apply(frame, output);

    cv::imshow("Input", frame);
    cv::imshow("Output", output);
}

int main()
{
    cv::VideoCapture capture("/tmp/people-walking.mp4", cv::CAP_ANY);
    cv::Mat input;

    char keyboard = 0;
    while (keyboard != 'q')
    {
        capture >> input;
        process(input);

        keyboard = cv::waitKey(0);
    }

    cv::destroyAllWindows();
    return EXIT_SUCCESS;
}
```

I got this result:
![gmg_input](https://user-images.githubusercontent.com/18099029/42825661-2a53715c-89eb-11e8-8eef-420582fed323.png)
![gmg_output](https://user-images.githubusercontent.com/18099029/42825676-324bfd66-89eb-11e8-9fe4-617664a454dd.png)

## Simple case

It looks like `medianBlur` (inside `GMG`) doesn't work (or it works and output is not updated). I tried to repeat such behavior with `threshold`, for clarity:

```cpp
#include <opencv2/opencv.hpp>

void process(cv::InputArray _frame, cv::OutputArray _fgmask)
{
    cv::Mat frame = _frame.getMat();
    _fgmask.create(frame.size(), CV_8UC1);
    cv::Mat fgmask = _fgmask.getMat();

    cv::Mat buf_;

    cv::threshold(frame, buf_, 128, 255, CV_THRESH_BINARY);

    printf("data before swap: %p \n", fgmask.data);
    cv::swap(fgmask, buf_);
    printf("data after swap: %p \n", fgmask.data);
}

int main()
{
    cv::Mat temp = cv::imread("/tmp/lena.png");
    cv::Mat input;
    cv::Mat output;

    cv::cvtColor(temp, input, CV_BGR2GRAY);
    process(input, output);

    printf("data outside: %p \n", output.data);

    cv::imshow("Input", input);
    cv::imshow("Output", output);

    cv::waitKey(0);

    cv::destroyAllWindows();
    return EXIT_SUCCESS;
}
```

I got the empty image:
![example_input](https://user-images.githubusercontent.com/18099029/42826377-ed60c108-89ec-11e8-94b0-58f16489a8ad.png)
![example_output](https://user-images.githubusercontent.com/18099029/42826385-f04e2338-89ec-11e8-9aee-533629e4bd76.png)

# Possible root cause 
I saw that `swap` changed data pointer inside the function, but not outside.
I changed `cv::Mat fgmask = _fgmask.getMat()` to `cv::Mat& fgmask = _fgmask.getMatRef()` and now it works fine.
![example_rightoutput](https://user-images.githubusercontent.com/18099029/42827534-4973eec8-89ef-11e8-96e2-5b0c1703716b.png)





