### PR TITLE
Added haze_removal module

### DIFF
--- a/modules/README.md
+++ b/modules/README.md
@@ -36,6 +36,8 @@ $ cmake -D OPENCV_EXTRA_MODULES_PATH=<opencv_contrib>/modules -D BUILD_opencv_<r
 
 - **freetype**: Drawing text using freetype and harfbuzz.
 
+- **haze_removal**: Remove haze from images.
+
 - **hdf**: Hierarchical Data Storage -- This module contains I/O routines for Hierarchical Data Format: https://en.m.wikipedia.org/wiki/Hierarchical_Data_Format meant to store large amounts of data.
 
 - **line_descriptor**: Line Segment Extract and Match -- Methods of extracting, describing and latching line segments using binary descriptors.

--- a/modules/haze_removal/CMakeLists.txt
+++ b/modules/haze_removal/CMakeLists.txt
@@ -1,0 +1,2 @@
+set(the_description "Dehazing algorithms")
+ocv_define_module(haze_removal opencv_core opencv_imgproc opencv_ximgproc WRAP java python)

--- a/modules/haze_removal/README.md
+++ b/modules/haze_removal/README.md
@@ -1,0 +1,4 @@
+Haze Removal algorithms
+========================
+
+This module contains functions which can dehaze hazy/foggy images.

--- a/modules/haze_removal/README.md
+++ b/modules/haze_removal/README.md
@@ -5,7 +5,7 @@ This module contains functions which can dehaze hazy/foggy images.
 
 Currently the following algorithms are implemented:
 
-* Single image haze removal using dark channel priors
+* Single image haze removal using dark channel priors (Guided Filter is used in place of soft matting.)
 
 
 Note that the " Single image haze removal using dark channel priors " algorithm was patented and its use may be restricted by following (but not limited to) list of patents:

--- a/modules/haze_removal/README.md
+++ b/modules/haze_removal/README.md
@@ -2,3 +2,17 @@ Haze Removal algorithms
 ========================
 
 This module contains functions which can dehaze hazy/foggy images.
+
+Currently the following algorithms are implemented:
+
+* Single image haze removal using dark channel priors
+
+
+Note that the " Single image haze removal using dark channel priors " algorithm was patented and its use may be restricted by following (but not limited to) list of patents:
+
+* _US8340461B2_ Single image haze removal using dark channel priors
+
+
+Since OpenCV's license imposes different restrictions on usage please consult a legal advisor before using this algorithm any way.
+
+That's why you need to set the OPENCV_ENABLE_NONFREE option in CMake to use this algorithm.

