### PR TITLE
Fix build error.

### DIFF
--- a/modules/cvv/src/qtutil/filter/sobelfilterwidget.cpp
+++ b/modules/cvv/src/qtutil/filter/sobelfilterwidget.cpp
@@ -12,6 +12,7 @@
 
 namespace cvv
 {
+using namespace cv;
 namespace qtutil
 {
 


### PR DESCRIPTION
resolves #1914

### This pullrequest changes

Fix the build error. (obelfilterwidget.cpp: error: ‘FILTER_SCHARR’ was not declared in this scope)
