### PR TITLE
fix memset error in CombinedDescriptor

### DIFF
--- a/modules/stereo/include/opencv2/stereo/descriptor.hpp
+++ b/modules/stereo/include/opencv2/stereo/descriptor.hpp
@@ -222,7 +222,7 @@ namespace cv
                     for (int j = n2 + 2; j <= width - n2 - 2; j++)
                     {
                         int c[nr_img];
-                        memset(c,0,nr_img);
+                        memset(c, 0, sizeof(c[0]) * nr_img);
                         for(int step = step_start; step <= step_end; step += step_inc)
                         {
                             for (int ii = - n2; ii <= + n2_stop; ii += step)


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->

the c array stores the element of binary descriptor, and its all bits should be init as 0.
the origin code will only set lowest 1 byte of c[0] if nr_img is 1. However there will be even worse if nr_img large than 1, the higher element of array c will remain uninit.