### PR TITLE
ovis: allow setting material at sub-entity granularity

### DIFF
--- a/modules/ovis/include/opencv2/ovis.hpp
+++ b/modules/ovis/include/opencv2/ovis.hpp
@@ -109,7 +109,8 @@ public:
     CV_WRAP virtual void setEntityProperty(const String& name, int prop, const Scalar& value) = 0;
 
     /// @overload
-    CV_WRAP virtual void setEntityProperty(const String& name, int prop, const String& value) = 0;
+    CV_WRAP virtual void setEntityProperty(const String& name, int prop, const String& value,
+                                           int subEntityIdx = -1) = 0;
 
     /**
      * get the property of an entity

--- a/modules/ovis/src/ovis.cpp
+++ b/modules/ovis/src/ovis.cpp
@@ -687,7 +687,7 @@ public:
         frameCtrlrs.erase(animstate);
     }
 
-    void setEntityProperty(const String& name, int prop, const String& value) CV_OVERRIDE
+    void setEntityProperty(const String& name, int prop, const String& value, int subEntityIdx) CV_OVERRIDE
     {
         CV_Assert(prop == ENTITY_MATERIAL);
         SceneNode& node = _getSceneNode(sceneMgr, name);
@@ -698,13 +698,18 @@ public:
         Camera* cam = dynamic_cast<Camera*>(node.getAttachedObject(name));
         if(cam)
         {
+            CV_Assert(subEntityIdx == -1 && "Camera Entities do not have SubEntities");
             cam->setMaterial(mat);
             return;
         }
 
         Entity* ent = dynamic_cast<Entity*>(node.getAttachedObject(name));
         CV_Assert(ent && "invalid entity");
-        ent->setMaterial(mat);
+
+        if (subEntityIdx < 0)
+            ent->setMaterial(mat);
+        else
+            ent->getSubEntities()[subEntityIdx]->setMaterial(mat);
     }
 
     void setEntityProperty(const String& name, int prop, const Scalar& value) CV_OVERRIDE


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
