### PR TITLE
Fixed bug in BTVL1 superres with UMat without OpenCL initialization

### DIFF
--- a/modules/superres/src/super_resolution.cpp
+++ b/modules/superres/src/super_resolution.cpp
@@ -63,7 +63,7 @@ void cv::superres::SuperResolution::nextFrame(OutputArray frame)
 {
     CV_INSTRUMENT_REGION();
 
-    isUmat_ = frame.isUMat();
+    isUmat_ = frame.isUMat() && cv::ocl::useOpenCL();
 
     if (firstCall_)
     {


### PR DESCRIPTION
Resolves #2221
