### PR TITLE
Patch cv::cudacodec::createVideoReader() memory leak

### DIFF
--- a/modules/cudacodec/src/cuvid_video_source.cpp
+++ b/modules/cudacodec/src/cuvid_video_source.cpp
@@ -62,7 +62,7 @@ cv::cudacodec::detail::CuvidVideoSource::CuvidVideoSource(const String& fname)
     // now create the actual source
     CUresult cuRes = cuvidCreateVideoSource(&videoSource_, fname.c_str(), &params);
     if (cuRes == CUDA_ERROR_INVALID_SOURCE)
-        throw std::runtime_error("");
+        CV_Error(Error::StsUnsupportedFormat, "Unsupported video source");
     cuSafeCall( cuRes );
 
     CUVIDEOFORMAT vidfmt;

--- a/modules/cudacodec/src/video_parser.cpp
+++ b/modules/cudacodec/src/video_parser.cpp
@@ -118,6 +118,7 @@ int CUDAAPI cv::cudacodec::detail::VideoParser::HandleVideoSequence(void* userDa
 
         try
         {
+            thiz->videoDecoder_->release();
             thiz->videoDecoder_->create(newFormat);
         }
         catch (const cv::Exception&)


### PR DESCRIPTION
### This pullrequest changes

Fixes memory leak when `cv::cudacodec::createVideoReader()` is called on a source which needs to be reconfigured during decoding.  This occurs when testing the [1920x1080.avi](https://github.com/opencv/opencv_contrib/blob/7011e1b1cb29af35d0bd526b0060f9d592c40133/modules/cudacodec/test/test_video.cpp#L125) because ffmpeg reports the height as 1080 but the decoder requires a height of 1088.  That said it could happen for different reasons during the decoding of other streams.

This fix is not ideal it would be much better to reconfigure the decoder as performed in the Nvidia [sample code](https://github.com/NVIDIA/video-sdk-samples/blob/aa3544dcea2fe63122e4feb83bf805ea40e58dbe/Samples/NvCodec/NvDecoder/NvDecoder.cpp#L193), however I don't think this is worth the effort because the whole of `cudacodec` should ideally be updated to mirror the sample code.  Therefore I am suggesting this inefficient patch to remove the memory leak until there is time to update `cudacodec` properly.
