### PR TITLE
Fix order of createTonemapDurand arguments

### DIFF
--- a/modules/xphoto/include/opencv2/xphoto/tonemap.hpp
+++ b/modules/xphoto/include/opencv2/xphoto/tonemap.hpp
@@ -46,11 +46,11 @@ You need to set the OPENCV_ENABLE_NONFREE option in cmake to use those. Use them
 @param contrast resulting contrast on logarithmic scale, i. e. log(max / min), where max and min
 are maximum and minimum luminance values of the resulting image.
 @param saturation saturation enhancement value. See createTonemapDrago
-@param sigma_space bilateral filter sigma in color space
-@param sigma_color bilateral filter sigma in coordinate space
+@param sigma_color bilateral filter sigma in color space
+@param sigma_space bilateral filter sigma in coordinate space
  */
 CV_EXPORTS_W Ptr<TonemapDurand>
-createTonemapDurand(float gamma = 1.0f, float contrast = 4.0f, float saturation = 1.0f, float sigma_space = 2.0f, float sigma_color = 2.0f);
+createTonemapDurand(float gamma = 1.0f, float contrast = 4.0f, float saturation = 1.0f, float sigma_color = 2.0f, float sigma_space = 2.0f);
 
 }} // namespace
 #endif  // OPENCV_XPHOTO_TONEMAP_HPP

--- a/modules/xphoto/test/test_hdr.cpp
+++ b/modules/xphoto/test/test_hdr.cpp
@@ -38,6 +38,34 @@ TEST(Photo_Tonemap, Durand_regression)
     checkEqual(result, expected, 3, "Durand");
 }
 
+TEST(Photo_Tonemap, Durand_property_regression)
+{
+    const float gamma = 1.0f;
+    const float contrast = 2.0f;
+    const float saturation = 3.0f;
+    const float sigma_color = 4.0f;
+    const float sigma_space = 5.0f;
+
+    const Ptr<TonemapDurand> durand1 = createTonemapDurand(gamma, contrast, saturation, sigma_color, sigma_space);
+    ASSERT_EQ(gamma, durand1->getGamma());
+    ASSERT_EQ(contrast, durand1->getContrast());
+    ASSERT_EQ(saturation, durand1->getSaturation());
+    ASSERT_EQ(sigma_space, durand1->getSigmaSpace());
+    ASSERT_EQ(sigma_color, durand1->getSigmaColor());
+
+    const Ptr<TonemapDurand> durand2 = createTonemapDurand();
+    durand2->setGamma(gamma);
+    durand2->setContrast(contrast);
+    durand2->setSaturation(saturation);
+    durand2->setSigmaColor(sigma_color);
+    durand2->setSigmaSpace(sigma_space);
+    ASSERT_EQ(gamma, durand2->getGamma());
+    ASSERT_EQ(contrast, durand2->getContrast());
+    ASSERT_EQ(saturation, durand2->getSaturation());
+    ASSERT_EQ(sigma_color, durand2->getSigmaColor());
+    ASSERT_EQ(sigma_space, durand2->getSigmaSpace());
+}
+
 #endif // OPENCV_ENABLE_NONFREE
 
 }} // namespace


### PR DESCRIPTION
### This pullrequest changes
The order of the arguments of `createTonemapDurand` is different between hpp and cpp. 
The test added by this pull request fails on the master branch.

I fixed it according to the order of `cv::bilateralFilter` arguments. (sigma_color first) 

## hpp
https://github.com/opencv/opencv_contrib/blob/master/modules/xphoto/include/opencv2/xphoto/tonemap.hpp#L53
```cpp
CV_EXPORTS_W Ptr<TonemapDurand>
createTonemapDurand(float gamma = 1.0f, float contrast = 4.0f, float saturation = 1.0f, float sigma_space = 2.0f, float sigma_color = 2.0f);
```

## cpp
https://github.com/opencv/opencv_contrib/blob/master/modules/xphoto/src/tonemap.cpp#L116
```cpp
Ptr<TonemapDurand> createTonemapDurand(float gamma, float contrast, float saturation, float sigma_color, float sigma_space)
```