### PR TITLE
Fix warning in VS 2019 build

### DIFF
--- a/modules/face/src/regtree.cpp
+++ b/modules/face/src/regtree.cpp
@@ -245,7 +245,7 @@ bool FacemarkKazemiImpl :: buildRegtree(regtree& tree,vector<training_sample>& s
     while(!curr.empty()){
         pair<long,long> range= make_pair(curr.front().index1,curr.front().index2);
         long node_no = curr.front().node_no;
-        splitr split;
+        splitr split = {0, 0, 0};
         //generate a split
         if(node_no<=numSplitNodes){
             if(generateSplit(curr,pixel_coordinates,samples,split,sum)){


### PR DESCRIPTION
```
opencv_contrib\modules\face\src\regtree.cpp(252): warning C4701: potentially uninitialized local variable 'split' used
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
