### PR TITLE
ximgproc: Fix support for CV_32F WLS Filter

### DIFF
--- a/modules/ximgproc/src/disparity_filters.cpp
+++ b/modules/ximgproc/src/disparity_filters.cpp
@@ -244,6 +244,8 @@ void DisparityWLSFilterImpl::filter(InputArray disparity_map_left, InputArray le
     filter_(left, left_view, filt_disp, right, ROI);
     if (disparity_map_left.depth() != CV_32F){
         filt_disp.convertTo(filtered_disparity_map, disparity_map_left.depth());
+    } else {
+        filt_disp.copyTo(filtered_disparity_map);
     }
 }
 


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes
Fix support for `CV_32F` disparity maps in the DisparityWLSFilter.

If the disparity maps have the depth `CV_32F`, they are wls-filtered
in `DisparityWLSFilterImpl::filter` but the result is not saved in the
`OutputArray` of the method. Now, the result is copied to that array.
<!-- Please describe what your pullrequest is changing -->
