### PR TITLE
text: do not calculate mean for empty angles list

### DIFF
--- a/modules/text/src/erfilter.cpp
+++ b/modules/text/src/erfilter.cpp
@@ -2687,7 +2687,8 @@ double MaxMeaningfulClustering::probability(vector<int> &cluster)
     //for (int kk=0; kk<angles.size(); kk++)
     //  cout << angles[kk] << " ";
     //cout << endl;
-
+    if (angles.empty() || edge_distances.empty())
+        return 0;
     meanStdDev( angles, mean, std );
     sample.push_back((float)std[0]);
     sample.push_back((float)mean[0]);


### PR DESCRIPTION
### This pullrequest changes

New debug assertion failed for some tests:
```
[ RUN      ] Text/Detection.sample/1, where GetParam() = ("text/scenetext01.jpg", true)
Image: text/scenetext01.jpg
Orientation: any
unknown file: Failure
C++ exception with description "OpenCV(3.4.2-dev) /build/precommit-contrib_linux64_no_opt/opencv/modules/core/include/opencv2/core/mat.inl.hpp:865: error: (-215:Assertion failed) res != 0 in function 'elemSize'
" thrown in the test body.
[  FAILED  ] Text/Detection.sample/1, where GetParam() = ("text/scenetext01.jpg", true) (9289 ms)
```
