### PR TITLE
[cudalegacy] Fix warnings about tautologies

### DIFF
--- a/modules/cudalegacy/src/cuda/NCVHaarObjectDetection.cu
+++ b/modules/cudalegacy/src/cuda/NCVHaarObjectDetection.cu
@@ -1414,7 +1414,7 @@ NCVStatus ncvGrowDetectionsVector_device(NCVVector<Ncv32u> &pixelMask,
 
     ncvAssertReturn(totalMaxDetections <= hypotheses.length() &&
                     numPixelMaskDetections <= pixelMask.length() &&
-                    totalMaxDetections <= totalMaxDetections, NCV_INCONSISTENT_INPUT);
+                    totalDetections <= totalMaxDetections, NCV_INCONSISTENT_INPUT);
 
     NCVStatus ncvStat = NCV_SUCCESS;
     Ncv32u numDetsToCopy = numPixelMaskDetections;
@@ -1994,7 +1994,7 @@ NCVStatus ncvGrowDetectionsVector_host(NCVVector<Ncv32u> &pixelMask,
     ncvAssertReturn(curScale > 0, NCV_INVALID_SCALE);
     ncvAssertReturn(totalMaxDetections <= hypotheses.length() &&
                     numPixelMaskDetections <= pixelMask.length() &&
-                    totalMaxDetections <= totalMaxDetections, NCV_INCONSISTENT_INPUT);
+                    totalDetections <= totalMaxDetections, NCV_INCONSISTENT_INPUT);
 
     NCVStatus ncvStat = NCV_SUCCESS;
     Ncv32u numDetsToCopy = numPixelMaskDetections;


### PR DESCRIPTION
### This pullrequest changes
[cudalegacy] Possibly fix assertion to use something more meaningful `totalDetections <= totalMaxDetections`

```
force_builders=Custom
buildworker:Custom=linux-4
build_image:Custom=ubuntu-cuda:18.04
```