### PR TITLE
ovis: add getCompositorTexture for reading custom render targets 

### DIFF
--- a/modules/ovis/include/opencv2/ovis.hpp
+++ b/modules/ovis/include/opencv2/ovis.hpp
@@ -162,6 +162,16 @@ public:
     CV_WRAP virtual void getScreenshot(OutputArray frame) = 0;
 
     /**
+     * read back the texture of an active compositor
+     * @param compname name of the compositor
+     * @param texname name of the texture inside the compositor
+     * @param mrtIndex if texture is a MRT, specifies the attachment
+     * @param out the texture contents
+     */
+    CV_WRAP virtual void getCompositorTexture(const String& compname, const String& texname,
+                                              OutputArray out, int mrtIndex = 0) = 0;
+
+    /**
      * get the depth for the current frame.
      *
      * return the per pixel distance to the camera in world units

--- a/modules/ovis/include/opencv2/ovis.hpp
+++ b/modules/ovis/include/opencv2/ovis.hpp
@@ -24,10 +24,8 @@ enum SceneSettings
     SCENE_INTERACTIVE = 2,
     /// draw coordinate system crosses for debugging
     SCENE_SHOW_CS_CROSS = 4,
-    /// @ref WindowScene::getScreenshot returns images as CV_32FC4 instead of CV_8UC3
-    SCENE_RENDER_FLOAT = 8,
     /// Apply anti-aliasing. The first window determines the setting for all windows.
-    SCENE_AA = 16
+    SCENE_AA = 8
 };
 
 enum MaterialProperty


### PR DESCRIPTION
not sure how API breaks are supposed to be handled in contrib, therefore SCENE_RENDER_FLOAT is a separate commit.

To review this change, take a look at:
https://ogrecave.github.io/ogre/api/latest/_compositor-_scripts.html#Format-1

with this change we get access to "rt0" of user defined content and format. Previously we hard-coded all of this via SCENE_RENDER_FLOAT.

```
allow_multiple_commits=1
```