### PR TITLE
Utilize CV_UNUSED macro

### DIFF
--- a/modules/bioinspired/src/templatebuffer.hpp
+++ b/modules/bioinspired/src/templatebuffer.hpp
@@ -293,7 +293,7 @@ public:
         * @param sensitivity: strenght of the sigmoide
         * @param maxOutputValue: the maximum output value
         */
-        inline void normalizeGrayOutputCentredSigmoide(const type meanValue=(type)0.0, const type sensitivity=(type)2.0, const type maxOutputValue=(type)255.0) {  (void)maxOutputValue; normalizeGrayOutputCentredSigmoide(meanValue, sensitivity, 255.0, this->Buffer(), this->Buffer(), this->getNBpixels()); }
+        inline void normalizeGrayOutputCentredSigmoide(const type meanValue=(type)0.0, const type sensitivity=(type)2.0, const type maxOutputValue=(type)255.0) {  CV_UNUSED(maxOutputValue); normalizeGrayOutputCentredSigmoide(meanValue, sensitivity, 255.0, this->Buffer(), this->Buffer(), this->getNBpixels()); }
 
         /**
         * sigmoide image normalization function (saturates min and max values), in this function, the sigmoide is centered on low values (high saturation of the medium and high values

--- a/modules/face/include/opencv2/face/predict_collector.hpp
+++ b/modules/face/include/opencv2/face/predict_collector.hpp
@@ -50,7 +50,7 @@ the use of this software, even if advised of the possibility of such damage.
 #include <utility>
 #include <cfloat>
 
-#include "opencv2/core/cvstd.hpp"
+#include "opencv2/core/base.hpp"
 
 namespace cv {
 namespace face {
@@ -66,7 +66,7 @@ public:
     /** @brief Interface method called by face recognizer before results processing
     @param size total size of prediction evaluation that recognizer could perform
     */
