### PR TITLE
fbs disparity filtering fix

### DIFF
--- a/modules/ximgproc/doc/ximgproc.bib
+++ b/modules/ximgproc/doc/ximgproc.bib
@@ -311,9 +311,11 @@
   url = {http://reference.wolfram.com/language/ref/RidgeFilter.html}
 }
 
-@article{BarronPoole2016,
-  author = {Jonathan T Barron and Ben Poole},
-  title = {The Fast Bilateral Solver},
-  journal = {ECCV},
-  year = {2016},
+@inproceedings{BarronPoole2016,
+author = {Jonathan T Barron and Ben Poole},
+title={The Fast Bilateral Solver},
+booktitle={European Conference on Computer Vision (ECCV)},
+year={2016},
+publisher={Springer International Publishing},
+pages={617--632},
 }

--- a/modules/ximgproc/include/opencv2/ximgproc/edge_filter.hpp
+++ b/modules/ximgproc/include/opencv2/ximgproc/edge_filter.hpp
@@ -384,9 +384,9 @@ class CV_EXPORTS_W FastBilateralSolverFilter : public Algorithm
 public:
     /** @brief Apply smoothing operation to the source image.
 
-    @param src source image for filtering with unsigned 8-bit or signed 16-bit or floating-point 32-bit depth and up to 4 channels.
+    @param src source image for filtering with unsigned 8-bit or signed 16-bit or floating-point 32-bit depth and up to 3 channels.
 
-    @param confidence confidence image with unsigned 8-bit or signed 16-bit or floating-point 32-bit confidence and 1 channel.
+    @param confidence confidence image with unsigned 8-bit or floating-point 32-bit confidence and 1 channel.
 
     @param dst destination image.
     */
@@ -405,9 +405,10 @@ public:
 
 @param num_iter number of iterations used for solving, 25 is usually enough.
 
-@param max_tol solving tolerance used for solving, 25 is usually enough.
+@param max_tol solving tolerance used for solving.
 
 For more details about the Fast Bilateral Solver parameters, see the original paper @cite BarronPoole2016.
+
 */
 CV_EXPORTS_W Ptr<FastBilateralSolverFilter> createFastBilateralSolverFilter(InputArray guide, double sigma_spatial, double sigma_luma, double sigma_chroma, int num_iter = 25, double max_tol = 1e-5);
 
@@ -419,7 +420,7 @@ guide then use FastBilateralSolverFilter interface to avoid extra computations.
 
 @param src source image for filtering with unsigned 8-bit or signed 16-bit or floating-point 32-bit depth and up to 4 channels.
 
-@param confidence confidence image with unsigned 8-bit or signed 16-bit or floating-point 32-bit confidence and 1 channel.
+@param confidence confidence image with unsigned 8-bit or floating-point 32-bit confidence and 1 channel.
 
 @param dst destination image.
 
@@ -431,7 +432,9 @@ guide then use FastBilateralSolverFilter interface to avoid extra computations.
 
 @param num_iter number of iterations used for solving, 25 is usually enough.
 
-@param max_tol solving tolerance used for solving, 25 is usually enough.
+@param max_tol solving tolerance used for solving.
+
+@note Confidence images with CV_8U depth are expected to in [0, 255] and CV_32F in [0, 1] range.
 */
 CV_EXPORTS_W void fastBilateralSolverFilter(InputArray guide, InputArray src, InputArray confidence, OutputArray dst, double sigma_spatial = 8, double sigma_luma = 8, double sigma_chroma = 8, int num_iter = 25, double max_tol = 1e-5);
 //////////////////////////////////////////////////////////////////////////

--- a/modules/ximgproc/samples/disparity_filtering.cpp
+++ b/modules/ximgproc/samples/disparity_filtering.cpp
@@ -292,7 +292,7 @@ int main(int argc, char** argv)
 
 #ifdef HAVE_EIGEN
         //! [filtering_fbs]
-        solving_time = (double)getTickCount();        
+        solving_time = (double)getTickCount();
         fastBilateralSolverFilter(left, left_disp_resized, conf_map/255.0f, solved_disp, fbs_spatial, fbs_luma, fbs_chroma);
         solving_time = ((double)getTickCount() - solving_time)/getTickFrequency();
         //! [filtering_fbs]
@@ -300,7 +300,13 @@ int main(int argc, char** argv)
         //! [filtering_wls2fbs]
         fastBilateralSolverFilter(left, filtered_disp, conf_map/255.0f, solved_filtered_disp, fbs_spatial, fbs_luma, fbs_chroma);
         //! [filtering_wls2fbs]
+
+#else
+        (void)fbs_spatial;
+        (void)fbs_luma;
+        (void)fbs_chroma;
 #endif
+
     }
     else if(filter=="wls_no_conf")
     {

--- a/modules/ximgproc/samples/disparity_filtering.cpp
+++ b/modules/ximgproc/samples/disparity_filtering.cpp
@@ -300,7 +300,6 @@ int main(int argc, char** argv)
         //! [filtering_wls2fbs]
         fastBilateralSolverFilter(left, filtered_disp, conf_map/255.0f, solved_filtered_disp, fbs_spatial, fbs_luma, fbs_chroma);
         //! [filtering_wls2fbs]
-
 #else
         (void)fbs_spatial;
         (void)fbs_luma;
@@ -370,7 +369,7 @@ int main(int argc, char** argv)
     cout.precision(2);
     cout<<"Matching time:  "<<matching_time<<"s"<<endl;
     cout<<"Filtering time: "<<filtering_time<<"s"<<endl;
-    cout<<"solving time: "<<solving_time<<"s"<<endl;
+    cout<<"Solving time: "<<solving_time<<"s"<<endl;
     cout<<endl;
 
     double MSE_before,percent_bad_before,MSE_after,percent_bad_after;

--- a/modules/ximgproc/samples/disparity_filtering.cpp
+++ b/modules/ximgproc/samples/disparity_filtering.cpp
@@ -113,7 +113,7 @@ int main(int argc, char** argv)
         }
     }
 
