### PR TITLE
Fix typo of ArUco Detector Parameter

### DIFF
--- a/modules/aruco/include/opencv2/aruco.hpp
+++ b/modules/aruco/include/opencv2/aruco.hpp
@@ -116,11 +116,11 @@ enum CornerRefineMethod{
  * - cornerRefinementMinAccuracy: minimum error for the stop cristeria of the corner refinement
  *   process (default: 0.1)
  * - markerBorderBits: number of bits of the marker border, i.e. marker border width (default 1).
- * - perpectiveRemovePixelPerCell: number of bits (per dimension) for each cell of the marker
+ * - perspectiveRemovePixelPerCell: number of bits (per dimension) for each cell of the marker
  *   when removing the perspective (default 8).
  * - perspectiveRemoveIgnoredMarginPerCell: width of the margin of pixels on each cell not
  *   considered for the determination of the cell bit. Represents the rate respect to the total
- *   size of the cell, i.e. perpectiveRemovePixelPerCell (default 0.13)
+ *   size of the cell, i.e. perspectiveRemovePixelPerCell (default 0.13)
  * - maxErroneousBitsInBorderRate: maximum number of accepted erroneous bits in the border (i.e.
  *   number of allowed white bits in the border). Represented as a rate respect to the total
  *   number of bits per marker (default 0.35).

--- a/modules/aruco/tutorials/aruco_detection/aruco_detection.markdown
+++ b/modules/aruco/tutorials/aruco_detection/aruco_detection.markdown
@@ -627,7 +627,7 @@ depending if the mean value is higher or lower than 128.
 
 Default value: 5.0
 
- - ```int perpectiveRemovePixelPerCell```
+ - ```int perspectiveRemovePixelPerCell```
 
 This parameter determines the number of pixels (per cell) in the obtained image after removing perspective
 distortion (including the border). This is the size of the red squares in the image above.
@@ -636,7 +636,7 @@ For instance, lets assume we are dealing with markers of 5x5 bits and border siz
 (see ```markerBorderBits```). Then, the total number of cells/bits per dimension is 5 + 2*1 = 7 (the border
 has to be counted twice). The total number of cells is 7x7.
 
-If the value of ```perpectiveRemovePixelPerCell``` is 10, then the size of the obtained image will be
+If the value of ```perspectiveRemovePixelPerCell``` is 10, then the size of the obtained image will be
 10*7 = 70 -> 70x70 pixels.
 
 A higher value of this parameter can improve the bits extraction process (up to some degree), however it can penalize


### PR DESCRIPTION
### This pullrequest changes

Fix minor typos in `DetectorParameters` struct doctring and in tutorial for aruco detection
