### PR TITLE
Merge 3.4

### DIFF
--- a/modules/cudev/test/CMakeLists.txt
+++ b/modules/cudev/test/CMakeLists.txt
@@ -16,7 +16,7 @@ if(OCV_DEPENDENCIES_FOUND)
   ocv_cuda_filter_options()
 
   CUDA_ADD_EXECUTABLE(${the_target} ${OPENCV_TEST_${the_module}_SOURCES} OPTIONS -std=c++11)
-  ocv_target_link_libraries(${the_target} LINK_PRIVATE
+  ocv_target_link_libraries(${the_target} PRIVATE
       ${test_deps} ${OPENCV_LINKER_LIBS} ${CUDA_LIBRARIES}
   )
   add_dependencies(opencv_tests ${the_target})

--- a/modules/viz/CMakeLists.txt
+++ b/modules/viz/CMakeLists.txt
@@ -35,10 +35,10 @@ ocv_add_accuracy_tests()
 ocv_add_perf_tests()
 ocv_add_samples(opencv_imgproc opencv_calib3d opencv_features2d opencv_flann)
 
-ocv_target_link_libraries(${the_module} LINK_PRIVATE ${VTK_LIBRARIES})
+ocv_target_link_libraries(${the_module} PRIVATE ${VTK_LIBRARIES})
 
 if(APPLE AND BUILD_opencv_viz)
-  ocv_target_link_libraries(${the_module} LINK_PRIVATE "-framework Cocoa")
+  ocv_target_link_libraries(${the_module} PRIVATE "-framework Cocoa")
 endif()
 
 if(TARGET opencv_test_viz)

--- a/modules/ximgproc/test/test_slic.cpp
+++ b/modules/ximgproc/test/test_slic.cpp
@@ -1,0 +1,22 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+#include "test_precomp.hpp"
+
+namespace opencv_test { namespace {
+
+TEST(ximgproc_SuperpixelSLIC, smoke)
+{
+    Mat img = imread(cvtest::findDataFile("cv/shared/lena.png"), IMREAD_COLOR);
+    Mat labImg;
+    cvtColor(img, labImg, COLOR_BGR2Lab);
+    Ptr< SuperpixelSLIC> slic = createSuperpixelSLIC(labImg);
+    slic->iterate(5);
+    Mat outLabels;
+    slic->getLabels(outLabels);
+    EXPECT_FALSE(outLabels.empty());
+    int numSuperpixels = slic->getNumberOfSuperpixels();
+    EXPECT_GT(numSuperpixels, 0);
+}
+
+}} // namespace


### PR DESCRIPTION
[move from opencv] opencv/opencv#16150 from alalek:cmake_avoid_deprecated_link_private
#2387 from alalek:fix_ximgproc_slic_empty_mat

Main PR: https://github.com/opencv/opencv/pull/16167
Previous "Merge 3.4": #2384

<cut/>

```
force_builders=Custom
buildworker:Custom=linux-4
build_image:Custom=ubuntu-cuda:18.04
```
