### PR TITLE
Add namespace cv for successful build

### DIFF
--- a/modules/cvv/src/qtutil/filter/diffFilterWidget.cpp
+++ b/modules/cvv/src/qtutil/filter/diffFilterWidget.cpp
@@ -14,6 +14,7 @@
 
 namespace cvv
 {
+using namespace cv;
 namespace qtutil
 {
 


### PR DESCRIPTION
### Add namespace cv
Add `using namespace cv;` for successful building of the file: **diffFilterWidget.cpp**. 
Current error:

```
In member function ‘virtual void cvv::qtutil::DiffFilterFunction::applyFilter(cvv::qtutil::DiffFilterFunction::InputArray, cvv::qtutil::DiffFilterFunction::OutputArray) const’:
/home/hp/OpenCV_installation/opencv_contrib/modules/cvv/src/qtutil/filter/diffFilterWidget.cpp:72:44: error: ‘COLOR_BGR2HSV’ was not declared in this scope
  cv::cvtColor(in.at(0).get(), originalHSV, COLOR_BGR2HSV);
```