### PR TITLE
use PF_DEPTH for compatibility

### DIFF
--- a/modules/ovis/src/ovis.cpp
+++ b/modules/ovis/src/ovis.cpp
@@ -442,7 +442,7 @@ public:
             dst_type = CV_32FC4;
             break;
         case PF_L16:
-        case PF_DEPTH16:
+        case PF_DEPTH:
             dst_type = CV_16U;
             break;
         default:


### PR DESCRIPTION
[PF_DEPTH16 is just an alias introduced in OGRE 1.11.2](https://github.com/OGRECave/ogre/releases/tag/v1.11.2).