### PR TITLE
fix cv::superres::SuperResolution::getLabmda/setLabmda typo

### DIFF
--- a/modules/superres/include/opencv2/superres.hpp
+++ b/modules/superres/include/opencv2/superres.hpp
@@ -123,10 +123,10 @@ namespace cv
             virtual void setTau(double val) = 0;
 
             //! @brief Weight parameter to balance data term and smoothness term
-            /** @see setLabmda */
-            virtual double getLabmda() const = 0;
-            /** @copybrief getLabmda @see getLabmda */
-            virtual void setLabmda(double val) = 0;
+            /** @see setLambda */
+            virtual double getLambda() const = 0;
+            /** @copybrief getLambda @see getLambda */
+            virtual void setLambda(double val) = 0;
 
             //! @brief Parameter of spacial distribution in Bilateral-TV
             /** @see setAlpha */

--- a/modules/superres/src/btv_l1.cpp
+++ b/modules/superres/src/btv_l1.cpp
@@ -478,8 +478,8 @@ namespace
         inline void setIterations(int val) CV_OVERRIDE { iterations_ = val; }
         inline double getTau() const CV_OVERRIDE { return tau_; }
         inline void setTau(double val) CV_OVERRIDE { tau_ = val; }
-        inline double getLabmda() const CV_OVERRIDE { return lambda_; }
-        inline void setLabmda(double val) CV_OVERRIDE { lambda_ = val; }
+        inline double getLambda() const CV_OVERRIDE { return lambda_; }
+        inline void setLambda(double val) CV_OVERRIDE { lambda_ = val; }
         inline double getAlpha() const CV_OVERRIDE { return alpha_; }
         inline void setAlpha(double val) CV_OVERRIDE { alpha_ = val; }
         inline int getKernelSize() const CV_OVERRIDE { return btvKernelSize_; }

--- a/modules/superres/src/btv_l1_cuda.cpp
+++ b/modules/superres/src/btv_l1_cuda.cpp
@@ -223,8 +223,8 @@ namespace
         inline void setIterations(int val) CV_OVERRIDE { iterations_ = val; }
         inline double getTau() const CV_OVERRIDE { return tau_; }
         inline void setTau(double val) CV_OVERRIDE { tau_ = val; }
-        inline double getLabmda() const CV_OVERRIDE { return lambda_; }
-        inline void setLabmda(double val) CV_OVERRIDE { lambda_ = val; }
+        inline double getLambda() const CV_OVERRIDE { return lambda_; }
+        inline void setLambda(double val) CV_OVERRIDE { lambda_ = val; }
         inline double getAlpha() const CV_OVERRIDE { return alpha_; }
         inline void setAlpha(double val) CV_OVERRIDE { alpha_ = val; }
         inline int getKernelSize() const CV_OVERRIDE { return btvKernelSize_; }


### PR DESCRIPTION
### This pullrequest changes

Fix typos of cv::superres::SuperResolution's lambda parameter accessors.
