### PR TITLE
Fix the list of box filter sizes

### DIFF
--- a/modules/xfeatures2d/src/surf.cpp
+++ b/modules/xfeatures2d/src/surf.cpp
@@ -485,6 +485,7 @@ static void fastHessianDetector( const Mat& sum, const Mat& mask_sum, std::vecto
 
     // Allocate space and calculate properties of each layer
     int index = 0, middleIndex = 0, step = SAMPLE_STEP0;
+    int octave_mask = SURF_HAAR_SIZE0;
 
     for( int octave = 0; octave < nOctaves; octave++ )
     {
@@ -493,7 +494,7 @@ static void fastHessianDetector( const Mat& sum, const Mat& mask_sum, std::vecto
             /* The integral image sum is one pixel bigger than the source image*/
             dets[index].create( (sum.rows-1)/step, (sum.cols-1)/step, CV_32F );
             traces[index].create( (sum.rows-1)/step, (sum.cols-1)/step, CV_32F );
-            sizes[index] = (SURF_HAAR_SIZE0 + SURF_HAAR_SIZE_INC*layer) << octave;
+            sizes[index] = octave_mask + (SURF_HAAR_SIZE_INC*layer<<(octave));
             sampleSteps[index] = step;
 
             if( 0 < layer && layer <= nOctaveLayers )
@@ -501,6 +502,7 @@ static void fastHessianDetector( const Mat& sum, const Mat& mask_sum, std::vecto
             index++;
         }
         step *= 2;
+        octave_mask += SURF_HAAR_SIZE_INC<<octave;
     }
 
     // Calculate hessian determinant and trace samples in each layer


### PR DESCRIPTION
According to the original paper of SURF, the list of box filter sizes is as follows : 
Octave 4 : 51, 99, 147, 195
Octave 3 : 27, 51, 75, 99
Octave 2 : 15, 27, 39, 51
Octave 1 : 9, 15, 21, 27
However, OpenCV SURF implementation has resulted in different values : 
Octave 4 : 72, 120, 168, 216
Octave 3 : 36, 60, 84, 108
Octave 2 : 18, 30, 42, 54
Octave 1 : 9, 15, 21, 27

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->the list of filter sizes to become consistent with the SURF paper.
