### PR TITLE
Build DoG Pyramid if useProvideKeypoints is false

### DIFF
--- a/modules/xfeatures2d/src/sift.cpp
+++ b/modules/xfeatures2d/src/sift.cpp
@@ -1151,13 +1151,13 @@ void SIFT_Impl::detectAndCompute(InputArray _image, InputArray _mask,
     //double t, tf = getTickFrequency();
     //t = (double)getTickCount();
     buildGaussianPyramid(base, gpyr, nOctaves);
-    buildDoGPyramid(gpyr, dogpyr);
-
+    
     //t = (double)getTickCount() - t;
     //printf("pyramid construction time: %g\n", t*1000./tf);
 
     if( !useProvidedKeypoints )
     {
+        buildDoGPyramid(gpyr, dogpyr);
         //t = (double)getTickCount();
         findScaleSpaceExtrema(gpyr, dogpyr, keypoints);
         KeyPointsFilter::removeDuplicatedSorted( keypoints );


### PR DESCRIPTION
The buildDoGPyramid operation need not be performed unconditionally. In cases where it is not needed, both memory and speed performance can be improved

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #2238 
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing
Building the DoG Pyramid conditionally
-->