--- a/modules/haze_removal/doc/haze_removal.bib
+++ b/modules/haze_removal/doc/haze_removal.bib
@@ -1,0 +1,5 @@
+@article{kaiminghe_cvpr09,
+  title={Single Image Haze Removal Using Dark Channel Prior},
+  author={Kaiming He, Jian Sun, Xiaoou Tang},
+  url={http://kaiminghe.com/publications/cvpr09.pdf}
+}

--- a/modules/haze_removal/include/opencv2/haze_removal.hpp
+++ b/modules/haze_removal/include/opencv2/haze_removal.hpp
@@ -1,0 +1,32 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#ifndef OPENCV_HAZE_REMOVAL_HPP
+#define OPENCV_HAZE_REMOVAL_HPP
+
+#include "opencv2/haze_removal/haze_removal_base.hpp"
+#include "opencv2/haze_removal/dark_channel_algorithm.hpp"
+
+/**
+@defgroup haze_removal The module contains implementations of haze removal algorithms.
+
+Provide algorithms to obtain a haze free image from a given hazy input image
+
+Namespace for all functions is cv::haze_removal.
+
+### Supported Algorithms
+
+- Single Image Haze Removal using Dark Channel Prior and Guided Filter
+
+### Code Example
+
+@include samples/haze_removal_sample.cpp
+
+### Motivation
+
+Haze and fog are a serious problem in photography. This module is created to improve quality of photographs.
+
+*/
+
+#endif

--- a/modules/haze_removal/include/opencv2/haze_removal/dark_channel_algorithm.hpp
+++ b/modules/haze_removal/include/opencv2/haze_removal/dark_channel_algorithm.hpp
@@ -24,7 +24,7 @@ public:
     CV_WRAP void setKernel(InputArray _kernelForEroding);
     CV_WRAP void setPercentageBrightestPixelsForAtmoLight(float _percentageBrightestPixelsForAtmoLight);
     CV_WRAP void setOmega(float _omega);
-    CV_WRAP void setGuidedFilterRadius(float _guidedFilterRadius);
+    CV_WRAP void setGuidedFilterRadius(int _guidedFilterRadius);
     CV_WRAP void setGuidedFilterEps(float _guidedFilterEps);
     CV_WRAP void setTransmissionLowerBound(float _transmissionLowerBoundsetPlotLineColor);
 

--- a/modules/haze_removal/include/opencv2/haze_removal/dark_channel_algorithm.hpp
+++ b/modules/haze_removal/include/opencv2/haze_removal/dark_channel_algorithm.hpp
@@ -21,7 +21,7 @@ class CV_EXPORTS_W DarkChannelPriorHazeRemoval : public HazeRemovalBase
 {
 public:
     CV_WRAP void setKernel(int _erosionSize, int _erosionType);
-    CV_WRAP void setKernel(cv::InputArray _kernelForEroding);
+    CV_WRAP void setKernel(InputArray _kernelForEroding);
     CV_WRAP void setPercentageBrightestPixelsForAtmoLight(float _percentageBrightestPixelsForAtmoLight);
     CV_WRAP void setOmega(float _omega);
     CV_WRAP void setGuidedFilterRadius(float _guidedFilterRadius);
@@ -35,11 +35,11 @@ protected:
 };
 
 /** @brief Dehazes using haze_removal::DarkChannelPriorHazeRemoval in one call
-@param inputMat input image you want to dehaze, must be a CV_8UC3  image
-@param outputMat dehazed image with same number of rows and columns as input in CV_8UC3 format
+@param _src input image you want to dehaze, must be a CV_8UC3  image
+@param _dst dehazed image with same number of rows and columns as input in CV_8UC3 format
 */
 
-CV_EXPORTS_W void darkChannelPriorHazeRemoval(cv::InputArray _src, cv::OutputArray _dst);
+CV_EXPORTS_W void darkChannelPriorHazeRemoval(InputArray _src, OutputArray _dst);
 
 //! @}
 

--- a/modules/haze_removal/include/opencv2/haze_removal/dark_channel_algorithm.hpp
+++ b/modules/haze_removal/include/opencv2/haze_removal/dark_channel_algorithm.hpp
@@ -1,0 +1,48 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#ifndef OPENCV_HAZE_REMOVAL_HE_ALGORITHM_HPP
+#define OPENCV_HAZE_REMOVAL_HE_ALGORITHM_HPP
+
+#include "haze_removal_base.hpp"
+
+namespace cv {
+namespace haze_removal {
+
+//! @addtogroup haze_removal
+//! @{
+
+/** @brief Dehazes a image using Dark Channel Prior
+
+For details refer to @cite kaiminghe_cvpr09
+*/
+class CV_EXPORTS_W DarkChannelPriorHazeRemoval : public HazeRemovalBase
+{
+public:
+    CV_WRAP void setKernel(int _erosionSize, int _erosionType);
+    CV_WRAP void setKernel(cv::InputArray _kernelForEroding);
+    CV_WRAP void setPercentageBrightestPixelsForAtmoLight(float _percentageBrightestPixelsForAtmoLight);
+    CV_WRAP void setOmega(float _omega);
+    CV_WRAP void setGuidedFilterRadius(float _guidedFilterRadius);
+    CV_WRAP void setGuidedFilterEps(float _guidedFilterEps);
+    CV_WRAP void setTransmissionLowerBound(float _transmissionLowerBoundsetPlotLineColor);
+
+    CV_WRAP static Ptr<DarkChannelPriorHazeRemoval> create();
+
+protected:
+    DarkChannelPriorHazeRemoval() {}
+};
+
+/** @brief Dehazes using haze_removal::DarkChannelPriorHazeRemoval in one call
+@param inputMat input image you want to dehaze, must be a CV_8UC3  image
+@param outputMat dehazed image with same number of rows and columns as input in CV_8UC3 format
+*/
+
+CV_EXPORTS_W void darkChannelPriorHazeRemoval(cv::InputArray _src, cv::OutputArray _dst);
+
+//! @}
+
+}} // cv::haze_removal::
+
+#endif

--- a/modules/haze_removal/include/opencv2/haze_removal/haze_removal_base.hpp
+++ b/modules/haze_removal/include/opencv2/haze_removal/haze_removal_base.hpp
@@ -1,0 +1,40 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#ifndef OPENCV_HAZE_REMOVAL_HAZE_REMOVAL_BASE_HPP
+#define OPENCV_HAZE_REMOVAL_HAZE_REMOVAL_BASE_HPP
+
+#include "opencv2/core.hpp"
+
+namespace cv {
+namespace haze_removal {
+
+//! @addtogroup haze_removal
+//! @{
+
+/** @brief The base class for haze removal algorithm
+ */
+
+class CV_EXPORTS_W HazeRemovalBase : public Algorithm
+{
+public:
+    class HazeRemovalImpl;
+
+    ~HazeRemovalBase();
+    /** @brief Dehazes a given image
+        @param _src hazy image as input
+        @param _dst output image with haze removed
+    */
+    CV_WRAP void dehaze(cv::InputArray _src, cv::OutputArray _dst);
+
+protected:
+    HazeRemovalBase();
+    Ptr<HazeRemovalImpl> pImpl;
+};
+
+//! @}
+
+}} // cv::haze_removal::
+
+#endif

--- a/modules/haze_removal/include/opencv2/haze_removal/haze_removal_base.hpp
+++ b/modules/haze_removal/include/opencv2/haze_removal/haze_removal_base.hpp
@@ -26,7 +26,7 @@ public:
         @param _src hazy image as input
         @param _dst output image with haze removed
     */
-    CV_WRAP void dehaze(cv::InputArray _src, cv::OutputArray _dst);
+    CV_WRAP void dehaze(InputArray _src, OutputArray _dst);
 
 protected:
     HazeRemovalBase();

--- a/modules/haze_removal/samples/haze_removal_sample.cpp
+++ b/modules/haze_removal/samples/haze_removal_sample.cpp
@@ -1,0 +1,30 @@
+#include "opencv2/core.hpp"
+#include "opencv2/imgproc.hpp"
+#include "opencv2/highgui.hpp"
+#include "opencv2/haze_removal.hpp"
+
+#include <iostream>
+using namespace std;
+using namespace cv;
+
+int main(int argc, char **argv)
+{
+    if (argc != 2)
+    {
+        cerr << "must input the path of input image. ex : ./haze_removal_sample input.jpg" << endl;
+        return -1;
+    }
+    Mat input, output;
+    input = imread(argv[1]);
+    namedWindow("original", WINDOW_AUTOSIZE);
+    imshow("original", input);
+
+    Ptr<cv::haze_removal::DarkChannelPriorHazeRemoval> dehazer = cv::haze_removal::DarkChannelPriorHazeRemoval::create();
+    dehazer->setKernel(15, cv::MORPH_RECT);
+    dehazer->dehaze(input, output);
+
+    namedWindow("radiance", WINDOW_AUTOSIZE);
+    imshow("radiance", output);
+    waitKey(0);
+    return 0;
+}

--- a/modules/haze_removal/src/dark_channel_algorithm.cpp
+++ b/modules/haze_removal/src/dark_channel_algorithm.cpp
@@ -1,0 +1,255 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "precomp.hpp"
+#include "opencv2/imgproc.hpp"
+#include "opencv2/ximgproc/edge_filter.hpp"
+#include <vector>
+
+using namespace cv;
+using namespace cv::haze_removal;
+
+namespace {
+
+int intensityOfNthBrightestPixel(cv::InputArray _src, int n)
+{
+    const Mat src = _src.getMat();
+
+    CV_Assert(src.channels() == 1);
+    CV_Assert(src.type() == CV_8UC1);
+
+    // simple histogram
+    std::vector<int> histogram(256, 0);
+    for (int i = 0; i < int(src.rows * src.cols); ++i)
+        histogram[src.at<uchar>(i)]++;
+
+    // find max threshold value (pixels from [0-max_threshold] will be removed)
+    int max_threshold = (int)histogram.size() - 1;
+    for (; max_threshold >= 0 && n > 0; --max_threshold)
+    {
+        n -= histogram[max_threshold];
+    }
+
+    max_threshold = max(max_threshold, 0);
+    return max_threshold;
+}
+
+class HazeRemovalHeImpl CV_FINAL : public HazeRemovalBase::HazeRemovalImpl
+{
+private:
+    int erosionSize; //Size of kernel to use for computing Dark Channeal
+    int erosionType; //Type of kernel to use for computing Dark Channel
+
+    float percentageBrightestPixelsForAtmoLight; //See the papers "Estimating the Atmospheric Light" section for details
+    float omega;                                 // controls how much fog to remove :range[0,1]: 1 means remove all fog, 0 means no fog
+    float guidedFilterRadius;
+    float guidedFilterEps;
+    float transmissionLowerBound; //each element of transmission matrix must be atleast this
+
+    Mat kernelForEroding; // The kernel used for eroding
+
+public:
+    HazeRemovalHeImpl()
+    {
+        erosionSize = 15;
+        erosionType = MORPH_RECT;
+        percentageBrightestPixelsForAtmoLight = 0.001;
+        omega = 0.95;
+        guidedFilterRadius = 60;
+        guidedFilterEps = 0.0001;
+        transmissionLowerBound = 0.1;
+
+        kernelForEroding = getStructuringElement(erosionType, Size(erosionSize, erosionSize));
+    }
+
+    //setter functions
+    void setKernel(int _erosionSize, int _erosionType)
+    {
+        erosionSize = _erosionSize;
+        erosionType = _erosionType;
+        kernelForEroding = getStructuringElement(erosionType, Size(erosionSize, erosionSize));
+    }
+    void setKernel(cv::InputArray _kernelForEroding)
+    {
+        kernelForEroding = _kernelForEroding.getMat();
+    }
+    void setPercentageBrightestPixelsForAtmoLight(float _percentageBrightestPixelsForAtmoLight)
+    {
+        percentageBrightestPixelsForAtmoLight = _percentageBrightestPixelsForAtmoLight;
+    }
+    void setOmega(float _omega)
+    {
+        omega = _omega;
+    }
+    void setGuidedFilterRadius(float _guidedFilterRadius)
+    {
+        guidedFilterRadius = _guidedFilterRadius;
+    }
+    void setGuidedFilterEps(float _guidedFilterEps)
+    {
+        guidedFilterEps = _guidedFilterEps;
+    }
+    void setTransmissionLowerBound(float _transmissionLowerBound)
+    {
+        transmissionLowerBound = _transmissionLowerBound;
+    }
+
+    void getDarkChannel(cv::InputArray _src, cv::OutputArray _dst)
+    {
+        const Mat src = _src.getMat();
+        if (src.channels() != 3)
+            CV_Error(Error::BadNumChannels,
+                     "Unsupported channels count: Only 3 channel BGR images supported");
+        erode(src, _dst, kernelForEroding);
+        std::vector<Mat> planes(3);
+        split(_dst, planes);
+        _dst.assign(min(planes[2], min(planes[1], planes[0])));
+        return;
+    }
+
+    Scalar getAtmoLight(cv::InputArray _src)
+    {
+
+        const Mat src = _src.getMat();
+        Mat darkChannel;
+        getDarkChannel(src, darkChannel);
+
+        int pixelsToKeep = src.rows * src.cols * percentageBrightestPixelsForAtmoLight;
+        int thresholdAtmo = intensityOfNthBrightestPixel(darkChannel, pixelsToKeep);
+
+        // Apply a threshold to get a mask of the $percentAtmo brightest pixels.
+        Mat dst;
+        threshold(darkChannel, dst, thresholdAtmo, 255, cv::THRESH_BINARY);
+
+        Scalar atmoLight = mean(src, dst);
+
+        return atmoLight;
+    }
+
+    void getTransmission(cv::InputArray _src, cv::OutputArray _dst, Scalar atmoLight)
+    {
+        const Mat src = _src.getMat();
+        Mat dst;
+        Mat src_float;
+        src.convertTo(src_float, CV_32FC3);
+        Mat src_normalized = src_float / atmoLight;
+        getDarkChannel(src_normalized, dst);
+        dst = 1 - dst * omega;
+        _dst.assign(dst);
+    }
+
+    void refineTransmission(cv::InputArray _src, cv::InputArray _unrefinedTransmission, cv::OutputArray _refinedTransmission)
+    {
+        Mat gray;
+        cvtColor(_src, gray, COLOR_BGR2GRAY);
+        ximgproc::guidedFilter(gray, _unrefinedTransmission, _refinedTransmission, guidedFilterRadius, guidedFilterEps);
+    }
+
+    virtual void dehaze(cv::InputArray _src, cv::OutputArray _dst) CV_OVERRIDE
+    {
+        const cv::Mat src = _src.getMat();
+        CV_Assert(src.channels() == 3);
+        CV_Assert(src.type() == CV_8UC3);
+
+        Scalar atmoLight = getAtmoLight(src);
+
+        Mat unrefinedTransmission;
+        getTransmission(src, unrefinedTransmission, atmoLight);
+
+        Mat refinedTransmission;
+
+        refineTransmission(src, unrefinedTransmission, refinedTransmission);
+        refinedTransmission = max(refinedTransmission, transmissionLowerBound);
+
+        std::vector<Mat> planes;
+
+        for (int i = 0; i < 3; i++)
+            planes.push_back(refinedTransmission);
+
+        merge(planes, refinedTransmission);
+
+        Mat src_32FC3;
+        src.convertTo(src_32FC3, CV_32F);
+
+        Mat radiance_32FC3;
+        Mat radiance;
+
+        radiance_32FC3 = (src_32FC3 - atmoLight) / refinedTransmission + atmoLight;
+        radiance_32FC3.convertTo(radiance, CV_8U);
+
+        _dst.assign(radiance);
+
+        return;
+    }
+};
+
+inline HazeRemovalHeImpl *getLocalImpl(HazeRemovalBase::HazeRemovalImpl *ptr)
+{
+    HazeRemovalHeImpl *impl = static_cast<HazeRemovalHeImpl *>(ptr);
+    CV_Assert(impl);
+    return impl;
+}
+
+} // namespace
+
+namespace cv {
+namespace haze_removal {
+
+#ifdef OPENCV_ENABLE_NONFREE
+
+Ptr<DarkChannelPriorHazeRemoval> DarkChannelPriorHazeRemoval::create()
+{
+
+    Ptr<DarkChannelPriorHazeRemoval> res(new DarkChannelPriorHazeRemoval());
+    res->pImpl = makePtr<HazeRemovalHeImpl>();
+    return res;
+}
+
+#else // ! #ifdef OPENCV_ENABLE_NONFREE
+
+Ptr<DarkChannelPriorHazeRemoval> DarkChannelPriorHazeRemoval::create()
+{
+
+    CV_Error(Error::StsNotImplemented,
+             "This algorithm is patented and is excluded in this configuration; "
+             "Set OPENCV_ENABLE_NONFREE CMake option and rebuild the library");
+}
+
+#endif
+
+void DarkChannelPriorHazeRemoval::setKernel(int _erosionSize, int _erosionType)
+{
+    getLocalImpl(pImpl)->setKernel(_erosionSize, _erosionType);
+}
+void DarkChannelPriorHazeRemoval::setKernel(cv::InputArray _kernelForEroding)
+{
+    getLocalImpl(pImpl)->setKernel(_kernelForEroding);
+}
+void DarkChannelPriorHazeRemoval::setPercentageBrightestPixelsForAtmoLight(float _percentageBrightestPixelsForAtmoLight)
+{
+    getLocalImpl(pImpl)->setPercentageBrightestPixelsForAtmoLight(_percentageBrightestPixelsForAtmoLight);
+}
+void DarkChannelPriorHazeRemoval::setOmega(float _omega)
+{
+    getLocalImpl(pImpl)->setOmega(_omega);
+}
+void DarkChannelPriorHazeRemoval::setGuidedFilterRadius(float _guidedFilterRadius)
+{
+    getLocalImpl(pImpl)->setGuidedFilterRadius(_guidedFilterRadius);
+}
+void DarkChannelPriorHazeRemoval::setGuidedFilterEps(float _guidedFilterEps)
+{
+    getLocalImpl(pImpl)->setGuidedFilterEps(_guidedFilterEps);
+}
+void DarkChannelPriorHazeRemoval::setTransmissionLowerBound(float _transmissionLowerBoundsetPlotLineColor)
+{
+    getLocalImpl(pImpl)->setTransmissionLowerBound(_transmissionLowerBoundsetPlotLineColor);
+}
+
+void darkChannelPriorHazeRemoval(cv::InputArray _src, cv::OutputArray _dst)
+{
+    HazeRemovalHeImpl().dehaze(_src, _dst);
+}
+
+}} // cv::haze_removal::

--- a/modules/haze_removal/src/dark_channel_algorithm.cpp
+++ b/modules/haze_removal/src/dark_channel_algorithm.cpp
@@ -25,7 +25,7 @@ int intensityOfNthBrightestPixel(InputArray _src, int n)
         histogram[src.at<uchar>(i)]++;
 
     // find max threshold value (pixels from [0-max_threshold] will be removed)
-    int max_threshold = (int)histogram.size() - 1;
+    int max_threshold = static_cast<int>(histogram.size()) - 1;
     for (; max_threshold >= 0 && n > 0; --max_threshold)
     {
         n -= histogram[max_threshold];
@@ -43,7 +43,7 @@ private:
 
     float percentageBrightestPixelsForAtmoLight; //See the papers "Estimating the Atmospheric Light" section for details
     float omega;                                 // controls how much fog to remove :range[0,1]: 1 means remove all fog, 0 means no fog
-    float guidedFilterRadius;
+    int guidedFilterRadius;
     float guidedFilterEps;
     float transmissionLowerBound; //each element of transmission matrix must be atleast this
 
@@ -54,11 +54,11 @@ public:
     {
         erosionSize = 15;
         erosionType = MORPH_RECT;
-        percentageBrightestPixelsForAtmoLight = 0.001;
-        omega = 0.95;
+        percentageBrightestPixelsForAtmoLight = 0.001f;
+        omega = 0.95f;
         guidedFilterRadius = 60;
-        guidedFilterEps = 0.0001;
-        transmissionLowerBound = 0.1;
+        guidedFilterEps = 0.0001f;
+        transmissionLowerBound = 0.1f;
 
         kernelForEroding = getStructuringElement(erosionType, Size(erosionSize, erosionSize));
     }
@@ -82,7 +82,7 @@ public:
     {
         omega = _omega;
     }
-    void setGuidedFilterRadius(float _guidedFilterRadius)
+    void setGuidedFilterRadius(int _guidedFilterRadius)
     {
         guidedFilterRadius = _guidedFilterRadius;
     }
@@ -115,7 +115,7 @@ public:
         Mat darkChannel;
         getDarkChannel(src, darkChannel);
 
-        int pixelsToKeep = src.rows * src.cols * percentageBrightestPixelsForAtmoLight;
+        int pixelsToKeep = static_cast<int>(src.rows * src.cols * percentageBrightestPixelsForAtmoLight);
         int thresholdAtmo = intensityOfNthBrightestPixel(darkChannel, pixelsToKeep);
 
         // Apply a threshold to get a mask of the $percentAtmo brightest pixels.
@@ -234,7 +234,7 @@ void DarkChannelPriorHazeRemoval::setOmega(float _omega)
 {
     getLocalImpl(pImpl)->setOmega(_omega);
 }
-void DarkChannelPriorHazeRemoval::setGuidedFilterRadius(float _guidedFilterRadius)
+void DarkChannelPriorHazeRemoval::setGuidedFilterRadius(int _guidedFilterRadius)
 {
     getLocalImpl(pImpl)->setGuidedFilterRadius(_guidedFilterRadius);
 }

--- a/modules/haze_removal/src/dark_channel_algorithm.cpp
+++ b/modules/haze_removal/src/dark_channel_algorithm.cpp
@@ -12,7 +12,7 @@ using namespace cv::haze_removal;
 
 namespace {
 
-int intensityOfNthBrightestPixel(cv::InputArray _src, int n)
+int intensityOfNthBrightestPixel(InputArray _src, int n)
 {
     const Mat src = _src.getMat();
 
@@ -35,7 +35,7 @@ int intensityOfNthBrightestPixel(cv::InputArray _src, int n)
     return max_threshold;
 }
 
-class HazeRemovalHeImpl CV_FINAL : public HazeRemovalBase::HazeRemovalImpl
+class DarkChannelPriorHazeRemovalImpl CV_FINAL : public HazeRemovalBase::HazeRemovalImpl
 {
 private:
     int erosionSize; //Size of kernel to use for computing Dark Channeal
@@ -50,7 +50,7 @@ private:
     Mat kernelForEroding; // The kernel used for eroding
 
 public:
-    HazeRemovalHeImpl()
+    DarkChannelPriorHazeRemovalImpl()
     {
         erosionSize = 15;
         erosionType = MORPH_RECT;
@@ -95,7 +95,7 @@ public:
         transmissionLowerBound = _transmissionLowerBound;
     }
 
-    void getDarkChannel(cv::InputArray _src, cv::OutputArray _dst)
+    void getDarkChannel(InputArray _src, OutputArray _dst)
     {
         const Mat src = _src.getMat();
         if (src.channels() != 3)
@@ -108,7 +108,7 @@ public:
         return;
     }
 
-    Scalar getAtmoLight(cv::InputArray _src)
+    Scalar getAtmoLight(InputArray _src)
     {
 
         const Mat src = _src.getMat();
@@ -127,7 +127,7 @@ public:
         return atmoLight;
     }
 
-    void getTransmission(cv::InputArray _src, cv::OutputArray _dst, Scalar atmoLight)
+    void getTransmission(InputArray _src, OutputArray _dst, Scalar atmoLight)
     {
         const Mat src = _src.getMat();
         Mat dst;
@@ -139,16 +139,16 @@ public:
         _dst.assign(dst);
     }
 
-    void refineTransmission(cv::InputArray _src, cv::InputArray _unrefinedTransmission, cv::OutputArray _refinedTransmission)
+    void refineTransmission(InputArray _src, InputArray _unrefinedTransmission, OutputArray _refinedTransmission)
     {
         Mat gray;
         cvtColor(_src, gray, COLOR_BGR2GRAY);
         ximgproc::guidedFilter(gray, _unrefinedTransmission, _refinedTransmission, guidedFilterRadius, guidedFilterEps);
     }
 
-    virtual void dehaze(cv::InputArray _src, cv::OutputArray _dst) CV_OVERRIDE
+    virtual void dehaze(InputArray _src, OutputArray _dst) CV_OVERRIDE
     {
-        const cv::Mat src = _src.getMat();
+        const Mat src = _src.getMat();
         CV_Assert(src.channels() == 3);
         CV_Assert(src.type() == CV_8UC3);
 
@@ -184,9 +184,9 @@ public:
     }
 };
 
-inline HazeRemovalHeImpl *getLocalImpl(HazeRemovalBase::HazeRemovalImpl *ptr)
+inline DarkChannelPriorHazeRemovalImpl *getLocalImpl(HazeRemovalBase::HazeRemovalImpl *ptr)
 {
-    HazeRemovalHeImpl *impl = static_cast<HazeRemovalHeImpl *>(ptr);
+    DarkChannelPriorHazeRemovalImpl *impl = dynamic_cast<DarkChannelPriorHazeRemovalImpl *>(ptr);
     CV_Assert(impl);
     return impl;
 }
@@ -202,7 +202,7 @@ Ptr<DarkChannelPriorHazeRemoval> DarkChannelPriorHazeRemoval::create()
 {
 
     Ptr<DarkChannelPriorHazeRemoval> res(new DarkChannelPriorHazeRemoval());
-    res->pImpl = makePtr<HazeRemovalHeImpl>();
+    res->pImpl = makePtr<DarkChannelPriorHazeRemovalImpl>();
     return res;
 }
 
@@ -247,9 +247,9 @@ void DarkChannelPriorHazeRemoval::setTransmissionLowerBound(float _transmissionL
     getLocalImpl(pImpl)->setTransmissionLowerBound(_transmissionLowerBoundsetPlotLineColor);
 }
 
-void darkChannelPriorHazeRemoval(cv::InputArray _src, cv::OutputArray _dst)
+void darkChannelPriorHazeRemoval(InputArray _src, OutputArray _dst)
 {
-    HazeRemovalHeImpl().dehaze(_src, _dst);
+    DarkChannelPriorHazeRemovalImpl().dehaze(_src, _dst);
 }
 
 }} // cv::haze_removal::

--- a/modules/haze_removal/src/haze_removal_base.cpp
+++ b/modules/haze_removal/src/haze_removal_base.cpp
@@ -1,0 +1,23 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "precomp.hpp"
+
+namespace cv {
+namespace haze_removal{
+
+HazeRemovalBase::HazeRemovalBase()
+{
+}
+
+HazeRemovalBase::~HazeRemovalBase()
+{
+}
+
+void HazeRemovalBase::dehaze(cv::InputArray _src, cv::OutputArray _dst)
+{
+    pImpl->dehaze(_src, _dst);
+}
+
+}} /// cv::haze_removal::

--- a/modules/haze_removal/src/haze_removal_base.cpp
+++ b/modules/haze_removal/src/haze_removal_base.cpp
@@ -15,7 +15,7 @@ HazeRemovalBase::~HazeRemovalBase()
 {
 }
 
-void HazeRemovalBase::dehaze(cv::InputArray _src, cv::OutputArray _dst)
+void HazeRemovalBase::dehaze(InputArray _src, OutputArray _dst)
 {
     pImpl->dehaze(_src, _dst);
 }

--- a/modules/haze_removal/src/precomp.hpp
+++ b/modules/haze_removal/src/precomp.hpp
@@ -14,7 +14,7 @@ namespace cv{ namespace haze_removal {
 class HazeRemovalBase::HazeRemovalImpl
 {
 public:
-    virtual void dehaze(cv::InputArray _src, cv::OutputArray _dst) = 0;
+    virtual void dehaze(InputArray _src, OutputArray _dst) = 0;
     virtual ~HazeRemovalImpl() {}
 };
 

--- a/modules/haze_removal/src/precomp.hpp
+++ b/modules/haze_removal/src/precomp.hpp
@@ -1,0 +1,23 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#ifndef OPENCV_HAZE_REMOVAL_PRECOMP_H
+#define OPENCV_HAZE_REMOVAL_PRECOMP_H
+
+#include "opencv2/core.hpp"
+#include "opencv2/haze_removal.hpp"
+
+
+namespace cv{ namespace haze_removal {
+
+class HazeRemovalBase::HazeRemovalImpl
+{
+public:
+    virtual void dehaze(cv::InputArray _src, cv::OutputArray _dst) = 0;
+    virtual ~HazeRemovalImpl() {}
+};
+
+}} // cv::haze_removal::
+
+#endif // OPENCV_HAZE_REMOVAL_PRECOMP_H

--- a/modules/haze_removal/test/test_dark_channel.cpp
+++ b/modules/haze_removal/test/test_dark_channel.cpp
@@ -23,16 +23,7 @@ TEST(dark_channel_haze_removal_test, accuracy)
     ASSERT_EQ((int)output.rows, (int)expectedOutput.rows);
     ASSERT_EQ((int)output.cols, (int)expectedOutput.cols);
 
-    for (int r = 0; r < output.rows; r++)
-    {
-        for (int c = 0; c < output.cols; c++)
-        {
-            for (int channel = 0; channel < 3; channel++)
-            {
-                EXPECT_NEAR(output.at<cv::Vec3b>(r, c)[channel], expectedOutput.at<cv::Vec3b>(r, c)[channel], 5);
-            }
-        }
-    }
+    EXPECT_LE(cvtest::norm(output, expectedOutput, NORM_INF), 5);
 }
 
 }} // opencv_test::namespace::

