### PR TITLE
replace internal usage of deprecated estimateRigidTransform in face

### DIFF
--- a/modules/face/CMakeLists.txt
+++ b/modules/face/CMakeLists.txt
@@ -2,7 +2,7 @@ set(the_description "Face recognition etc")
 ocv_define_module(face opencv_core
     opencv_imgproc
     opencv_objdetect
-    opencv_video     # estimateRigidTransform() (trainFacemark)
+    opencv_calib3d   # estimateAffinePartial2D() (trainFacemark)
     opencv_photo     # seamlessClone() (face_swap sample)
     WRAP python java
 )

--- a/modules/face/src/trainFacemark.cpp
+++ b/modules/face/src/trainFacemark.cpp
@@ -4,7 +4,7 @@
 
 #include "precomp.hpp"
 #include "face_alignmentimpl.hpp"
-#include "opencv2/video/tracking.hpp"
+#include "opencv2/calib3d.hpp"
 #include <climits>
 
 using namespace std;
@@ -123,7 +123,7 @@ bool FacemarkKazemiImpl :: getRelativePixels(vector<Point2f> sample,vector<Point
         CV_Error(Error::StsBadArg, error_message);
     }
     Mat transform_mat;
-    transform_mat = estimateRigidTransform(meanshape,sample,false);
+    transform_mat = estimateAffinePartial2D(meanshape, sample);
     unsigned long index;
     for (unsigned long i = 0;i<pixel_coordinates.size();i++) {
         if(!nearest.empty())


### PR DESCRIPTION
* face module now links to calib3d instead of video module

merge with https://github.com/opencv/opencv/pull/12248
