### PR TITLE
num_linear_solver_threads has been deprecated since Ceres 1.14.0

### DIFF
--- a/modules/sfm/src/libmv_light/libmv/simple_pipeline/bundle.cc
+++ b/modules/sfm/src/libmv_light/libmv/simple_pipeline/bundle.cc
@@ -430,7 +430,10 @@ void EuclideanBundlePointsOnly(const DistortionModelType distortion_model,
 
 #ifdef _OPENMP
   options.num_threads = omp_get_max_threads();
+#if CERES_VERSION_MAJOR <= 1 && CERES_VERSION_MINOR <= 13
+  // deprecated since Ceres 1.14.0
   options.num_linear_solver_threads = omp_get_max_threads();
+#endif
 #endif
 
   // Solve!
@@ -600,7 +603,10 @@ void EuclideanBundleCommonIntrinsics(
 
 #ifdef _OPENMP
   options.num_threads = omp_get_max_threads();
+#if CERES_VERSION_MAJOR <= 1 && CERES_VERSION_MINOR <= 13
+  // deprecated since Ceres 1.14.0
   options.num_linear_solver_threads = omp_get_max_threads();
+#endif
 #endif
 
   // Solve!


### PR DESCRIPTION
[http://ceres-solver.org/version_history.html#backward-incompatible-api-changes](http://ceres-solver.org/version_history.html#backward-incompatible-api-changes).
