### PR TITLE
Do not copy/assign CommandLineParser object

### DIFF
--- a/modules/face/samples/facemark_demo_aam.cpp
+++ b/modules/face/samples/facemark_demo_aam.cpp
@@ -53,15 +53,14 @@ using namespace cv::face;
 bool myDetector( InputArray image, OutputArray ROIs, CascadeClassifier *face_cascade);
 bool getInitialFitting(Mat image, Rect face, std::vector<Point2f> s0,
     CascadeClassifier eyes_cascade, Mat & R, Point2f & Trans, float & scale);
-bool parseArguments(int argc, char** argv, CommandLineParser & , String & cascade,
+bool parseArguments(int argc, char** argv, String & cascade,
     String & model, String & images, String & annotations, String & testImages
 );
 
 int main(int argc, char** argv )
 {
-    CommandLineParser parser(argc, argv,"");
     String cascade_path,eyes_cascade_path,images_path, annotations_path, test_images_path;
-    if(!parseArguments(argc, argv, parser,cascade_path,eyes_cascade_path,images_path, annotations_path, test_images_path))
+    if(!parseArguments(argc, argv, cascade_path,eyes_cascade_path,images_path, annotations_path, test_images_path))
        return -1;
 
     //! [instance_creation]
@@ -247,7 +246,7 @@ bool getInitialFitting(Mat image, Rect face, std::vector<Point2f> s0 ,CascadeCla
     return found;
 }
 
-bool parseArguments(int argc, char** argv, CommandLineParser & parser,
+bool parseArguments(int argc, char** argv,
     String & cascade,
     String & model,
     String & images,
@@ -263,7 +262,7 @@ bool parseArguments(int argc, char** argv, CommandLineParser & parser,
         "{ help h usage ?     |      | facemark_demo_aam -face-cascade -eyes-cascade -images -annotations [-t]\n"
              " example: facemark_demo_aam ../face_cascade.xml ../eyes_cascade.xml ../images_train.txt ../points_train.txt ../test.txt}"
     ;
-    parser = CommandLineParser(argc, argv,keys);
+    CommandLineParser parser(argc, argv,keys);
     parser.about("hello");
 
     if (parser.has("help")){

--- a/modules/face/samples/facemark_demo_lbf.cpp
+++ b/modules/face/samples/facemark_demo_lbf.cpp
@@ -48,15 +48,14 @@ using namespace cv;
 using namespace cv::face;
 
 static bool myDetector( InputArray image, OutputArray roi, CascadeClassifier *face_detector);
-static bool parseArguments(int argc, char** argv, CommandLineParser & , String & cascade,
+static bool parseArguments(int argc, char** argv, String & cascade,
    String & model, String & images, String & annotations, String & testImages
 );
 
 int main(int argc, char** argv)
 {
-    CommandLineParser parser(argc, argv,"");
     String cascade_path,model_path,images_path, annotations_path, test_images_path;
-    if(!parseArguments(argc, argv, parser,cascade_path,model_path,images_path, annotations_path, test_images_path))
+    if(!parseArguments(argc, argv, cascade_path,model_path,images_path, annotations_path, test_images_path))
        return -1;
 
     /*create the facemark instance*/
@@ -137,7 +136,7 @@ bool myDetector(InputArray image, OutputArray faces, CascadeClassifier *face_cas
     return true;
 }
 
-bool parseArguments(int argc, char** argv, CommandLineParser & parser,
+bool parseArguments(int argc, char** argv,
     String & cascade,
     String & model,
     String & images,
@@ -153,7 +152,7 @@ bool parseArguments(int argc, char** argv, CommandLineParser & parser,
         "{ help h usage ?     |      | facemark_demo_lbf -cascade -images -annotations -model [-t] \n"
          " example: facemark_demo_lbf ../face_cascade.xml ../images_train.txt ../points_train.txt ../lbf.model}"
     ;
-    parser = CommandLineParser(argc, argv,keys);
+    CommandLineParser parser(argc, argv,keys);
     parser.about("hello");
 
     if (parser.has("help")){

--- a/modules/face/samples/facemark_lbf_fitting.cpp
+++ b/modules/face/samples/facemark_lbf_fitting.cpp
@@ -58,13 +58,12 @@ using namespace cv;
 using namespace cv::face;
 
 static bool myDetector(InputArray image, OutputArray ROIs, CascadeClassifier *face_cascade);
-static bool parseArguments(int argc, char** argv, CommandLineParser & parser,
+static bool parseArguments(int argc, char** argv,
     String & cascade, String & model,String & video);
 
 int main(int argc, char** argv ){
-    CommandLineParser parser(argc, argv,"");
     String cascade_path,model_path,images_path, video_path;
-    if(!parseArguments(argc, argv, parser,cascade_path,model_path,video_path))
+    if(!parseArguments(argc, argv, cascade_path,model_path,video_path))
        return -1;
 
     CascadeClassifier face_cascade;
@@ -161,7 +160,7 @@ bool myDetector(InputArray image, OutputArray faces, CascadeClassifier *face_cas
     return true;
 }
 
-bool parseArguments(int argc, char** argv, CommandLineParser & parser,
+bool parseArguments(int argc, char** argv,
     String & cascade,
     String & model,
     String & video
@@ -173,7 +172,7 @@ bool parseArguments(int argc, char** argv, CommandLineParser & parser,
        "{ help h usage ?     |      | facemark_lbf_fitting -cascade -model -video [-t]\n"
             " example: facemark_lbf_fitting ../face_cascade.xml ../LBF.model ../video.mp4}"
    ;
-   parser = CommandLineParser(argc, argv,keys);
+   CommandLineParser parser(argc, argv,keys);
    parser.about("hello");
 
    if (parser.has("help")){

--- a/modules/stereo/samples/sample.cpp
+++ b/modules/stereo/samples/sample.cpp
@@ -10,7 +10,7 @@ using namespace cv;
 using namespace cv::stereo;
 
 enum { STEREO_BINARY_BM, STEREO_BINARY_SGM };
-static cv::CommandLineParser parse_argument_values(int argc, char **argv, string &left, string &right, int &kernel_size, int &number_of_disparities,
+static bool parse_argument_values(int argc, char **argv, string &left, string &right, int &kernel_size, int &number_of_disparities,
                                                    int &aggregation_window, int &P1, int &P2, float &scale, int &algo, int &binary_descriptor_type, int &success);
 int main(int argc, char** argv)
 {
@@ -22,17 +22,14 @@ int main(int argc, char** argv)
     int success;
     // here we extract the values that were added as arguments
     // we also test to see if they are provided correcly
-    cv::CommandLineParser parser =
-        parse_argument_values(argc, argv, left, right,
-        kernel_size,
-        number_of_disparities,
-        aggregation_window,
-        P1, P2,
-        scale,
-        algo, binary_descriptor_type,success);
-    if (!parser.check() || !success)
+    if (!parse_argument_values(argc, argv, left, right,
+                               kernel_size,
+                               number_of_disparities,
+                               aggregation_window,
+                               P1, P2,
+                               scale,
+                               algo, binary_descriptor_type,success))
     {
-        parser.printMessage();
         return 1;
     }
     // verify if the user inputs the correct number of parameters
@@ -44,8 +41,6 @@ int main(int argc, char** argv)
     if (image1.empty() || image2.empty())
     {
         cout << " --(!) Error reading images \n";
-
-        parser.printMessage();
         return 1;
     }
     // we display the parsed parameters
@@ -112,7 +107,7 @@ int main(int argc, char** argv)
     waitKey(0);
     return 0;
 }
-static cv::CommandLineParser parse_argument_values(int argc, char **argv, string &left, string &right, int &kernel_size, int &number_of_disparities,
+static bool parse_argument_values(int argc, char **argv, string &left, string &right, int &kernel_size, int &number_of_disparities,
                                                    int &aggregation_window, int &P1, int &P2, float &scale, int &algo, int &binary_descriptor_type, int &success)
 {
     static const char* keys =
@@ -192,5 +187,10 @@ static cv::CommandLineParser parse_argument_values(int argc, char **argv, string
         cout << " Penalties should be greater than 0\n";
         success = 0;
     }
-    return parser;
+    if (!parser.check() || !success)
+    {
+        parser.printMessage();
+        return false;
+    }
+    return true;
 }


### PR DESCRIPTION
### This pullrequest changes

Some of samples used copy/assignment operators of `CommandLineParser` object.

```
opencv=
```