### PR TITLE
cmake(cuda): update handling of -std=c++11/14 flags

### DIFF
--- a/modules/cudev/test/CMakeLists.txt
+++ b/modules/cudev/test/CMakeLists.txt
@@ -15,7 +15,14 @@ if(OCV_DEPENDENCIES_FOUND)
 
   ocv_cuda_filter_options()
 
-  CUDA_ADD_EXECUTABLE(${the_target} ${OPENCV_TEST_${the_module}_SOURCES} OPTIONS -std=c++11)
+  if(CUDA_VERSION VERSION_LESS "11.0")
+    ocv_update(OPENCV_CUDA_OPTIONS_opencv_test_cudev "-std=c++11")
+  else()
+    ocv_update(OPENCV_CUDA_OPTIONS_opencv_test_cudev "-std=c++14")
+    ocv_warnings_disable(CMAKE_CXX_FLAGS -Wdeprecated-declarations)
+  endif()
+
+  CUDA_ADD_EXECUTABLE(${the_target} ${OPENCV_TEST_${the_module}_SOURCES} OPTIONS ${OPENCV_CUDA_OPTIONS_opencv_test_cudev})
   ocv_target_link_libraries(${the_target} PRIVATE
       ${test_deps} ${OPENCV_LINKER_LIBS} ${CUDA_LIBRARIES}
   )


### PR DESCRIPTION
**Main PR**: https://github.com/opencv/opencv/pull/17686

```
force_builders=Custom
buildworker:Custom=linux-4
build_image:Custom=ubuntu-cuda:18.04
```
