### PR TITLE
Fix initial guide image of rolling guidance filter

### DIFF
--- a/modules/ximgproc/samples/rollingGuidanceFilter_demo.cpp
+++ b/modules/ximgproc/samples/rollingGuidanceFilter_demo.cpp
@@ -1,0 +1,95 @@
+/*
+ *  By downloading, copying, installing or using the software you agree to this license.
+ *  If you do not agree to this license, do not download, install,
+ *  copy or use the software.
+ *
+ *
+ *  License Agreement
+ *  For Open Source Computer Vision Library
+ *  (3 - clause BSD License)
+ *
+ *  Redistribution and use in source and binary forms, with or without modification,
+ *  are permitted provided that the following conditions are met :
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *  this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and / or other materials provided with the distribution.
+ *
+ *  * Neither the names of the copyright holders nor the names of the contributors
+ *  may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  This software is provided by the copyright holders and contributors "as is" and
+ *  any express or implied warranties, including, but not limited to, the implied
+ *  warranties of merchantability and fitness for a particular purpose are disclaimed.
+ *  In no event shall copyright holders or contributors be liable for any direct,
+ *  indirect, incidental, special, exemplary, or consequential damages
+ *  (including, but not limited to, procurement of substitute goods or services;
+ *  loss of use, data, or profits; or business interruption) however caused
+ *  and on any theory of liability, whether in contract, strict liability,
+ *  or tort(including negligence or otherwise) arising in any way out of
+ *  the use of this software, even if advised of the possibility of such damage.
+ */
+
+#include <opencv2/core.hpp>
+#include <opencv2/core/utility.hpp>
+#include <opencv2/highgui.hpp>
+#include <opencv2/ximgproc.hpp>
+
+using namespace cv;
+using namespace cv::ximgproc;
+
+#include <iostream>
+using namespace std;
+
+int sColor = 10, sSpace = 3,nbIter=4;
+
+const char* window_name = "Rolling guidance filter";
+
+
+
+/**
+ * @function paillouFilter
+ * @brief Trackbar callback
+ */
+static void rollingFilter(int, void *pm)
+{
+    Mat img = *((Mat*)pm);
+    double sigmaColor(sColor/10.0), sigmaSpace(sSpace);
+    Mat dst;
+    rollingGuidanceFilter(img, dst, -1, sigmaColor, sigmaSpace, nbIter);
+    imshow("rollingGuidanceFilter",dst );
+}
+
+
+int main(int argc, char* argv[])
+{
+    if (argc < 2)
+    {
+        cout << "usage: rollingGuidanceFilter_demo [image]" << endl;
+        return 1;
+    }
+    Mat img = imread(argv[1]);
+    if (img.empty())
+    {
+        cout << "File not found or empty image\n";
+        return 1;
+    }
+
+    imshow("Original",img);
+    Mat imgF;
+    img.convertTo(imgF, CV_32F,1.0/255);
+    namedWindow( window_name, WINDOW_KEEPRATIO);
+    imshow(window_name, img);
+
+    /// Create a Trackbar for user to enter threshold
+    createTrackbar( "sColor",window_name, &sColor, 10, rollingFilter, &imgF );
+    createTrackbar("sSpace", window_name, &sSpace, 400, rollingFilter, &imgF);
+    createTrackbar("iter", window_name, &nbIter, 10, rollingFilter, &imgF);
+    rollingFilter(0, &imgF);
+    waitKey();
+    return 0;
+}

--- a/modules/ximgproc/src/rolling_guidance_filter.cpp
+++ b/modules/ximgproc/src/rolling_guidance_filter.cpp
@@ -46,11 +46,9 @@ namespace ximgproc
     {
         CV_Assert(!src_.empty());
 
-        Mat guidance = src_.getMat();
         Mat src = src_.getMat();
 
-        CV_Assert(src.size() == guidance.size());
-        CV_Assert(src.depth() == guidance.depth() && (src.depth() == CV_8U || src.depth() == CV_32F) );
+        CV_Assert(src.depth() == CV_8U || src.depth() == CV_32F);
 
         if (sigmaColor <= 0)
             sigmaColor = 1;
@@ -59,9 +57,8 @@ namespace ximgproc
 
         dst_.create(src.size(), src.type());
         Mat dst = dst_.getMat();
+        Mat& guidance = dst;  // dst and guidance are the same
 
-        if (src.data == guidance.data)
-            guidance = guidance.clone();
         if (dst.data == src.data)
             src = src.clone();
 
@@ -69,8 +66,15 @@ namespace ximgproc
 
         if (srcCnNum == 1 || srcCnNum == 3)
         {
-            while(numOfIter--){
-                jointBilateralFilter(guidance, src, guidance, d, sigmaColor, sigmaSpace, borderType);
+            if (numOfIter > 0) {
+                GaussianBlur(src, guidance, Size(0, 0), sigmaSpace, sigmaSpace, borderType);
+                numOfIter--;
+                while (numOfIter--) {
+                    jointBilateralFilter(guidance, src, guidance, d, sigmaColor, sigmaSpace, borderType);
+                }
+            }
+            else {
+                guidance = Scalar::all(0);
             }
             guidance.copyTo(dst_);
         }

--- a/modules/ximgproc/test/test_rolling_guidance_filter.cpp
+++ b/modules/ximgproc/test/test_rolling_guidance_filter.cpp
@@ -137,9 +137,9 @@ INSTANTIATE_TEST_CASE_P(TypicalSet1, RollingGuidanceFilterTest,
 //////////////////////////////////////////////////////////////////////////
 
 typedef tuple<double, string, int> RGFBFParam;
-typedef TestWithParam<RGFBFParam> RollingGuidanceFilterTest_BilateralRef;
+typedef TestWithParam<RGFBFParam> RollingGuidanceFilterTest_GaussianRef;
 
-TEST_P(RollingGuidanceFilterTest_BilateralRef, Accuracy)
+TEST_P(RollingGuidanceFilterTest_GaussianRef, Accuracy)
 {
     RGFBFParam params = GetParam();
     double sigmaS       = get<0>(params);
@@ -154,15 +154,15 @@ TEST_P(RollingGuidanceFilterTest_BilateralRef, Accuracy)
     double sigmaC = rnd.uniform(0.0, 255.0);
 
     Mat resRef;
-    bilateralFilter(src, resRef, 0, sigmaC, sigmaS);
+    GaussianBlur(src, resRef, Size(0, 0), sigmaS);
 
-    Mat res, joint = src.clone();
+    Mat res;
     rollingGuidanceFilter(src, res, 0, sigmaC, sigmaS, 1);
 
     checkSimilarity(res, resRef);
 }
 
-INSTANTIATE_TEST_CASE_P(TypicalSet2, RollingGuidanceFilterTest_BilateralRef,
+INSTANTIATE_TEST_CASE_P(TypicalSet2, RollingGuidanceFilterTest_GaussianRef,
     Combine(
     Values(4.0, 6.0, 8.0),
     Values("/cv/shared/pic2.png", "/cv/shared/lena.png", "cv/shared/box_in_scene.png"),


### PR DESCRIPTION
resolves #1738

### This pullrequest changes

This fixes a bug that a src image instead of a constant image is used as a guide image in the first iteration of rolling guidance filter.
This uses gaussian filter in the first iteration because it is theoretically equivalent to joint bilateral filter with a constant guide image and is more efficient (thanks to @LaurentBerger).
This also fixes a corresponding testcase.
In addition, this also includes a demo of the filter created by @LaurentBerger.