### PR TITLE
CUDA: disable code using obsolete objdetect API

### DIFF
--- a/modules/cudalegacy/src/cuda/NCVHaarObjectDetection.cu
+++ b/modules/cudalegacy/src/cuda/NCVHaarObjectDetection.cu
@@ -66,7 +66,7 @@
 
 #ifdef HAVE_OPENCV_OBJDETECT
 #  include "opencv2/objdetect.hpp"
-#  include "opencv2/objdetect/objdetect_c.h"
+//#  include "opencv2/objdetect/objdetect_c.h"
 #endif
 
 #include "opencv2/cudalegacy/NCV.hpp"
@@ -2112,15 +2112,13 @@ static NCVStatus loadFromXML(const cv::String &filename,
                       std::vector<HaarClassifierNode128> &haarClassifierNodes,
                       std::vector<HaarFeature64> &haarFeatures)
 {
-#ifndef HAVE_OPENCV_OBJDETECT
     CV_UNUSED(filename);
     CV_UNUSED(haar);
     CV_UNUSED(haarStages);
     CV_UNUSED(haarClassifierNodes);
     CV_UNUSED(haarFeatures);
-    CV_Error(cv::Error::StsNotImplemented, "This functionality requires objdetect module");
-    return NCV_HAAR_XML_LOADING_EXCEPTION;
-#else
+    CV_Error(cv::Error::StsNotImplemented, "Loading from XML file is not available");
+#if 0 // CvLoad is not available since OpenCV 4.0
     NCVStatus ncvStat;
 
     haar.NumStages = 0;

--- a/modules/cudalegacy/test/test_nvidia.cpp
+++ b/modules/cudalegacy/test/test_nvidia.cpp
@@ -116,14 +116,14 @@ CUDA_TEST_P(NCV, VectorOperations)
     ASSERT_TRUE(res);
 }
 
-CUDA_TEST_P(NCV, HaarCascadeLoader)
+CUDA_TEST_P(NCV, DISABLED_HaarCascadeLoader)
 {
     bool res = nvidia_NCV_Haar_Cascade_Loader(_path, nvidiaTestOutputLevel);
 
     ASSERT_TRUE(res);
 }
 
-CUDA_TEST_P(NCV, HaarCascadeApplication)
+CUDA_TEST_P(NCV, DISABLED_HaarCascadeApplication)
 {
     bool res = nvidia_NCV_Haar_Cascade_Application(_path, nvidiaTestOutputLevel);
 

--- a/modules/cudaobjdetect/src/cascadeclassifier.cpp
+++ b/modules/cudaobjdetect/src/cascadeclassifier.cpp
@@ -41,7 +41,7 @@
 //M*/
 
 #include "precomp.hpp"
-#include "opencv2/objdetect/objdetect_c.h"
+#define CUDA_DISABLER //#include "opencv2/objdetect/objdetect_c.h"
 
 using namespace cv;
 using namespace cv::cuda;

--- a/modules/cudaobjdetect/test/test_objdetect.cpp
+++ b/modules/cudaobjdetect/test/test_objdetect.cpp
@@ -263,7 +263,7 @@ CUDA_TEST_P(CalTech, HOG)
 #endif
 }
 
