### PR TITLE
fix densecensus when computing stereo matching

### DIFF
--- a/modules/stereo/src/stereo_binary_bm.cpp
+++ b/modules/stereo/src/stereo_binary_bm.cpp
@@ -368,7 +368,7 @@ namespace cv
                 }
                 else if(params.kernelType == CV_DENSE_CENSUS)
                 {
-                    censusTransform(left,right,params.kernelSize,censusImage[0],censusImage[1],CV_SPARSE_CENSUS);
+                    censusTransform(left,right,params.kernelSize,censusImage[0],censusImage[1],CV_DENSE_CENSUS);
                 }
                 else if(params.kernelType == CV_CS_CENSUS)
                 {

--- a/modules/stereo/src/stereo_binary_sgbm.cpp
+++ b/modules/stereo/src/stereo_binary_sgbm.cpp
@@ -653,7 +653,7 @@ namespace cv
                 }
                 else if(params.kernelType == CV_DENSE_CENSUS)
                 {
-                    censusTransform(left,right,params.kernelSize,censusImageLeft,censusImageRight,CV_SPARSE_CENSUS);
+                    censusTransform(left,right,params.kernelSize,censusImageLeft,censusImageRight,CV_DENSE_CENSUS);
                 }
                 else if(params.kernelType == CV_CS_CENSUS)
                 {


### PR DESCRIPTION
I have fixed typos in census transform when using DENSE_CENSUS

### This pullrequest changes
stereo_binary_bm.cpp
stereo_binary_sgbm.cpp


