### PR TITLE
Incomplete sentence corrected. Resolves Issue #1997

### DIFF
--- a/modules/face/include/opencv2/face.hpp
+++ b/modules/face/include/opencv2/face.hpp
@@ -162,7 +162,7 @@ public:
     @param src The training images, that means the faces you want to learn. The data has to be
     given as a vector\<Mat\>.
     @param labels The labels corresponding to the images have to be given either as a vector\<int\>
-    or a
+    or a Mat of type CV_32SC1.
 
     The following source code snippet shows you how to learn a Fisherfaces model on a given set of
     images. The images are read with imread and pushed into a std::vector\<Mat\>. The labels of each
@@ -174,7 +174,9 @@ public:
     @code
     // holds images and labels
     vector<Mat> images;
-    vector<int> labels;
+    vector<int> labels; 
+    // using Mat of type CV_32SC1
+    // Mat labels(number_of_samples, 1, CV_32SC1); 
     // images for first person
     images.push_back(imread("person0/0.jpg", CV_LOAD_IMAGE_GRAYSCALE)); labels.push_back(0);
     images.push_back(imread("person0/1.jpg", CV_LOAD_IMAGE_GRAYSCALE)); labels.push_back(0);
@@ -211,7 +213,7 @@ public:
     @param src The training images, that means the faces you want to learn. The data has to be given
     as a vector\<Mat\>.
     @param labels The labels corresponding to the images have to be given either as a vector\<int\> or
-    a
+    a Mat of type CV_32SC1.
 
     This method updates a (probably trained) FaceRecognizer, but only if the algorithm supports it. The
     Local Binary Patterns Histograms (LBPH) recognizer (see createLBPHFaceRecognizer) can be updated.

--- a/modules/face/include/opencv2/face.hpp
+++ b/modules/face/include/opencv2/face.hpp
@@ -174,9 +174,9 @@ public:
     @code
     // holds images and labels
     vector<Mat> images;
-    vector<int> labels; 
+    vector<int> labels;
     // using Mat of type CV_32SC1
-    // Mat labels(number_of_samples, 1, CV_32SC1); 
+    // Mat labels(number_of_samples, 1, CV_32SC1);
     // images for first person
     images.push_back(imread("person0/0.jpg", CV_LOAD_IMAGE_GRAYSCALE)); labels.push_back(0);
     images.push_back(imread("person0/1.jpg", CV_LOAD_IMAGE_GRAYSCALE)); labels.push_back(0);


### PR DESCRIPTION
### This pullrequest changes
* Resolves Issue #1997
* Corrects the documentation for `FaceRecognizer::train()` function.

```python
FaceRecognizer::train(InputArrayOfArrays src, InputArray labels); 
```

The type `InputArray` can accept `vector<T>` or `Mat` types as mentioned here: https://docs.opencv.org/3.4/d4/d32/classcv_1_1__InputArray.html

Also added the way of using `Mat` for labels. (with type `CV_32SC1`)

```
force_builders=Docs
```