### PR TITLE
Added a parameter to mask features used for video stabilization

### DIFF
--- a/modules/videostab/include/opencv2/videostab/frame_source.hpp
+++ b/modules/videostab/include/opencv2/videostab/frame_source.hpp
@@ -86,6 +86,28 @@ private:
     Ptr<IFrameSource> impl;
 };
 
+class MaskFrameSource : public IFrameSource
+{
+public:
+    MaskFrameSource(const Ptr<IFrameSource>& source): impl(source) {};
+
+    virtual void reset() CV_OVERRIDE { impl->reset(); }
+    virtual Mat nextFrame() CV_OVERRIDE {
+        Mat nextFrame = impl->nextFrame();
+        maskCallback_(nextFrame);
+        return nextFrame;
+    }
+
+    void setMaskCallback(std::function<void(Mat&)> MaskCallback)
+    {
+        maskCallback_ = std::bind(MaskCallback, std::placeholders::_1);
+    };
+
+private:
+    Ptr<IFrameSource> impl;
+    std::function<void(Mat&)> maskCallback_;
+};
+
 //! @}
 
 } // namespace videostab

--- a/modules/videostab/include/opencv2/videostab/global_motion.hpp
+++ b/modules/videostab/include/opencv2/videostab/global_motion.hpp
@@ -180,6 +180,12 @@ public:
     virtual void setMotionModel(MotionModel val) { motionModel_ = val; }
     virtual MotionModel motionModel() const { return motionModel_; }
 
+    virtual void setFrameMask(InputArray mask)
+    {
+        if (!mask.empty())
+            CV_Error(Error::StsNotImplemented, "Mask support is not implemented.");
+    }
+
     virtual Mat estimate(const Mat &frame0, const Mat &frame1, bool *ok = 0) = 0;
 
 protected:
@@ -208,6 +214,8 @@ public:
     virtual void setMotionModel(MotionModel val) CV_OVERRIDE { motionEstimator_->setMotionModel(val); }
     virtual MotionModel motionModel() const CV_OVERRIDE { return motionEstimator_->motionModel(); }
 
+    virtual void setFrameMask(InputArray mask) CV_OVERRIDE { motionEstimator_->setFrameMask(mask); }
+
     virtual Mat estimate(const Mat &frame0, const Mat &frame1, bool *ok = 0) CV_OVERRIDE;
 
 private:
@@ -235,6 +243,8 @@ public:
     void setOutlierRejector(Ptr<IOutlierRejector> val) { outlierRejector_ = val; }
     Ptr<IOutlierRejector> outlierRejector() const { return outlierRejector_; }
 
+    virtual void setFrameMask(InputArray mask) CV_OVERRIDE { mask_ = mask.getMat(); }
+
     virtual Mat estimate(const Mat &frame0, const Mat &frame1, bool *ok = 0) CV_OVERRIDE;
     Mat estimate(InputArray frame0, InputArray frame1, bool *ok = 0);
 
@@ -243,6 +253,7 @@ private:
     Ptr<FeatureDetector> detector_;
     Ptr<ISparseOptFlowEstimator> optFlowEstimator_;
     Ptr<IOutlierRejector> outlierRejector_;
+    Mat mask_;
 
     std::vector<uchar> status_;
     std::vector<KeyPoint> keypointsPrev_;
@@ -263,6 +274,8 @@ public:
     void setOutlierRejector(Ptr<IOutlierRejector> val) { outlierRejector_ = val; }
     Ptr<IOutlierRejector> outlierRejector() const { return outlierRejector_; }
 
+    virtual void setFrameMask(InputArray mask) CV_OVERRIDE { mask_ = mask.getMat(); }
+
     virtual Mat estimate(const Mat &frame0, const Mat &frame1, bool *ok = 0) CV_OVERRIDE;
     Mat estimate(const cuda::GpuMat &frame0, const cuda::GpuMat &frame1, bool *ok = 0);
 
@@ -271,6 +284,7 @@ private:
     Ptr<cuda::CornersDetector> detector_;
     SparsePyrLkOptFlowEstimatorGpu optFlowEstimator_;
     Ptr<IOutlierRejector> outlierRejector_;
+    GpuMat mask_;
 
     cuda::GpuMat frame0_, grayFrame0_, frame1_;
     cuda::GpuMat pointsPrev_, points_;

--- a/modules/videostab/include/opencv2/videostab/stabilizer.hpp
+++ b/modules/videostab/include/opencv2/videostab/stabilizer.hpp
@@ -77,6 +77,9 @@ public:
     void setFrameSource(Ptr<IFrameSource> val) { frameSource_ = val; }
     Ptr<IFrameSource> frameSource() const { return frameSource_; }
 
+    void setMaskSource(const Ptr<IFrameSource>& val) { maskSource_ = val; }
+    Ptr<IFrameSource> maskSource() const { return maskSource_; }
+
     void setMotionEstimator(Ptr<ImageMotionEstimatorBase> val) { motionEstimator_ = val; }
     Ptr<ImageMotionEstimatorBase> motionEstimator() const { return motionEstimator_; }
 
@@ -110,6 +113,7 @@ protected:
 
     Ptr<ILog> log_;
     Ptr<IFrameSource> frameSource_;
+    Ptr<IFrameSource> maskSource_;
     Ptr<ImageMotionEstimatorBase> motionEstimator_;
     Ptr<DeblurerBase> deblurer_;
     Ptr<InpainterBase> inpainter_;

--- a/modules/videostab/src/global_motion.cpp
+++ b/modules/videostab/src/global_motion.cpp
@@ -725,7 +725,7 @@ Mat KeypointBasedMotionEstimator::estimate(const Mat &frame0, const Mat &frame1,
 Mat KeypointBasedMotionEstimator::estimate(InputArray frame0, InputArray frame1, bool *ok)
 {
     // find keypoints
-    detector_->detect(frame0, keypointsPrev_);
+    detector_->detect(frame0, keypointsPrev_, mask_);
     if (keypointsPrev_.empty())
         return Mat::eye(3, 3, CV_32F);
 
@@ -815,7 +815,7 @@ Mat KeypointBasedMotionEstimatorGpu::estimate(const cuda::GpuMat &frame0, const 
     }
 
     // find keypoints
-    detector_->detect(grayFrame0, pointsPrev_);
+    detector_->detect(grayFrame0, pointsPrev_, mask_);
 
     // find correspondences
     optFlowEstimator_.run(frame0, frame1, pointsPrev_, points_, status_);

--- a/modules/videostab/src/stabilizer.cpp
+++ b/modules/videostab/src/stabilizer.cpp
@@ -391,6 +391,9 @@ void TwoPassStabilizer::runPrePassIfNecessary()
         {
             if (frameCount_ > 0)
             {
+                if (maskSource_)
+                    motionEstimator_->setFrameMask(maskSource_->nextFrame());
+
                 motions_.push_back(motionEstimator_->estimate(prevFrame, frame, &ok));
 
                 if (doWobbleSuppression_)


### PR DESCRIPTION
This PR adds an additional video path parameter to modules/videostab/samples/videostab.cpp, which allows to mask features during video stabilization. 

The mask video must contain black (0 values) for parts, which are ignored during stabilization.


