### PR TITLE
dnn_objdetect: remove highgui header from core_detect.hpp

### DIFF
--- a/modules/dnn_objdetect/include/opencv2/core_detect.hpp
+++ b/modules/dnn_objdetect/include/opencv2/core_detect.hpp
@@ -7,7 +7,6 @@
 #include <vector>
 #include <memory>
 
-#include <opencv2/highgui.hpp>
 #include <opencv2/imgproc.hpp>
 
 /** @defgroup dnn_objdetect DNN used for object detection


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x ] I agree to contribute to the project under OpenCV (BSD) License.
- [ x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ x] The PR is proposed to proper branch
- [ x] There is reference to original bug report and related work
- [ x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ x] The feature is well documented and sample code can be built with the project CMake

this removes a dependancy on highgui.hpp from the core_detect.hpp header, so the module can compile if highgui is disabled from cmake
(it's not needed here, and only the samples should depend on gui)