### PR TITLE
aruco: new feature testCharucoCornersCollinear() in charuco.hpp/cpp

### DIFF
--- a/modules/aruco/include/opencv2/aruco/charuco.hpp
+++ b/modules/aruco/include/opencv2/aruco/charuco.hpp
@@ -334,7 +334,18 @@ CV_EXPORTS void drawCharucoDiamond(const Ptr<Dictionary> &dictionary, Vec4i ids,
                                    int borderBits = 1);
 
 
-
+/**
+ * @brief test whether the ChArUco markers are collinear
+ *
+ * @param board layout of ChArUco board.
+ * @param image charucoIds list of identifiers for each corner in charucoCorners.
+ * @return bool value, 1 (true) if detected corners form a line, 0 (false) if they do not.
+      solvePnP, calibration functions will fail if the corners are collinear (true).
+ *
+ * The number of ids in charucoIDs should be <= the number of chessboard corners in the board.  This functions checks whether the charuco corners are on a straight line (returns true, if so), or not (false).  Axis parallel, as well as diagonal and other straight lines detected.  Degenerate cases: for number of charucoIDs <= 2, the function returns true.
+ */
+CV_EXPORTS_W bool testCharucoCornersCollinear(const Ptr<CharucoBoard> &_board,
+                                              InputArray _charucoIds);
 
 //! @}
 }

--- a/modules/aruco/include/opencv2/aruco/charuco.hpp
+++ b/modules/aruco/include/opencv2/aruco/charuco.hpp
@@ -337,8 +337,8 @@ CV_EXPORTS void drawCharucoDiamond(const Ptr<Dictionary> &dictionary, Vec4i ids,
 /**
  * @brief test whether the ChArUco markers are collinear
  *
- * @param board layout of ChArUco board.
- * @param image charucoIds list of identifiers for each corner in charucoCorners.
+ * @param _board layout of ChArUco board.
+ * @param _charucoIds list of identifiers for each corner in charucoCorners per frame.
  * @return bool value, 1 (true) if detected corners form a line, 0 (false) if they do not.
       solvePnP, calibration functions will fail if the corners are collinear (true).
  *

--- a/modules/aruco/src/charuco.cpp
+++ b/modules/aruco/src/charuco.cpp
@@ -938,5 +938,62 @@ void drawDetectedDiamonds(InputOutputArray _image, InputArrayOfArrays _corners,
         }
     }
 }
+
+/**
+   @param board layout of ChArUco board.
+ * @param image charucoIds list of identifiers for each corner in charucoCorners.
+ * @return bool value, 1 (true) for detected corners form a line, 0 for non-linear.
+      solvePnP will fail if the corners are collinear (true).
+  * Check that the set of charuco markers in _charucoIds does not identify a straight line on
+    the charuco board.  Axis parallel, as well as diagonal and other straight lines detected.
+  */
+bool testCharucoCornersCollinear(const Ptr<CharucoBoard> &_board, InputArray _charucoIds){
+
+    unsigned int nCharucoCorners = (unsigned int)_charucoIds.getMat().total();
+
+    // only test if there are 3 or more corners
+    if (nCharucoCorners > 2){
+
+    CV_Assert( _board->chessboardCorners.size() >= _charucoIds.getMat().total());
+
+    Vec<double, 3> point0( _board->chessboardCorners[_charucoIds.getMat().at< int >(0)].x,
+                           _board->chessboardCorners[_charucoIds.getMat().at< int >(0)].y,
+                           1);
+
+    Vec<double, 3> point1( _board->chessboardCorners[_charucoIds.getMat().at< int >(1)].x,
+                           _board->chessboardCorners[_charucoIds.getMat().at< int >(1)].y,
+                           1);
+
+    // create a line from the first two points.
+    Vec<double, 3> testLine = point0.cross(point1);
+
+    Vec<double, 3> testPoint(0, 0, 1);
+
+    double divisor = sqrt(testLine[0]*testLine[0] + testLine[1]*testLine[1]);
+
+    CV_Assert( divisor != 0);
+
+     // normalize the line with normal
+     testLine /= divisor;
+
+     double dotProduct;
+     for (unsigned int i = 2; i < nCharucoCorners; i++){
+         testPoint(0) = _board->chessboardCorners[_charucoIds.getMat().at< int >(i)].x;
+         testPoint(1) = _board->chessboardCorners[_charucoIds.getMat().at< int >(i)].y;
+
+         // if testPoint is on testLine, dotProduct will be zero (or very, very close)
+         dotProduct = testPoint.dot(testLine);
+
+         if (std::abs(dotProduct) > 1e-6){
+             return false;
+         }
+     }
+
+    // no points found that were off of testLine, return true that all points collinear.
+    return true;
+    }
+
+    return true;
+}
 }
 }

