### PR TITLE
Fixed the information about default values in aruco documentation

### DIFF
--- a/modules/aruco/include/opencv2/aruco.hpp
+++ b/modules/aruco/include/opencv2/aruco.hpp
@@ -99,7 +99,7 @@ enum CornerRefineMethod{
  * - maxMarkerPerimeterRate:  determine maximum perimeter for marker contour to be detected. This
  *   is defined as a rate respect to the maximum dimension of the input image (default 4.0).
  * - polygonalApproxAccuracyRate: minimum accuracy during the polygonal approximation process to
- *   determine which contours are squares.
+ *   determine which contours are squares. (default 0.03)
  * - minCornerDistanceRate: minimum distance between corners for detected markers relative to its
  *   perimeter (default 0.05)
  * - minDistanceToBorder: minimum distance of any corner to the image border for detected markers
@@ -109,7 +109,7 @@ enum CornerRefineMethod{
  *   of the two markers (default 0.05).
  * - cornerRefinementMethod: corner refinement method. (CORNER_REFINE_NONE, no refinement.
  *   CORNER_REFINE_SUBPIX, do subpixel refinement. CORNER_REFINE_CONTOUR use contour-Points,
- *   CORNER_REFINE_APRILTAG  use the AprilTag2 approach)
+ *   CORNER_REFINE_APRILTAG  use the AprilTag2 approach). (default CORNER_REFINE_NONE)
  * - cornerRefinementWinSize: window size for the corner refinement process (in pixels) (default 5).
  * - cornerRefinementMaxIterations: maximum number of iterations for stop criteria of the corner
  *   refinement process (default 30).
@@ -117,7 +117,7 @@ enum CornerRefineMethod{
  *   process (default: 0.1)
  * - markerBorderBits: number of bits of the marker border, i.e. marker border width (default 1).
  * - perspectiveRemovePixelPerCell: number of bits (per dimension) for each cell of the marker
- *   when removing the perspective (default 8).
+ *   when removing the perspective (default 4).
  * - perspectiveRemoveIgnoredMarginPerCell: width of the margin of pixels on each cell not
  *   considered for the determination of the cell bit. Represents the rate respect to the total
  *   size of the cell, i.e. perspectiveRemovePixelPerCell (default 0.13)
@@ -129,21 +129,21 @@ enum CornerRefineMethod{
  *   than 128 or not) (default 5.0)
  * - errorCorrectionRate error correction rate respect to the maximun error correction capability
  *   for each dictionary. (default 0.6).
- * - aprilTagMinClusterPixels: reject quads containing too few pixels.
- * - aprilTagMaxNmaxima: how many corner candidates to consider when segmenting a group of pixels into a quad.
+ * - aprilTagMinClusterPixels: reject quads containing too few pixels. (default 5)
+ * - aprilTagMaxNmaxima: how many corner candidates to consider when segmenting a group of pixels into a quad. (default 10)
  * - aprilTagCriticalRad: Reject quads where pairs of edges have angles that are close to straight or close to
- *   180 degrees. Zero means that no quads are rejected. (In radians).
+ *   180 degrees. Zero means that no quads are rejected. (In radians) (default 10*PI/180)
  * - aprilTagMaxLineFitMse:  When fitting lines to the contours, what is the maximum mean squared error
  *   allowed?  This is useful in rejecting contours that are far from being quad shaped; rejecting
- *   these quads "early" saves expensive decoding processing.
+ *   these quads "early" saves expensive decoding processing. (default 10.0)
  * - aprilTagMinWhiteBlackDiff: When we build our model of black & white pixels, we add an extra check that
- *   the white model must be (overall) brighter than the black model.  How much brighter? (in pixel values, [0,255]).
- * - aprilTagDeglitch:  should the thresholded image be deglitched? Only useful for very noisy images
+ *   the white model must be (overall) brighter than the black model.  How much brighter? (in pixel values, [0,255]). (default 5)
+ * - aprilTagDeglitch:  should the thresholded image be deglitched? Only useful for very noisy images. (default 0)
  * - aprilTagQuadDecimate: Detection of quads can be done on a lower-resolution image, improving speed at a
  *   cost of pose accuracy and a slight decrease in detection rate. Decoding the binary payload is still
- *   done at full resolution.
+ *   done at full resolution. (default 0.0)
  * - aprilTagQuadSigma: What Gaussian blur should be applied to the segmented image (used for quad detection?)
- *   Parameter is the standard deviation in pixels.  Very noisy images benefit from non-zero values (e.g. 0.8).
+ *   Parameter is the standard deviation in pixels.  Very noisy images benefit from non-zero values (e.g. 0.8). (default 0.0)
  * - detectInvertedMarker: to check if there is a white marker. In order to generate a "white" marker just
  *   invert a normal marker by using a tilde, ~markerImage. (default false)
  */


### PR DESCRIPTION
resolves #2420

Changed the default value of DetectorParameters.perspectiveRemovePixelPerCell to 4 in the documentation as per the initialization in the code.
Also the default values of some parameters were missing in the documentation, added them.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under OpenCV (BSD) License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