-    virtual void init(size_t size) { (void)size; }
+    virtual void init(size_t size) { CV_UNUSED(size); }
 
     /** @brief Interface method called by face recognizer for each result
     @param label current prediction label

--- a/modules/face/src/facerec.cpp
+++ b/modules/face/src/facerec.cpp
@@ -48,8 +48,8 @@ void FaceRecognizer::setLabelInfo(int label, const String &strInfo)
 
 void FaceRecognizer::update(InputArrayOfArrays src, InputArray labels)
 {
-    (void)src;
-    (void)labels;
+    CV_UNUSED(src);
+    CV_UNUSED(labels);
     String error_msg = format("This FaceRecognizer does not support updating, you have to use FaceRecognizer::train to update it.");
     CV_Error(Error::StsNotImplemented, error_msg);
 }

--- a/modules/optflow/src/sparse_matching_gpc.cpp
+++ b/modules/optflow/src/sparse_matching_gpc.cpp
@@ -292,7 +292,7 @@ void getAllDCTDescriptorsForImage( const Mat *imgCh, std::vector< GPCPatchDescri
   const Size sz = imgCh[0].size();
   descr.reserve( ( sz.height - 2 * patchRadius ) * ( sz.width - 2 * patchRadius ) );
 
-  (void)mp; // Fix unused parameter warning in case OpenCL is not available
+  CV_UNUSED(mp); // Fix unused parameter warning in case OpenCL is not available
   CV_OCL_RUN( mp.useOpenCL, ocl_getAllDCTDescriptorsForImage( imgCh, descr ) )
 
   descr.resize( ( sz.height - 2 * patchRadius ) * ( sz.width - 2 * patchRadius ) );

--- a/modules/stereo/include/opencv2/stereo/descriptor.hpp
+++ b/modules/stereo/include/opencv2/stereo/descriptor.hpp
@@ -79,7 +79,7 @@ namespace cv
             }
             void operator()(int rrWidth,int w2, int rWidth, int jj, int j, int c[num_images]) const
             {
-                (void)w2;
+                CV_UNUSED(w2);
                 for (int i = 0; i < stop; i++)
                 {
                     if (image[i][rrWidth + jj] > image[i][rWidth + j])
@@ -114,7 +114,7 @@ namespace cv
             }
             void operator()(int rrWidth,int w2, int rWidth, int jj, int j, int c[num_images]) const
             {
-                (void)w2;
+                CV_UNUSED(w2);
                 for(int i = 0; i < imageStop; i++)
                 {
                     if (image[i][rrWidth + jj] > image[i][rWidth + j] - t)
@@ -154,8 +154,8 @@ namespace cv
             }
             void operator()(int rrWidth,int w2, int rWidth, int jj, int j, int c[num_images]) const
             {
-                (void)j;
-                (void)rWidth;
+                CV_UNUSED(j);
+                CV_UNUSED(rWidth);
                 for(int i = 0; i < imageStop; i++)
                 {
                     if (image[i][(rrWidth + jj)] > image[i][(w2 + (jj + n2))])
@@ -181,7 +181,7 @@ namespace cv
             }
             void operator()(int rrWidth,int w2, int rWidth, int jj, int j, int c[num_images]) const
             {
-                (void)w2;
+                CV_UNUSED(w2);
                 for(int i = 0; i < imageStop; i++)
                 {
                     ////compare a pixel with the center from the kernel

--- a/modules/structured_light/src/sinusoidalpattern.cpp
+++ b/modules/structured_light/src/sinusoidalpattern.cpp
@@ -263,11 +263,11 @@ bool SinusoidalPatternProfilometry_Impl::decode(const std::vector< std::vector<M
                                                 InputArrayOfArrays blackImages,
                                                 InputArrayOfArrays whiteImages, int flags ) const
 {
-    (void) patternImages;
-    (void) disparityMap;
-    (void) blackImages;
-    (void) whiteImages;
-    (void) flags;
+    CV_UNUSED(patternImages);
+    CV_UNUSED(disparityMap);
+    CV_UNUSED(blackImages);
+    CV_UNUSED(whiteImages);
+    CV_UNUSED(flags);
     return true;
 }
 // Most of the steps described in the paper to get the wrapped phase map take place here
@@ -310,7 +310,7 @@ void SinusoidalPatternProfilometry_Impl::computePhaseMap( InputArrayOfArrays pat
     {
         Mat &shadowMask_ = *(Mat*) shadowMask.getObj();
         //Mat &fundamental_ = *(Mat*) fundamental.getObj();
-        (void) fundamental;
+        CV_UNUSED(fundamental);
         Mat dmt;
         int nbrOfPatterns = static_cast<int>(pattern_.size());
         std::vector<Mat> filteredPatterns(nbrOfPatterns);
@@ -425,9 +425,9 @@ void SinusoidalPatternProfilometry_Impl::findProCamMatches( InputArray projUnwra
                                                             InputArray camUnwrappedPhaseMap,
                                                             OutputArrayOfArrays matches )
 {
-    (void) projUnwrappedPhaseMap;
-    (void) camUnwrappedPhaseMap;
-    (void) matches;
+    CV_UNUSED(projUnwrappedPhaseMap);
+    CV_UNUSED(camUnwrappedPhaseMap);
+    CV_UNUSED(matches);
 }
 
 void SinusoidalPatternProfilometry_Impl::computeDft( InputArray patternImage,
@@ -896,8 +896,8 @@ void SinusoidalPatternProfilometry_Impl::convertToAbsolutePhaseMap( InputArrayOf
                                                                     InputArray fundamentalMatrix )
 {
     std::vector<Mat> &camPatterns_ = *(std::vector<Mat>*) camPatterns.getObj();
-    (void) unwrappedCamPhaseMap;
-    (void) unwrappedProjPhaseMap;
+    CV_UNUSED(unwrappedCamPhaseMap);
+    CV_UNUSED(unwrappedProjPhaseMap);
 
     Mat &fundamental = *(Mat*) fundamentalMatrix.getObj();
 

--- a/modules/text/src/ocr_tesseract.cpp
+++ b/modules/text/src/ocr_tesseract.cpp
@@ -262,7 +262,7 @@ public:
   #ifdef HAVE_TESSERACT
         tess.SetVariable("tessedit_char_whitelist", char_whitelist.c_str());
   #else
-        (void)char_whitelist;
+        CV_UNUSED(char_whitelist);
   #endif
     }
 };


### PR DESCRIPTION
Preferably merge with opencv/opencv#12460

Minor change for coding style unification

### This pullrequest changes
- Utilized `CV_UNUSED(x);` instead of `(void)x;`
