### PR TITLE
Fix default parameter to be coherent with documentation

### DIFF
--- a/modules/ximgproc/include/opencv2/ximgproc/lsc.hpp
+++ b/modules/ximgproc/include/opencv2/ximgproc/lsc.hpp
@@ -126,7 +126,7 @@ public:
     The function merge component that is too small, assigning the previously found adjacent label
     to this component. Calling this function may change the final number of superpixels.
      */
-    CV_WRAP virtual void enforceLabelConnectivity( int min_element_size = 20 ) = 0;
+    CV_WRAP virtual void enforceLabelConnectivity( int min_element_size = 25 ) = 0;
 
 
 };


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ x] I agree to contribute to the project under OpenCV (BSD) License.
- [ x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
