### PR TITLE
Add python binding and sample for LSD

### DIFF
--- a/modules/line_descriptor/include/opencv2/line_descriptor/descriptor.hpp
+++ b/modules/line_descriptor/include/opencv2/line_descriptor/descriptor.hpp
@@ -99,73 +99,73 @@ Apart from fields inspired to KeyPoint class, KeyLines stores information about 
 original image and in octave it was extracted from, about line's length and number of pixels it
 covers.
  */
-struct CV_EXPORTS KeyLine
+struct CV_EXPORTS_W_SIMPLE KeyLine
 {
  public:
   /** orientation of the line */
-  float angle;
+  CV_PROP_RW float angle;
 
   /** object ID, that can be used to cluster keylines by the line they represent */
-  int class_id;
+  CV_PROP_RW int class_id;
 
   /** octave (pyramid layer), from which the keyline has been extracted */
-  int octave;
+  CV_PROP_RW int octave;
 
   /** coordinates of the middlepoint */
-  Point2f pt;
+  CV_PROP_RW Point2f pt;
 
   /** the response, by which the strongest keylines have been selected.
    It's represented by the ratio between line's length and maximum between
    image's width and height */
-  float response;
+  CV_PROP_RW float response;
 
   /** minimum area containing line */
-  float size;
+  CV_PROP_RW float size;
 
   /** lines's extremes in original image */
-  float startPointX;
-  float startPointY;
-  float endPointX;
-  float endPointY;
+  CV_PROP_RW float startPointX;
+  CV_PROP_RW float startPointY;
+  CV_PROP_RW float endPointX;
+  CV_PROP_RW float endPointY;
 
   /** line's extremes in image it was extracted from */
-  float sPointInOctaveX;
-  float sPointInOctaveY;
-  float ePointInOctaveX;
-  float ePointInOctaveY;
+  CV_PROP_RW float sPointInOctaveX;
+  CV_PROP_RW float sPointInOctaveY;
+  CV_PROP_RW float ePointInOctaveX;
+  CV_PROP_RW float ePointInOctaveY;
 
   /** the length of line */
-  float lineLength;
+  CV_PROP_RW float lineLength;
 
   /** number of pixels covered by the line */
-  int numOfPixels;
+  CV_PROP_RW int numOfPixels;
 
   /** Returns the start point of the line in the original image */
-  Point2f getStartPoint() const
+  CV_WRAP Point2f getStartPoint() const
   {
     return Point2f(startPointX, startPointY);
   }
 
   /** Returns the end point of the line in the original image */
-  Point2f getEndPoint() const
+  CV_WRAP Point2f getEndPoint() const
   {
     return Point2f(endPointX, endPointY);
   }
 
   /** Returns the start point of the line in the octave it was extracted from */
-  Point2f getStartPointInOctave() const
+  CV_WRAP Point2f getStartPointInOctave() const
   {
     return Point2f(sPointInOctaveX, sPointInOctaveY);
   }
 
   /** Returns the end point of the line in the octave it was extracted from */
-  Point2f getEndPointInOctave() const
+  CV_WRAP Point2f getEndPointInOctave() const
   {
     return Point2f(ePointInOctaveX, ePointInOctaveY);
   }
 
   /** constructor */
-  KeyLine()
+  CV_WRAP KeyLine()
   {
   }
 };
@@ -892,7 +892,7 @@ the one used in *BinaryDescriptor* class, data associated to a line's extremes i
 in octave it was extracted from, coincide. KeyLine's field *class_id* is used as an index to
 indicate the order of extraction of a line inside a single octave.
 */
