### PR TITLE
NVOF-Cuda Bug Fix. Should not reset runtime context

### DIFF
--- a/modules/cudaoptflow/src/nvidiaOpticalFlow.cpp
+++ b/modules/cudaoptflow/src/nvidiaOpticalFlow.cpp
@@ -578,11 +578,6 @@ void NvidiaOpticalFlowImpl::collectGarbage()
     {
         NVOF_API_CALL(GetAPI()->nvOFDestroy(m_hOF));
     }
-    if (m_cuContext)
-    {
-        cuSafeCall(cudaDeviceReset());
-        m_cuContext = nullptr;
-    }
 }
 
 void NvidiaOpticalFlowImpl::upSampler(InputArray _flow, int width, int height,


### PR DESCRIPTION
m_cuContext is the CUDA runtime context which we fetch and use and we should not be destroying it by calling cudaDeviceReset(). There are many applications which pipeline NVIDIA-Optical-Flow as an intermediate block and say if any block after it uses m_cuContext then that blocks will fail because the context they were using was destroyed without their knowledge.

<cut/>

```
force_builders=Custom
buildworker:Custom=linux-4
build_image:Custom=ubuntu-cuda:18.04
```