### PR TITLE
[Multi TLD] Removed early exit in case of sampling failure

### DIFF
--- a/modules/tracking/src/multiTracker.cpp
+++ b/modules/tracking/src/multiTracker.cpp
@@ -127,6 +127,7 @@ namespace cv
 #endif
 			detect_all(imageForDetector, image_blurred, tmpCandidates, detectorResults, detect_flgs, trackers);
 
+		bool success = false;
 		for (int k = 0; k < targetNum; k++)
 		{
 			//TLD Tracker data extraction
@@ -174,10 +175,11 @@ namespace cv
 
 				data->confident = false;
 				data->failedLastTime = true;
-				return false;
+				continue;
 			}
 			else
 			{
+				success = true;
 				boundingBoxes[k] = candidates[k][it - candidatesRes[k].begin()];
 				data->failedLastTime = false;
 				if (trackerNeedsReInit[k] || it != candidatesRes[k].begin())
@@ -244,7 +246,7 @@ namespace cv
 
 		}
 
-		return true;
+		return success;
 	}
 
 	void detect_all(const Mat& img, const Mat& imgBlurred, std::vector<Rect2d>& res, std::vector < std::vector < tld::TLDDetector::LabeledPatch > > &patches, std::vector<bool> &detect_flgs,


### PR DESCRIPTION
### This pullrequest changes

Minor change in the post-detect loop of `MultiTracker_TLD` to delay early exit in case of low Sc value in NN classification.

Instead of early exit, it continues for all trackers. Return value is `false` in case of failure for all trackers, not just one tracker.
