### PR TITLE
UMat::getMat(): Utilize `ACCESS_READ` instead of 0

### DIFF
--- a/modules/optflow/src/sparse_matching_gpc.cpp
+++ b/modules/optflow/src/sparse_matching_gpc.cpp
@@ -278,7 +278,7 @@ bool ocl_getAllDCTDescriptorsForImage( const Mat *imgCh, std::vector< GPCPatchDe
            (int)globSize[0], (int)globSize[1], (int)patchRadius )
     .run( 2, globSize, 0, true ) == false )
     return false;
-  Mat cpuOut = out.getMat( 0 );
+  Mat cpuOut = out.getMat( ACCESS_READ );
   for ( int i = 0; i + 2 * patchRadius < sz.height; ++i )
     for ( int j = 0; j + 2 * patchRadius < sz.width; ++j )
       descr.push_back( *cpuOut.ptr< GPCPatchDescriptor >( i * globSize[1] + j ) );


### PR DESCRIPTION
### This pullrequest changes
Minor fix