### PR TITLE
cmake: fix tesseract detection

### DIFF
--- a/modules/text/CMakeLists.txt
+++ b/modules/text/CMakeLists.txt
@@ -1,23 +1,20 @@
 set(the_description "Text Detection and Recognition")
-ocv_define_module(text opencv_ml opencv_imgproc opencv_core opencv_features2d opencv_dnn OPTIONAL opencv_highgui WRAP python java)
+set(__extra_deps "")
+if(DEBUG_opencv_text)
+  list(APPEND __extra_deps PRIVATE opencv_highgui)
+endif()
 
-if(NOT CMAKE_CROSSCOMPILING OR OPENCV_FIND_TESSERACT)
-  find_package(Tesseract QUIET)  # Prefer CMake's standard locations (including Tesseract_DIR)
-  if(NOT Tesseract_FOUND)
-    include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindTesseract.cmake")  # OpenCV's fallback
-  endif()
-  if(Tesseract_FOUND)
-    if(Tesseract_VERSION)
-      message(STATUS "Tesseract:   YES (ver ${Tesseract_VERSION})")
-    else()
-      message(STATUS "Tesseract:   YES (ver unknown)")
-    endif()
-    set(HAVE_TESSERACT 1)
-    ocv_include_directories(${Tesseract_INCLUDE_DIRS})
-    ocv_target_link_libraries(${the_module} ${Tesseract_LIBRARIES})
-  else()
-    message(STATUS "Tesseract:   NO")
-  endif()
+ocv_define_module(text
+    opencv_ml opencv_imgproc opencv_core opencv_features2d opencv_dnn
+    ${__extra_deps}
+    WRAP
+      python
+      java
+)
+
+if(HAVE_TESSERACT)
+  ocv_include_directories(${Tesseract_INCLUDE_DIRS})
+  ocv_target_link_libraries(${the_module} ${Tesseract_LIBRARIES})
 endif()
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/text_config.hpp.in

--- a/modules/text/cmake/checks/tesseract_test.cpp
+++ b/modules/text/cmake/checks/tesseract_test.cpp
@@ -1,0 +1,12 @@
+#if !defined(USE_STD_NAMESPACE)
+#define USE_STD_NAMESPACE
+#endif
+#include <tesseract/baseapi.h>
+#include <tesseract/resultiterator.h>
+
+static void test()
+{
+    tesseract::TessBaseAPI tess;
+}
+
+int main() { test(); return 0; }

--- a/modules/text/cmake/init.cmake
+++ b/modules/text/cmake/init.cmake
@@ -1,0 +1,39 @@
+OCV_OPTION(WITH_TESSERACT "Include Tesseract OCR library support" (NOT CMAKE_CROSSCOMPILING)
+  VERIFY HAVE_TESSERACT)
+
+if(NOT HAVE_TESSERACT
+    AND (WITH_TESSERACT OR OPENCV_FIND_TESSERACT)
+)
+  if(NOT Tesseract_FOUND)
+    find_package(Tesseract QUIET)  # Prefer CMake's standard locations (including Tesseract_DIR)
+  endif()
+  if(NOT Tesseract_FOUND)
+    include("${CMAKE_CURRENT_LIST_DIR}/FindTesseract.cmake")  # OpenCV's fallback
+  endif()
+  if(Tesseract_FOUND)
+    if(Tesseract_VERSION)
+      message(STATUS "Tesseract:   YES (ver ${Tesseract_VERSION})")
+    else()
+      message(STATUS "Tesseract:   YES (ver unknown)")
+    endif()
+    if(NOT ENABLE_CXX11 AND NOT OPENCV_SKIP_TESSERACT_BUILD_CHECK)
+      try_compile(__VALID_TESSERACT
+        "${OpenCV_BINARY_DIR}/cmake_check/tesseract"
+        "${CMAKE_CURRENT_LIST_DIR}/checks/tesseract_test.cpp"
+        CMAKE_FLAGS "-DINCLUDE_DIRECTORIES:STRING=${Tesseract_INCLUDE_DIRS}"
+        LINK_LIBRARIES ${Tesseract_LIBRARIES}
+        OUTPUT_VARIABLE TRY_OUT
+        )
+      if(NOT __VALID_TESSERACT)
+        if(OPENCV_DEBUG_TESSERACT_BUILD)
+          message(STATUS "${TRY_OUT}")
+        endif()
+        message(STATUS "Can't use Tesseract (details: https://github.com/opencv/opencv_contrib/pull/2220)")
+        return()
+      endif()
+    endif()
+    set(HAVE_TESSERACT 1)
+  else()
+    message(STATUS "Tesseract:   NO")
+  endif()
+endif()


### PR DESCRIPTION
resolves #1378

tesseract 4.x headers require C++11 (can't be used by OpenCV 3.4 without C++11)

Workaround:
- (OpenCV 3.4.x) build in C++11 mode: `cmake -DENABLE_CXX11=ON ...`

Debug:
- `cmake -DOPENCV_DEBUG_TESSERACT_BUILD=1 ...`

<cut/>

<details>

Error messages:

> In file included from /build/precommit_macosx/3.4/opencv_contrib/modules/text/src/ocr_tesseract.cpp:55:
In file included from /usr/local/Cellar/tesseract/4.1.0/include/tesseract/baseapi.h:26:
In file included from /usr/local/Cellar/tesseract/4.1.0/include/tesseract/apitypes.h:23:
/usr/local/Cellar/tesseract/4.1.0/include/tesseract/publictypes.h:33:1: error: unknown type name 'constexpr'
constexpr int kPointsPerInch = 72;
^
/usr/local/Cellar/tesseract/4.1.0/include/tesseract/publictypes.h:33:11: error: expected unqualified-id
constexpr int kPointsPerInch = 72;

</details>

```
opencv=build_warnings_xcode_10_3
```