### PR TITLE
Fix 2102 redux

### DIFF
--- a/modules/ximgproc/src/selectivesearchsegmentation.cpp
+++ b/modules/ximgproc/src/selectivesearchsegmentation.cpp
@@ -558,9 +558,14 @@ namespace cv {
 
                         center = Point((int)(img_plane_rotated.cols / 2.0), (int)(img_plane_rotated.rows / 2.0));
                         rot = cv::getRotationMatrix2D(center, -45.0, 1.0);
-                        warpAffine(tmp_gradiant, tmp_rot, rot, bbox.size());
+                        // Using this bigger box avoids clipping the ends of narrow images
+                        Rect bbox2 = cv::RotatedRect(center, img_plane_rotated.size(), -45.0).boundingRect();\
+                        warpAffine(tmp_gradiant, tmp_rot, rot, bbox2.size());
 
-                        tmp_gradiant = tmp_rot(Rect((bbox.width - img.cols) / 2, (bbox.height - img.rows) / 2, img.cols, img.rows));
+                        // for narrow images, bbox might be less tall or wide than img
+                        int start_x = std::max(0, (bbox.width - img.cols) / 2);
+                        int start_y = std::max(0, (bbox.height - img.rows) / 2);
+                        tmp_gradiant = tmp_rot(Rect(start_x, start_y, img.cols, img.rows));
 
                         threshold(tmp_gradiant, tmp_gradiant_pos, 0, 0, THRESH_TOZERO);
                         threshold(tmp_gradiant, tmp_gradiant_neg, 0, 0, THRESH_TOZERO_INV);
@@ -573,9 +578,12 @@ namespace cv {
 
                         center = Point((int)(img_plane_rotated.cols / 2.0), (int)(img_plane_rotated.rows / 2.0));
                         rot = cv::getRotationMatrix2D(center, -45.0, 1.0);
-                        warpAffine(tmp_gradiant, tmp_rot, rot, bbox.size());
+                        bbox2 = cv::RotatedRect(center, img_plane_rotated.size(), -45.0).boundingRect();\
+                        warpAffine(tmp_gradiant, tmp_rot, rot, bbox2.size());
 
-                        tmp_gradiant = tmp_rot(Rect((bbox.width - img.cols) / 2, (bbox.height - img.rows) / 2, img.cols, img.rows));
+                        start_x = std::max(0, (bbox.width - img.cols) / 2);
+                        start_y = std::max(0, (bbox.height - img.rows) / 2);
+                        tmp_gradiant = tmp_rot(Rect(start_x, start_y, img.cols, img.rows));
 
                         threshold(tmp_gradiant, tmp_gradiant_pos, 0, 0, THRESH_TOZERO);
                         threshold(tmp_gradiant, tmp_gradiant_neg, 0, 0, THRESH_TOZERO_INV);


### PR DESCRIPTION
resolves #2102

### This pullrequest changes

During one of the stages of selective search, the image is rotated 45 degrees and gradients are computed along the X and Y directions in the rotated image.  The gradient image is then rotated back to the original orientation and cropped to remove surrounding empty space, leaving it with the same shape as the original image.  However, the implementation of the crop will specify an ROI with negative x or y values if the image's native aspect ratio is too high or too low (basically, if the image is far from square).

This is because the bounding box of the rotated image is strictly bigger than the original image if the original is sufficiently close to square; but if the original is too "skinny", the bounding box of its rotation will be less tall or wide than the original.

The fix is to threshold the x and y computed for the ROI at 0.

Note: while fixing this bug, I also discovered that parts of "narrow" gradient images were being clipped at their edges due to improper cropping, again due to the apparent assumption that the bounding box of the rotated image was always strictly bigger in both axes than the original image.  This PR includes a fix for that as well.

Another note: Something seemed to go wrong with the previous PR, so I've created this new one.