### PR TITLE
Fix popcnt errors for UWP ARM/ARM64

### DIFF
--- a/modules/bgsegm/src/bgfg_gsoc.cpp
+++ b/modules/bgsegm/src/bgfg_gsoc.cpp
@@ -63,14 +63,14 @@ namespace
 
 const float LSBPtau = 0.05f;
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !(defined(_M_ARM) || defined(_M_ARM64))
 #include <intrin.h>
 #pragma intrinsic(__popcnt)
 #endif
 inline int LSBPDist32(unsigned n) {
 #if defined(__GNUC__) || defined(__clang__)
     return __builtin_popcount(n);
-#elif defined(_MSC_VER)
+#elif defined(_MSC_VER) && !(defined(_M_ARM) || defined(_M_ARM64))
     return __popcnt(n);
 #else
     // Taken from http://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetParallel

--- a/modules/line_descriptor/src/bitops.hpp
+++ b/modules/line_descriptor/src/bitops.hpp
@@ -46,12 +46,20 @@
 #include "precomp.hpp"
 
 #ifdef _MSC_VER
+#if defined(_M_ARM) || defined(_M_ARM64)
+static inline UINT32 popcnt(UINT32 v)
+{
+    v = v - ((v >> 1) & 0x55555555);
+    v = (v & 0x33333333) + ((v >> 2) & 0x33333333);
+    return ((v + (v >> 4) & 0xF0F0F0F) * 0x1010101) >> 24;
+}
+#else
 # include <intrin.h>
 # define popcnt __popcnt
 # pragma warning( disable : 4267 )
+#endif
 #else
 # define popcnt __builtin_popcount
-
 #endif
 
 /* LUT */

--- a/modules/saliency/src/BING/kyheader.hpp
+++ b/modules/saliency/src/BING/kyheader.hpp
@@ -152,17 +152,6 @@ inline cv::Rect Vec4i2Rect( cv::Vec4i &v )
 }
 
 
-#if defined(_MSC_VER)
-# include <intrin.h>
-# define POPCNT(x) __popcnt(x)
-# define POPCNT64(x) (__popcnt((unsigned)(x)) + __popcnt((unsigned)((uint64_t)(x) >> 32)))
-#endif
-
-#if defined(__GNUC__)
-# define POPCNT(x) __builtin_popcount(x)
-# define POPCNT64(x) __builtin_popcountll(x)
-#endif
-
 inline int popcnt64( uint64_t u )
 {
   u = ( u & 0x5555555555555555 ) + ( ( u >> 1 ) & 0x5555555555555555 );
@@ -251,6 +240,22 @@ inline int popcnt_byte( uint32_t u )
   }
   return (int)c;
 }
+
+#if defined(_MSC_VER)
+#if defined(_M_ARM) || defined(_M_ARM64)
+# define POPCNT(x) popcnt((x))
+# define POPCNT64(x) popcnt64((x))
+#else
+# include <intrin.h>
+# define POPCNT(x) __popcnt(x)
+# define POPCNT64(x) (__popcnt((unsigned)(x)) + __popcnt((unsigned)((uint64_t)(x) >> 32)))
+#endif
+#endif
+
+#if defined(__GNUC__)
+# define POPCNT(x) __builtin_popcount(x)
+# define POPCNT64(x) __builtin_popcountll(x)
+#endif
 
 }
 }


### PR DESCRIPTION
## This pullrequest changes
Fix #2275

I use `_M_ARM` and `_M_ARM64` to determine if the platform is ARM or not.
https://docs.microsoft.com/ja-jp/cpp/preprocessor/predefined-macros?view=vs-2019

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake


```
Xbuild_image:Win64=msvs2019-arm64
buildworker:Win64=windows-1
```