### PR TITLE
optflow: is depending on opencv_flann

### DIFF
--- a/modules/optflow/CMakeLists.txt
+++ b/modules/optflow/CMakeLists.txt
@@ -1,2 +1,2 @@
 set(the_description "Optical Flow Algorithms")
-ocv_define_module(optflow opencv_core opencv_imgproc opencv_video opencv_ximgproc opencv_imgcodecs WRAP python)
+ocv_define_module(optflow opencv_core opencv_imgproc opencv_video opencv_ximgproc opencv_imgcodecs opencv_flann WRAP python)


### PR DESCRIPTION
"opencv2/flann/miniflann.hpp" is included (and used) in "sparse_matching_gpc.cpp". This patch adds the missing "opencv_flann" dependency declaration to the optflow CMakeLists.txt.