### PR TITLE
Fix depth registeration 

### DIFF
--- a/modules/rgbd/src/depth_registration.cpp
+++ b/modules/rgbd/src/depth_registration.cpp
@@ -309,7 +309,6 @@ namespace rgbd
 
             } // iterate cols
         } // iterate rows
-        
     }
 
 

--- a/modules/rgbd/src/depth_registration.cpp
+++ b/modules/rgbd/src/depth_registration.cpp
@@ -185,14 +185,14 @@ namespace rgbd
         // Apply the initial projection to the input depth
         Mat_<Point3f> transformedCloud;
         {
-            Mat_<Point3f> point_tmp(outputImagePlaneSize);
+            Mat_<Point3f> point_tmp(outputImagePlaneSize,Point3f(0.,0.,0.));
 
-            for(int j = 0; j < point_tmp.rows; ++j)
+            for(int j = 0; j < unregisteredDepth.rows; ++j)
             {
                 const DepthDepth *unregisteredDepthPtr = unregisteredDepth[j];
 
                 Point3f *point = point_tmp[j];
-                for(int i = 0; i < point_tmp.cols; ++i, ++unregisteredDepthPtr, ++point)
+                for(int i = 0; i < unregisteredDepth.cols; ++i, ++unregisteredDepthPtr, ++point)
                 {
                     float rescaled_depth = float(*unregisteredDepthPtr) * inputDepthToMetersScale;
 
@@ -309,7 +309,7 @@ namespace rgbd
 
             } // iterate cols
         } // iterate rows
-
+        
     }
 
 

--- a/modules/rgbd/test/test_registration.cpp
+++ b/modules/rgbd/test/test_registration.cpp
@@ -153,9 +153,8 @@ TEST(Rgbd_DepthRegistration, compute)
 
 TEST(Rgbd_DepthRegistration, issue_2234)
 {
-    Matx33f intrinsicsDepth, intrinsicsColor;
-    intrinsicsDepth << 100., 0., 50., 0., 100., 50., 0., 0., 1.;
-    intrinsicsColor << 100., 0., 200., 0., 100., 50., 0., 0., 1.;
+    Matx33f intrinsicsDepth(100, 0,  50, 0, 100, 50, 0, 0, 1);
+    Matx33f intrinsicsColor(100, 0, 200, 0, 100, 50, 0, 0, 1);
 
     Mat_<float> depthMat(100, 100, (float)0.);
     for(int i = 1; i <= 100; i++)

--- a/modules/rgbd/test/test_registration.cpp
+++ b/modules/rgbd/test/test_registration.cpp
@@ -153,9 +153,10 @@ TEST(Rgbd_DepthRegistration, compute)
 
 TEST(Rgbd_DepthRegistration, issue_2234)
 {
-    Mat intrinsicsDepth = (Mat_<float>(3, 3) << 100., 0., 50., 0., 100., 50., 0., 0., 1.);
-    Mat intrinsicsColor = (Mat_<float>(3, 3) << 100., 0., 200., 0., 100., 50., 0., 0., 1.);
-    
+    Matx33f intrinsicsDepth, intrinsicsColor;
+    intrinsicsDepth << 100., 0., 50., 0., 100., 50., 0., 0., 1.;
+    intrinsicsColor << 100., 0., 200., 0., 100., 50., 0., 0., 1.;
+
     Mat_<float> depthMat(100, 100, (float)0.);
     for(int i = 1; i <= 100; i++)
     {
@@ -165,11 +166,11 @@ TEST(Rgbd_DepthRegistration, issue_2234)
 
     Mat registeredDepth;
     registerDepth(intrinsicsDepth, intrinsicsColor, Mat(), Matx44f::eye(), depthMat, Size(400, 100), registeredDepth);
-    
-    Rect roi( 150, 0, 100, 100 );  
+
+    Rect roi( 150, 0, 100, 100 );
     Mat subM(registeredDepth,roi);
-    
-    ASSERT_TRUE(cv::countNonZero(subM==depthMat)==100*100);
+
+    EXPECT_EQ(0, cvtest::norm(subM, depthMat, NORM_INF));
 }
 
 

--- a/modules/rgbd/test/test_registration.cpp
+++ b/modules/rgbd/test/test_registration.cpp
@@ -151,5 +151,26 @@ TEST(Rgbd_DepthRegistration, compute)
   test.safe_run();
 }
 
+TEST(Rgbd_DepthRegistration, issue_2234)
+{
+    Mat intrinsicsDepth = (Mat_<float>(3, 3) << 100., 0., 50., 0., 100., 50., 0., 0., 1.);
+    Mat intrinsicsColor = (Mat_<float>(3, 3) << 100., 0., 200., 0., 100., 50., 0., 0., 1.);
+    
+    Mat_<float> depthMat(100, 100, (float)0.);
+    for(int i = 1; i <= 100; i++)
+    {
+        for(int j = 1; j <= 100; j++)
+            depthMat(i-1,j-1) = (float)j;
+    }
+
+    Mat registeredDepth;
+    registerDepth(intrinsicsDepth, intrinsicsColor, Mat(), Matx44f::eye(), depthMat, Size(400, 100), registeredDepth);
+    
+    Rect roi( 150, 0, 100, 100 );  
+    Mat subM(registeredDepth,roi);
+    
+    ASSERT_TRUE(cv::countNonZero(subM==depthMat)==100*100);
+}
+
 
 }} // namespace


### PR DESCRIPTION
Fixes #2234
relates #132

The for loop was iterating redundantly which caused it to wrap pixels around boundaries when the color image has a larger field of view than the depth image. 

Also added a test case for the same.

**Before**
![63403041-6d6cd000-c392-11e9-8a2f-36956075d5ac](https://user-images.githubusercontent.com/21956575/76498564-806ced80-6413-11ea-8ab8-99ca75d7ff17.png)

**After**
![Figure_1](https://user-images.githubusercontent.com/21956575/76498534-734ffe80-6413-11ea-8014-2255c7a7723f.png)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] The feature is well documented and sample code can be built with the project CMake
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
