### PR TITLE
Added override empty method for BRISQUE

### DIFF
--- a/modules/quality/include/opencv2/quality/qualitybrisque.hpp
+++ b/modules/quality/include/opencv2/quality/qualitybrisque.hpp
@@ -62,6 +62,9 @@ public:
     */
     CV_WRAP static void computeFeatures(InputArray img, OutputArray features);
 
+    /** @brief Implements QualityBase::empty()  */
+    CV_WRAP bool empty() const CV_OVERRIDE { return _range.empty() || _model.empty(); }
+
 protected:
 
     cv::Ptr<cv::ml::SVM> _model = nullptr;

--- a/modules/quality/test/test_brisque.cpp
+++ b/modules/quality/test/test_brisque.cpp
@@ -77,6 +77,18 @@ TEST(TEST_CASE_NAME, compute_features)
     EXPECT_EQ(features.cols, 36);
 }
 
+// check empty method
+TEST(TEST_CASE_NAME, check_empty)
+{
+    auto ptr1 = create_brisque();
+    EXPECT_FALSE(ptr1->empty());
+
+    const auto model = cvtest::findDataFile(MODEL_FNAME, false);
+    const auto range = cvtest::findDataFile("some_wrong_range_name", false);
+    auto ptr2 = quality::QualityBRISQUE::create(model, range);
+    EXPECT_TRUE(ptr1->empty());
+}
+
 /*
 // internal a/b test
 TEST(TEST_CASE_NAME, performance)


### PR DESCRIPTION
Fixed this issue: https://github.com/opencv/opencv_contrib/issues/2548