### PR TITLE
sfm module calls imread function, which is in imgcodecs module

### DIFF
--- a/modules/sfm/CMakeLists.txt
+++ b/modules/sfm/CMakeLists.txt
@@ -81,6 +81,7 @@ ocv_add_module(sfm
   opencv_calib3d
   opencv_features2d
   opencv_xfeatures2d
+  opencv_imgcodecs
   WRAP python
 )
 

--- a/modules/sfm/src/libmv_light/libmv/correspondence/nRobustViewMatching.cc
+++ b/modules/sfm/src/libmv_light/libmv/correspondence/nRobustViewMatching.cc
@@ -18,7 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 
-#include <opencv2/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
 
 #include "libmv/base/vector_utils.h"
 #include "libmv/correspondence/feature.h"


### PR DESCRIPTION
This built correctly before because tests were run with the highgui module enabled.
The sfm module links against the features2d module, which brings in the highgui module as an optional target if enabled.
Through this path, imread was working correctly despite the file including the wrong header and not declaring its linking dependency.

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

Module `sfm` now explicitly links against module `imgcodecs`.

See related pull request: https://github.com/opencv/opencv/pull/13849
