### PR TITLE
Process InputOutputArray when BM3D_STEPALL is set

### DIFF
--- a/modules/xphoto/src/bm3d_image_denoising.cpp
+++ b/modules/xphoto/src/bm3d_image_denoising.cpp
@@ -148,6 +148,7 @@ void bm3dDenoising(
         _dst.create(srcSize, type);
         break;
     case BM3D_STEPALL:
+        _basic.create(srcSize, type);
         _dst.create(srcSize, type);
         break;
     default:

--- a/modules/xphoto/src/bm3d_image_denoising.cpp
+++ b/modules/xphoto/src/bm3d_image_denoising.cpp
@@ -148,7 +148,8 @@ void bm3dDenoising(
         _dst.create(srcSize, type);
         break;
     case BM3D_STEPALL:
-        _basic.create(srcSize, type);
+        if (_basic.needed())
+            _basic.create(srcSize, type);
         _dst.create(srcSize, type);
         break;
     default:

--- a/modules/xphoto/test/test_denoise_bm3d.cpp
+++ b/modules/xphoto/test/test_denoise_bm3d.cpp
@@ -76,7 +76,7 @@ namespace opencv_test { namespace {
 
         // BM3D: two different calls doing exactly the same thing
         cv::Mat result, resultSec;
-        cv::xphoto::bm3dDenoising(original, cv::Mat(), resultSec, 10, 4, 16, 2500, 400, 8, 1, 0.0f, cv::NORM_L2, cv::xphoto::BM3D_STEPALL);
+        cv::xphoto::bm3dDenoising(original, result, resultSec, 10, 4, 16, 2500, 400, 8, 1, 0.0f, cv::NORM_L2, cv::xphoto::BM3D_STEPALL);
         cv::xphoto::bm3dDenoising(original, result, 10, 4, 16, 2500, 400, 8, 1, 0.0f, cv::NORM_L2, cv::xphoto::BM3D_STEPALL);
 
         DUMP(result, expected_path + ".res.png");

--- a/modules/xphoto/test/test_denoise_bm3d.cpp
+++ b/modules/xphoto/test/test_denoise_bm3d.cpp
@@ -76,7 +76,7 @@ namespace opencv_test { namespace {
 
         // BM3D: two different calls doing exactly the same thing
         cv::Mat result, resultSec;
-        cv::xphoto::bm3dDenoising(original, result, resultSec, 10, 4, 16, 2500, 400, 8, 1, 0.0f, cv::NORM_L2, cv::xphoto::BM3D_STEPALL);
+        cv::xphoto::bm3dDenoising(original, noArray(), resultSec, 10, 4, 16, 2500, 400, 8, 1, 0.0f, cv::NORM_L2, cv::xphoto::BM3D_STEPALL);
         cv::xphoto::bm3dDenoising(original, result, 10, 4, 16, 2500, 400, 8, 1, 0.0f, cv::NORM_L2, cv::xphoto::BM3D_STEPALL);
 
         DUMP(result, expected_path + ".res.png");


### PR DESCRIPTION
solves http://answers.opencv.org/question/196559/after-applying-cvxphotobm3ddenoising-imshow-is-giving-insertion-error/