### PR TITLE
ximgproc: [niBlackThreshold] add R parameter for Sauvola's method

### DIFF
--- a/modules/ximgproc/include/opencv2/ximgproc.hpp
+++ b/modules/ximgproc/include/opencv2/ximgproc.hpp
@@ -159,7 +159,7 @@ of standard deviation.
  */
 CV_EXPORTS_W void niBlackThreshold( InputArray _src, OutputArray _dst,
                                     double maxValue, int type,
-                                    int blockSize, double k, int binarizationMethod = BINARIZATION_NIBLACK, 
+                                    int blockSize, double k, int binarizationMethod = BINARIZATION_NIBLACK,
                                     double r = 128 );
 
 /** @brief Applies a binary blob thinning operation, to achieve a skeletization of the input image.

--- a/modules/ximgproc/include/opencv2/ximgproc.hpp
+++ b/modules/ximgproc/include/opencv2/ximgproc.hpp
@@ -153,12 +153,14 @@ normally a value between 0 and 1 that is multiplied with the standard deviation 
 the mean.
 @param binarizationMethod Binarization method to use. By default, Niblack's technique is used.
 Other techniques can be specified, see cv::ximgproc::LocalBinarizationMethods.
-
+@param r The user-adjustable parameter used by Sauvola's technique. This is the dynamic range
+of standard deviation.
 @sa  threshold, adaptiveThreshold
  */
 CV_EXPORTS_W void niBlackThreshold( InputArray _src, OutputArray _dst,
                                     double maxValue, int type,
-                                    int blockSize, double k, int binarizationMethod = BINARIZATION_NIBLACK );
+                                    int blockSize, double k, int binarizationMethod = BINARIZATION_NIBLACK, 
+                                    double r = 128 );
 
 /** @brief Applies a binary blob thinning operation, to achieve a skeletization of the input image.
 

--- a/modules/ximgproc/src/niblack_thresholding.cpp
+++ b/modules/ximgproc/src/niblack_thresholding.cpp
@@ -47,7 +47,7 @@ namespace cv {
 namespace ximgproc {
 
 void niBlackThreshold( InputArray _src, OutputArray _dst, double maxValue,
-        int type, int blockSize, double k, int binarizationMethod )
+        int type, int blockSize, double k, int binarizationMethod, double r)
 {
     // Input grayscale image
     Mat src = _src.getMat();
@@ -55,6 +55,7 @@ void niBlackThreshold( InputArray _src, OutputArray _dst, double maxValue,
     CV_Assert(blockSize % 2 == 1 && blockSize > 1);
     if (binarizationMethod == BINARIZATION_SAUVOLA) {
 	CV_Assert(src.depth() == CV_8U);
+    CV_Assert(r != 0);
     }
     type &= THRESH_MASK;
 
@@ -78,7 +79,7 @@ void niBlackThreshold( InputArray _src, OutputArray _dst, double maxValue,
 		thresh = mean + stddev * static_cast<float>(k);
 		break;
         case BINARIZATION_SAUVOLA:
-		thresh = mean.mul(1. + static_cast<float>(k) * (stddev / 128.0 - 1.));
+		thresh = mean.mul(1. + static_cast<float>(k) * (stddev / r - 1.));
 		break;
         case BINARIZATION_WOLF:
 		minMaxIdx(src, &srcMin);

--- a/modules/ximgproc/src/niblack_thresholding.cpp
+++ b/modules/ximgproc/src/niblack_thresholding.cpp
@@ -54,8 +54,8 @@ void niBlackThreshold( InputArray _src, OutputArray _dst, double maxValue,
     CV_Assert(src.channels() == 1);
     CV_Assert(blockSize % 2 == 1 && blockSize > 1);
     if (binarizationMethod == BINARIZATION_SAUVOLA) {
-	CV_Assert(src.depth() == CV_8U);
-    CV_Assert(r != 0);
+        CV_Assert(src.depth() == CV_8U);
+        CV_Assert(r != 0);
     }
     type &= THRESH_MASK;
 
@@ -76,23 +76,23 @@ void niBlackThreshold( InputArray _src, OutputArray _dst, double maxValue,
         switch (binarizationMethod)
         {
         case BINARIZATION_NIBLACK:
-		thresh = mean + stddev * static_cast<float>(k);
-		break;
+            thresh = mean + stddev * static_cast<float>(k);
+            break;
         case BINARIZATION_SAUVOLA:
-		thresh = mean.mul(1. + static_cast<float>(k) * (stddev / r - 1.));
-		break;
+            thresh = mean.mul(1. + static_cast<float>(k) * (stddev / r - 1.));
+            break;
         case BINARIZATION_WOLF:
-		minMaxIdx(src, &srcMin);
-		minMaxIdx(stddev, NULL, &stddevMax);
-		thresh = mean - static_cast<float>(k) * (mean - srcMin - stddev.mul(mean - srcMin) / stddevMax);
-		break;
+            minMaxIdx(src, &srcMin);
+            minMaxIdx(stddev, NULL, &stddevMax);
+            thresh = mean - static_cast<float>(k) * (mean - srcMin - stddev.mul(mean - srcMin) / stddevMax);
+            break;
         case BINARIZATION_NICK:
-		sqrt(variance + sqmean, sqrtVarianceMeanSum);
-		thresh = mean + static_cast<float>(k) * sqrtVarianceMeanSum;
-		break;
+            sqrt(variance + sqmean, sqrtVarianceMeanSum);
+            thresh = mean + static_cast<float>(k) * sqrtVarianceMeanSum;
+            break;
         default:
-		CV_Error( CV_StsBadArg, "Unknown binarization method" );
-		break;
+            CV_Error(CV_StsBadArg, "Unknown binarization method");
+            break;
         }
         thresh.convertTo(thresh, src.depth());
     }

--- a/modules/ximgproc/test/test_niblack_threshold.cpp
+++ b/modules/ximgproc/test/test_niblack_threshold.cpp
@@ -7,9 +7,9 @@ namespace opencv_test { namespace {
 
 TEST(ximgproc_niBlackThreshold, sauvola)
 {
-    Mat src = (Mat_<uchar>(3, 3) << 0, 0, 0, 1, 1, 1, 2, 2, 2);
+    Mat src = (Mat_<uchar>(3, 3) << 1, 1, 1, 2, 2, 2, 3, 3, 3);
     Mat dst;
-    cv::ximgproc::niBlackThreshold(src, dst, 255, THRESH_BINARY, 3, 1, BINARIZATION_SAUVOLA, 64);
+    cv::ximgproc::niBlackThreshold(src, dst, 255, THRESH_BINARY, 3, 1, BINARIZATION_SAUVOLA, 1);
 
     EXPECT_EQ(CV_8U, dst.type());
     EXPECT_EQ(3, dst.rows);
@@ -18,9 +18,9 @@ TEST(ximgproc_niBlackThreshold, sauvola)
     EXPECT_EQ(0, dst.at<uchar>(0, 0));
     EXPECT_EQ(0, dst.at<uchar>(0, 1));
     EXPECT_EQ(0, dst.at<uchar>(0, 2));
-    EXPECT_EQ(255, dst.at<uchar>(1, 0));
-    EXPECT_EQ(255, dst.at<uchar>(1, 1));
-    EXPECT_EQ(255, dst.at<uchar>(1, 2));
+    EXPECT_EQ(0, dst.at<uchar>(1, 0));
+    EXPECT_EQ(0, dst.at<uchar>(1, 1));
+    EXPECT_EQ(0, dst.at<uchar>(1, 2));
     EXPECT_EQ(255, dst.at<uchar>(2, 0));
     EXPECT_EQ(255, dst.at<uchar>(2, 1));
     EXPECT_EQ(255, dst.at<uchar>(2, 2));

--- a/modules/ximgproc/test/test_niblack_threshold.cpp
+++ b/modules/ximgproc/test/test_niblack_threshold.cpp
@@ -1,0 +1,29 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+#include "test_precomp.hpp"
+
+namespace opencv_test { namespace {
+
+TEST(ximgproc_niBlackThreshold, sauvola)
+{
+    Mat src = (Mat_<uchar>(3, 3) << 0, 0, 0, 1, 1, 1, 2, 2, 2);
+    Mat dst;
+    cv::ximgproc::niBlackThreshold(src, dst, 255, THRESH_BINARY, 3, 1, BINARIZATION_SAUVOLA, 64);
+
+    EXPECT_EQ(CV_8U, dst.type());
+    EXPECT_EQ(3, dst.rows);
+    EXPECT_EQ(3, dst.cols);
+
+    EXPECT_EQ(0, dst.at<uchar>(0, 0));
+    EXPECT_EQ(0, dst.at<uchar>(0, 1));
+    EXPECT_EQ(0, dst.at<uchar>(0, 2));
+    EXPECT_EQ(255, dst.at<uchar>(1, 0));
+    EXPECT_EQ(255, dst.at<uchar>(1, 1));
+    EXPECT_EQ(255, dst.at<uchar>(1, 2));
+    EXPECT_EQ(255, dst.at<uchar>(2, 0));
+    EXPECT_EQ(255, dst.at<uchar>(2, 1));
+    EXPECT_EQ(255, dst.at<uchar>(2, 2));
+}
+
+}} // namespace


### PR DESCRIPTION
Fix https://github.com/opencv/opencv_contrib/issues/2490
This is one idea.

I also fixed a mix of tabs and spaces.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
