### PR TITLE
Fix "'tesseract/baseapi.h' file not found"

### DIFF
--- a/modules/text/cmake/FindTesseract.cmake
+++ b/modules/text/cmake/FindTesseract.cmake
@@ -3,24 +3,24 @@ if(COMMAND pkg_check_modules)
   pkg_check_modules(Tesseract tesseract lept)
 endif()
 if(NOT Tesseract_FOUND)
-  find_path(Tesseract_INCLUDE_DIR tesseract/baseapi.h
+  find_path(Tesseract_INCLUDE_DIRS tesseract/baseapi.h
     HINTS
     /usr/include
     /usr/local/include)
 
-  find_library(Tesseract_LIBRARY NAMES tesseract
+  find_library(Tesseract_LIBRARIES NAMES tesseract
     HINTS
     /usr/lib
     /usr/local/lib)
 
-  find_library(Lept_LIBRARY NAMES lept
+  find_library(Tesseract_Lept_LIBRARY NAMES lept
     HINTS
     /usr/lib
     /usr/local/lib)
 
-  if(Tesseract_INCLUDE_DIR AND Tesseract_LIBRARY AND Lept_LIBRARY)
-    set(Tesseract_INCLUDE_DIRS ${Tesseract_INCLUDE_DIR})
-    set(Tesseract_LIBRARIES ${Tesseract_LIBRARY} ${Lept_LIBRARY})
+  if(Tesseract_INCLUDE_DIRS AND Tesseract_LIBRARIES AND Tesseract_Lept_LIBRARY)
+    set(Tesseract_INCLUDE_DIRS ${Tesseract_INCLUDE_DIRS} CACHE INTERNAL)
+    set(Tesseract_LIBRARIES ${Tesseract_LIBRARIES} ${Tesseract_Lept_LIBRARY} CACHE INTERNAL)
     set(Tesseract_FOUND 1)
   endif()
 endif()


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->
Resolves #920 

### This pullrequest changes

* Fixes compilation error detailed below
* Renames similarly named cache entries to prevent confusion that caused this bug

```
Scanning dependencies of target opencv_text
[ 76%] Building CXX object modules/text/CMakeFiles/opencv_text.dir/src/erfilter.cpp.o
In file included from /Users/travis/build/skvark/opencv-python/opencv_contrib/modules/text/src/erfilter.cpp:43:
/Users/travis/build/skvark/opencv-python/opencv_contrib/modules/text/src/precomp.hpp:54:10: fatal error: 'tesseract/baseapi.h' file not found
#include <tesseract/baseapi.h>
         ^
1 error generated.
make[2]: *** [modules/text/CMakeFiles/opencv_text.dir/src/erfilter.cpp.o] Error 1
make[1]: *** [modules/text/CMakeFiles/opencv_text.dir/all] Error 2
```

Sample failure: https://travis-ci.org/skvark/opencv-python/jobs/510374018

CMake command line: `cmake /Users/admin/Documents/opencv-python/opencv -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX:PATH=/Users/admin/Documents/opencv-python/_skbuild/macosx-10.7-x86_64-3.7/cmake-install -DPYTHON_EXECUTABLE:FILEPATH=/usr/local/opt/python/bin/python3.7 -DPYTHON_VERSION_STRING:STRING=3.7.2 -DPYTHON_INCLUDE_DIR:PATH=/usr/local/opt/python/Frameworks/Python.framework/Versions/3.7/include/python3.7m -DPYTHON_LIBRARY:FILEPATH=/usr/local/opt/python/Frameworks/Python.framework/Versions/3.7/lib/libpython3.7m.dylib -DSKBUILD:BOOL=TRUE -DCMAKE_MODULE_PATH:PATH=/usr/local/lib/python3.7/site-packages/skbuild/resources/cmake -DPYTHON3_EXECUTABLE=/usr/local/opt/python/bin/python3.7 -DBUILD_opencv_python3=ON -DOPENCV_SKIP_PYTHON_LOADER=ON -DOPENCV_PYTHON3_INSTALL_PATH=python -DINSTALL_CREATE_DISTRIB=ON -DBUILD_opencv_apps=OFF -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTS=OFF -DBUILD_PERF_TESTS=OFF -DBUILD_DOCS=OFF -DOPENCV_EXTRA_MODULES_PATH=/Users/admin/Documents/opencv-python/opencv_contrib/modules -DWITH_QT=4 -DWITH_LAPACK=OFF -DCMAKE_CXX_FLAGS=-stdlib=libc++ -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7 -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_OSX_ARCHITECTURES:STRING=x86_64 -DOPENCV_CMAKE_DEBUG_MESSAGES=1`
