### PR TITLE
scan vector from end to beginning when removing elements

### DIFF
--- a/modules/line_descriptor/src/binary_descriptor.cpp
+++ b/modules/line_descriptor/src/binary_descriptor.cpp
@@ -623,9 +623,9 @@ void BinaryDescriptor::computeImpl( const Mat& imageSrc, std::vector<KeyLine>& k
   }
 
   /* delete useless OctaveSingleLines */
-  for ( size_t i = 0; i < sl.size(); i++ )
+  for ( int i = 0; i < sl.size(); i++ )
   {
-    for ( size_t j = sl[i].size() - 1; j >= 0; --j )
+    for ( int j = sl[i].size() - 1; j >= 0; --j )
     {
       //if( (int) ( sl[i][j] ).octaveCount > params.numOfOctave_ )
       if( (int) ( sl[i][j] ).octaveCount > octaveIndex )

--- a/modules/line_descriptor/src/binary_descriptor.cpp
+++ b/modules/line_descriptor/src/binary_descriptor.cpp
@@ -625,7 +625,7 @@ void BinaryDescriptor::computeImpl( const Mat& imageSrc, std::vector<KeyLine>& k
   /* delete useless OctaveSingleLines */
   for ( size_t i = 0; i < sl.size(); i++ )
   {
-    for ( size_t j = 0; j < sl[i].size(); j++ )
+    for ( size_t j = sl[i].size() - 1; j > -1; --j )
     {
       //if( (int) ( sl[i][j] ).octaveCount > params.numOfOctave_ )
       if( (int) ( sl[i][j] ).octaveCount > octaveIndex )

--- a/modules/line_descriptor/src/binary_descriptor.cpp
+++ b/modules/line_descriptor/src/binary_descriptor.cpp
@@ -625,7 +625,7 @@ void BinaryDescriptor::computeImpl( const Mat& imageSrc, std::vector<KeyLine>& k
   /* delete useless OctaveSingleLines */
   for ( size_t i = 0; i < sl.size(); i++ )
   {
-    for ( size_t j = sl[i].size() - 1; j > -1; --j )
+    for ( size_t j = sl[i].size() - 1; j >= 0; --j )
     {
       //if( (int) ( sl[i][j] ).octaveCount > params.numOfOctave_ )
       if( (int) ( sl[i][j] ).octaveCount > octaveIndex )


### PR DESCRIPTION
resolves #1859

### This pullrequest changes
this PR changes the inner loop for removing useless `OctaveSingleLines` so that the index goes from the vector's end to its beginning thus preventing element skipping when an `erase` operation occurs.
