### PR TITLE
ovis: add cpp samples

### DIFF
--- a/modules/ovis/samples/aruco_ar_demo.cpp
+++ b/modules/ovis/samples/aruco_ar_demo.cpp
@@ -1,0 +1,68 @@
+#include <opencv2/highgui.hpp>
+#include <opencv2/calib3d.hpp>
+#include <opencv2/videoio.hpp>
+
+#include <opencv2/ovis.hpp>
+#include <opencv2/aruco.hpp>
+
+#include <iostream>
+
+
+#define KEY_ESCAPE 27
+
+using namespace cv;
+
+int main()
+{
+  Mat img;
+  std::vector<std::vector<Point2f>> corners;
+  std::vector<int> ids;
+  std::vector<Vec3d> rvecs;
+  std::vector<Vec3d> tvecs;
+
+  const Size2i imsize(800, 600);
+  const double focal_length = 800.0;
+
+  // aruco
+  Ptr<aruco::Dictionary> adict = aruco::getPredefinedDictionary(aruco::DICT_4X4_50);
+  //Mat out_img;
+  //aruco::drawMarker(adict, 0, 400, out_img);
+  //imshow("marker", out_img);
+
+  // random calibration data, your mileage may vary
+  Mat1d cm = Mat1d::zeros(3, 3); // init empty matrix
+  cm.at<double>(0, 0) = focal_length; // f_x
+  cm.at<double>(1, 1) = focal_length; // f_y
+  cm.at<double>(2, 2) = 1; // f_z
+  Mat K = getDefaultNewCameraMatrix(cm, imsize, true);
+
+  // AR scene
+  ovis::addResourceLocation("packs/Sinbad.zip"); // shipped with Ogre
+
+  Ptr<ovis::WindowScene> win = ovis::createWindow(String("arucoAR"), imsize, ovis::SCENE_INTERACTIVE | ovis::SCENE_AA);
+  win->setCameraIntrinsics(K, imsize);
+  win->createEntity("sinbad", "Sinbad.mesh", Vec3i(0, 0, 5), Vec3f(1.57, 0.0, 0.0));
+  win->createLightEntity("sun", Vec3i(0, 0, 100));
+
+  // video capture
+  VideoCapture cap{0};
+  cap.set(CAP_PROP_FRAME_WIDTH, imsize.width);
+  cap.set(CAP_PROP_FRAME_HEIGHT, imsize.height);
+
+  std::cout << "Press ESCAPE to exit demo" << std::endl;
+  while (ovis::waitKey(1) != KEY_ESCAPE) {
+    cap.read(img);
+    win->setBackground(img);
+    aruco::detectMarkers(img, adict, corners, ids);
+
+    waitKey(1);
+
+    if (ids.size() == 0)
+      continue;
+
+    aruco::estimatePoseSingleMarkers(corners, 5, K, noArray(), rvecs, tvecs);
+    win->setCameraPose(tvecs.at(0), rvecs.at(0), true);
+  }
+
+  return 0;
+}

--- a/modules/ovis/samples/ovis_demo.cpp
+++ b/modules/ovis/samples/ovis_demo.cpp
@@ -1,0 +1,54 @@
+#include <opencv2/calib3d.hpp>
+#include <opencv2/videoio.hpp>
+
+#include <opencv2/ovis.hpp>
+#include <opencv2/aruco.hpp>
+
+#include <iostream>
+
+
+#define KEY_ESCAPE 27
+
+using namespace cv;
+
+int main()
+{
+  Mat R;
+  Vec3d t;
+
+  const Size2i imsize(800, 600);
+  const double focal_length = 800.0;
+
+  //add some external resources
+  ovis::addResourceLocation("packs/Sinbad.zip"); // shipped with Ogre
+
+  //camera intrinsics
+  Mat1d K = Mat1d::zeros(3, 3); // init empty matrix
+  K.at<double>(0, 0) = focal_length; // f_x
+  K.at<double>(1, 1) = focal_length; // f_y
+  K.at<double>(0, 2) = 400; // t_x
+  K.at<double>(1, 2) = 500; // t_y
+  K.at<double>(2, 2) = 1; // f_z
+
+  //observer scene
+  Ptr<ovis::WindowScene> owin = ovis::createWindow(String("VR"), imsize);
+  ovis::createGridMesh("ground", Size2i(10, 10), Size2i(10, 10));
+  owin->createEntity("ground", "ground", Vec3f(1.57, 0, 0));
+  owin->createCameraEntity("cam", K, imsize, 5);
+  owin->createEntity("figure", "Sinbad.mesh", Vec3i(0, 0, 5), Vec3f(CV_PI/2.0, 0.0, 0.0)); // externally defined mesh
+  owin->createLightEntity("sun", Vec3i(0, 0, -100));
+
+  //interaction scene
+  Ptr<ovis::WindowScene> iwin = ovis::createWindow(String("AR"), imsize, ovis::SCENE_SEPERATE | ovis::SCENE_INTERACTIVE);
+  iwin->createEntity("figure", "Sinbad.mesh", Vec3i(0, -5, 0), Vec3f(CV_PI, 0.0, 0.0));
+  iwin->createLightEntity("sun", Vec3i(0, 0, -100));
+  iwin->setCameraIntrinsics(K, imsize);
+
+  std::cout << "Press ESCAPE to exit demo" << std::endl;
+  while (ovis::waitKey(1) != KEY_ESCAPE) {
+      iwin->getCameraPose(R, t);
+      owin->setEntityPose("cam", t, R);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
### PR changes
This PR adds samples for the __ovis__ module in _C++_.
These are directly translated from the existing _Python_ samples in the __ovis__ module.

### Tested on
OS: `5.1.7-arch1-1-ARCH`
Platform: `x86_64 GNU/Linux`
Compiler: `g++ (GCC) 8.3.0`
OpenCV: `4.1.0`