### PR TITLE
Fix memory corruption in RgbdPlane

### DIFF
--- a/modules/rgbd/src/plane.cpp
+++ b/modules/rgbd/src/plane.cpp
@@ -584,8 +584,8 @@ private:
         plane = Ptr<PlaneBase>(new PlaneABC(plane_grid.m_(y, x), n, (int)index_plane,
 			(float)sensor_error_a_, (float)sensor_error_b_, (float)sensor_error_c_));
 
-      Mat_<unsigned char> plane_mask = Mat_<unsigned char>::zeros((points3d.rows + block_size_ - 1) / block_size_,
-                                                                  (points3d.cols + block_size_ - 1) / block_size_);
+      Mat_<unsigned char> plane_mask = Mat_<unsigned char>::zeros(divUp(points3d.rows, block_size_),
+                                                                  divUp(points3d.cols, block_size_));
       std::set<TileQueue::PlaneTile> neighboring_tiles;
       neighboring_tiles.insert(front_tile);
       plane_queue.remove(front_tile.y_, front_tile.x_);

--- a/modules/rgbd/src/plane.cpp
+++ b/modules/rgbd/src/plane.cpp
@@ -584,8 +584,8 @@ private:
         plane = Ptr<PlaneBase>(new PlaneABC(plane_grid.m_(y, x), n, (int)index_plane,
 			(float)sensor_error_a_, (float)sensor_error_b_, (float)sensor_error_c_));
 
-      Mat_<unsigned char> plane_mask = Mat_<unsigned char>::zeros(points3d.rows / block_size_,
-                                                                          points3d.cols / block_size_);
+      Mat_<unsigned char> plane_mask = Mat_<unsigned char>::zeros((points3d.rows + block_size_ - 1) / block_size_,
+                                                                  (points3d.cols + block_size_ - 1) / block_size_);
       std::set<TileQueue::PlaneTile> neighboring_tiles;
       neighboring_tiles.insert(front_tile);
       plane_queue.remove(front_tile.y_, front_tile.x_);

--- a/modules/rgbd/test/test_normal.cpp
+++ b/modules/rgbd/test/test_normal.cpp
@@ -470,4 +470,15 @@ TEST(Rgbd_Plane, compute)
   test.safe_run();
 }
 
+TEST(Rgbd_Plane, regression_2309_valgrind_check)
+{
+    Mat points(640, 480, CV_32FC3, Scalar::all(0));
+    rgbd::RgbdPlane plane_detector;
+    plane_detector.setBlockSize(9);  // Note, 640%9 is 1 and 480%9 is 3
+
+    Mat mask;
+    std::vector<cv::Vec4f> planes;
+    plane_detector(points, mask, planes);  // Will corrupt memory; valgrind gets triggered
+}
+
 }} // namespace


### PR DESCRIPTION
Hi there!

This PR fixes memory corruption that happens when a block size is not a multiplier of the width and the height.
In this case, traversing over the grid goes beyond an allocated matrix and corrupts memory.
This change makes sure that grid cells are allocated for the remainder after dividing the width and/or the height by a block size, just like it's done here: https://github.com/deni64k/opencv_contrib/blob/7288772fdf973eef9e756c41bf775b7cc7c9aa4d/modules/rgbd/src/plane.cpp#L205.