### PR TITLE
Adding constructor for kinfu_Params()

### DIFF
--- a/modules/rgbd/include/opencv2/rgbd/kinfu.hpp
+++ b/modules/rgbd/include/opencv2/rgbd/kinfu.hpp
@@ -17,9 +17,21 @@ namespace kinfu {
 
 struct CV_EXPORTS_W Params
 {
-    /** @brief Default parameters
-    A set of parameters which provides better model quality, can be very slow.
-    */
+
+    CV_WRAP Params(){}
+
+    /** 
+     * @brief Set Initial Volume Pose
+     * Sets the initial pose of the TSDF volume.
+     * @param R rotation matrix
+     * @param t translation vector
+     */
+    CV_WRAP void setInitialVolumePose(Matx33f R, Vec3f t);
+
+    /** 
+     * @brief Default parameters
+     * A set of parameters which provides better model quality, can be very slow.
+     */
     CV_WRAP static Ptr<Params> defaultParams();
 
     /** @brief Coarse parameters
@@ -32,7 +44,7 @@ struct CV_EXPORTS_W Params
     CV_PROP_RW Size frameSize;
 
     /** @brief camera intrinsics */
-    CV_PROP Matx33f intr;
+    CV_PROP_RW Matx33f intr;
 
     /** @brief pre-scale per 1 meter for input values
 
@@ -93,14 +105,14 @@ struct CV_EXPORTS_W Params
     // float gradient_delta_factor;
 
     /** @brief light pose for rendering in meters */
-    CV_PROP Vec3f lightPose;
+    CV_PROP_RW Vec3f lightPose;
 
     /** @brief distance theshold for ICP in meters */
     CV_PROP_RW float icpDistThresh;
     /** angle threshold for ICP in radians */
     CV_PROP_RW float icpAngleThresh;
     /** number of ICP iterations for each pyramid level */
-    CV_PROP std::vector<int> icpIterations;
+    CV_PROP_RW std::vector<int> icpIterations;
 
     /** @brief Threshold for depth truncation in meters
 

--- a/modules/rgbd/include/opencv2/rgbd/kinfu.hpp
+++ b/modules/rgbd/include/opencv2/rgbd/kinfu.hpp
@@ -21,12 +21,40 @@ struct CV_EXPORTS_W Params
     CV_WRAP Params(){}
 
     /**
+     * @brief Constructor for Params
+     * Sets the initial pose of the TSDF volume.
+     * @param volumeIntialPoseRot rotation matrix
+     * @param volumeIntialPoseTransl translation vector
+     */
+    CV_WRAP Params(Matx33f volumeIntialPoseRot, Vec3f volumeIntialPoseTransl)
+    {
+      setInitialVolumePose(volumeIntialPoseRot,volumeIntialPoseTransl);
+    }
+
+    /**
+     * @brief Constructor for Params
+     * Sets the initial pose of the TSDF volume.
+     * @param volumeIntialPose 4 by 4 Homogeneous Transform matrix to set the intial pose of TSDF volume
+     */
+    CV_WRAP Params(Matx44f volumeIntialPose)
+    {
+      setInitialVolumePose(volumeIntialPose);
+    }
+
+    /**
      * @brief Set Initial Volume Pose
      * Sets the initial pose of the TSDF volume.
      * @param R rotation matrix
      * @param t translation vector
      */
     CV_WRAP void setInitialVolumePose(Matx33f R, Vec3f t);
+
+    /**
+     * @brief Set Initial Volume Pose
+     * Sets the initial pose of the TSDF volume.
+     * @param homogen_tf 4 by 4 Homogeneous Transform matrix to set the intial pose of TSDF volume
+     */
+    CV_WRAP void setInitialVolumePose(Matx44f homogen_tf);
 
     /**
      * @brief Default parameters

--- a/modules/rgbd/include/opencv2/rgbd/kinfu.hpp
+++ b/modules/rgbd/include/opencv2/rgbd/kinfu.hpp
@@ -20,7 +20,7 @@ struct CV_EXPORTS_W Params
 
     CV_WRAP Params(){}
 
-    /** 
+    /**
      * @brief Set Initial Volume Pose
      * Sets the initial pose of the TSDF volume.
      * @param R rotation matrix
@@ -28,7 +28,7 @@ struct CV_EXPORTS_W Params
      */
     CV_WRAP void setInitialVolumePose(Matx33f R, Vec3f t);
 
-    /** 
+    /**
      * @brief Default parameters
      * A set of parameters which provides better model quality, can be very slow.
      */

--- a/modules/rgbd/src/kinfu.cpp
+++ b/modules/rgbd/src/kinfu.cpp
@@ -14,7 +14,12 @@ namespace kinfu {
 
 void Params::setInitialVolumePose(Matx33f R, Vec3f t)
 {
-    Params::volumePose.matrix = Affine3f(R,t).matrix;
+    setInitialVolumePose(Affine3f(R,t).matrix);
+}
+
+void Params::setInitialVolumePose(Matx44f homogen_tf)
+{
+    Params::volumePose.matrix = homogen_tf;
 }
 
 Ptr<Params> Params::defaultParams()

--- a/modules/rgbd/src/kinfu.cpp
+++ b/modules/rgbd/src/kinfu.cpp
@@ -12,6 +12,11 @@
 namespace cv {
 namespace kinfu {
 
+void Params::setInitialVolumePose(Matx33f R, Vec3f t)
+{
+    Params::volumePose.matrix = Affine3f(R,t).matrix;
+}
+
 Ptr<Params> Params::defaultParams()
 {
     Params p;
@@ -299,6 +304,8 @@ void KinFuImpl<T>::getNormals(InputArray points, OutputArray normals) const
 
 Ptr<KinFu> KinFu::create(const Ptr<Params>& params)
 {
+    CV_Assert((int)params->icpIterations.size() == params->pyramidLevels);
+    CV_Assert(params->intr(0,1) == 0 && params->intr(1,0) == 0 && params->intr(2,0) == 0 && params->intr(2,1) == 0 && params->intr(2,2) == 1);
 #ifdef HAVE_OPENCL
     if(cv::ocl::useOpenCL())
         return makePtr< KinFuImpl<UMat> >(*params);


### PR DESCRIPTION
Fixes issue #1903. Kindly review @savuor 

Created a default constructor which allows users to configure Parameter values for KinFu algorithm. 

- Created `Params()` constructor with wrapper macro `CV_WRAP` so users can access members of `struct Params`.
- Created `Params::setInitialVolumePose()` with wrapper macro `CV_WRAP` so users can configure the `Affine3f volumePose`. There was no python wrapper on `Affine3f`, so had to create this function.
- Added `CV_Assert` to check if the size of the `Params::icpIterations` is equal to `Params::pyramidLevels`.
- Added `CV_Assert` to check if `Params::intr` is valid.

![pybinding_kinfu_Params](https://user-images.githubusercontent.com/21956575/76130148-c4a55b80-5fd7-11ea-9032-d1a6b49b96ee.png)