### PR TITLE
Fix build of dnn_superres module without the quality module

### DIFF
--- a/modules/dnn_superres/CMakeLists.txt
+++ b/modules/dnn_superres/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(the_description "Super Resolution using CNNs")
 
 ocv_define_module(dnn_superres opencv_core opencv_imgproc opencv_dnn
-    OPTIONAL opencv_datasets opencv_quality # samples
+    OPTIONAL opencv_quality # samples
 )

--- a/modules/dnn_superres/include/opencv2/dnn_superres.hpp
+++ b/modules/dnn_superres/include/opencv2/dnn_superres.hpp
@@ -49,11 +49,7 @@ private:
 
     int sc; //scale factor
 
-    void preprocess(InputArray inpImg, OutputArray outpImg);
-
     void reconstruct_YCrCb(InputArray inpImg, InputArray origImg, OutputArray outpImg, int scale);
-
-    void reconstruct_YCrCb(InputArray inpImg, InputArray origImg, OutputArray outpImg);
 
     void preprocess_YCrCb(InputArray inpImg, OutputArray outpImg);
 

--- a/modules/dnn_superres/samples/dnn_superres_benchmark_quality.cpp
+++ b/modules/dnn_superres/samples/dnn_superres_benchmark_quality.cpp
@@ -3,7 +3,9 @@
 // of this distribution and at http://opencv.org/license.html.
 
 #include <iostream>
+#include <opencv2/opencv_modules.hpp>
 
+#ifdef HAVE_OPENCV_QUALITY
 #include <opencv2/dnn_superres.hpp>
 #include <opencv2/quality.hpp>
 #include <opencv2/imgproc.hpp>
@@ -197,3 +199,10 @@ int main(int argc, char *argv[])
 
     return 0;
 }
+#else
+int main()
+{
+    std::cout << "This sample requires the OpenCV Quality module." << std::endl;
+    return 0;
+}
+#endif

--- a/modules/dnn_superres/samples/dnn_superres_benchmark_time.cpp
+++ b/modules/dnn_superres/samples/dnn_superres_benchmark_time.cpp
@@ -5,7 +5,6 @@
 #include <iostream>
 
 #include <opencv2/dnn_superres.hpp>
-#include <opencv2/quality.hpp>
 #include <opencv2/imgproc.hpp>
 #include <opencv2/highgui.hpp>
 

--- a/modules/ximgproc/samples/colorize.cpp
+++ b/modules/ximgproc/samples/colorize.cpp
@@ -159,7 +159,7 @@ int main(int argc, char* argv[])
             if(show_count%5==0)
             {
                 cv::Mat target_temp(target.size(),target.type());
-                filtering_time = (double)getTickCount();
+                filtering_time = static_cast<float>(getTickCount());
                 if(mouseDraw)
                 {
                     cv::cvtColor(target, target_temp, cv::COLOR_BGR2YCrCb);
@@ -184,7 +184,7 @@ int main(int argc, char* argv[])
                 {
                   target_temp = target.clone();
                 }
-                filtering_time = ((double)getTickCount() - filtering_time)/getTickFrequency();
+                filtering_time = static_cast<float>(((double)getTickCount() - filtering_time)/getTickFrequency());
                 std::cout << "solver time: " << filtering_time << "s" << std::endl;
 
                 cv::Mat color_selected(target_temp.rows-mat_pallet.rows,PALLET_RADIUS*2,CV_8UC3,cv::Scalar(selected_b, selected_g, selected_r));
@@ -209,7 +209,7 @@ int main(int argc, char* argv[])
     cv::Mat result1 = cv::Mat(mat_input_gray.size(),mat_input_gray.type());
     cv::Mat result2 = cv::Mat(mat_input_gray.size(),mat_input_gray.type());
 
-    filtering_time = (double)getTickCount();
+    filtering_time = static_cast<float>(getTickCount());
 
     // dst_channels.push_back(src_channels[0]);
     dst_channels.push_back(mat_input_gray);
@@ -221,7 +221,7 @@ int main(int argc, char* argv[])
     cv::merge(dst_channels,target);
     cv::cvtColor(target, target, cv::COLOR_YCrCb2BGR);
 
-    filtering_time = ((double)getTickCount() - filtering_time)/getTickFrequency();
+    filtering_time = static_cast<float>(((double)getTickCount() - filtering_time)/getTickFrequency());
     std::cout << "solver time: " << filtering_time << "s" << std::endl;
 
 
@@ -331,7 +331,7 @@ void drawTrajectoryByReference(cv::Mat& img)
                 gray = *grayPix;
                 grayPix++;
                 mat_input_confidence.at<uchar>(y,x) = 255;
-                float draw_y = 0.229*(float(selected_r)) + 0.587*(float(selected_g)) + 0.114*(float(selected_b));
+                float draw_y = 0.229f*(float(selected_r)) + 0.587f*(float(selected_g)) + 0.114f*(float(selected_b));
                 int draw_b = int(float(selected_b)*(gray/draw_y));
                 int draw_g = int(float(selected_g)*(gray/draw_y));
                 int draw_r = int(float(selected_r)*(gray/draw_y));
@@ -397,13 +397,13 @@ void createPlate(Mat &im1, int radius)
 			Point pt2(j - cx, i - cy);
 			if (inCircle(Point(0, 0), pt2, radius))
 			{
-				int theta = angle(pt1, pt2) * 180 / CV_PI;
+				int theta = static_cast<int>(angle(pt1, pt2) * 180 / CV_PI);
 				if (i > cx)
 				{
 					theta = -theta + 360;
 				}
-				hsvImag.at<Vec3b>(i, j)[0] = theta / 2;
-				hsvImag.at<Vec3b>(i, j)[1] = module(pt2) / cx * 255;
+				hsvImag.at<Vec3b>(i, j)[0] = saturate_cast<uchar>(theta / 2);
+				hsvImag.at<Vec3b>(i, j)[1] = saturate_cast<uchar>(module(pt2) / cx * 255);
 				hsvImag.at<Vec3b>(i, j)[2] = 255;
 			}
 		}

--- a/modules/ximgproc/src/fbs_filter.cpp
+++ b/modules/ximgproc/src/fbs_filter.cpp
@@ -186,8 +186,8 @@ namespace ximgproc
             bs_params()
             {
                 lam = 128.0;
-                A_diag_min = 1e-5;
-                cg_tol = 1e-5;
+                A_diag_min = 1e-5f;
+                cg_tol = 1e-5f;
                 cg_maxiter = 25;
             }
         };
@@ -261,7 +261,7 @@ namespace ximgproc
                     ++pix_idx;
                 }
             }
-            nvertices = hashed_coords.size();
+            nvertices = static_cast<int>(hashed_coords.size());
 
             // construct Blur matrices
             Eigen::VectorXf ones_nvertices = Eigen::VectorXf::Ones(nvertices);
@@ -373,7 +373,7 @@ namespace ximgproc
                     ++pix_idx;
                 }
             }
-            nvertices = hashed_coords.size();
+            nvertices = static_cast<int>(hashed_coords.size());
 
             // construct Blur matrices
             Eigen::VectorXf ones_nvertices = Eigen::VectorXf::Ones(nvertices);


### PR DESCRIPTION
Fix build of `dnn_superres` module without the `quality` module.
Fix some warnings reported by VS2017.
Remove `opencv_datasets` dependy.