### PR TITLE
rgbd: fix python bindings

### DIFF
--- a/modules/rgbd/include/opencv2/rgbd.hpp
+++ b/modules/rgbd/include/opencv2/rgbd.hpp
@@ -146,7 +146,7 @@ namespace rgbd
      * @param points a rows x cols x 3 matrix of CV_32F/CV64F or a rows x cols x 1 CV_U16S
      * @param normals a rows x cols x 3 matrix
      */
-    void
+    CV_WRAP_AS(apply) void
     operator()(InputArray points, OutputArray normals) const;
 
     /** Initializes some data that is cached for later computation
@@ -253,7 +253,7 @@ namespace rgbd
      * @param points a rows x cols x 3 matrix of CV_32F/CV64F or a rows x cols x 1 CV_U16S
      * @param depth a rows x cols matrix of the cleaned up depth
      */
-    void
+    CV_WRAP_AS(apply) void
     operator()(InputArray points, OutputArray depth) const;
 
     /** Initializes some data that is cached for later computation
@@ -387,7 +387,7 @@ namespace rgbd
      * @param plane_coefficients the coefficients of the corresponding planes (a,b,c,d) such that ax+by+cz+d=0, norm(a,b,c)=1
      *        and c < 0 (so that the normal points towards the camera)
      */
-    void
+    CV_WRAP_AS(apply) void
     operator()(InputArray points3d, InputArray normals, OutputArray mask,
                OutputArray plane_coefficients);
 
@@ -397,7 +397,7 @@ namespace rgbd
      *        and 255 if it does not belong to any plane
      * @param plane_coefficients the coefficients of the corresponding planes (a,b,c,d) such that ax+by+cz+d=0
      */
-    void
+    CV_WRAP_AS(apply) void
     operator()(InputArray points3d, OutputArray mask, OutputArray plane_coefficients);
 
     CV_WRAP int getBlockSize() const


### PR DESCRIPTION
resolves #1920

add python/java overloads for some `operator()` instances using `CV_WRAP_AS(apply)`

(main work is done there, and without those the algorithms can only be used from c++)