### PR TITLE
change area() emptiness checks to empty()

### DIFF
--- a/modules/aruco/src/aruco.cpp
+++ b/modules/aruco/src/aruco.cpp
@@ -1767,7 +1767,7 @@ void drawMarker(const Ptr<Dictionary> &dictionary, int id, int sidePixels, Outpu
 void _drawPlanarBoardImpl(Board *_board, Size outSize, OutputArray _img, int marginSize,
                      int borderBits) {
 
-    CV_Assert(outSize.area() > 0);
+    CV_Assert(!outSize.empty());
     CV_Assert(marginSize >= 0);
 
     _img.create(outSize, CV_8UC1);

--- a/modules/aruco/src/charuco.cpp
+++ b/modules/aruco/src/charuco.cpp
@@ -53,7 +53,7 @@ using namespace std;
  */
 void CharucoBoard::draw(Size outSize, OutputArray _img, int marginSize, int borderBits) {
 
-    CV_Assert(outSize.area() > 0);
+    CV_Assert(!outSize.empty());
     CV_Assert(marginSize >= 0);
 
     _img.create(outSize, CV_8UC1);

--- a/modules/ccalib/src/omnidir.cpp
+++ b/modules/ccalib/src/omnidir.cpp
@@ -532,7 +532,7 @@ void cv::omnidir::initUndistortRectifyMap(InputArray K, InputArray D, InputArray
 void cv::omnidir::undistortImage(InputArray distorted, OutputArray undistorted,
     InputArray K, InputArray D, InputArray xi, int flags, InputArray Knew, const Size& new_size, InputArray R)
 {
-    Size size = new_size.area() != 0 ? new_size : distorted.size();
+    Size size = new_size.empty() ? distorted.size() : new_size;
 
     cv::Mat map1, map2;
     omnidir::initUndistortRectifyMap(K, D, xi, R, Knew, size, CV_16SC2, map1, map2, flags);

--- a/modules/tracking/src/TrackingFunctionPF.hpp
+++ b/modules/tracking/src/TrackingFunctionPF.hpp
@@ -66,7 +66,7 @@ namespace cv{
     }
     double TrackingFunctionPF::calc(const double* x) const{
         Rect rect=rectFromRow(x);
-        if(rect.area()==0){
+        if(rect.empty()){
             return 2.0;
         }
         return _origHist.dist(TrackingHistogram(_image(rect),_nh,_ns,_nv));

--- a/modules/ximgproc/src/disparity_filters.cpp
+++ b/modules/ximgproc/src/disparity_filters.cpp
@@ -261,7 +261,7 @@ void DisparityWLSFilterImpl::filter_(InputArray disparity_map_left, InputArray l
         resize_factor = disparity_map_left.cols()/(float)left_view.cols();
     else
         resize_factor = 1.0;
-    if(ROI.area()!=0) /* user provided a ROI */
+    if(!ROI.empty()) /* user provided a ROI */
         valid_disp_ROI = ROI;
     else
         valid_disp_ROI = Rect(left_offset,top_offset,


### PR DESCRIPTION
relates to opencv https://github.com/opencv/opencv/pull/12823
###This pullrequest changes

changes area() emptiness checks to use empty()

cases:
.area() == 0 to empty()
.area() != 0 to !empty()
.area() > 0 to !empty()

_src.size().area() > 0 to !_src.empty() //no need to create size here

if( r.area() ) to if( !r.empty() )