### PR TITLE
xfeatures2d: fix compilation error on MSVS

### DIFF
--- a/modules/xfeatures2d/test/test_surf.cuda.cpp
+++ b/modules/xfeatures2d/test/test_surf.cuda.cpp
@@ -171,15 +171,22 @@ CUDA_TEST_P(CUDA_SURF, Descriptor)
     EXPECT_GT(matchedRatio, 0.6);
 }
 
-INSTANTIATE_TEST_CASE_P(CUDA_Features2D, CUDA_SURF, testing::Combine(
-    testing::Values(
 #if defined (__x86_64__) || defined (_M_X64)
-            SURF_HessianThreshold(100.0), SURF_HessianThreshold(500.0),
+testing::internal::ValueArray3<SURF_HessianThreshold, SURF_HessianThreshold, SURF_HessianThreshold> thresholdValues =
+    testing::Values(
+            SURF_HessianThreshold(100.0),
+            SURF_HessianThreshold(500.0),
+            SURF_HessianThreshold(1000.0));
 #else
-            // hessian computation is not bit-exact and lower threshold causes difference count of detection
+// hessian computation is not bit-exact and lower threshold causes different count of detection
+internal::ValueArray2<SURF_HessianThreshold, SURF_HessianThreshold> thresholdValues =
+    testing::Values(
             SURF_HessianThreshold(813.0),
+            SURF_HessianThreshold(1000.0));
 #endif
-            SURF_HessianThreshold(1000.0)),
+
+INSTANTIATE_TEST_CASE_P(CUDA_Features2D, CUDA_SURF, testing::Combine(
+    thresholdValues,
     testing::Values(SURF_Octaves(3), SURF_Octaves(4)),
     testing::Values(SURF_OctaveLayers(2), SURF_OctaveLayers(3)),
     testing::Values(SURF_Extended(false), SURF_Extended(true)),


### PR DESCRIPTION
relates #2588 

<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
buildworker:Custom=linux-4
docker_image:Custom=ubuntu-cuda:16.04
```