### PR TITLE
(3.4) backport bindings generator from OpenCV 4.x

### DIFF
--- a/modules/aruco/include/opencv2/aruco/dictionary.hpp
+++ b/modules/aruco/include/opencv2/aruco/dictionary.hpp
@@ -138,7 +138,7 @@ class CV_EXPORTS_W Dictionary {
  * - DICT_ARUCO_ORIGINAL: standard ArUco Library Markers. 1024 markers, 5x5 bits, 0 minimum
                           distance
  */
-enum CV_EXPORTS_W_SIMPLE PREDEFINED_DICTIONARY_NAME {
+enum PREDEFINED_DICTIONARY_NAME {
     DICT_4X4_50 = 0,
     DICT_4X4_100,
     DICT_4X4_250,

--- a/modules/ximgproc/include/opencv2/ximgproc/slic.hpp
+++ b/modules/ximgproc/include/opencv2/ximgproc/slic.hpp
@@ -62,6 +62,7 @@ namespace ximgproc
 //! @{
 
     enum SLIC { SLIC = 100, SLICO = 101, MSLIC = 102 };
+    typedef enum SLIC SLICType;
 
 /** @brief Class implementing the SLIC (Simple Linear Iterative Clustering) superpixels
 algorithm described in @cite Achanta2012.


### PR DESCRIPTION
relates https://github.com/opencv/opencv/pull/13945

```
allow_multiple_commits=1
```