### PR TITLE
sift: optimization stage1

### DIFF
--- a/modules/xfeatures2d/perf/perf_sift.cpp
+++ b/modules/xfeatures2d/perf/perf_sift.cpp
@@ -1,0 +1,72 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+#include "perf_precomp.hpp"
+
+namespace opencv_test { namespace {
+
+typedef perf::TestBaseWithParam<std::string> sift;
+
+#define SIFT_IMAGES \
+    "cv/detectors_descriptors_evaluation/images_datasets/leuven/img1.png",\
+    "stitching/a3.png"
+
+PERF_TEST_P(sift, detect, testing::Values(SIFT_IMAGES))
+{
+    string filename = getDataPath(GetParam());
+    Mat frame = imread(filename, IMREAD_GRAYSCALE);
+    ASSERT_FALSE(frame.empty()) << "Unable to load source image " << filename;
+
+    Mat mask;
+    declare.in(frame).time(90);
+    Ptr<SIFT> detector = SIFT::create();
+    vector<KeyPoint> points;
+
+    PERF_SAMPLE_BEGIN();
+        detector->detect(frame, points, mask);
+    PERF_SAMPLE_END();
+
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P(sift, extract, testing::Values(SIFT_IMAGES))
+{
+    string filename = getDataPath(GetParam());
+    Mat frame = imread(filename, IMREAD_GRAYSCALE);
+    ASSERT_FALSE(frame.empty()) << "Unable to load source image " << filename;
+
+    Mat mask;
+    declare.in(frame).time(90);
+
+    Ptr<SIFT> detector = SIFT::create();
+    vector<KeyPoint> points;
+    Mat descriptors;
+    detector->detect(frame, points, mask);
+
+    PERF_SAMPLE_BEGIN();
+        detector->compute(frame, points, descriptors);
+    PERF_SAMPLE_END();
+
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P(sift, full, testing::Values(SIFT_IMAGES))
+{
+    string filename = getDataPath(GetParam());
+    Mat frame = imread(filename, IMREAD_GRAYSCALE);
+    ASSERT_FALSE(frame.empty()) << "Unable to load source image " << filename;
+
+    Mat mask;
+    declare.in(frame).time(90);
+    Ptr<SIFT> detector = SIFT::create();
+    vector<KeyPoint> points;
+    Mat descriptors;
+
+    PERF_SAMPLE_BEGIN();
+        detector->detectAndCompute(frame, mask, points, descriptors, false);
+    PERF_SAMPLE_END();
+
+    SANITY_CHECK_NOTHING();
+}
+
+}} // namespace

--- a/modules/xfeatures2d/src/sift.cpp
+++ b/modules/xfeatures2d/src/sift.cpp
@@ -158,6 +158,7 @@ protected:
 Ptr<SIFT> SIFT::create( int _nfeatures, int _nOctaveLayers,
                      double _contrastThreshold, double _edgeThreshold, double _sigma )
 {
+    CV_TRACE_FUNCTION();
     return makePtr<SIFT_Impl>(_nfeatures, _nOctaveLayers, _contrastThreshold, _edgeThreshold, _sigma);
 }
 
@@ -221,6 +222,8 @@ unpackOctave(const KeyPoint& kpt, int& octave, int& layer, float& scale)
 
 static Mat createInitialImage( const Mat& img, bool doubleImageSize, float sigma )
 {
+    CV_TRACE_FUNCTION();
+
     Mat gray, gray_fpt;
     if( img.channels() == 3 || img.channels() == 4 )
     {
@@ -255,6 +258,8 @@ static Mat createInitialImage( const Mat& img, bool doubleImageSize, float sigma
 
 void SIFT_Impl::buildGaussianPyramid( const Mat& base, std::vector<Mat>& pyr, int nOctaves ) const
 {
+    CV_TRACE_FUNCTION();
+
     std::vector<double> sig(nOctaveLayers + 3);
     pyr.resize(nOctaves*(nOctaveLayers + 3));
 
@@ -306,6 +311,8 @@ public:
 
     void operator()( const cv::Range& range ) const CV_OVERRIDE
     {
+        CV_TRACE_FUNCTION();
+
         const int begin = range.start;
         const int end = range.end;
 
@@ -329,6 +336,8 @@ private:
 
 void SIFT_Impl::buildDoGPyramid( const std::vector<Mat>& gpyr, std::vector<Mat>& dogpyr ) const
 {
+    CV_TRACE_FUNCTION();
+
     int nOctaves = (int)gpyr.size()/(nOctaveLayers + 3);
     dogpyr.resize( nOctaves*(nOctaveLayers + 2) );
 
@@ -339,6 +348,8 @@ void SIFT_Impl::buildDoGPyramid( const std::vector<Mat>& gpyr, std::vector<Mat>&
 static float calcOrientationHist( const Mat& img, Point pt, int radius,
                                   float sigma, float* hist, int n )
 {
+    CV_TRACE_FUNCTION();
+
     int i, j, k, len = (radius*2+1)*(radius*2+1);
 
     float expf_scale = -1.f/(2.f * sigma * sigma);
@@ -477,6 +488,8 @@ static bool adjustLocalExtrema( const std::vector<Mat>& dog_pyr, KeyPoint& kpt, 
                                 int& layer, int& r, int& c, int nOctaveLayers,
                                 float contrastThreshold, float edgeThreshold, float sigma )
 {
+    CV_TRACE_FUNCTION();
+
     const float img_scale = 1.f/(255*SIFT_FIXPT_SCALE);
     const float deriv_scale = img_scale*0.5f;
     const float second_deriv_scale = img_scale;
@@ -609,6 +622,8 @@ public:
           tls_kpts_struct(_tls_kpts_struct) { }
     void operator()( const cv::Range& range ) const CV_OVERRIDE
     {
+        CV_TRACE_FUNCTION();
+
         const int begin = range.start;
         const int end = range.end;
 
@@ -653,6 +668,8 @@ public:
                      val <= prevptr[c-step-1] && val <= prevptr[c-step] && val <= prevptr[c-step+1] &&
                      val <= prevptr[c+step-1] && val <= prevptr[c+step] && val <= prevptr[c+step+1])))
                 {
+                    CV_TRACE_REGION("pixel_candidate");
+
                     int r1 = r, c1 = c, layer = i;
                     if( !adjustLocalExtrema(dog_pyr, kpt, o, layer, r1, c1,
                                             nOctaveLayers, (float)contrastThreshold,
@@ -705,6 +722,8 @@ private:
 void SIFT_Impl::findScaleSpaceExtrema( const std::vector<Mat>& gauss_pyr, const std::vector<Mat>& dog_pyr,
                                   std::vector<KeyPoint>& keypoints ) const
 {
+    CV_TRACE_FUNCTION();
+
     const int nOctaves = (int)gauss_pyr.size()/(nOctaveLayers + 3);
     const int threshold = cvFloor(0.5 * contrastThreshold / nOctaveLayers * 255 * SIFT_FIXPT_SCALE);
 
@@ -740,6 +759,8 @@ void SIFT_Impl::findScaleSpaceExtrema( const std::vector<Mat>& gauss_pyr, const 
 static void calcSIFTDescriptor( const Mat& img, Point2f ptf, float ori, float scl,
                                int d, int n, float* dst )
 {
+    CV_TRACE_FUNCTION();
+
     Point pt(cvRound(ptf.x), cvRound(ptf.y));
     float cos_t = cosf(ori*(float)(CV_PI/180));
     float sin_t = sinf(ori*(float)(CV_PI/180));
@@ -1050,6 +1071,8 @@ public:
 
     void operator()( const cv::Range& range ) const CV_OVERRIDE
     {
+        CV_TRACE_FUNCTION();
+
         const int begin = range.start;
         const int end = range.end;
 
@@ -1083,6 +1106,7 @@ private:
 static void calcDescriptors(const std::vector<Mat>& gpyr, const std::vector<KeyPoint>& keypoints,
                             Mat& descriptors, int nOctaveLayers, int firstOctave )
 {
+    CV_TRACE_FUNCTION();
     parallel_for_(Range(0, static_cast<int>(keypoints.size())), calcDescriptorsComputer(gpyr, keypoints, descriptors, nOctaveLayers, firstOctave));
 }
 
@@ -1116,6 +1140,8 @@ void SIFT_Impl::detectAndCompute(InputArray _image, InputArray _mask,
                       OutputArray _descriptors,
                       bool useProvidedKeypoints)
 {
+    CV_TRACE_FUNCTION();
+
     int firstOctave = -1, actualNOctaves = 0, actualNLayers = 0;
     Mat image = _image.getMat(), mask = _mask.getMat();
 

--- a/modules/xfeatures2d/src/sift.cpp
+++ b/modules/xfeatures2d/src/sift.cpp
@@ -244,14 +244,16 @@ static Mat createInitialImage( const Mat& img, bool doubleImageSize, float sigma
 #else
         resize(gray_fpt, dbl, Size(gray_fpt.cols*2, gray_fpt.rows*2), 0, 0, INTER_LINEAR);
 #endif
-        GaussianBlur(dbl, dbl, Size(), sig_diff, sig_diff);
-        return dbl;
+        Mat result;
+        GaussianBlur(dbl, result, Size(), sig_diff, sig_diff);
+        return result;
     }
     else
     {
         sig_diff = sqrtf( std::max(sigma * sigma - SIFT_INIT_SIGMA * SIFT_INIT_SIGMA, 0.01f) );
-        GaussianBlur(gray_fpt, gray_fpt, Size(), sig_diff, sig_diff);
-        return gray_fpt;
+        Mat result;
+        GaussianBlur(gray_fpt, result, Size(), sig_diff, sig_diff);
+        return result;
     }
 }
 


### PR DESCRIPTION
**Tested with main PR**: https://github.com/opencv/opencv/pull/17092

- perf tests
- trace regions
- avoid inplace arrays in `GaussianBlur()` calls

<details>

<summary>SIFT performance results (i5-6600)</summary>

|Name of Test|base|ipp|avx2+ipp|ipp speedup|ipp+avx2 speedup|
|---|:-:|:-:|:-:|:-:|:-:|
|SIFT::SIFT_detect::"leuven/img1.png"|79.523|34.281|34.230|2.32|2.32|
|SIFT::SIFT_detect::"stitching/a3.png"|71.424|31.850|31.629|2.24|2.26|
|SIFT::SIFT_extract::"leuven/img1.png"|78.763|34.135|26.981|2.31|2.92|
|SIFT::SIFT_extract::"stitching/a3.png"|85.059|46.014|33.927|1.85|2.51|
|SIFT::SIFT_full::"leuven/img1.png"|100.167|55.374|48.046|1.81|2.08|
|SIFT::SIFT_full::"stitching/a3.png"|106.117|66.773|54.400|1.59|1.95|
</details>

<!--
allow_multiple_commits=1
-->