### PR TITLE
Add missing codecs to cv::cudacodec::VideoReader which uses Nvidia Video Codec SDK

### DIFF
--- a/modules/cudacodec/include/opencv2/cudacodec.hpp
+++ b/modules/cudacodec/include/opencv2/cudacodec.hpp
@@ -250,6 +250,9 @@ enum Codec
     JPEG,
     H264_SVC,
     H264_MVC,
+    HEVC,
+    VP8,
+    VP9,
 
     Uncompressed_YUV420 = (('I'<<24)|('Y'<<16)|('U'<<8)|('V')),   //!< Y,U,V (4:2:0)
     Uncompressed_YV12   = (('Y'<<24)|('V'<<16)|('1'<<8)|('2')),   //!< Y,V,U (4:2:0)
@@ -274,6 +277,7 @@ struct FormatInfo
 {
     Codec codec;
     ChromaFormat chromaFormat;
+    int nBitDepthMinus8;
     int width;
     int height;
 };

--- a/modules/cudacodec/perf/perf_video.cpp
+++ b/modules/cudacodec/perf/perf_video.cpp
@@ -51,7 +51,7 @@ DEF_PARAM_TEST_1(FileName, string);
 //////////////////////////////////////////////////////
 // VideoReader
 
-#if defined(HAVE_NVCUVID) && defined(HAVE_VIDEO_INPUT)
+#if defined(HAVE_NVCUVID)
 
 PERF_TEST_P(FileName, VideoReader, Values("gpu/video/768x576.avi", "gpu/video/1920x1080.avi"))
 {

--- a/modules/cudacodec/src/cuvid_video_source.cpp
+++ b/modules/cudacodec/src/cuvid_video_source.cpp
@@ -70,6 +70,7 @@ cv::cudacodec::detail::CuvidVideoSource::CuvidVideoSource(const String& fname)
 
     format_.codec = static_cast<Codec>(vidfmt.codec);
     format_.chromaFormat = static_cast<ChromaFormat>(vidfmt.chroma_format);
+    format_.nBitDepthMinus8 = vidfmt.bit_depth_luma_minus8;
     format_.width = vidfmt.coded_width;
     format_.height = vidfmt.coded_height;
 }

--- a/modules/cudacodec/src/ffmpeg_video_source.cpp
+++ b/modules/cudacodec/src/ffmpeg_video_source.cpp
@@ -111,6 +111,7 @@ cv::cudacodec::detail::FFmpegVideoSource::FFmpegVideoSource(const String& fname)
 
     format_.codec = static_cast<Codec>(codec);
     format_.chromaFormat = static_cast<ChromaFormat>(chroma_format);
+    format_.nBitDepthMinus8 = -1;
     format_.width = width;
     format_.height = height;
 }


### PR DESCRIPTION
Currently the latest codecs supported by the Nvidia Video Codec SDK are not supported by 
`cv::cudacodec::VideoReader`

<cut/>

For example creating a video reader with a hevc encoded file ('hevc.mkv') as below
`createVideoReader('hevc.mkv');`
results in the following assertion failure
`OpenCV(4.1.0-dev) cudacodec\src\video_decoder.cpp:70: error: (-215:Assertion failed) cudaVideoCodec_MPEG1 == _codec || cudaVideoCodec_MPEG2 == _codec || cudaVideoCodec_MPEG4 == _codec || cudaVideoCodec_VC1 == _codec || cudaVideoCodec_H264 == _codec || cudaVideoCodec_JPEG == _codec || cudaVideoCodec_YUV420== _codec || cudaVideoCodec_YV12 == _codec || cudaVideoCodec_NV12 == _codec || cudaVideoCodec_YUYV == _codec || cudaVideoCodec_UYVY == _codec in function 'cv::cudacodec::detail::VideoDecoder::create'`

Additionally if `createVideoReader('hevc.mkv');` is called on hardware which does not support hevc decoding (maxwell and before excluding GM206) the same assertion error is produced, which is not as informative as it could be.  Therefore the PR also includes additional checks to ensure the codec used in 'hevc.mkv' is supported on the current device.  This changes the result of requesting a hevc encoded file on a pre-maxwell device results to
`OpenCV(4.1.0-dev) modules\cudacodec\src\video_decoder.cpp:89: error: (-210:Unsupported format or combination of formats) Video source is not supported by hardware video decoder in function 'cv::cudacodec::detail::VideoDecoder::create'`

### This pullrequest changes

Adds missing codecs to cv::cudacodec::VideoReader which uses Nvidia Video Codec SDK including checks to ensure codec used in input video file is supported on the current device.

```
force_builders=Custom
buildworker:Custom=linux-1,linux-2,linux-4
docker_image:Custom=ubuntu-cuda:16.04
```