### PR TITLE
sfm: fix public includes

### DIFF
--- a/modules/sfm/include/opencv2/sfm/numeric.hpp
+++ b/modules/sfm/include/opencv2/sfm/numeric.hpp
@@ -38,8 +38,6 @@
 
 #include <opencv2/core.hpp>
 
-#include <Eigen/Core>
-
 namespace cv
 {
 namespace sfm


### PR DESCRIPTION
don't include internal 3rdparty header