-    Mat left_for_matcher, right_for_matcher, guide;
+    Mat left_for_matcher, right_for_matcher;
     Mat left_disp,right_disp;
     Mat filtered_disp,solved_disp,solved_filtered_disp;
     Mat conf_map = Mat(left.rows,left.cols,CV_8U);
@@ -228,7 +228,6 @@ int main(int argc, char** argv)
             left_for_matcher  = left.clone();
             right_for_matcher = right.clone();
         }
-        guide = left_for_matcher.clone();
 
         if(algo=="bm")
         {

--- a/modules/ximgproc/src/fbs_filter.cpp
+++ b/modules/ximgproc/src/fbs_filter.cpp
@@ -475,7 +475,7 @@ namespace ximgproc
         Eigen::VectorXf y1(nvertices);
         Eigen::VectorXf w_splat(nvertices);
 
-        Eigen::VectorXf x(npixels);        
+        Eigen::VectorXf x(npixels);
         Eigen::VectorXf w(npixels);
 
         if(target.depth() == CV_16S)

--- a/modules/ximgproc/src/fbs_filter.cpp
+++ b/modules/ximgproc/src/fbs_filter.cpp
@@ -89,8 +89,8 @@ namespace ximgproc
         void filter(InputArray src, InputArray confidence, OutputArray dst) CV_OVERRIDE
         {
 
-            CV_Assert(!src.empty() && (src.depth() == CV_8U || src.depth() == CV_16U || src.depth() == CV_32F) && src.channels()<=4);
-            CV_Assert(!confidence.empty() && (confidence.depth() == CV_8U || confidence.depth() == CV_16S || confidence.depth() == CV_32F) && confidence.channels()==1);
+            CV_Assert(!src.empty() && (src.depth() == CV_8U || src.depth() == CV_16S || src.depth() == CV_32F) && src.channels()<=4);
+            CV_Assert(!confidence.empty() && (confidence.depth() == CV_8U || confidence.depth() == CV_32F) && confidence.channels()==1);
             if (src.rows() != rows || src.cols() != cols)
             {
                 CV_Error(Error::StsBadSize, "Size of the filtered image must be equal to the size of the guide image");
@@ -110,8 +110,6 @@ namespace ximgproc
                 split(src,src_channels);
 
             Mat conf = confidence.getMat();
-            if(conf.depth() != CV_8UC1)
-                conf.convertTo(conf, CV_8UC1);
 
             for(int i=0;i<src.channels();i++)
             {
@@ -167,7 +165,6 @@ namespace ximgproc
         Eigen::SparseMatrix<float, Eigen::ColMajor> S;
         Eigen::SparseMatrix<float, Eigen::ColMajor> Dn;
         Eigen::SparseMatrix<float, Eigen::ColMajor> Dm;
-        cv::Mat guide;
 
         struct grid_params
         {
@@ -206,8 +203,6 @@ namespace ximgproc
 
     void FastBilateralSolverFilterImpl::init(cv::Mat& reference, double sigma_spatial, double sigma_luma, double sigma_chroma, int num_iter, double max_tol)
     {
-
-        guide = reference.clone();
 
         bs_param.cg_maxiter = num_iter;
         bs_param.cg_tol = max_tol;
@@ -480,51 +475,69 @@ namespace ximgproc
         Eigen::VectorXf y1(nvertices);
         Eigen::VectorXf w_splat(nvertices);
 
-        cv::Mat x;
-        cv::Mat w;
-        cv::Mat xw;
-        cv::Mat filtered_xw;
-        cv::Mat filtered_w;
-        cv::Mat filtered_disp;
-        float fgs_colorSigma = 1.5;
-        float fgs_spatialSigma = 2000;
+        Eigen::VectorXf x(npixels);        
+        Eigen::VectorXf w(npixels);
 
-        if(target.depth() == CV_16U)
-            target.convertTo(x, CV_32FC1, 1.0f/65535.0f);
+        if(target.depth() == CV_16S)
+        {
+            const int16_t *pft = reinterpret_cast<const int16_t*>(target.data);
+            for (int i = 0; i < npixels; i++)
+            {
+                x(i) = (cv::saturate_cast<float>(pft[i])+32768.0f)/65535.0f;
+            }
+        }
         else if(target.depth() == CV_8U)
-            target.convertTo(x, CV_32FC1, 1.0f/255.0f);
+        {
+            const uchar *pft = reinterpret_cast<const uchar*>(target.data);
+            for (int i = 0; i < npixels; i++)
+            {
+                x(i) = cv::saturate_cast<float>(pft[i])/255.0f;
+            }
+        }
+        else if(confidence.depth() == CV_32F)
+        {
+            const float *pft = reinterpret_cast<const float*>(target.data);
+            for (int i = 0; i < npixels; i++)
+            {
+                x(i) = pft[i];
+            }
+        }
 
-        confidence.convertTo(w, CV_32FC1);
-
-        xw = x.mul(w);
-        cv::ximgproc::fastGlobalSmootherFilter(guide, xw, filtered_xw, fgs_spatialSigma, fgs_colorSigma);
-        cv::ximgproc::fastGlobalSmootherFilter(guide, w, filtered_w, fgs_spatialSigma, fgs_colorSigma);
-        cv::divide(filtered_xw, filtered_w+EPS, filtered_disp, 1.0f, CV_32FC1);
-
+        if(confidence.depth() == CV_8U)
+        {
+            const uchar *pfc = reinterpret_cast<const uchar*>(confidence.data);
+            for (int i = 0; i < npixels; i++)
+            {
+                w(i) = cv::saturate_cast<float>(pfc[i])/255.0f;
+            }
+        }
+        else if(confidence.depth() == CV_32F)
+        {
+            const float *pfc = reinterpret_cast<const float*>(confidence.data);
+            for (int i = 0; i < npixels; i++)
+            {
+                w(i) = pfc[i];
+            }
+        }
 
         //construct A
-        w_splat.setZero();
-        const float *pfw = reinterpret_cast<const float*>(w.data);
-        for (int i = 0; i < int(splat_idx.size()); i++)
-        {
-            w_splat(splat_idx[i]) += pfw[i]/255.0f;
-        }
+        Splat(w,w_splat);
+
         diagonal(w_splat,A_data);
         A = bs_param.lam * (Dm - Dn * (blurs*Dn)) + A_data ;
 
         //construct b
         b.setZero();
-        const float *pfx = reinterpret_cast<const float*>(filtered_disp.data);
         for (int i = 0; i < int(splat_idx.size()); i++)
         {
-            b(splat_idx[i]) += pfx[i]*pfw[i]/255.0f;
+            b(splat_idx[i]) += x(i) * w(i);
         }
 
         //construct guess for y
         y0.setZero();
         for (int i = 0; i < int(splat_idx.size()); i++)
         {
-            y0(splat_idx[i]) += pfx[i];
+            y0(splat_idx[i]) += x(i);
         }
         y1.setZero();
         for (int i = 0; i < int(splat_idx.size()); i++)
@@ -548,12 +561,12 @@ namespace ximgproc
         std::cout << "estimated error: " << cg.error()      << std::endl;
 
         //slice
-        if(target.depth() == CV_16U)
+        if(target.depth() == CV_16S)
         {
-            uint16_t *pftar = (uint16_t*) output.data;
+            int16_t *pftar = (int16_t*) output.data;
             for (int i = 0; i < int(splat_idx.size()); i++)
             {
-                pftar[i] = uint16_t(y(splat_idx[i]) * 65535.0f);
+                pftar[i] = cv::saturate_cast<ushort>(y(splat_idx[i]) * 65535.0f - 32768.0f);
             }
         }
         else if (target.depth() == CV_8U)
@@ -561,7 +574,7 @@ namespace ximgproc
             uchar *pftar = (uchar*) output.data;
             for (int i = 0; i < int(splat_idx.size()); i++)
             {
-                pftar[i] = uchar(y(splat_idx[i]) * 255.0f);
+                pftar[i] = cv::saturate_cast<uchar>(y(splat_idx[i]) * 255.0f);
             }
         }
         else


### PR DESCRIPTION
### This pullrequest changes

- Fixes Fast Bilateral Solver (FBS) disparity filtering demo, i.e. FBS works now with `int16` disparity images
- Revises data type handling for both input and confidence map images
- Adds option to give command line arguments to FBS in addition to WLS
- Moves Fast Global Smoothing (FGS) pre-filtering from `fbs_filter.cpp` to `disparity_filtering.cpp` demo code

```
force_builders=linux,docs,windows,macosx
```