-class CV_EXPORTS LSDDetector : public Algorithm
+class CV_EXPORTS_W LSDDetector : public Algorithm
 {
 public:
 
@@ -905,7 +905,7 @@ LSDDetector()
 
 /** @brief Creates ad LSDDetector object, using smart pointers.
  */
-static Ptr<LSDDetector> createLSDDetector();
+CV_WRAP static Ptr<LSDDetector> createLSDDetector();
 
 /** @brief Detect lines inside an image.
 
@@ -915,7 +915,7 @@ static Ptr<LSDDetector> createLSDDetector();
 @param numOctaves number of octaves inside pyramid
 @param mask mask matrix to detect only KeyLines of interest
  */
-void detect( const Mat& image, CV_OUT std::vector<KeyLine>& keypoints, int scale, int numOctaves, const Mat& mask = Mat() );
+CV_WRAP void detect( const Mat& image, CV_OUT std::vector<KeyLine>& keypoints, int scale, int numOctaves, const Mat& mask = Mat() );
 
 /** @overload
 @param images input images
@@ -924,7 +924,7 @@ void detect( const Mat& image, CV_OUT std::vector<KeyLine>& keypoints, int scale
 @param numOctaves number of octaves inside pyramid
 @param masks vector of mask matrices to detect only KeyLines of interest from each input image
 */
-void detect( const std::vector<Mat>& images, std::vector<std::vector<KeyLine> >& keylines, int scale, int numOctaves,
+CV_WRAP void detect( const std::vector<Mat>& images, std::vector<std::vector<KeyLine> >& keylines, int scale, int numOctaves,
 const std::vector<Mat>& masks = std::vector<Mat>() ) const;
 
 private:

--- a/modules/line_descriptor/misc/python/pyopencv_LSDDetector.hpp
+++ b/modules/line_descriptor/misc/python/pyopencv_LSDDetector.hpp
@@ -1,0 +1,17 @@
+#include "opencv2/line_descriptor.hpp"
+
+template<> struct pyopencvVecConverter<line_descriptor::KeyLine>
+{
+    static bool to(PyObject* obj, std::vector<line_descriptor::KeyLine>& value, const ArgInfo info)
+    {
+        return pyopencv_to_generic_vec(obj, value, info);
+    }
+
+    static PyObject* from(const std::vector<line_descriptor::KeyLine>& value)
+    {
+        return pyopencv_from_generic_vec(value);
+    }
+};
+
+typedef std::vector<line_descriptor::KeyLine> vector_KeyLine;
+typedef std::vector<std::vector<line_descriptor::KeyLine> > vector_vector_KeyLine;

--- a/samples/python2/lsd_lines_extraction.py
+++ b/samples/python2/lsd_lines_extraction.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+'''
+This example shows the functionalities of lines extraction finished by LSDDetector class.
+
+USAGE: lsd_lines_extraction.py [<path_to_input_image>]
+'''
+
+import sys
+import cv2 as cv
+
+if __name__ == '__main__':
+    print(__doc__)
+
+    if len(sys.argv) > 1:
+        fname = sys.argv[1]
+    else :
+        fname = '../data/corridor.jpg'
+
+    img = cv.imread(fname)
+
+    if img is None:
+        print('Failed to load image file:', fname)
+        sys.exit(1)
+
+    gray = cv.cvtColor(img, cv.COLOR_BGR2GRAY)
+
+    lsd = cv.line_descriptor_LSDDetector.createLSDDetector()
+
+    lines = lsd.detect(gray, 2, 1)
+    for kl in lines:
+        if kl.octave == 0:
+            # cv.line only accepts integer coordinate
+            pt1 = (int(kl.startPointX), int(kl.startPointY))
+            pt2 = (int(kl.endPointX), int(kl.endPointY))
+            cv.line(img, pt1, pt2, [255, 0, 0], 2)
+
+    cv.imshow('output', img)
+    cv.waitKey(0)
+    cv.destroyAllWindows()


### PR DESCRIPTION
This PR adds python binding for [cv::line_descriptor::LSDDetector](https://docs.opencv.org/3.4.2/d1/dbd/classcv_1_1line__descriptor_1_1LSDDetector.html). A python example is attached as well.

**I don't use java so I don't know whether java binding works.**

Result:

![result](https://user-images.githubusercontent.com/5774651/43061863-6b2193c4-8e89-11e8-99d7-63b70da57d45.png)

```
foce_builders=linux,windows,macosx,docs
```