### PR TITLE
rgbd: fix build

### DIFF
--- a/modules/rgbd/samples/kinfu_demo.cpp
+++ b/modules/rgbd/samples/kinfu_demo.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <fstream>
 #include <opencv2/imgproc.hpp>
+#include <opencv2/calib3d.hpp>
 #include <opencv2/highgui.hpp>
 #include <opencv2/rgbd/kinfu.hpp>
 


### PR DESCRIPTION
```
/build/precommit_linux64/opencv_contrib/modules/rgbd/samples/kinfu_demo.cpp: In member function 'void DepthSource::updateParams(cv::kinfu::Params&)':
/build/precommit_linux64/opencv_contrib/modules/rgbd/samples/kinfu_demo.cpp:206:69: error: 'initUndistortRectifyMap' was not declared in this scope
                                         undistortMap1, undistortMap2);
```