### PR TITLE
tracking: add a threshold to the CSRT tracker

### DIFF
--- a/modules/tracking/doc/tracking.bib
+++ b/modules/tracking/doc/tracking.bib
@@ -107,3 +107,10 @@ author={Bolme, David S. and Beveridge, J. Ross and Draper, Bruce A. and Lui Yui,
 booktitle = {Conference on Computer Vision and Pattern Recognition (CVPR)},
 year      = {2010}
 }
+
+@Article{Lukezic_IJCV2018,
+author={Luke{\v{z}}i{\v{c}}, Alan and Voj{'i}{\v{r}}, Tom{'a}{\v{s}} and {\v{C}}ehovin Zajc, Luka and Matas, Ji{\v{r}}{'i} and Kristan, Matej},
+title={Discriminative Correlation Filter Tracker with Channel and Spatial Reliability},
+journal={International Journal of Computer Vision},
+year={2018},
+}

--- a/modules/tracking/include/opencv2/tracking/tracker.hpp
+++ b/modules/tracking/include/opencv2/tracking/tracker.hpp
@@ -1513,6 +1513,8 @@ public:
     float scale_model_max_area;
     float scale_lr;
     float scale_step;
+
+    float psr_threshold; //!< we lost the target, if the psr is lower than this.
   };
 
   /** @brief Constructor


### PR DESCRIPTION
resolves #1783, #1663

add a threshold to the CSRT tracker, so it can properly report "lost" in the update function.
(an empirical value of 0.035 was choosen, so all tests should still pass)

also add a bibref [from the author's github](https://github.com/alanlukezic/csr-dcf) 
