### PR TITLE
Fixed warnings produced by clang-9.0.0

### DIFF
--- a/modules/cvv/src/impl/call.hpp
+++ b/modules/cvv/src/impl/call.hpp
@@ -101,9 +101,6 @@ class Call
 	Call(const Call &) = default;
 	Call(Call &&) = default;
 
-	Call &operator=(const Call &) = default;
-	Call &operator=(Call &&) = default;
-
 	impl::CallMetaData metaData_;
 	size_t id;
 	QString calltype;

--- a/modules/face/src/facemarkLBF.cpp
+++ b/modules/face/src/facemarkLBF.cpp
@@ -633,7 +633,7 @@ Mat FacemarkLBFImpl::BBox::project(const Mat &shape) const {
         res(i, 0) = (shape_(i, 0) - x_center) / x_scale;
         res(i, 1) = (shape_(i, 1) - y_center) / y_scale;
     }
-    return res;
+    return std::move(res);
 }
 
 // Project relative shape to absolute shape binding to this bbox
@@ -644,7 +644,7 @@ Mat FacemarkLBFImpl::BBox::reproject(const Mat &shape) const {
         res(i, 0) = shape_(i, 0)*x_scale + x_center;
         res(i, 1) = shape_(i, 1)*y_scale + y_center;
     }
-    return res;
+    return std::move(res);
 }
 
 Mat FacemarkLBFImpl::getMeanShape(std::vector<Mat> &gt_shapes, std::vector<BBox> &bboxes) {
@@ -1005,7 +1005,7 @@ Mat FacemarkLBFImpl::RandomForest::generateLBF(Mat &img, Mat &current_shape, BBo
             lbf_feat(i*trees_n + j) = (i*trees_n + j)*base + code;
         }
     }
-    return lbf_feat;
+    return std::move(lbf_feat);
 }
 
 void FacemarkLBFImpl::RandomForest::write(FileStorage fs, int k) {
@@ -1347,7 +1347,7 @@ Mat FacemarkLBFImpl::Regressor::globalRegressionPredict(const Mat &lbf, int stag
         for (int j = 0; j < lbf.cols; j++) y += w_ptr[lbf_ptr[j]];
         delta_shape(i, 1) = y;
     }
-    return delta_shape;
+    return std::move(delta_shape);
 } // Regressor::globalRegressionPredict
 
 Mat FacemarkLBFImpl::Regressor::predict(Mat &img, BBox &bbox) {

--- a/modules/face/src/mace.cpp
+++ b/modules/face/src/mace.cpp
@@ -106,7 +106,7 @@ struct MACEImpl CV_FINAL : MACE {
         complexInput.copyTo(dftImg(Rect(0,0,IMGSIZE,IMGSIZE)));
 
         dft(dftImg, dftImg);
-        return dftImg;
+        return std::move(dftImg);
     }
 
 

--- a/modules/ovis/src/ovis.cpp
+++ b/modules/ovis/src/ovis.cpp
@@ -603,7 +603,7 @@ public:
         node.setScale(value[0], value[1], value[2]);
     }
 
-    void getEntityProperty(const String& name, int prop, OutputArray value)
+    void getEntityProperty(const String& name, int prop, OutputArray value) CV_OVERRIDE
     {
         SceneNode& node = _getSceneNode(sceneMgr, name);
         switch(prop)

--- a/modules/rgbd/test/test_kinfu.cpp
+++ b/modules/rgbd/test/test_kinfu.cpp
@@ -141,7 +141,7 @@ struct CubeSpheresScene : Scene
         Range range(0, frame.rows);
         parallel_for_(range, RenderInvoker<CubeSpheresScene>(frame, pose, reproj, depthFactor));
 
-        return frame;
+        return std::move(frame);
     }
 
     std::vector<Affine3f> getPoses() override
@@ -237,7 +237,7 @@ struct RotatingScene : Scene
         Range range(0, frame.rows);
         parallel_for_(range, RenderInvoker<RotatingScene>(frame, pose, reproj, depthFactor));
 
-        return frame;
+        return std::move(frame);
     }
 
     std::vector<Affine3f> getPoses() override

--- a/modules/sfm/src/numeric.cpp
+++ b/modules/sfm/src/numeric.cpp
@@ -140,7 +140,7 @@ skewMat( const Mat_<T> &x )
           x(2),    0 , -x(0),
          -x(1),  x(0),    0;
 
-  return skew;
+  return std::move(skew);
 }
 
 Mat

