### PR TITLE
PyrLKOpticalFlowBase::buildImagePyramid() is public

### DIFF
--- a/modules/cudaoptflow/src/pyrlk.cpp
+++ b/modules/cudaoptflow/src/pyrlk.cpp
@@ -89,13 +89,14 @@ namespace
 
         void dense(const GpuMat& prevImg, const GpuMat& nextImg, GpuMat& u, GpuMat& v, Stream& stream);
 
+        void buildImagePyramid(const GpuMat& prevImg, std::vector<GpuMat>& prevPyr, const GpuMat& nextImg, std::vector<GpuMat>& nextPyr, Stream stream);
+
     protected:
         int winSize_[2];
         int halfWinSize_[2];
         int maxLevel_;
         int iters_;
         bool useInitialFlow_;
-        void buildImagePyramid(const GpuMat& prevImg, std::vector<GpuMat>& prevPyr, const GpuMat& nextImg, std::vector<GpuMat>& nextPyr, Stream stream);
     private:
         friend class SparsePyrLKOpticalFlowImpl;
         std::vector<GpuMat> prevPyr_;


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->
resolves #2324 

### This pullrequest changes

I have changed the scope of PyrLKOpticalFlowBase::buildImagePyramid() from protected to public. The issue suggested to do SparsePyrLKOpticalFlow::buildImagePyramid() to public or free. AFAICT, SparsePyrLKOpticalFlowImpl is a friend of PyrLKOpticalFlowBase, and hence it is able to access buildImagePyramid(). So if that's the case then making it free is also a good choice. 
Please let me know if I have done or said anything wrong. Thanks. 

<!-- Please describe what your pullrequest is changing -->
