### PR TITLE
SFM - reconstruct decomposition of K matrix fix

### DIFF
--- a/modules/sfm/include/opencv2/sfm/simple_pipeline.hpp
+++ b/modules/sfm/include/opencv2/sfm/simple_pipeline.hpp
@@ -55,7 +55,8 @@ enum {
 
 /** @brief Data structure describing the camera model and its parameters.
   @param _distortion_model Type of camera model.
-  @param _focal_length focal length of the camera (in pixels).
+  @param _focal_length_x focal length of the camera (in pixels).
+  @param _focal_length_y focal length of the camera (in pixels).
   @param _principal_point_x principal point of the camera in the x direction (in pixels).
   @param _principal_point_y principal point of the camera in the y direction (in pixels).
   @param _polynomial_k1 radial distortion parameter.
@@ -73,7 +74,8 @@ class CV_EXPORTS_W_SIMPLE libmv_CameraIntrinsicsOptions
 public:
   CV_WRAP
   libmv_CameraIntrinsicsOptions(const int _distortion_model=0,
-                                const double _focal_length=0,
+                                const double _focal_length_x=0,
+                                const double _focal_length_y=0,
                                 const double _principal_point_x=0,
                                 const double _principal_point_y=0,
                                 const double _polynomial_k1=0,
@@ -84,7 +86,8 @@ public:
     : distortion_model(_distortion_model),
       image_width(2*_principal_point_x),
       image_height(2*_principal_point_y),
-      focal_length(_focal_length),
+      focal_length_x(_focal_length_x),
+      focal_length_y(_focal_length_y),
       principal_point_x(_principal_point_x),
       principal_point_y(_principal_point_y),
       polynomial_k1(_polynomial_k1),
@@ -103,7 +106,8 @@ public:
   // Common settings of all distortion models.
   CV_PROP_RW int distortion_model;
   CV_PROP_RW int image_width, image_height;
-  CV_PROP_RW double focal_length;
+  CV_PROP_RW double focal_length_x;
+  CV_PROP_RW double focal_length_y;
   CV_PROP_RW double principal_point_x, principal_point_y;
 
   // Radial distortion model.

--- a/modules/sfm/src/libmv_capi.h
+++ b/modules/sfm/src/libmv_capi.h
@@ -203,8 +203,8 @@ static bool selectTwoKeyframesBasedOnGRICAndVariance(
 static void libmv_cameraIntrinsicsFillFromOptions(
     const libmv_CameraIntrinsicsOptions* camera_intrinsics_options,
     CameraIntrinsics* camera_intrinsics) {
-  camera_intrinsics->SetFocalLength(camera_intrinsics_options->focal_length,
-                                    camera_intrinsics_options->focal_length);
+  camera_intrinsics->SetFocalLength(camera_intrinsics_options->focal_length_x,
+                                    camera_intrinsics_options->focal_length_y);
 
   camera_intrinsics->SetPrincipalPoint(
       camera_intrinsics_options->principal_point_x,

--- a/modules/sfm/src/reconstruct.cpp
+++ b/modules/sfm/src/reconstruct.cpp
@@ -69,7 +69,8 @@ namespace sfm
 
     // Camera data
     Matx33d Ka = K.getMat();
-    const double focal_length = Ka(0,0);
+    const double focal_length_x = Ka(0,0);
+    const double focal_length_y = Ka(1,1);
     const double principal_x = Ka(0,2), principal_y = Ka(1,2), k1 = 0, k2 = 0, k3 = 0;
 
     // Set reconstruction options
@@ -77,7 +78,8 @@ namespace sfm
 
     libmv_CameraIntrinsicsOptions camera_instrinsic_options =
       libmv_CameraIntrinsicsOptions(SFM_DISTORTION_MODEL_POLYNOMIAL,
-                                    focal_length, principal_x, principal_y,
+                                    focal_length_x, focal_length_y,
+                                    principal_x, principal_y,
                                     k1, k2, k3);
 
     //-- Instantiate reconstruction pipeline

--- a/modules/xfeatures2d/include/opencv2/xfeatures2d.hpp
+++ b/modules/xfeatures2d/include/opencv2/xfeatures2d.hpp
@@ -960,7 +960,7 @@ FastFeatureDetector::TYPE_5_8
 Detects corners using the FAST algorithm by @cite Rosten06 .
  */
 CV_EXPORTS void FASTForPointSet( InputArray image, CV_IN_OUT std::vector<KeyPoint>& keypoints,
-                      int threshold, bool nonmaxSuppression=true, FastFeatureDetector::DetectorType type=FastFeatureDetector::TYPE_9_16);
+                      int threshold, bool nonmaxSuppression=true, cv::FastFeatureDetector::DetectorType type=FastFeatureDetector::TYPE_9_16);
 
 
 //! @}


### PR DESCRIPTION
resolves #1812

### This pullrequest changes

SFM::reconstruct ignores value in K matrix K(1,1). The algorithm expects that K(0,0)==K(1,1). There are focal lengths which are normally the same for standard cameras. Cameras on mobile devices have focal length different (e.g. calibrations provided by ARCore or ARKit).

```
allow_multiple_commits=1
```