### PR TITLE
Build DoG Pyramid if useProvideKeypoints is false

### DIFF
--- a/modules/xfeatures2d/src/sift.cpp
+++ b/modules/xfeatures2d/src/sift.cpp
@@ -1153,13 +1153,13 @@ void SIFT_Impl::detectAndCompute(InputArray _image, InputArray _mask,
     //double t, tf = getTickFrequency();
     //t = (double)getTickCount();
     buildGaussianPyramid(base, gpyr, nOctaves);
-    buildDoGPyramid(gpyr, dogpyr);
 
     //t = (double)getTickCount() - t;
     //printf("pyramid construction time: %g\n", t*1000./tf);
 
     if( !useProvidedKeypoints )
     {
+        buildDoGPyramid(gpyr, dogpyr);
         //t = (double)getTickCount();
         findScaleSpaceExtrema(gpyr, dogpyr, keypoints);
         KeyPointsFilter::removeDuplicatedSorted( keypoints );

--- a/modules/xfeatures2d/src/sift.cpp
+++ b/modules/xfeatures2d/src/sift.cpp
@@ -1147,7 +1147,7 @@ void SIFT_Impl::detectAndCompute(InputArray _image, InputArray _mask,
     }
 
     Mat base = createInitialImage(image, firstOctave < 0, (float)sigma);
-    std::vector<Mat> gpyr, dogpyr;
+    std::vector<Mat> gpyr;
     int nOctaves = actualNOctaves > 0 ? actualNOctaves : cvRound(std::log( (double)std::min( base.cols, base.rows ) ) / std::log(2.) - 2) - firstOctave;
 
     //double t, tf = getTickFrequency();
@@ -1159,6 +1159,7 @@ void SIFT_Impl::detectAndCompute(InputArray _image, InputArray _mask,
 
     if( !useProvidedKeypoints )
     {
+        std::vector<Mat> dogpyr;
         buildDoGPyramid(gpyr, dogpyr);
         //t = (double)getTickCount();
         findScaleSpaceExtrema(gpyr, dogpyr, keypoints);


### PR DESCRIPTION
The buildDoGPyramid operation need not be performed unconditionally. In cases where it is not needed, both memory and speed performance can be improved

resolves #2238 

### This pullrequest changes

Build DoG Pyramid conditionally during detectAndCompute in SIFT
