### PR TITLE
Allows structured_light pipeline to be run from Python

### DIFF
--- a/modules/phase_unwrapping/include/opencv2/phase_unwrapping/histogramphaseunwrapping.hpp
+++ b/modules/phase_unwrapping/include/opencv2/phase_unwrapping/histogramphaseunwrapping.hpp
@@ -75,20 +75,21 @@ public:
      * @param nbrOfSmallBins Number of bins between 0 and "histThresh". Default value is 10.
      * @param nbrOfLargeBins Number of bins between "histThresh" and 32*pi*pi (highest edge reliability value). Default value is 5.
      */
-    struct CV_EXPORTS Params
+    struct CV_EXPORTS_W_SIMPLE Params
     {
-        Params();
-        int width;
-        int height;
-        float histThresh;
-        int nbrOfSmallBins;
-        int nbrOfLargeBins;
+        CV_WRAP Params();
+        CV_PROP_RW int width;
+        CV_PROP_RW int height;
+        CV_PROP_RW float histThresh;
+        CV_PROP_RW int nbrOfSmallBins;
+        CV_PROP_RW int nbrOfLargeBins;
     };
     /**
      * @brief Constructor
 
      * @param parameters HistogramPhaseUnwrapping parameters HistogramPhaseUnwrapping::Params: width,height of the phase map and histogram characteristics.
      */
+    CV_WRAP
     static Ptr<HistogramPhaseUnwrapping> create( const HistogramPhaseUnwrapping::Params &parameters =
                                                  HistogramPhaseUnwrapping::Params() );
 

--- a/modules/phase_unwrapping/misc/python/pyopencv_phase_unwrapping.hpp
+++ b/modules/phase_unwrapping/misc/python/pyopencv_phase_unwrapping.hpp
@@ -1,0 +1,3 @@
+#ifdef HAVE_OPENCV_PHASE_UNWRAPPING
+typedef cv::phase_unwrapping::HistogramPhaseUnwrapping::Params HistogramPhaseUnwrapping_Params;
+#endif