--- a/modules/aruco/src/charuco.cpp
+++ b/modules/aruco/src/charuco.cpp
@@ -947,22 +947,23 @@ void drawDetectedDiamonds(InputOutputArray _image, InputArrayOfArrays _corners,
   * Check that the set of charuco markers in _charucoIds does not identify a straight line on
     the charuco board.  Axis parallel, as well as diagonal and other straight lines detected.
   */
-bool testCharucoCornersCollinear(const Ptr<CharucoBoard> &_board, InputArray _charucoIds){
+ bool testCharucoCornersCollinear(const Ptr<CharucoBoard> &_board, InputArray _charucoIds){
 
     unsigned int nCharucoCorners = (unsigned int)_charucoIds.getMat().total();
 
-    // only test if there are 3 or more corners
-    if (nCharucoCorners > 2){
+    if (nCharucoCorners <= 2)
+        return true;
 
+    // only test if there are 3 or more corners
     CV_Assert( _board->chessboardCorners.size() >= _charucoIds.getMat().total());
 
     Vec<double, 3> point0( _board->chessboardCorners[_charucoIds.getMat().at< int >(0)].x,
-                           _board->chessboardCorners[_charucoIds.getMat().at< int >(0)].y,
-                           1);
+            _board->chessboardCorners[_charucoIds.getMat().at< int >(0)].y,
+            1);
 
     Vec<double, 3> point1( _board->chessboardCorners[_charucoIds.getMat().at< int >(1)].x,
-                           _board->chessboardCorners[_charucoIds.getMat().at< int >(1)].y,
-                           1);
+            _board->chessboardCorners[_charucoIds.getMat().at< int >(1)].y,
+            1);
 
     // create a line from the first two points.
     Vec<double, 3> testLine = point0.cross(point1);
@@ -973,26 +974,23 @@ bool testCharucoCornersCollinear(const Ptr<CharucoBoard> &_board, InputArray _ch
 
     CV_Assert( divisor != 0);
 
-     // normalize the line with normal
-     testLine /= divisor;
+    // normalize the line with normal
+    testLine /= divisor;
 
-     double dotProduct;
-     for (unsigned int i = 2; i < nCharucoCorners; i++){
-         testPoint(0) = _board->chessboardCorners[_charucoIds.getMat().at< int >(i)].x;
-         testPoint(1) = _board->chessboardCorners[_charucoIds.getMat().at< int >(i)].y;
+    double dotProduct;
+    for (unsigned int i = 2; i < nCharucoCorners; i++){
+        testPoint(0) = _board->chessboardCorners[_charucoIds.getMat().at< int >(i)].x;
+        testPoint(1) = _board->chessboardCorners[_charucoIds.getMat().at< int >(i)].y;
 
-         // if testPoint is on testLine, dotProduct will be zero (or very, very close)
-         dotProduct = testPoint.dot(testLine);
+        // if testPoint is on testLine, dotProduct will be zero (or very, very close)
+        dotProduct = testPoint.dot(testLine);
 
-         if (std::abs(dotProduct) > 1e-6){
-             return false;
-         }
-     }
-
-    // no points found that were off of testLine, return true that all points collinear.
-    return true;
+        if (std::abs(dotProduct) > 1e-6){
+            return false;
+        }
     }
 
+    // no points found that were off of testLine, return true that all points collinear.
     return true;
 }
 }

--- a/modules/aruco/test/test_charucodetection.cpp
+++ b/modules/aruco/test/test_charucodetection.cpp
@@ -616,9 +616,21 @@ TEST(Charuco, testCharucoCornersCollinear_true)
     Ptr<aruco::CharucoBoard> charucoBoard =
             aruco::CharucoBoard::create(squaresX, squaresY, squareLength, markerLength, dictionary);
 
-    vector<int> charucoIdsAxisLine {192, 204, 216, 228, 240, 252, 264, 276, 288};
+    // consistency with C++98
+    const int arrLine[9] = {192, 204, 216, 228, 240, 252, 264, 276, 288};
+    vector<int> charucoIdsAxisLine(9, 0);
 
-    vector<int> charucoIdsDiagonalLine {198, 209, 220, 231, 242, 253, 264};
+    for (int i = 0; i < 9; i++){
+        charucoIdsAxisLine[i] = arrLine[i];
+    }
+
+    const int arrDiag[7] = {198, 209, 220, 231, 242, 253, 264};
+
+    vector<int> charucoIdsDiagonalLine(7, 0);
+
+    for (int i = 0; i < 7; i++){
+        charucoIdsDiagonalLine[i] = arrDiag[i];
+    }
 
     bool resultAxisLine = cv::aruco::testCharucoCornersCollinear(charucoBoard, charucoIdsAxisLine);
 
@@ -646,12 +658,19 @@ TEST(Charuco, testCharucoCornersCollinear_false)
     Ptr<aruco::CharucoBoard> charucoBoard =
             aruco::CharucoBoard::create(squaresX, squaresY, squareLength, markerLength, dictionary);
 
-    vector<int> charucoIds {192, 193, 194, 195, 196, 197, 198, 204, 205, 206, 207, 208,
-                            209, 210, 216, 217, 218, 219, 220, 221, 222, 228, 229, 230,
-                            231, 232, 233, 234, 240, 241, 242, 243, 244, 245, 246, 252,
-                            253, 254, 255, 256, 257, 258, 264, 265, 266, 267, 268, 269,
-                            270, 276, 277, 278, 279, 280, 281, 282, 288, 289, 290, 291,
-                            292, 293, 294};
+    // consistency with C++98
+    const int arr[63] = {192, 193, 194, 195, 196, 197, 198, 204, 205, 206, 207, 208,
+                                209, 210, 216, 217, 218, 219, 220, 221, 222, 228, 229, 230,
+                                231, 232, 233, 234, 240, 241, 242, 243, 244, 245, 246, 252,
+                                253, 254, 255, 256, 257, 258, 264, 265, 266, 267, 268, 269,
+                                270, 276, 277, 278, 279, 280, 281, 282, 288, 289, 290, 291,
+                                292, 293, 294};
+
+    vector<int> charucoIds(63, 0);
+    for (int i = 0; i < 63; i++){
+        charucoIds[i] = arr[i];
+    }
+
 
     bool result = cv::aruco::testCharucoCornersCollinear(charucoBoard, charucoIds);
 

--- a/modules/aruco/test/test_charucodetection.cpp
+++ b/modules/aruco/test/test_charucodetection.cpp
@@ -199,9 +199,6 @@ static Mat projectCharucoBoard(Ptr<aruco::CharucoBoard> &board, Mat cameraMatrix
     return img;
 }
 
-
-
-
 /**
  * @brief Check Charuco detection
  */
@@ -600,6 +597,65 @@ TEST(CV_CharucoDiamondDetection, accuracy) {
 TEST(CV_CharucoBoardCreation, accuracy) {
     CV_CharucoBoardCreation test;
     test.safe_run();
+}
+
+TEST(Charuco, testCharucoCornersCollinear_true)
+{
+    int squaresX = 13;
+    int squaresY = 28;
+    float squareLength = 300;
+    float markerLength = 150;
+    int dictionaryId = 11;
+
+
+    Ptr<aruco::DetectorParameters> detectorParams = aruco::DetectorParameters::create();
+
+    Ptr<aruco::Dictionary> dictionary =
+            aruco::getPredefinedDictionary(aruco::PREDEFINED_DICTIONARY_NAME(dictionaryId));
+
+    Ptr<aruco::CharucoBoard> charucoBoard =
+            aruco::CharucoBoard::create(squaresX, squaresY, squareLength, markerLength, dictionary);
+
+    vector<int> charucoIdsAxisLine {192, 204, 216, 228, 240, 252, 264, 276, 288};
+
+    vector<int> charucoIdsDiagonalLine {198, 209, 220, 231, 242, 253, 264};
+
+    bool resultAxisLine = cv::aruco::testCharucoCornersCollinear(charucoBoard, charucoIdsAxisLine);
+
+    bool resultDiagonalLine = cv::aruco::testCharucoCornersCollinear(charucoBoard, charucoIdsDiagonalLine);
+
+    EXPECT_TRUE(resultAxisLine);
+
+    EXPECT_TRUE(resultDiagonalLine);
+}
+
+TEST(Charuco, testCharucoCornersCollinear_false)
+{
+    int squaresX = 13;
+    int squaresY = 28;
+    float squareLength = 300;
+    float markerLength = 150;
+    int dictionaryId = 11;
+
+
+    Ptr<aruco::DetectorParameters> detectorParams = aruco::DetectorParameters::create();
+
+    Ptr<aruco::Dictionary> dictionary =
+            aruco::getPredefinedDictionary(aruco::PREDEFINED_DICTIONARY_NAME(dictionaryId));
+
+    Ptr<aruco::CharucoBoard> charucoBoard =
+            aruco::CharucoBoard::create(squaresX, squaresY, squareLength, markerLength, dictionary);
+
+    vector<int> charucoIds {192, 193, 194, 195, 196, 197, 198, 204, 205, 206, 207, 208,
+                            209, 210, 216, 217, 218, 219, 220, 221, 222, 228, 229, 230,
+                            231, 232, 233, 234, 240, 241, 242, 243, 244, 245, 246, 252,
+                            253, 254, 255, 256, 257, 258, 264, 265, 266, 267, 268, 269,
+                            270, 276, 277, 278, 279, 280, 281, 282, 288, 289, 290, 291,
+                            292, 293, 294};
+
+    bool result = cv::aruco::testCharucoCornersCollinear(charucoBoard, charucoIds);
+
+    EXPECT_FALSE(result);
 }
 
 }} // namespace


