### PR TITLE
FREAK : better rounding off for weighted dx and dy of orientation pairs

### DIFF
--- a/modules/xfeatures2d/src/freak.cpp
+++ b/modules/xfeatures2d/src/freak.cpp
@@ -287,8 +287,8 @@ void FREAK_Impl::buildPattern()
         const float dx = patternLookup[orientationPairs[m].i].x-patternLookup[orientationPairs[m].j].x;
         const float dy = patternLookup[orientationPairs[m].i].y-patternLookup[orientationPairs[m].j].y;
         const float norm_sq = (dx*dx+dy*dy);
-        orientationPairs[m].weight_dx = int((dx/(norm_sq))*4096.0+0.5);
-        orientationPairs[m].weight_dy = int((dy/(norm_sq))*4096.0+0.5);
+        orientationPairs[m].weight_dx = int((dx/(norm_sq))*4096.0+0.5*((dx>0)-(dx<0)));
+        orientationPairs[m].weight_dy = int((dy/(norm_sq))*4096.0+0.5*((dy>0)-(dy<0)));
     }
 
     // build the list of description pairs

--- a/modules/xfeatures2d/src/freak.cpp
+++ b/modules/xfeatures2d/src/freak.cpp
@@ -486,7 +486,7 @@ void FREAK_Impl::computeDescriptors( InputArray _image, std::vector<KeyPoint>& k
     }
     else
     {
-        const int scIdx = std::max( (int)(1.0986122886681*sizeCst+0.5) ,0);
+        const int scIdx = std::max( cvRound(1.0986122886681*sizeCst) ,0);
         for( size_t k = keypoints.size(); k--; )
         {
             kpScaleIdx[k] = scIdx; // equivalent to the formule when the scale is normalized with a constant size of keypoints[k].size=3*SMALLEST_KP_SIZE
@@ -543,10 +543,7 @@ void FREAK_Impl::computeDescriptors( InputArray _image, std::vector<KeyPoint>& k
 
                 keypoints[k].angle = static_cast<float>(atan2((float)direction1,(float)direction0)*(180.0/CV_PI));//estimate orientation
 
-                if(keypoints[k].angle < 0.f)
-                    thetaIdx = int(FREAK_NB_ORIENTATION*keypoints[k].angle*(1/360.0)-0.5);
-                else
-                    thetaIdx = int(FREAK_NB_ORIENTATION*keypoints[k].angle*(1/360.0)+0.5);
+                thetaIdx = cvRound(FREAK_NB_ORIENTATION*keypoints[k].angle*(1/360.0));
 
                 if( thetaIdx < 0 )
                     thetaIdx += FREAK_NB_ORIENTATION;
@@ -600,10 +597,7 @@ void FREAK_Impl::computeDescriptors( InputArray _image, std::vector<KeyPoint>& k
 
                 keypoints[k].angle = static_cast<float>(atan2((float)direction1,(float)direction0)*(180.0/CV_PI)); //estimate orientation
 
-                if(keypoints[k].angle < 0.f)
-                    thetaIdx = int(FREAK_NB_ORIENTATION*keypoints[k].angle*(1/360.0)-0.5);
-                else
-                    thetaIdx = int(FREAK_NB_ORIENTATION*keypoints[k].angle*(1/360.0)+0.5);
+                thetaIdx = cvRound(FREAK_NB_ORIENTATION*keypoints[k].angle*(1/360.0));
 
                 if( thetaIdx < 0 )
                     thetaIdx += FREAK_NB_ORIENTATION;
@@ -675,10 +669,10 @@ imgType FREAK_Impl::meanIntensity( InputArray _image, InputArray _integral,
     // expected case:
 
     // calculate borders
-    const int x_left = int(xf-radius+0.5);
-    const int y_top = int(yf-radius+0.5);
-    const int x_right = int(xf+radius+1.5);//integral image is 1px wider
-    const int y_bottom = int(yf+radius+1.5);//integral image is 1px higher
+    const int x_left = cvRound(xf-radius);
+    const int y_top = cvRound(yf-radius);
+    const int x_right = cvRound(xf+radius+1);//integral image is 1px wider
+    const int y_bottom = cvRound(yf+radius+1);//integral image is 1px higher
     iiType ret_val;
 
     ret_val = integral.at<iiType>(y_bottom,x_right);//bottom right corner

--- a/modules/xfeatures2d/src/freak.cpp
+++ b/modules/xfeatures2d/src/freak.cpp
@@ -287,8 +287,8 @@ void FREAK_Impl::buildPattern()
         const float dx = patternLookup[orientationPairs[m].i].x-patternLookup[orientationPairs[m].j].x;
         const float dy = patternLookup[orientationPairs[m].i].y-patternLookup[orientationPairs[m].j].y;
         const float norm_sq = (dx*dx+dy*dy);
-        orientationPairs[m].weight_dx = int((dx/(norm_sq))*4096.0+0.5*((dx>0)-(dx<0)));
-        orientationPairs[m].weight_dy = int((dy/(norm_sq))*4096.0+0.5*((dy>0)-(dy<0)));
+        orientationPairs[m].weight_dx = cvRound((dx/(norm_sq))*4096.0);
+        orientationPairs[m].weight_dy = cvRound((dy/(norm_sq))*4096.0);
     }
 
     // build the list of description pairs


### PR DESCRIPTION
**Merge with extra**: https://github.com/opencv/opencv_extra/pull/721

resolves #2430, when value of dx/(norm_sq) is -ve, adding -0.5 will lead to better rounding off.


