### PR TITLE
face: fix I/O for 'splitr' structure on 32-bit platforms

### DIFF
--- a/modules/face/src/face_alignmentimpl.hpp
+++ b/modules/face/src/face_alignmentimpl.hpp
@@ -103,7 +103,7 @@ protected:
     // This function randomly  generates test splits to get the best split.
     splitr getTestSplits(std::vector<Point2f> pixel_coordinates,int seed);
     // This function writes a split node to the XML file storing the trained model
-    void writeSplit(std::ofstream& os,const splitr split);
+    void writeSplit(std::ofstream& os, const splitr& split);
     // This function writes a leaf node to the binary file storing the trained model
     void writeLeaf(std::ofstream& os, const std::vector<Point2f> &leaf);
     // This function writes a tree to the binary file containing the model

--- a/modules/face/src/getlandmarks.cpp
+++ b/modules/face/src/getlandmarks.cpp
@@ -26,7 +26,12 @@ bool FacemarkKazemiImpl :: findNearestLandmarks( vector< vector<int> >& nearest)
 }
 void FacemarkKazemiImpl :: readSplit(ifstream& is, splitr &vec)
 {
-    is.read((char*)&vec, sizeof(splitr));
+    is.read((char*)&vec.index1, sizeof(vec.index1));
+    is.read((char*)&vec.index2, sizeof(vec.index2));
+    is.read((char*)&vec.thresh, sizeof(vec.thresh));
+    uint32_t dummy_ = 0;
+    is.read((char*)&dummy_, sizeof(dummy_)); // buggy writer structure alignment
+    CV_CheckEQ((int)(sizeof(vec.index1) + sizeof(vec.index2) + sizeof(vec.thresh) + sizeof(dummy_)), 24, "Invalid build configuration");
 }
 void FacemarkKazemiImpl :: readLeaf(ifstream& is, vector<Point2f> &leaf)
 {

--- a/modules/face/src/trainFacemark.cpp
+++ b/modules/face/src/trainFacemark.cpp
@@ -219,9 +219,15 @@ void FacemarkKazemiImpl :: writeLeaf(ofstream& os, const vector<Point2f> &leaf)
     os.write((char*)&size, sizeof(size));
     os.write((char*)&leaf[0], leaf.size() * sizeof(Point2f));
 }
-void FacemarkKazemiImpl :: writeSplit(ofstream& os, splitr split)
+void FacemarkKazemiImpl :: writeSplit(ofstream& os, const splitr& vec)
 {
-    os.write((char*)&split, sizeof(split));
+    os.write((char*)&vec.index1, sizeof(vec.index1));
+    os.write((char*)&vec.index2, sizeof(vec.index2));
+    os.write((char*)&vec.thresh, sizeof(vec.thresh));
+    uint32_t dummy_ = 0;
+    os.write((char*)&dummy_, sizeof(dummy_)); // buggy original writer structure alignment
+    CV_CheckEQ((int)(sizeof(vec.index1) + sizeof(vec.index2) + sizeof(vec.thresh) + sizeof(dummy_)), 24, "Invalid build configuration");
+
 }
 void FacemarkKazemiImpl :: writeTree(ofstream &f,regtree tree)
 {


### PR DESCRIPTION
Memory layout of this structure is different, including `sizeof()`.

Fix [failed builds](http://pullrequest.opencv.org/buildbot/builders/3_4-contrib_noOCL-lin32/builds/111).