### PR TITLE
Fix MultiTrackerTLD::update tracking bug

### DIFF
--- a/modules/tracking/src/multiTracker.cpp
+++ b/modules/tracking/src/multiTracker.cpp
@@ -75,11 +75,11 @@ namespace cv
 
     bool MultiTracker_Alt::update(InputArray image)
 	{
+ 		bool result = true;
 		for (int i = 0; i < (int)trackers.size(); i++)
-			if (!trackers[i]->update(image, boundingBoxes[i]))
-				return false;
+			result &= trackers[i]->update(image, boundingBoxes[i]);
 
-		return true;
+		return result;
 	}
 
 	//Multitracker TLD


### PR DESCRIPTION
Fixed a bug where one sub-tracker losing track of an object would result in other trackers not being updated