### PR TITLE
Add link directories for freetype

### DIFF
--- a/modules/freetype/CMakeLists.txt
+++ b/modules/freetype/CMakeLists.txt
@@ -22,6 +22,7 @@ endif()
 
 
 if( FREETYPE_FOUND AND HARFBUZZ_FOUND )
+  link_directories( ${FREETYPE_LIBRARY_DIRS} ${HARFBUZZ_LIBRARY_DIRS} )
   ocv_define_module(freetype opencv_core opencv_imgproc WRAP python)
   ocv_target_link_libraries(${the_module} ${FREETYPE_LIBRARIES} ${HARFBUZZ_LIBRARIES})
   ocv_include_directories( ${FREETYPE_INCLUDE_DIRS} ${HARFBUZZ_INCLUDE_DIRS} )


### PR DESCRIPTION


<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

This change allows the freetype module to be built against external
libraries that are not found on the standard system path.  I ran into
this issue building OpenCV on MacOS against freetype installed by
macports.  CMake found the libraries at configure time but linking
failed at build time.
