### PR TITLE
Correction for computeBinaryMap crash:

### DIFF
--- a/modules/saliency/src/staticSaliency.cpp
+++ b/modules/saliency/src/staticSaliency.cpp
@@ -53,7 +53,7 @@ namespace saliency
 bool StaticSaliency::computeBinaryMap( InputArray _saliencyMap, OutputArray _binaryMap )
 {
   Mat saliencyMap = _saliencyMap.getMat();
-  CV_Assert( saliencyMap.depth() == CV_32F );
+  CV_CheckTypeEQ(saliencyMap.type(), CV_32FC1, "");
   Mat labels = Mat::zeros( saliencyMap.rows * saliencyMap.cols, 1, 1 );
   Mat samples = Mat_<float>( saliencyMap.rows * saliencyMap.cols, 1 );
   Mat centers;

--- a/modules/saliency/src/staticSaliency.cpp
+++ b/modules/saliency/src/staticSaliency.cpp
@@ -53,6 +53,7 @@ namespace saliency
 bool StaticSaliency::computeBinaryMap( InputArray _saliencyMap, OutputArray _binaryMap )
 {
   Mat saliencyMap = _saliencyMap.getMat();
+  CV_Assert( saliencyMap.depth() == CV_32F );
   Mat labels = Mat::zeros( saliencyMap.rows * saliencyMap.cols, 1, 1 );
   Mat samples = Mat_<float>( saliencyMap.rows * saliencyMap.cols, 1 );
   Mat centers;

--- a/modules/saliency/src/staticSaliencyFineGrained.cpp
+++ b/modules/saliency/src/staticSaliencyFineGrained.cpp
@@ -66,7 +66,9 @@ bool StaticSaliencyFineGrained::computeSaliencyImpl(InputArray image, OutputArra
 {
     Mat dst(Size(image.getMat().cols, image.getMat().rows), CV_8UC1);
     calcIntensityChannel(image.getMat(), dst);
-    dst.copyTo(saliencyMap);
+    double minVal, maxVal;
+    minMaxLoc( dst, &minVal, &maxVal );
+    dst.convertTo(saliencyMap, CV_32F, 1.0f/maxVal);
 
     #ifdef SALIENCY_DEBUG
     // visualize saliency map

--- a/modules/saliency/src/staticSaliencyFineGrained.cpp
+++ b/modules/saliency/src/staticSaliencyFineGrained.cpp
@@ -66,9 +66,7 @@ bool StaticSaliencyFineGrained::computeSaliencyImpl(InputArray image, OutputArra
 {
     Mat dst(Size(image.getMat().cols, image.getMat().rows), CV_8UC1);
     calcIntensityChannel(image.getMat(), dst);
-    double minVal, maxVal;
-    minMaxLoc( dst, &minVal, &maxVal );
-    dst.convertTo(saliencyMap, CV_32F, 1.0f/maxVal);
+    dst.convertTo(saliencyMap, CV_32F, 1.0f/255.0f); // values are in range [0; 1]
 
     #ifdef SALIENCY_DEBUG
     // visualize saliency map


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->
resolves #1735

### This pullrequest changes

This PR corrects the function cv::saliency::staticSaliencyFineGrained::computeSaliencyImpl() by changing the output image depth (CV_8UC1 to CV_32F) and normalizing it by the max value (as in staticSaliencySpectralResidual). It also adds an assert in cv::saliency::staticSaliency::computeBinaryMap() in order to check the input image depth which must be CV_32F.
