### PR TITLE
Create CUDA backend support for dnn_superres

### DIFF
--- a/modules/dnn_superres/include/opencv2/dnn_superres.hpp
+++ b/modules/dnn_superres/include/opencv2/dnn_superres.hpp
@@ -94,9 +94,13 @@ public:
      */
     CV_WRAP void setModel(const String& algo, int scale);
 
-    /** @brief Set CUDA backend and target
+    /** @brief Set computation backend
     */
-    CV_WRAP void setCUDA();
+    CV_WRAP void setPreferableBackend(int backendId);
+
+    /** @brief Set computation target
+    */
+    CV_WRAP void setPreferableTarget(int targetId);
 
     /** @brief Upsample via neural network
     @param img Image to upscale

--- a/modules/dnn_superres/include/opencv2/dnn_superres.hpp
+++ b/modules/dnn_superres/include/opencv2/dnn_superres.hpp
@@ -94,6 +94,10 @@ public:
      */
     CV_WRAP void setModel(const String& algo, int scale);
 
+    /** @brief Set CUDA backend and target
+    */
+    CV_WRAP void setCUDA();
+
     /** @brief Upsample via neural network
     @param img Image to upscale
     @param result Destination upscaled image

--- a/modules/dnn_superres/src/dnn_superres.cpp
+++ b/modules/dnn_superres/src/dnn_superres.cpp
@@ -91,6 +91,13 @@ void DnnSuperResImpl::setModel(const String& algo, int scale)
     this->alg = algo;
 }
 
+void DnnSuperResImpl::setCUDA()
+{
+    net.setPreferableBackend(cv::dnn::DNN_BACKEND_CUDA);
+    net.setPreferableTarget(cv::dnn::DNN_TARGET_CUDA);
+    CV_LOG_INFO(NULL, "Successfully set CUDA backend and target.");
+}
+
 void DnnSuperResImpl::upsample(InputArray img, OutputArray result)
 {
     if (net.empty())

--- a/modules/dnn_superres/src/dnn_superres.cpp
+++ b/modules/dnn_superres/src/dnn_superres.cpp
@@ -91,11 +91,22 @@ void DnnSuperResImpl::setModel(const String& algo, int scale)
     this->alg = algo;
 }
 
-void DnnSuperResImpl::setCUDA()
-{
-    net.setPreferableBackend(cv::dnn::DNN_BACKEND_CUDA);
-    net.setPreferableTarget(cv::dnn::DNN_TARGET_CUDA);
-    CV_LOG_INFO(NULL, "Successfully set CUDA backend and target.");
+void DnnSuperResImpl::setPreferableBackend(int backendId)
+{   
+    if (net.empty())
+        CV_Error(Error::StsError, "Model is emtpy. Please read a model before setting the backend.");
+
+    net.setPreferableBackend(backendId);
+    CV_LOG_INFO(NULL, "Successfully set computation backend.");
+}
+
+void DnnSuperResImpl::setPreferableTarget(int targetId)
+{   
+    if (net.empty())
+        CV_Error(Error::StsError, "Model is empty. Please read a model before setting the target.");
+
+    net.setPreferableTarget(targetId);
+    CV_LOG_INFO(NULL, "Successfully set target device.");
 }
 
 void DnnSuperResImpl::upsample(InputArray img, OutputArray result)

--- a/modules/dnn_superres/src/dnn_superres.cpp
+++ b/modules/dnn_superres/src/dnn_superres.cpp
@@ -92,7 +92,7 @@ void DnnSuperResImpl::setModel(const String& algo, int scale)
 }
 
 void DnnSuperResImpl::setPreferableBackend(int backendId)
-{   
+{
     if (net.empty())
         CV_Error(Error::StsError, "Model is emtpy. Please read a model before setting the backend.");
 
@@ -101,7 +101,7 @@ void DnnSuperResImpl::setPreferableBackend(int backendId)
 }
 
 void DnnSuperResImpl::setPreferableTarget(int targetId)
-{   
+{
     if (net.empty())
         CV_Error(Error::StsError, "Model is empty. Please read a model before setting the target.");
 


### PR DESCRIPTION
Hi there,

This PR allows users to set CUDA backend in the dnn_superres module. Now users can use their GPU's for inference while upscaling images via the neural networks. I've tried a few images, and I've seen around an 6x increase in speed (GTX 1080Ti).

I'm not sure this is the best way of doing this. Perhaps it is better to also allow users to choose other types of backends? What do you think? I'll wait for the feedback before adding a tutorial (and test?) for this.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