--- a/modules/videostab/src/global_motion.cpp
+++ b/modules/videostab/src/global_motion.cpp
@@ -113,7 +113,7 @@ static Mat normalizePoints(int npoints, Point2f *points)
     T(0,0) = T(1,1) = s;
     T(0,2) = -cx*s;
     T(1,2) = -cy*s;
-    return T;
+    return std::move(T);
 }
 
 
@@ -138,7 +138,7 @@ static Mat estimateGlobMotionLeastSquaresTranslation(
         *rmse = std::sqrt(*rmse / npoints);
     }
 
-    return M;
+    return std::move(M);
 }
 
 
@@ -219,7 +219,7 @@ static Mat estimateGlobMotionLeastSquaresRotation(
         *rmse = std::sqrt(*rmse / npoints);
     }
 
-    return M;
+    return std::move(M);
 }
 
 static Mat  estimateGlobMotionLeastSquaresRigid(
@@ -273,7 +273,7 @@ static Mat  estimateGlobMotionLeastSquaresRigid(
         *rmse = std::sqrt(*rmse / npoints);
     }
 
-    return M;
+    return std::move(M);
 }
 
 
@@ -484,7 +484,7 @@ Mat estimateGlobalMotionRansac(
     if (ninliers)
         *ninliers = ninliersMax;
 
-    return bestM;
+    return std::move(bestM);
 }
 
 
@@ -527,7 +527,7 @@ Mat MotionEstimatorRansacL2::estimate(InputArray points0, InputArray points1, bo
         if (ok) *ok = false;
     }
 
-    return M;
+    return std::move(M);
 }
 
 
@@ -681,7 +681,7 @@ Mat FromFileMotionReader::estimate(const Mat &/*frame0*/, const Mat &/*frame1*/,
           >> M(1,0) >> M(1,1) >> M(1,2)
           >> M(2,0) >> M(2,1) >> M(2,2) >> ok_;
     if (ok) *ok = ok_;
-    return M;
+    return std::move(M);
 }
 
 
@@ -701,7 +701,7 @@ Mat ToFileMotionWriter::estimate(const Mat &frame0, const Mat &frame1, bool *ok)
           << M(1,0) << " " << M(1,1) << " " << M(1,2) << " "
           << M(2,0) << " " << M(2,1) << " " << M(2,2) << " " << ok_ << std::endl;
     if (ok) *ok = ok_;
-    return M;
+    return std::move(M);
 }
 
 

--- a/modules/ximgproc/samples/colorize.cpp
+++ b/modules/ximgproc/samples/colorize.cpp
@@ -338,11 +338,11 @@ void drawTrajectoryByReference(cv::Mat& img)
 
                 if(drawByReference)
                 {
-                    cv::circle(img, cv::Point2d(x, y), 0.1, cv::Scalar(blue, green, red), -1);
+                    cv::circle(img, cv::Point2d(x, y), 1, cv::Scalar(blue, green, red), -1);
                 }
                 else
                 {
-                    cv::circle(img, cv::Point2d(x, y), 0.1, cv::Scalar(draw_b, draw_g, draw_r), -1);
+                    cv::circle(img, cv::Point2d(x, y), 1, cv::Scalar(draw_b, draw_g, draw_r), -1);
                 }
             }
         }

--- a/modules/ximgproc/test/test_sparse_match_interpolator.cpp
+++ b/modules/ximgproc/test/test_sparse_match_interpolator.cpp
@@ -20,12 +20,12 @@ Mat readOpticalFlow( const String& path )
     Mat_<Point2f> flow;
     std::ifstream file(path.c_str(), std::ios_base::binary);
     if ( !file.good() )
-        return flow; // no file - return empty matrix
+        return std::move(flow); // no file - return empty matrix
 
     float tag;
     file.read((char*) &tag, sizeof(float));
     if ( tag != FLOW_TAG_FLOAT )
-        return flow;
+        return std::move(flow);
 
     int width, height;
 
@@ -44,14 +44,14 @@ Mat readOpticalFlow( const String& path )
             if ( !file.good() )
             {
                 flow.release();
-                return flow;
+                return std::move(flow);
             }
 
             flow(i, j) = u;
         }
     }
     file.close();
-    return flow;
+    return std::move(flow);
 }
 
 CV_ENUM(GuideTypes, CV_8UC1, CV_8UC3)


### PR DESCRIPTION
Merge with opencv/opencv#13705

### This pullrequest changes

Fixed warnings:
* `warning: local variable xxxxx will be copied despite being returned by name [-Wreturn-std-move]`
* `warning: explicitly defaulted copy assignment operator is implicitly deleted [-Wdefaulted-function-deleted]`