### PR TITLE
Fix cuda merge and split python bindings

### DIFF
--- a/modules/cudaarithm/include/opencv2/cudaarithm.hpp
+++ b/modules/cudaarithm/include/opencv2/cudaarithm.hpp
@@ -438,7 +438,7 @@ CV_EXPORTS_W void polarToCart(InputArray magnitude, InputArray angle, OutputArra
 
 @sa merge
  */
-CV_EXPORTS_W void merge(const GpuMat* src, size_t n, OutputArray dst, Stream& stream = Stream::Null());
+CV_EXPORTS void merge(const GpuMat* src, size_t n, OutputArray dst, Stream& stream = Stream::Null());
 /** @overload */
 CV_EXPORTS_W void merge(const std::vector<GpuMat>& src, OutputArray dst, Stream& stream = Stream::Null());
 
@@ -450,9 +450,9 @@ CV_EXPORTS_W void merge(const std::vector<GpuMat>& src, OutputArray dst, Stream&
 
 @sa split
  */
-CV_EXPORTS_W void split(InputArray src, GpuMat* dst, Stream& stream = Stream::Null());
+CV_EXPORTS void split(InputArray src, GpuMat* dst, Stream& stream = Stream::Null());
 /** @overload */
-CV_EXPORTS_W void split(InputArray src, std::vector<GpuMat>& dst, Stream& stream = Stream::Null());
+CV_EXPORTS_W void split(InputArray src, CV_OUT std::vector<GpuMat>& dst, Stream& stream = Stream::Null());
 
 /** @brief Transposes a matrix.
 


### PR DESCRIPTION
### This pullrequest changes

The python bindings for merge and split which are inconsistent with the format of existing cuda python functions.  Currently `cv.cuda.split()` does not return its output and the documentation for `cv.cuda.merge(`) is incorrect.

Tests to confirm this fix will be added to the opencv repository.

<cut/>

```
force_builders=Custom
buildworker:Custom=linux-4
build_image:Custom=ubuntu-cuda:18.04
```
