### PR TITLE
docs: remove redundant `return`

### DIFF
--- a/modules/aruco/include/opencv2/aruco.hpp
+++ b/modules/aruco/include/opencv2/aruco.hpp
@@ -257,7 +257,7 @@ CV_EXPORTS_W void estimatePoseSingleMarkers(InputArrayOfArrays corners, float ma
 /**
  * @brief Board of markers
  *
- * A board is a set of markers in the 3D space with a common cordinate system.
+ * A board is a set of markers in the 3D space with a common coordinate system.
  * The common form of a board of marker is a planar (2D) board, however any 3D layout can be used.
  * A Board object is composed by:
  * - The object points of the marker corners, i.e. their coordinates respect to the board system.
@@ -268,7 +268,7 @@ class CV_EXPORTS_W Board {
 
     public:
     /**
-    * @brief Provide way to create Board by passing nessesary data. Specially needed in Python.
+    * @brief Provide way to create Board by passing necessary data. Specially needed in Python.
     *
     * @param objPoints array of object points of all the marker corners in the board
     * @param dictionary the dictionary of markers employed for this board
@@ -292,7 +292,7 @@ class CV_EXPORTS_W Board {
 
 /**
  * @brief Planar board with grid arrangement of markers
- * More common type of board. All markers are placed in the same plane in a grid arrangment.
+ * More common type of board. All markers are placed in the same plane in a grid arrangement.
  * The board can be drawn using drawPlanarBoard() function (@sa drawPlanarBoard)
  */
 class CV_EXPORTS_W GridBoard : public Board {

--- a/modules/bioinspired/include/opencv2/bioinspired/transientareassegmentationmodule.hpp
+++ b/modules/bioinspired/include/opencv2/bioinspired/transientareassegmentationmodule.hpp
@@ -180,8 +180,8 @@ public:
     CV_WRAP virtual void run(InputArray inputToSegment, const int channelIndex=0)=0;
 
     /** @brief access function
-    @return the last segmentation result: a boolean picture which is resampled between 0 and 255 for a display purpose
-   */
+    return the last segmentation result: a boolean picture which is resampled between 0 and 255 for a display purpose
+    */
     CV_WRAP virtual void getSegmentationPicture(OutputArray transientAreas)=0;
 
     /** @brief cleans all the buffers of the instance

--- a/modules/bioinspired/src/transientareassegmentationmodule.cpp
+++ b/modules/bioinspired/src/transientareassegmentationmodule.cpp
@@ -166,7 +166,7 @@ public:
 
     /**
      * access function
-     * @return the last segmentation result: a boolean picture which is resampled between 0 and 255 for a display purpose
+     * return the last segmentation result: a boolean picture which is resampled between 0 and 255 for a display purpose
      */
     void getSegmentationPicture(OutputArray transientAreas);
 

--- a/modules/img_hash/include/opencv2/img_hash/block_mean_hash.hpp
+++ b/modules/img_hash/include/opencv2/img_hash/block_mean_hash.hpp
@@ -27,7 +27,7 @@ class CV_EXPORTS_W BlockMeanHash : public ImgHashBase
 {
 public:
     /** @brief Create BlockMeanHash object
-        @param mode
+        @param mode the mode
     */
     CV_WRAP void setMode(int mode);
     CV_WRAP std::vector<double> getMean() const;
@@ -39,7 +39,7 @@ protected:
 /** @brief Computes block mean hash of the input image
     @param inputArr input image want to compute hash value, type should be CV_8UC4, CV_8UC3 or CV_8UC1.
     @param outputArr Hash value of input, it will contain 16 hex decimal number, return type is CV_8U
-    @param mode
+    @param mode the mode
 */
 CV_EXPORTS_W void blockMeanHash(cv::InputArray inputArr,
                                 cv::OutputArray outputArr,

--- a/modules/tracking/samples/tracker.cpp
+++ b/modules/tracking/samples/tracker.cpp
@@ -50,14 +50,14 @@ int main( int argc, char** argv ){
       for(size_t npos=0,pos=0,ctr=0;ctr<4;ctr++){
         npos=initBoundingBox.find_first_of(',',pos);
         if(npos==string::npos && ctr<3){
-           printf("bounding box should be given in format \"x1,y1,x2,y2\",where x's and y's are integer cordinates of opposed corners of bdd box\n");
+           printf("bounding box should be given in format \"x1,y1,x2,y2\",where x's and y's are integer coordinates of opposed corners of bdd box\n");
            printf("got: %s\n",initBoundingBox.substr(pos,string::npos).c_str());
            printf("manual selection of bounding box will be employed\n");
            break;
         }
         int num=atoi(initBoundingBox.substr(pos,(ctr==3)?(string::npos):(npos-pos)).c_str());
         if(num<=0){
-           printf("bounding box should be given in format \"x1,y1,x2,y2\",where x's and y's are integer cordinates of opposed corners of bdd box\n");
+           printf("bounding box should be given in format \"x1,y1,x2,y2\",where x's and y's are integer coordinates of opposed corners of bdd box\n");
            printf("got: %s\n",initBoundingBox.substr(pos,npos-pos).c_str());
            printf("manual selection of bounding box will be employed\n");
            break;

--- a/modules/tracking/src/feature.cpp
+++ b/modules/tracking/src/feature.cpp
@@ -908,7 +908,7 @@ void CvHOGEvaluator::Feature::write( FileStorage &fs ) const
 //}
 
 //cell[0] and featComponent idx writing. By cell[0] it's possible to recover all block
-//All block is nessesary for block normalization
+//All block is necessary for block normalization
 void CvHOGEvaluator::Feature::write( FileStorage &fs, int featComponentIdx ) const
 {
   fs << CC_RECT << "[:" << rect[0].x << rect[0].y << rect[0].width << rect[0].height << featComponentIdx << "]";

--- a/modules/ximgproc/include/opencv2/ximgproc/edge_filter.hpp
+++ b/modules/ximgproc/include/opencv2/ximgproc/edge_filter.hpp
@@ -107,7 +107,7 @@ guided image then use DTFilter interface to avoid extra computations on initiali
 @param guide guided image (also called as joint image) with unsigned 8-bit or floating-point 32-bit
 depth and up to 4 channels.
 @param src filtering image with unsigned 8-bit or floating-point 32-bit depth and up to 4 channels.
-@param dst
+@param dst destination image
 @param sigmaSpatial \f${\sigma}_H\f$ parameter in the original article, it's similar to the sigma in the
 coordinate space into bilateralFilter.
 @param sigmaColor \f${\sigma}_r\f$ parameter in the original article, it's similar to the sigma in the


### PR DESCRIPTION
This change is to remove redundant `return` doc, for a method with `void` type.

It prevents the success of https://github.com/opencv/opencv/pull/14667, and the corresponding error is [here](https://pullrequest.opencv.org/buildbot/builders/precommit_docs/builds/20631/steps/make%20doxygen/logs/warnings%20%282%29)

Please suggest if other text should be written instead.

```
opencv=javadoc
**WIP**
force_builders=Docs
```