### PR TITLE
Merge 3.4

### DIFF
--- a/modules/cudalegacy/include/opencv2/cudalegacy/NPP_staging.hpp
+++ b/modules/cudalegacy/include/opencv2/cudalegacy/NPP_staging.hpp
@@ -72,7 +72,7 @@ CV_EXPORTS
 cudaStream_t nppStSetActiveCUDAstream(cudaStream_t cudaStream);
 
 
-/*@}*/
+/** @} */
 
 
 /** \defgroup nppi NPPST Image Processing
@@ -787,7 +787,7 @@ NCVStatus nppiStSqrIntegral_8u64u_C1R_host(Ncv8u *h_src, Ncv32u srcStep,
                                            Ncv64u *h_dst, Ncv32u dstStep, NcvSize32u roiSize);
 
 
-/*@}*/
+/** @} */
 
 
 /** \defgroup npps NPPST Signal Processing
@@ -899,8 +899,8 @@ NCVStatus nppsStCompact_32f_host(Ncv32f *h_src, Ncv32u srcLen,
                                  Ncv32f *h_dst, Ncv32u *dstLen, Ncv32f elemRemove);
 
 
-/*@}*/
+/** @} */
 
-//! @}
+//! @} cudalegacy
 
 #endif // _npp_staging_hpp_


### PR DESCRIPTION
update moved code from 'opencv' repository

Main PR: https://github.com/opencv/opencv/pull/15460
Previous "Merge 3.4": #2243

<cut/>

```
force_builders=Custom
buildworker:Custom=linux-1,linux-2,linux-4
build_image:Custom=ubuntu-cuda:16.04
```
