### PR TITLE
Now when the element of the vector is removed j does not increase

### DIFF
--- a/modules/line_descriptor/src/binary_descriptor.cpp
+++ b/modules/line_descriptor/src/binary_descriptor.cpp
@@ -625,11 +625,12 @@ void BinaryDescriptor::computeImpl( const Mat& imageSrc, std::vector<KeyLine>& k
   /* delete useless OctaveSingleLines */
   for ( size_t i = 0; i < sl.size(); i++ )
   {
-    for ( size_t j = 0; j < sl[i].size(); j++ )
+    for ( size_t j = 0; j < sl[i].size(); )
     {
       //if( (int) ( sl[i][j] ).octaveCount > params.numOfOctave_ )
       if( (int) ( sl[i][j] ).octaveCount > octaveIndex )
         ( sl[i] ).erase( ( sl[i] ).begin() + j );
+      else j++;
     }
   }
 


### PR DESCRIPTION
resolves [#1859](https://github.com/opencv/opencv_contrib/issues/1859#issue-375463049)

This pullrequest changes the inner loop for removing useless OctaveSingleLines so that the index does not increase when an element erases thus preventing next element skipping.
