### PR TITLE
Check for 1 channel instead of a 3 channel image

### DIFF
--- a/modules/ximgproc/src/anisodiff.cpp
+++ b/modules/ximgproc/src/anisodiff.cpp
@@ -248,7 +248,7 @@ void anisotropicDiffusion(InputArray src_, OutputArray dst_, float alpha, float 
     }
 
     int type = src_.type();
-    CV_Assert(src_.dims() == 2 && type == CV_8UC3);
+    CV_Assert(src_.dims() == 2 && type == CV_8UC1);
     CV_Assert(K != 0);
     CV_Assert(alpha > 0);
     CV_Assert(niters >= 0);


### PR DESCRIPTION
With reference to the issue #1970. The function cv::ximgproc::anisotropicDiffusion requires the source image to be gray scale but the assertion checks for 3 channel. Fixed that.

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
