### PR TITLE
fix typo

### DIFF
--- a/modules/ximgproc/src/selectivesearchsegmentation.cpp
+++ b/modules/ximgproc/src/selectivesearchsegmentation.cpp
@@ -811,7 +811,7 @@ namespace cv {
                 Ptr<SelectiveSearchSegmentationStrategyTexture> texture2 = createSelectiveSearchSegmentationStrategyTexture();
                 Ptr<SelectiveSearchSegmentationStrategySize> size2 = createSelectiveSearchSegmentationStrategySize();
 
-                Ptr<SelectiveSearchSegmentationStrategyMultiple> m2 = createSelectiveSearchSegmentationStrategyMultiple(fill, texture, size);
+                Ptr<SelectiveSearchSegmentationStrategyMultiple> m2 = createSelectiveSearchSegmentationStrategyMultiple(fill2, texture2, size2);
 
                 addStrategy(m2);
 
@@ -839,10 +839,7 @@ namespace cv {
                 addImage(channel[0]);
 
                 split(base_image, channel);
-                std::vector<Mat> channel2;
-                channel2.push_back(channel[2]);
-                channel2.push_back(channel[1]);
-                channel2.push_back(I);
+                std::vector<Mat> channel2 = {channel[2], channel[1], I};
 
                 Mat rgI;
                 merge(channel2, rgI);
@@ -868,7 +865,7 @@ namespace cv {
                 Ptr<SelectiveSearchSegmentationStrategyTexture> texture2 = createSelectiveSearchSegmentationStrategyTexture();
                 Ptr<SelectiveSearchSegmentationStrategySize> size2 = createSelectiveSearchSegmentationStrategySize();
 
-                Ptr<SelectiveSearchSegmentationStrategyMultiple> m2 = createSelectiveSearchSegmentationStrategyMultiple(fill, texture, size);
+                Ptr<SelectiveSearchSegmentationStrategyMultiple> m2 = createSelectiveSearchSegmentationStrategyMultiple(fill2, texture2, size2);
 
                 addStrategy(m2);
 


### PR DESCRIPTION
I think that that there was a typo in the variable names. fill2, texture2, and size2 were never used. 
Also, minor fix to reduce initialization costs of vector

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
