### PR TITLE
ovis, fixes: windows build, play multiple animations

### DIFF
--- a/modules/ovis/src/ovis.cpp
+++ b/modules/ovis/src/ovis.cpp
@@ -12,6 +12,7 @@
 #include <opencv2/calib3d.hpp>
 #include <opencv2/core/utils/configuration.private.hpp>
 
+
 namespace cv
 {
 namespace ovis
@@ -277,7 +278,7 @@ class WindowSceneImpl : public WindowScene
     RenderWindow* rWin;
     Ptr<OgreBites::CameraMan> camman;
     Ptr<Rectangle2D> bgplane;
-    std::unordered_map<String, Controller<Real>*> frameCtrlrs;
+    std::unordered_map<AnimationState*, Controller<Real>*> frameCtrlrs;
 
     Ogre::RenderTarget* depthRTT;
     int flags;
@@ -600,9 +601,9 @@ public:
         animstate->setEnabled(true);
         animstate->setLoop(loop);
 
-        if (frameCtrlrs.find(animname) != frameCtrlrs.end()) return;
+        if (frameCtrlrs.find(animstate) != frameCtrlrs.end()) return;
         frameCtrlrs.insert({
-            animname,
+            animstate,
             Ogre::ControllerManager::getSingleton().createFrameTimePassthroughController(
                 Ogre::AnimationStateControllerValue::create(animstate, true)
             )
@@ -620,8 +621,8 @@ public:
 
         animstate->setEnabled(false);
         animstate->setTimePosition(0);
-        Ogre::ControllerManager::getSingleton().destroyController(frameCtrlrs[animname]);
-        frameCtrlrs.erase(animname);
+        Ogre::ControllerManager::getSingleton().destroyController(frameCtrlrs[animstate]);
+        frameCtrlrs.erase(animstate);
     }
 
     void setEntityProperty(const String& name, int prop, const String& value) CV_OVERRIDE
@@ -659,7 +660,7 @@ public:
             Entity* ent = dynamic_cast<Entity*>(node.getAttachedObject(name));
             CV_Assert(ent && "invalid entity");
 
-            ent->getSkeleton()->setBlendMode(static_cast<Ogre::SkeletonAnimationBlendMode>(value[0]));
+            ent->getSkeleton()->setBlendMode(static_cast<Ogre::SkeletonAnimationBlendMode>(int(value[0])));
             break;
         }
         default:


### PR DESCRIPTION
Fixes #2177 

##### This pullrequest fixes two issues
1. Animations only played (/stopped) for one entity instance
- Fix: Save each animation **state** instead of the animation name
2. Build failure on the Windows platform because MSVC can't handle a static type conversion (#2177)
- Fix: Add explicit cast to *int* before the static type cast

@paroj 