--- a/modules/phase_unwrapping/src/histogramphaseunwrapping.cpp
+++ b/modules/phase_unwrapping/src/histogramphaseunwrapping.cpp
@@ -712,7 +712,10 @@ void HistogramPhaseUnwrapping_Impl::addIncrement( OutputArray unwrappedPhaseMap 
     int rows = params.height;
     int cols = params.width;
     if( uPhaseMap.empty() )
+    {
         uPhaseMap.create(rows, cols, CV_32FC1);
+        uPhaseMap = Scalar::all(0);
+    }
     int nbrOfPixels = static_cast<int>(pixels.size());
     for( int i = 0; i < nbrOfPixels; ++i )
     {

--- a/modules/structured_light/include/opencv2/structured_light/sinusoidalpattern.hpp
+++ b/modules/structured_light/include/opencv2/structured_light/sinusoidalpattern.hpp
@@ -119,7 +119,7 @@ public:
      * @param shadowMask Mask used to discard shadow regions.
      */
     CV_WRAP
-    virtual void unwrapPhaseMap( InputArrayOfArrays wrappedPhaseMap,
+    virtual void unwrapPhaseMap( InputArray wrappedPhaseMap,
                                  OutputArray unwrappedPhaseMap,
                                  cv::Size camSize,
                                  InputArray shadowMask = noArray() ) = 0;

--- a/modules/structured_light/misc/python/test/test_structured_light.py
+++ b/modules/structured_light/misc/python/test/test_structured_light.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+
+# Python 2/3 compatibility
+from __future__ import print_function
+
+import os, numpy
+
+import cv2 as cv
+
+from tests_common import NewOpenCVTests
+
+class structured_light_test(NewOpenCVTests):
+
+    def test_unwrap(self):
+        paramsPsp = cv.structured_light_SinusoidalPattern_Params();
+        paramsFtp = cv.structured_light_SinusoidalPattern_Params();
+        paramsFaps = cv.structured_light_SinusoidalPattern_Params();
+        paramsPsp.methodId = cv.structured_light.PSP;
+        paramsFtp.methodId = cv.structured_light.FTP;
+        paramsFaps.methodId = cv.structured_light.FAPS;
+
+        sinusPsp = cv.structured_light.SinusoidalPattern_create(paramsPsp)
+        sinusFtp = cv.structured_light.SinusoidalPattern_create(paramsFtp)
+        sinusFaps = cv.structured_light.SinusoidalPattern_create(paramsFaps)
+
+        captures = []
+        for i in range(0,3):
+            capture = self.get_sample('/cv/structured_light/data/capture_sin_%d.jpg'%i, cv.IMREAD_GRAYSCALE)
+            if capture is None:
+                raise unittest.SkipTest("Missing files with test data")
+            captures.append(capture)
+
+        rows,cols = captures[0].shape
+
+        unwrappedPhaseMapPspRef = self.get_sample('/cv/structured_light/data/unwrappedPspTest.jpg',
+                                                  cv.IMREAD_GRAYSCALE)
+        unwrappedPhaseMapFtpRef = self.get_sample('/cv/structured_light/data/unwrappedFtpTest.jpg',
+                                                  cv.IMREAD_GRAYSCALE)
+        unwrappedPhaseMapFapsRef = self.get_sample('/cv/structured_light/data/unwrappedFapsTest.jpg',
+                                                  cv.IMREAD_GRAYSCALE)
+
+        wrappedPhaseMap,shadowMask = sinusPsp.computePhaseMap(captures);
+        unwrappedPhaseMap = sinusPsp.unwrapPhaseMap(wrappedPhaseMap, (cols, rows), shadowMask=shadowMask)
+        unwrappedPhaseMap8 = unwrappedPhaseMap*1 + 128
+        unwrappedPhaseMap8 = numpy.uint8(unwrappedPhaseMap8)
+
+        sumOfDiff = 0
+        count = 0
+        for i in range(rows):
+            for j in range(cols):
+                ref = int(unwrappedPhaseMapPspRef[i, j])
+                comp = int(unwrappedPhaseMap8[i, j])
+                sumOfDiff += (ref - comp)
+                count += 1
+
+        ratio = sumOfDiff/float(count)
+        self.assertLessEqual(ratio, 0.2)
+
+        wrappedPhaseMap,shadowMask = sinusFtp.computePhaseMap(captures);
+        unwrappedPhaseMap = sinusFtp.unwrapPhaseMap(wrappedPhaseMap, (cols, rows), shadowMask=shadowMask)
+        unwrappedPhaseMap8 = unwrappedPhaseMap*1 + 128
+        unwrappedPhaseMap8 = numpy.uint8(unwrappedPhaseMap8)
+
+        sumOfDiff = 0
+        count = 0
+        for i in range(rows):
+            for j in range(cols):
+                ref = int(unwrappedPhaseMapFtpRef[i, j])
+                comp = int(unwrappedPhaseMap8[i, j])
+                sumOfDiff += (ref - comp)
+                count += 1
+
+        ratio = sumOfDiff/float(count)
+        self.assertLessEqual(ratio, 0.2)
+
+        wrappedPhaseMap,shadowMask2 = sinusFaps.computePhaseMap(captures);
+        unwrappedPhaseMap = sinusFaps.unwrapPhaseMap(wrappedPhaseMap, (cols, rows), shadowMask=shadowMask)
+        unwrappedPhaseMap8 = unwrappedPhaseMap*1 + 128
+        unwrappedPhaseMap8 = numpy.uint8(unwrappedPhaseMap8)
+
+        sumOfDiff = 0
+        count = 0
+        for i in range(rows):
+            for j in range(cols):
+                ref = int(unwrappedPhaseMapFapsRef[i, j])
+                comp = int(unwrappedPhaseMap8[i, j])
+                sumOfDiff += (ref - comp)
+                count += 1
+
+        ratio = sumOfDiff/float(count)
+        self.assertLessEqual(ratio, 0.2)
+
+if __name__ == '__main__':
+    NewOpenCVTests.bootstrap()


### PR DESCRIPTION
SinusoidalPattern::unwrapPhaseMap now takes an InputArray instead of InputArrayOfArrays to correct a Python binding problem

present a scriptable HistogramPhaseUnwrapping::create

This patch solves issue #1704 and allow to write a whole pipeline including reliability computation.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