-INSTANTIATE_TEST_CASE_P(detect, CalTech, testing::Combine(ALL_DEVICES,
+INSTANTIATE_TEST_CASE_P(DISABLED_detect, CalTech, testing::Combine(ALL_DEVICES,
     ::testing::Values<std::string>("caltech/image_00000009_0.png", "caltech/image_00000032_0.png",
         "caltech/image_00000165_0.png", "caltech/image_00000261_0.png", "caltech/image_00000469_0.png",
         "caltech/image_00000527_0.png", "caltech/image_00000574_0.png")));
@@ -325,7 +325,7 @@ CUDA_TEST_P(Hog_var, HOG)
     cpu_hog.compute(c_img, cpu_desc_vec, win_stride, Size(0,0));
 }
 
-INSTANTIATE_TEST_CASE_P(detect, Hog_var, testing::Combine(ALL_DEVICES,
+INSTANTIATE_TEST_CASE_P(DISABLED_detect, Hog_var, testing::Combine(ALL_DEVICES,
     ::testing::Values<std::string>("/hog/road.png")));
 
 struct Hog_var_cell : public ::testing::TestWithParam<tuple<cv::cuda::DeviceInfo, std::string> >
@@ -465,7 +465,7 @@ CUDA_TEST_P(Hog_var_cell, HOG)
 //------------------------------------------------------------------------------
 }
 
-INSTANTIATE_TEST_CASE_P(detect, Hog_var_cell, testing::Combine(ALL_DEVICES,
+INSTANTIATE_TEST_CASE_P(DISABLED_detect, Hog_var_cell, testing::Combine(ALL_DEVICES,
     ::testing::Values<std::string>("/hog/road.png")));
 //////////////////////////////////////////////////////////////////////////////////////////
 /// LBP classifier
@@ -494,7 +494,7 @@ CUDA_TEST_P(LBP_Read_classifier, Accuracy)
     ASSERT_FALSE(d_cascade.empty());
 }
 
-INSTANTIATE_TEST_CASE_P(CUDA_ObjDetect, LBP_Read_classifier,
+INSTANTIATE_TEST_CASE_P(DISABLED_CUDA_ObjDetect, LBP_Read_classifier,
                         testing::Combine(ALL_DEVICES, testing::Values<int>(0)));
 
 
@@ -555,7 +555,7 @@ CUDA_TEST_P(LBP_classify, Accuracy)
 #endif
 }
 
-INSTANTIATE_TEST_CASE_P(CUDA_ObjDetect, LBP_classify,
+INSTANTIATE_TEST_CASE_P(DISABLED_CUDA_ObjDetect, LBP_classify,
                         testing::Combine(ALL_DEVICES, testing::Values<int>(0)));
 
 

--- a/modules/cudaoptflow/CMakeLists.txt
+++ b/modules/cudaoptflow/CMakeLists.txt
@@ -6,4 +6,4 @@ set(the_description "CUDA-accelerated Optical Flow")
 
 ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4127 /wd4324 /wd4512 -Wundef -Wmissing-declarations -Wshadow)
 
-ocv_define_module(cudaoptflow opencv_video opencv_cudaarithm opencv_cudawarping opencv_cudaimgproc OPTIONAL opencv_cudalegacy WRAP python)
+ocv_define_module(cudaoptflow opencv_video opencv_optflow opencv_cudaarithm opencv_cudawarping opencv_cudaimgproc OPTIONAL opencv_cudalegacy WRAP python)

--- a/modules/cudaoptflow/perf/perf_optflow.cpp
+++ b/modules/cudaoptflow/perf/perf_optflow.cpp
@@ -316,7 +316,7 @@ PERF_TEST_P(ImagePair, OpticalFlowDual_TVL1,
     {
         cv::Mat flow;
 
-        cv::Ptr<cv::DualTVL1OpticalFlow> alg = cv::createOptFlow_DualTVL1();
+        cv::Ptr<cv::optflow::DualTVL1OpticalFlow> alg = cv::optflow::createOptFlow_DualTVL1();
         alg->setMedianFiltering(1);
         alg->setInnerIterations(1);
         alg->setOuterIterations(300);

--- a/modules/cudaoptflow/perf/perf_precomp.hpp
+++ b/modules/cudaoptflow/perf/perf_precomp.hpp
@@ -48,6 +48,7 @@
 #include "opencv2/cudaoptflow.hpp"
 #include "opencv2/cudaarithm.hpp"
 #include "opencv2/video.hpp"
+#include "opencv2/optflow.hpp"
 
 namespace opencv_test {
 using namespace perf;

--- a/modules/cudaoptflow/test/test_optflow.cpp
+++ b/modules/cudaoptflow/test/test_optflow.cpp
@@ -385,7 +385,7 @@ CUDA_TEST_P(OpticalFlowDual_TVL1, Accuracy)
     cv::cuda::GpuMat d_flow;
     d_alg->calc(loadMat(frame0), loadMat(frame1), d_flow);
 
-    cv::Ptr<cv::DualTVL1OpticalFlow> alg = cv::createOptFlow_DualTVL1();
+    cv::Ptr<cv::optflow::DualTVL1OpticalFlow> alg = cv::optflow::createOptFlow_DualTVL1();
     alg->setMedianFiltering(1);
     alg->setInnerIterations(1);
     alg->setOuterIterations(d_alg->getNumIterations());

--- a/modules/cudaoptflow/test/test_precomp.hpp
+++ b/modules/cudaoptflow/test/test_precomp.hpp
@@ -48,6 +48,7 @@
 #include "opencv2/cudaoptflow.hpp"
 #include "opencv2/cudaarithm.hpp"
 #include "opencv2/video.hpp"
+#include "opencv2/optflow.hpp"
 
 #include "cvconfig.h"
 


### PR DESCRIPTION
To fix CUDA build.
Related tests are disabled too.

```
force_builders=Custom
docker_image:Custom=ubuntu-cuda:16.04
```