### PR DESCRIPTION
When using charuco corners for calibration, specifically in the robotics context when full-pattern images of the charuco boards are not gauranteed, there are cases when the chaurco corners identified are collinear.

The corners (in my application) are usually axis aligned, but when these identified corners are axis aligned or just linear (some diagonal within the pattern), using these corners will result in errors via CV_ASSERT checks, or poor results b/c of the numerical issues of using collinear points for estimating calibration parameters.

There does not exist any functionality w/in the opencv_contrib module for checking whether the charuco corners are collinear, given a charuco board.  In `charuco.cpp`, there is function `static bool _arePointsEnoughForPoseEstimation(const vector< Point3f > &points)` called by  `estimatePoseCharucoBoard()`.  This function is local to `charuco.cpp`, though, and only checks for axis-aligned collinear charuco corners.

The new feature is a function in charuco.hpp/.cpp that checks for collinear charuco corners, `testCharucoCornersCollinear()`.

[mwe.zip](https://github.com/opencv/opencv_contrib/files/4539926/mwe.zip)

The MWE mwe.zip (with some input images) alters `calibrate_camera_charuco.cpp` to demonstrate situations in which calibration fails when there are collinear charuco corners.  In 3.4, the warning message  


```
** On entry to DLASCLS parameter number  4 had an illegal value
```

is displayed and the intrinisic camera calibration matrix contains nan values.

In 4.3/master, an exception is thrown:

```
terminate called after throwing an instance of 'cv::Exception'
  what():  OpenCV(4.3.0-dev) /home/atabb/git/opencv-charuco/charuco-bool-feature/opencv/modules/calib3d/src/calibration.cpp:1213: error: (-215:Assertion failed) fabs(sc) > DBL_EPSILON in function 'cvFindExtrinsicCameraParams2'
```

The image below illustrate one such image.  I did not have a diagonal case detected in my dataset, but created one to test.  

![image_00018](https://user-images.githubusercontent.com/25328047/80377788-b6521e00-8869-11ea-98e6-f6dd72daa746.png)

![image_00016_diag](https://user-images.githubusercontent.com/25328047/80378729-16958f80-886b-11ea-81ac-dc615cc60795.png)


Within the MWE, I show how I would use this new feature -- to choose whether to include (or not) detected charuco boards.  

```cpp
//			// TODO Uncomment this when testing the new feature.
//			bool collinear = testCharucoCornersCollinear(charucoboard, currentCharucoIds);
//
//			cout << "file " << vectorFiles[i] << " is collinear ? " << collinear << endl;
//
//			if (currentCharucoCorners.size() >= 6 && collinear== false){
//				{
//					allCharucoCorners.push_back(currentCharucoCorners);
//					allCharucoIds.push_back(currentCharucoIds);
//				}
//			}

			// TODO  comment this when testing the new feature
			if (currentCharucoCorners.size() >= 6){
				{
					allCharucoCorners.push_back(currentCharucoCorners);
					allCharucoIds.push_back(currentCharucoIds);
				}
			}

```

For this PR, I included everything in the PR versus putting the failure cases in a separate issue.  I am new to submitting PRs to OpenCV, let me know what works better.  I also used the 3.4 branch this time. 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under OpenCV (BSD) License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [X] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X] The feature is well documented and sample code can be built with the project CMake