--- a/modules/haze_removal/test/test_dark_channel.cpp
+++ b/modules/haze_removal/test/test_dark_channel.cpp
@@ -1,0 +1,38 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "test_precomp.hpp"
+namespace opencv_test {
+namespace {
+
+TEST(dark_channel_haze_removal_test, accuracy)
+{
+    string inputFilepath = cvtest::findDataFile("haze_removal/input.png");
+    string expectedOutputFilepath = cvtest::findDataFile("haze_removal/expectedOutput.png");
+
+    cv::Mat input, expectedOutput, output;
+    input = cv::imread(inputFilepath);
+    expectedOutput = cv::imread(expectedOutputFilepath);
+
+    ASSERT_FALSE(input.empty());
+    ASSERT_FALSE(expectedOutput.empty());
+
+    cv::haze_removal::darkChannelPriorHazeRemoval(input, output);
+
+    ASSERT_EQ((int)output.rows, (int)expectedOutput.rows);
+    ASSERT_EQ((int)output.cols, (int)expectedOutput.cols);
+
+    for (int r = 0; r < output.rows; r++)
+    {
+        for (int c = 0; c < output.cols; c++)
+        {
+            for (int channel = 0; channel < 3; channel++)
+            {
+                EXPECT_NEAR(output.at<cv::Vec3b>(r, c)[channel], expectedOutput.at<cv::Vec3b>(r, c)[channel], 5);
+            }
+        }
+    }
+}
+
+}} // opencv_test::namespace::

