### PR TITLE
build: suppress noisy warning

### DIFF
--- a/modules/hfs/CMakeLists.txt
+++ b/modules/hfs/CMakeLists.txt
@@ -1,5 +1,6 @@
 if(HAVE_CUDA)
   add_definitions(-D_HFS_CUDA_ON_)
+  ocv_warnings_disable(CMAKE_CXX_FLAGS -Wundef)
 endif()
 
 set(the_description "Hierarchical Feature Selection for Efficient Image Segmentation")

--- a/modules/xfeatures2d/CMakeLists.txt
+++ b/modules/xfeatures2d/CMakeLists.txt
@@ -1,5 +1,8 @@
 set(the_description "Contributed/Experimental Algorithms for Salient 2D Features Detection")
 
+if(HAVE_CUDA)
+  ocv_warnings_disable(CMAKE_CXX_FLAGS -Wundef)
+endif()
 ocv_define_module(xfeatures2d opencv_core opencv_imgproc opencv_features2d opencv_calib3d OPTIONAL opencv_shape opencv_ml opencv_cudaarithm WRAP python java)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/download_vgg.cmake)


### PR DESCRIPTION
### This pullrequest changes
  - removes noisy warning outside OpenCV
```
[ 40%] Building NVCC (Device) object modules/hfs/CMakeFiles/cuda_compile_1.dir/src/cuda/cuda_compile_1_generated_magnitude.cu.o
In file included from /usr/local/cuda/include/crt/common_functions.h:267:0,
                 from /usr/local/cuda/include/cuda_runtime.h:120,
                 from <command-line>:0:
/usr/local/cuda/include/crt/math_functions.h:8929:5: warning: "_GLIBCXX_HAVE_OBSOLETE_ISNAN" is not defined, evaluates to 0 [-Wundef]
 #if _GLIBCXX_HAVE_OBSOLETE_ISNAN && !_GLIBCXX_NO_OBSOLETE_ISINF_ISNAN_DYNAMIC
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

```
[ 48%] Building NVCC (Device) object modules/xfeatures2d/CMakeFiles/cuda_compile_1.dir/src/cuda/cuda_compile_1_generated_surf.cu.o
In file included from /usr/local/cuda/include/crt/common_functions.h:267:0,
                 from /usr/local/cuda/include/cuda_runtime.h:120,
                 from <command-line>:0:
/usr/local/cuda/include/crt/math_functions.h:8929:5: warning: "_GLIBCXX_HAVE_OBSOLETE_ISNAN" is not defined, evaluates to 0 [-Wundef]
 #if _GLIBCXX_HAVE_OBSOLETE_ISNAN && !_GLIBCXX_NO_OBSOLETE_ISINF_ISNAN_DYNAMIC
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

```
force_builders=Custom
buildworker:Custom=linux-1,linux-2,linux-4
docker_image:Custom=ubuntu-cuda:16.04
```