### PR TITLE
Ensures that l0smooth input arguments are valid

### DIFF
--- a/modules/ximgproc/src/l0_smooth.cpp
+++ b/modules/ximgproc/src/l0_smooth.cpp
@@ -252,6 +252,8 @@ namespace cv
             CV_Assert(!S.empty());
             CV_Assert(S.depth() == CV_8U || S.depth() == CV_16U
             || S.depth() == CV_32F || S.depth() == CV_64F);
+            CV_Assert(lambda > 0.0);
+            CV_Assert(kappa > 1.0);
 
             dst.create(src.size(), src.type());
 


### PR DESCRIPTION

### This pullrequest changes

Adds two asserts to ensure that the input arguments 'lambda' and 'kappa' are valid.
If 'lambda <= 0' or 'kappa <= 1.0', the stop condition for the solver is never met because beta would not be increasing.