### PR TITLE
Add test for ximgproc/edgeboxes and fix up Python sample to work with returning scores

### DIFF
--- a/modules/ximgproc/samples/edgeboxes_demo.py
+++ b/modules/ximgproc/samples/edgeboxes_demo.py
@@ -27,10 +27,17 @@ if __name__ == '__main__':
     edge_boxes = cv.ximgproc.createEdgeBoxes()
     edge_boxes.setMaxBoxes(30)
     boxes = edge_boxes.getBoundingBoxes(edges, orimap)
+    boxes, scores = edge_boxes.getBoundingBoxes(edges, orimap)
 
-    for b in boxes:
-        x, y, w, h = b
-        cv.rectangle(im, (x, y), (x+w, y+h), (0, 255, 0), 1, cv.LINE_AA)
+    if len(boxes) > 0:
+        boxes_scores = zip(boxes, scores)
+        for b_s in boxes_scores:
+            box = b_s[0]
+            x, y, w, h = box
+            cv.rectangle(im, (x, y), (x+w, y+h), (0, 255, 0), 1, cv.LINE_AA)
+            score = b_s[1][0]
+            cv.putText(im, "{:.2f}".format(score), (x, y), cv.FONT_HERSHEY_PLAIN, 0.8, (255, 255, 255), 1, cv.LINE_AA)
+            print("Box at (x,y)=({:d},{:d}); score={:f}".format(x, y, score))
 
     cv.imshow("edges", edges)
     cv.imshow("edgeboxes", im)

--- a/modules/ximgproc/test/test_edgeboxes.cpp
+++ b/modules/ximgproc/test/test_edgeboxes.cpp
@@ -1,0 +1,44 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+#include "test_precomp.hpp"
+
+namespace opencv_test { namespace {
+
+TEST(ximpgroc_Edgeboxes, regression)
+{
+	//Testing Edgeboxes implementation by asking for one proposal
+	//on a simple test image from the PASCAL VOC 2012 dataset.
+    std::vector<Rect> boxes;
+    std::vector<float> scores;
+    float expectedScore = 0.48742563;
+    Rect expectedProposal(158, 69, 125, 154);
+
+    //Using sample model file, compute orientations map for use with edge detection.
+    cv::String testImagePath = cvtest::TS::ptr()->get_data_path() + "cv/ximgproc/" + "pascal_voc_bird.jpg";
+    Mat testImg = imread(testImagePath);
+    cvtColor(testImg, testImg, COLOR_BGR2RGB);
+    testImg.convertTo(testImg, CV_32F, 1.0 / 255.0f);
+
+    //Use the model for structured edge detection that is already provided in opencv_extra.
+    cv::String model_path = cvtest::TS::ptr()->get_data_path() + "cv/ximgproc/" + "model.yml.gz";
+    Ptr<StructuredEdgeDetection> sed = createStructuredEdgeDetection(model_path);
+    Mat edgeImage, edgeOrientations;
+    sed->detectEdges(testImg, edgeImage);
+    sed->computeOrientation(edgeImage, edgeOrientations);
+
+    //Obtain one proposal and its score from Edgeboxes.
+    Ptr<EdgeBoxes> edgeboxes = createEdgeBoxes();
+    edgeboxes->setMaxBoxes(1);
+    edgeboxes->getBoundingBoxes(edgeImage, edgeOrientations, boxes, scores);
+
+    //We asked for one proposal and thus one score, we better get one back only.
+    ASSERT_TRUE(boxes.size() == 1);
+    ASSERT_TRUE(scores.size() == 1);
+
+    //Check the proposal and its score.
+    EXPECT_FLOAT_EQ(scores[0], expectedScore);
+    EXPECT_TRUE(expectedProposal.x == boxes[0].x && expectedProposal.y == boxes[0].y && expectedProposal.height == boxes[0].height && expectedProposal.width == boxes[0].width);
+}
+
+}} // namespace

--- a/modules/ximgproc/test/test_edgeboxes.cpp
+++ b/modules/ximgproc/test/test_edgeboxes.cpp
@@ -11,7 +11,7 @@ TEST(ximpgroc_Edgeboxes, regression)
 	//on a simple test image from the PASCAL VOC 2012 dataset.
     std::vector<Rect> boxes;
     std::vector<float> scores;
-    float expectedScore = 0.48742563;
+    float expectedScore = 0.48742563f;
     Rect expectedProposal(158, 69, 125, 154);
 
     //Using sample model file, compute orientations map for use with edge detection.

--- a/modules/ximgproc/test/test_edgeboxes.cpp
+++ b/modules/ximgproc/test/test_edgeboxes.cpp
@@ -7,16 +7,17 @@ namespace opencv_test { namespace {
 
 TEST(ximpgroc_Edgeboxes, regression)
 {
-	//Testing Edgeboxes implementation by asking for one proposal
-	//on a simple test image from the PASCAL VOC 2012 dataset.
+    //Testing Edgeboxes implementation by asking for one proposal
+    //on a simple test image from the PASCAL VOC 2012 dataset.
     std::vector<Rect> boxes;
     std::vector<float> scores;
     float expectedScore = 0.48742563f;
     Rect expectedProposal(158, 69, 125, 154);
 
     //Using sample model file, compute orientations map for use with edge detection.
-    cv::String testImagePath = cvtest::TS::ptr()->get_data_path() + "cv/ximgproc/" + "pascal_voc_bird.jpg";
+    cv::String testImagePath = cvtest::TS::ptr()->get_data_path() + "cv/ximgproc/" + "pascal_voc_bird.png";
     Mat testImg = imread(testImagePath);
+    ASSERT_FALSE(testImg.empty()) << "Could not load input image " << testImagePath;
     cvtColor(testImg, testImg, COLOR_BGR2RGB);
     testImg.convertTo(testImg, CV_32F, 1.0 / 255.0f);
 
@@ -37,8 +38,11 @@ TEST(ximpgroc_Edgeboxes, regression)
     ASSERT_TRUE(scores.size() == 1);
 
     //Check the proposal and its score.
-    EXPECT_FLOAT_EQ(scores[0], expectedScore);
-    EXPECT_TRUE(expectedProposal.x == boxes[0].x && expectedProposal.y == boxes[0].y && expectedProposal.height == boxes[0].height && expectedProposal.width == boxes[0].width);
+    EXPECT_NEAR(scores[0], expectedScore, 1e-8);
+    EXPECT_EQ(expectedProposal.x, boxes[0].x);
+    EXPECT_EQ(expectedProposal.y, boxes[0].y);
+    EXPECT_EQ(expectedProposal.height, boxes[0].height);
+    EXPECT_EQ(expectedProposal.width, boxes[0].width);
 }
 
 }} // namespace


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

Adds a regression test for the edgeboxes implementation in ximgproc, and fixes up a Python sample for the edgeboxes which now works for returning scores.
