### PR TITLE
waldboost_detector train: avoid failed asserts while training by exiting early

### DIFF
--- a/modules/xobjdetect/src/waldboost.cpp
+++ b/modules/xobjdetect/src/waldboost.cpp
@@ -333,13 +333,14 @@ void WaldBoost::fit(Mat& data_pos, Mat& data_neg)
 
 
         if (loss < 1e-50 || min_err > 0.5) {
-            std::cerr << "Stopping early" << std::endl;
+            std::cerr << "Stopping early. loss=" << loss << " min_err=" << min_err << std::endl;
             weak_count_ = i + 1;
             break;
         }
 
         // Avoid crashing on next Mat creation
         if (pos <= 1) {
+            std::cerr << "Stopping early. pos=" << pos << std::endl;
             weak_count_ = i + 1;
             break;
         }

--- a/modules/xobjdetect/src/waldboost.cpp
+++ b/modules/xobjdetect/src/waldboost.cpp
@@ -338,6 +338,12 @@ void WaldBoost::fit(Mat& data_pos, Mat& data_neg)
             break;
         }
 
+        // Avoid crashing on next Mat creation
+        if (pos <= 1) {
+            weak_count_ = i + 1;
+            break;
+        }
+
         // Normalize weights
         double z = (sum(pos_weights) + sum(neg_weights))[0];
         pos_weights /= z;


### PR DESCRIPTION
resolves #457
resolves #633

### This pullrequest changes
This simply stops the training early if the number of positive samples becomes ≤ 1.