### PR TITLE
bioinspired: fix program build failure

### DIFF
--- a/modules/bioinspired/src/opencl/retina_kernel.cl
+++ b/modules/bioinspired/src/opencl/retina_kernel.cl
@@ -411,9 +411,9 @@ kernel void amacrineCellsComputing(
     float4 val_opl_off = vload4(0, opl_off);
 
     float4 magnoXonPixelResult = coeff * (vload4(0, out_on) + val_opl_on - vload4(0, prev_in_on));
-    vstore4(fmax(magnoXonPixelResult, 0), 0, out_on);
+    vstore4(fmax(magnoXonPixelResult, 0.f), 0, out_on);
     float4 magnoXoffPixelResult = coeff * (vload4(0, out_off) + val_opl_off - vload4(0, prev_in_off));
-    vstore4(fmax(magnoXoffPixelResult, 0), 0, out_off);
+    vstore4(fmax(magnoXoffPixelResult, 0.f), 0, out_off);
 
     vstore4(val_opl_on, 0, prev_in_on);
     vstore4(val_opl_off, 0, prev_in_off);


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes
resolves #2108

<!-- Please describe what your pullrequest is changing -->

Also confirmed on Firefly-RK3399 (Aarch64 + Mali-T860) and Tinkerboard (Armv7 + Mali-T760)

```
OpenCL program build log: bioinspired/retina_kernel
Status -11: CL_BUILD_PROGRAM_FAILURE

<source>:299:9: error: call to 'fmax' is ambiguous
vstore4(fmax(magnoXonPixelResult, 0), 0, out_on);
        ^~~~

note: candidate function
note: candidate function
<source>:301:9: error: call to 'fmax' is ambiguous
vstore4(fmax(magnoXoffPixelResult, 0), 0, out_off);
        ^~~~

note: candidate function
note: candidate function
error: Compiler frontend failed (error code 59)
```