### PR TITLE
text: fix build on windows

### DIFF
--- a/modules/text/src/ocr_tesseract.cpp
+++ b/modules/text/src/ocr_tesseract.cpp
@@ -48,6 +48,14 @@
 #include <fstream>
 #include <queue>
 
+#ifdef HAVE_TESSERACT
+#if !defined(USE_STD_NAMESPACE)
+#define USE_STD_NAMESPACE
+#endif
+#include <tesseract/baseapi.h>
+#include <tesseract/resultiterator.h>
+#endif
+
 namespace cv
 {
 namespace text

--- a/modules/text/src/precomp.hpp
+++ b/modules/text/src/precomp.hpp
@@ -47,12 +47,4 @@
 
 #include "text_config.hpp"
 
-#ifdef HAVE_TESSERACT
-#if !defined(USE_STD_NAMESPACE)
-#define USE_STD_NAMESPACE
-#endif
-#include <tesseract/baseapi.h>
-#include <tesseract/resultiterator.h>
-#endif
-
 #endif


### PR DESCRIPTION
avoid broken min/max macros from tesseract headers

resolves #2084
replaces #2083