--- a/modules/haze_removal/test/test_dark_channel.cpp
+++ b/modules/haze_removal/test/test_dark_channel.cpp
@@ -9,7 +9,7 @@ namespace {
 TEST(dark_channel_haze_removal_test, accuracy)
 {
     string inputFilepath = cvtest::findDataFile("haze_removal/input.png");
-    string expectedOutputFilepath = cvtest::findDataFile("haze_removal/expectedOutput.png");
+    string expectedOutputFilepath = cvtest::findDataFile("haze_removal/expected_output.png");
 
     cv::Mat input, expectedOutput, output;
     input = cv::imread(inputFilepath);

--- a/modules/haze_removal/test/test_main.cpp
+++ b/modules/haze_removal/test/test_main.cpp
@@ -1,0 +1,7 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "test_precomp.hpp"
+
+CV_TEST_MAIN("cv")

--- a/modules/haze_removal/test/test_precomp.hpp
+++ b/modules/haze_removal/test/test_precomp.hpp
@@ -1,0 +1,10 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+#ifndef __OPENCV_TEST_PRECOMP_HPP__
+#define __OPENCV_TEST_PRECOMP_HPP__
+
+#include "opencv2/ts.hpp"
+#include "opencv2/haze_removal.hpp"
+
+#endif


### PR DESCRIPTION
resolves #2073 

Merge with extra: opencv/opencv_extra#712

This module currently contains the implementation of :http://kaiminghe.com/publications/cvpr09.pdf. But instead of soft matting, guided filter has been used. Since this algorithm is patented, it has been implemented under NONFREE.

Link to patent: https://patents.google.com/patent/US8340461B2/en

### This pullrequest changes
A new module named "haze_removal" has been added.

