### PR TITLE
Fixes error occurs in cv::ppf_match_3d::ICP::registerModelToScene()

### DIFF
--- a/modules/surface_matching/src/icp.cpp
+++ b/modules/surface_matching/src/icp.cpp
@@ -281,10 +281,7 @@ int ICP::registerModelToScene(const Mat& srcPC, const Mat& dstPC, double& residu
   // walk the pyramid
   for (int level = m_numLevels-1; level >=0; level--)
   {
-    const double impact = 2;
-    double div = pow((double)impact, (double)level);
-    //double div2 = div*div;
-    const int numSamples = divUp(n, div);
+    const int numSamples = divUp(n, 1 << level);
     const double TolP = m_tolerance*(double)(level+1)*(level+1);
     const int MaxIterationsPyr = cvRound((double)m_maxIterations/(level+1));
 

--- a/modules/surface_matching/src/icp.cpp
+++ b/modules/surface_matching/src/icp.cpp
@@ -246,6 +246,7 @@ static hashtable_int* getHashtable(int* data, size_t length, int numMaxElement)
 int ICP::registerModelToScene(const Mat& srcPC, const Mat& dstPC, double& residual, Matx44d& pose)
 {
   int n = srcPC.rows;
+  CV_CheckGT(n, 0, "");
 
   const bool useRobustReject = m_rejectionScale>0;
 
@@ -283,7 +284,7 @@ int ICP::registerModelToScene(const Mat& srcPC, const Mat& dstPC, double& residu
     const double impact = 2;
     double div = pow((double)impact, (double)level);
     //double div2 = div*div;
-    const int numSamples = cvRound((double)n/(double)div) + 1;
+    const int numSamples = divUp(n, div);
     const double TolP = m_tolerance*(double)(level+1)*(level+1);
     const int MaxIterationsPyr = cvRound((double)m_maxIterations/(level+1));
 
@@ -291,6 +292,7 @@ int ICP::registerModelToScene(const Mat& srcPC, const Mat& dstPC, double& residu
     Mat srcPCT = transformPCPose(srcPC0, pose);
 
     const int sampleStep = cvRound((double)n/(double)numSamples);
+
     srcPCT = samplePCUniform(srcPCT, sampleStep);
     /*
     Tolga Birdal thinks that downsampling the scene points might decrease the accuracy.
@@ -302,7 +304,6 @@ int ICP::registerModelToScene(const Mat& srcPC, const Mat& dstPC, double& residu
     double fval_old=9999999999;
     double fval_perc=0;
     double fval_min=9999999999;
-    // std::cout<<srcPCT.rows<<" "<<srcPCT.cols<<std::endl;
     Mat Src_Moved = srcPCT.clone();
 
     int i=0;
@@ -327,6 +328,7 @@ int ICP::registerModelToScene(const Mat& srcPC, const Mat& dstPC, double& residu
     while ( (!(fval_perc<(1+TolP) && fval_perc>(1-TolP))) && i<MaxIterationsPyr)
     {
       uint di=0, selInd = 0;
+
       queryPCFlann(flann, Src_Moved, Indices, Distances);
 
       for (di=0; di<numElSrc; di++)

--- a/modules/surface_matching/src/icp.cpp
+++ b/modules/surface_matching/src/icp.cpp
@@ -283,7 +283,7 @@ int ICP::registerModelToScene(const Mat& srcPC, const Mat& dstPC, double& residu
     const double impact = 2;
     double div = pow((double)impact, (double)level);
     //double div2 = div*div;
-    const int numSamples = cvRound((double)(n/(div)));
+    const int numSamples = cvRound((double)n/(double)div) + 1;
     const double TolP = m_tolerance*(double)(level+1)*(level+1);
     const int MaxIterationsPyr = cvRound((double)m_maxIterations/(level+1));
 
@@ -291,7 +291,6 @@ int ICP::registerModelToScene(const Mat& srcPC, const Mat& dstPC, double& residu
     Mat srcPCT = transformPCPose(srcPC0, pose);
 
     const int sampleStep = cvRound((double)n/(double)numSamples);
-
     srcPCT = samplePCUniform(srcPCT, sampleStep);
     /*
     Tolga Birdal thinks that downsampling the scene points might decrease the accuracy.
@@ -303,6 +302,7 @@ int ICP::registerModelToScene(const Mat& srcPC, const Mat& dstPC, double& residu
     double fval_old=9999999999;
     double fval_perc=0;
     double fval_min=9999999999;
+    // std::cout<<srcPCT.rows<<" "<<srcPCT.cols<<std::endl;
     Mat Src_Moved = srcPCT.clone();
 
     int i=0;
@@ -327,7 +327,6 @@ int ICP::registerModelToScene(const Mat& srcPC, const Mat& dstPC, double& residu
     while ( (!(fval_perc<(1+TolP) && fval_perc>(1-TolP))) && i<MaxIterationsPyr)
     {
       uint di=0, selInd = 0;
-
       queryPCFlann(flann, Src_Moved, Indices, Distances);
 
       for (di=0; di<numElSrc; di++)

--- a/modules/surface_matching/src/ppf_helpers.cpp
+++ b/modules/surface_matching/src/ppf_helpers.cpp
@@ -250,7 +250,7 @@ void writePLYVisibleNormals(Mat PC, const char* FileName)
 
 Mat samplePCUniform(Mat PC, int sampleStep)
 {
-  int numRows = cvRound((double)PC.rows/(double)sampleStep);
+  int numRows = PC.rows/sampleStep;
   Mat sampledPC = Mat(numRows, PC.cols, PC.type());
 
   int c=0;
@@ -280,7 +280,7 @@ Mat samplePCUniformInd(Mat PC, int sampleStep, std::vector<int> &indices)
 
 void* indexPCFlann(Mat pc)
 {
-  Mat dest_32f = Mat(pc.rows, 4, pc.type());
+  Mat dest_32f;
   pc.colRange(0,3).copyTo(dest_32f);
   return new FlannIndex(dest_32f, cvflann::KDTreeSingleIndexParams(8));
 }
@@ -298,7 +298,7 @@ void queryPCFlann(void* flannIndex, Mat& pc, Mat& indices, Mat& distances)
 
 void queryPCFlann(void* flannIndex, Mat& pc, Mat& indices, Mat& distances, const int numNeighbors)
 {
-  Mat obj_32f = Mat(pc.rows, 4, pc.type());
+  Mat obj_32f;
   pc.colRange(0, 3).copyTo(obj_32f);
   ((FlannIndex*)flannIndex)->knnSearch(obj_32f, indices, distances, numNeighbors, cvflann::SearchParams(32));
 }

--- a/modules/surface_matching/src/ppf_helpers.cpp
+++ b/modules/surface_matching/src/ppf_helpers.cpp
@@ -250,7 +250,7 @@ void writePLYVisibleNormals(Mat PC, const char* FileName)
 
 Mat samplePCUniform(Mat PC, int sampleStep)
 {
-  int numRows = PC.rows/sampleStep;
+  int numRows = cvRound((double)PC.rows/(double)sampleStep);
   Mat sampledPC = Mat(numRows, PC.cols, PC.type());
 
   int c=0;
@@ -280,7 +280,7 @@ Mat samplePCUniformInd(Mat PC, int sampleStep, std::vector<int> &indices)
 
 void* indexPCFlann(Mat pc)
 {
-  Mat dest_32f;
+  Mat dest_32f = Mat(pc.rows, 4, pc.type());
   pc.colRange(0,3).copyTo(dest_32f);
   return new FlannIndex(dest_32f, cvflann::KDTreeSingleIndexParams(8));
 }
@@ -298,7 +298,7 @@ void queryPCFlann(void* flannIndex, Mat& pc, Mat& indices, Mat& distances)
 
 void queryPCFlann(void* flannIndex, Mat& pc, Mat& indices, Mat& distances, const int numNeighbors)
 {
-  Mat obj_32f;
+  Mat obj_32f = Mat(pc.rows, 4, pc.type());
   pc.colRange(0, 3).copyTo(obj_32f);
   ((FlannIndex*)flannIndex)->knnSearch(obj_32f, indices, distances, numNeighbors, cvflann::SearchParams(32));
 }


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->
Fixes https://github.com/opencv/opencv_contrib/issues/2339
### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
This PR tries to fix the out of range error that occurs due to `numSamples=0` and hence `sampleStep` becomes `INT_MIN` which is the root cause of all the errors.