### PR TITLE
Fix cudacodec::VideoReader::nextFrame python bindings

### DIFF
--- a/modules/cudacodec/include/opencv2/cudacodec.hpp
+++ b/modules/cudacodec/include/opencv2/cudacodec.hpp
@@ -302,9 +302,7 @@ public:
     If no frames has been grabbed (there are no more frames in video file), the methods return false .
     The method throws Exception if error occurs.
      */
-    virtual bool nextFrame(OutputArray frame, Stream &stream = Stream::Null()) = 0;
-
-    CV_WRAP inline bool nextFrame(CV_OUT GpuMat& frame, Stream &stream = Stream::Null()) { return nextFrame(OutputArray(frame), stream); }
+    CV_WRAP virtual bool nextFrame(CV_OUT GpuMat& frame, Stream &stream = Stream::Null()) = 0;
 
     /** @brief Returns information about video file format.
     */

--- a/modules/cudacodec/include/opencv2/cudacodec.hpp
+++ b/modules/cudacodec/include/opencv2/cudacodec.hpp
@@ -302,7 +302,9 @@ public:
     If no frames has been grabbed (there are no more frames in video file), the methods return false .
     The method throws Exception if error occurs.
      */
-    CV_WRAP virtual bool nextFrame(CV_GPU OutputArray frame, Stream &stream = Stream::Null()) = 0;
+    virtual bool nextFrame(OutputArray frame, Stream &stream = Stream::Null()) = 0;
+
+    CV_WRAP inline bool nextFrame(CV_OUT GpuMat& frame, Stream &stream = Stream::Null()) { return nextFrame(OutputArray(frame), stream); }
 
     /** @brief Returns information about video file format.
     */

--- a/modules/cudacodec/include/opencv2/cudacodec.hpp
+++ b/modules/cudacodec/include/opencv2/cudacodec.hpp
@@ -302,7 +302,7 @@ public:
     If no frames has been grabbed (there are no more frames in video file), the methods return false .
     The method throws Exception if error occurs.
      */
-    CV_WRAP virtual bool nextFrame(OutputArray frame, Stream &stream = Stream::Null()) = 0;
+    CV_WRAP virtual bool nextFrame(CV_GPU OutputArray frame, Stream &stream = Stream::Null()) = 0;
 
     /** @brief Returns information about video file format.
     */

--- a/modules/cudacodec/src/cuda/nv12_to_rgb.cu
+++ b/modules/cudacodec/src/cuda/nv12_to_rgb.cu
@@ -60,7 +60,7 @@
 using namespace cv;
 using namespace cv::cudev;
 
-void videoDecPostProcessFrame(const GpuMat& decodedFrame, OutputArray _outFrame, int width, int height, cudaStream_t stream);
+void videoDecPostProcessFrame(const GpuMat& decodedFrame, GpuMat& _outFrame, int width, int height, cudaStream_t stream);
 
 namespace
 {
@@ -186,12 +186,11 @@ namespace
     }
 }
 
-void videoDecPostProcessFrame(const GpuMat& decodedFrame, OutputArray _outFrame, int width, int height, cudaStream_t stream)
+void videoDecPostProcessFrame(const GpuMat& decodedFrame, GpuMat& outFrame, int width, int height, cudaStream_t stream)
 {
     // Final Stage: NV12toARGB color space conversion
 
-    _outFrame.create(height, width, CV_8UC4);
-    GpuMat outFrame = _outFrame.getGpuMat();
+    outFrame.create(height, width, CV_8UC4);
 
     dim3 block(32, 8);
     dim3 grid(divUp(width, 2 * block.x), divUp(height, block.y));

--- a/modules/cudacodec/src/video_reader.cpp
+++ b/modules/cudacodec/src/video_reader.cpp
@@ -53,7 +53,7 @@ Ptr<VideoReader> cv::cudacodec::createVideoReader(const Ptr<RawVideoSource>&) { 
 
 #else // HAVE_NVCUVID
 
-void videoDecPostProcessFrame(const GpuMat& decodedFrame, OutputArray _outFrame, int width, int height, cudaStream_t stream);
+void videoDecPostProcessFrame(const GpuMat& decodedFrame, GpuMat& _outFrame, int width, int height, cudaStream_t stream);
 
 using namespace cv::cudacodec::detail;
 
@@ -65,7 +65,7 @@ namespace
         explicit VideoReaderImpl(const Ptr<VideoSource>& source);
         ~VideoReaderImpl();
 
-        bool nextFrame(OutputArray frame, Stream& stream) CV_OVERRIDE;
+        bool nextFrame(GpuMat& frame, Stream& stream) CV_OVERRIDE;
 
         FormatInfo format() const CV_OVERRIDE;
 
@@ -122,7 +122,7 @@ namespace
         CUvideoctxlock m_lock;
     };
 
-    bool VideoReaderImpl::nextFrame(OutputArray frame, Stream& stream)
+    bool VideoReaderImpl::nextFrame(GpuMat& frame, Stream& stream)
     {
         if (videoSource_->hasError() || videoParser_->hasError())
             CV_Error(Error::StsUnsupportedFormat, "Unsupported video source");

--- a/modules/cudacodec/test/test_video.cpp
+++ b/modules/cudacodec/test/test_video.cpp
@@ -123,8 +123,7 @@ CUDA_TEST_P(Video, Writer)
 #endif // _WIN32, HAVE_NVCUVENC
 
 #define VIDEO_SRC "gpu/video/768x576.avi", "gpu/video/1920x1080.avi", "highgui/video/big_buck_bunny.avi", \
-    "highgui/video/big_buck_bunny.h264", "highgui/video/big_buck_bunny.h265", "highgui/video/big_buck_bunny.mpg", \
-    "highgui/video/big_buck_bunny.mpg"
+    "highgui/video/big_buck_bunny.h264", "highgui/video/big_buck_bunny.h265", "highgui/video/big_buck_bunny.mpg"
 INSTANTIATE_TEST_CASE_P(CUDA_Codec, Video, testing::Combine(
     ALL_DEVICES,
     testing::Values(VIDEO_SRC)));


### PR DESCRIPTION
### This pullrequest fixes nextFrame python bindings

Makes the frame argument to cudacodec::VideoReader::nextFrame() optional when called from python.


```
force_builders=Custom
buildworker:Custom=linux-4
build_image:Custom=ubuntu-cuda:18.04
```