### PR TITLE
Add Objective-C/Swift wrappers for opencv_contrib modules

### DIFF
--- a/modules/aruco/CMakeLists.txt
+++ b/modules/aruco/CMakeLists.txt
@@ -1,2 +1,2 @@
 set(the_description "ArUco Marker Detection")
-ocv_define_module(aruco opencv_core opencv_imgproc opencv_calib3d WRAP python java)
+ocv_define_module(aruco opencv_core opencv_imgproc opencv_calib3d WRAP python java objc)

--- a/modules/aruco/misc/objc/gen_dict.json
+++ b/modules/aruco/misc/objc/gen_dict.json
@@ -1,0 +1,7 @@
+{
+    "AdditionalImports" : {
+        "*" : [ "\"aruco.hpp\"" ],
+        "CharucoBoard" : [ "\"aruco/charuco.hpp\"" ],
+        "Dictionary" : [ "\"aruco/dictionary.hpp\"" ]
+    }
+}

--- a/modules/bgsegm/CMakeLists.txt
+++ b/modules/bgsegm/CMakeLists.txt
@@ -1,2 +1,2 @@
 set(the_description "Background Segmentation Algorithms")
-ocv_define_module(bgsegm opencv_core opencv_imgproc opencv_video opencv_calib3d WRAP python java)
+ocv_define_module(bgsegm opencv_core opencv_imgproc opencv_video opencv_calib3d WRAP python java objc)

--- a/modules/bgsegm/misc/objc/gen_dict.json
+++ b/modules/bgsegm/misc/objc/gen_dict.json
@@ -1,0 +1,11 @@
+{
+    "AdditionalImports" : {
+        "*" : [ "\"bgsegm.hpp\"" ]
+    },
+    "func_arg_fix" : {
+        "Bgsegm" : {
+            "createBackgroundSubtractorGSOC" : { "mc" : {"ctype" : "LSBPCameraMotionCompensation"} },
+            "createBackgroundSubtractorLSBP" : { "mc" : {"ctype" : "LSBPCameraMotionCompensation"} }
+        }
+    }
+}

--- a/modules/bioinspired/CMakeLists.txt
+++ b/modules/bioinspired/CMakeLists.txt
@@ -1,3 +1,3 @@
 set(the_description "Biologically inspired algorithms")
 ocv_warnings_disable(CMAKE_CXX_FLAGS -Wundef)
-ocv_define_module(bioinspired opencv_core OPTIONAL opencv_highgui WRAP java python)
+ocv_define_module(bioinspired opencv_core OPTIONAL opencv_highgui WRAP java objc python)

--- a/modules/bioinspired/misc/objc/gen_dict.json
+++ b/modules/bioinspired/misc/objc/gen_dict.json
@@ -1,0 +1,5 @@
+{
+    "AdditionalImports" : {
+        "*" : [ "\"bioinspired.hpp\"" ]
+    }
+}

--- a/modules/face/CMakeLists.txt
+++ b/modules/face/CMakeLists.txt
@@ -4,7 +4,7 @@ ocv_define_module(face opencv_core
     opencv_objdetect
     opencv_calib3d   # estimateAffinePartial2D() (trainFacemark)
     opencv_photo     # seamlessClone() (face_swap sample)
-    WRAP python java
+    WRAP python java objc
 )
 # NOTE: objdetect module is needed for one of the samples
 

--- a/modules/face/misc/objc/gen_dict.json
+++ b/modules/face/misc/objc/gen_dict.json
@@ -1,0 +1,6 @@
+{
+    "AdditionalImports" : {
+        "*" : [ "\"face.hpp\"" ],
+        "BIF" : [ "\"face/bif.hpp\"" ]
+    }
+}

--- a/modules/img_hash/CMakeLists.txt
+++ b/modules/img_hash/CMakeLists.txt
@@ -1,3 +1,3 @@
 set(the_description "Image hash algorithms")
 set(OPENCV_MODULE_IS_PART_OF_WORLD OFF)
-ocv_define_module(img_hash opencv_imgproc opencv_core WRAP python java)
+ocv_define_module(img_hash opencv_imgproc opencv_core WRAP python java objc)

--- a/modules/img_hash/misc/objc/gen_dict.json
+++ b/modules/img_hash/misc/objc/gen_dict.json
@@ -1,0 +1,11 @@
+{
+    "AdditionalImports" : {
+        "*" : [ "\"img_hash.hpp\"" ]
+    },
+    "func_arg_fix" : {
+        "BlockMeanHash" : {
+            "create" : { "mode" : {"ctype" : "BlockMeanHashMode"} },
+            "setMode" : { "mode" : {"ctype" : "BlockMeanHashMode"} }
+        }
+    }
+}

--- a/modules/phase_unwrapping/CMakeLists.txt
+++ b/modules/phase_unwrapping/CMakeLists.txt
@@ -1,2 +1,2 @@
 set(the_description "Phase Unwrapping API")
-ocv_define_module(phase_unwrapping opencv_core opencv_imgproc WRAP python java)
+ocv_define_module(phase_unwrapping opencv_core opencv_imgproc WRAP python java objc)

--- a/modules/phase_unwrapping/misc/objc/gen_dict.json
+++ b/modules/phase_unwrapping/misc/objc/gen_dict.json
@@ -1,0 +1,6 @@
+{
+    "AdditionalImports" : {
+        "*" : [ "\"phase_unwrapping.hpp\"" ],
+        "HistogramPhaseUnwrapping" : [ "\"phase_unwrapping/histogramphaseunwrapping.hpp\"" ]
+    }
+}

--- a/modules/plot/CMakeLists.txt
+++ b/modules/plot/CMakeLists.txt
@@ -1,2 +1,2 @@
 set(the_description "Plot function for Mat data.")
-ocv_define_module(plot opencv_core opencv_imgproc WRAP python java)
+ocv_define_module(plot opencv_core opencv_imgproc WRAP python java objc)

--- a/modules/plot/misc/objc/gen_dict.json
+++ b/modules/plot/misc/objc/gen_dict.json
@@ -1,0 +1,5 @@
+{
+    "AdditionalImports" : {
+        "*" : [ "\"plot.hpp\"" ]
+    }
+}

--- a/modules/structured_light/CMakeLists.txt
+++ b/modules/structured_light/CMakeLists.txt
@@ -1,2 +1,2 @@
 set(the_description "Structured Light API")
-ocv_define_module(structured_light opencv_core opencv_imgproc opencv_calib3d opencv_phase_unwrapping OPTIONAL opencv_viz WRAP python java)
+ocv_define_module(structured_light opencv_core opencv_imgproc opencv_calib3d opencv_phase_unwrapping OPTIONAL opencv_viz WRAP python java objc)

--- a/modules/structured_light/misc/objc/gen_dict.json
+++ b/modules/structured_light/misc/objc/gen_dict.json
@@ -1,0 +1,5 @@
+{
+    "AdditionalImports" : {
+        "*" : [ "\"structured_light.hpp\"" ]
+    }
+}

--- a/modules/text/CMakeLists.txt
+++ b/modules/text/CMakeLists.txt
@@ -10,6 +10,7 @@ ocv_define_module(text
     WRAP
       python
       java
+      objc
 )
 
 if(TARGET ocv.3rdparty.tesseract)

--- a/modules/text/misc/objc/gen_dict.json
+++ b/modules/text/misc/objc/gen_dict.json
@@ -1,0 +1,28 @@
+{
+    "AdditionalImports" : {
+        "*" : [ "\"text.hpp\"" ]
+    },
+    "func_arg_fix" : {
+        "Text" : {
+            "detectRegions" : { "method" : {"ctype" : "erGrouping_Modes"} },
+            "erGrouping" : { "method" : {"ctype" : "erGrouping_Modes"} },
+            "loadOCRHMMClassifier" : { "classifier" : {"ctype" : "classifier_type"} },
+            "(ERFilter*)createERFilterNM1:(NSString*)filename thresholdDelta:(int)thresholdDelta minArea:(float)minArea maxArea:(float)maxArea minProbability:(float)minProbability nonMaxSuppression:(BOOL)nonMaxSuppression minProbabilityDiff:(float)minProbabilityDiff" : { "createERFilterNM1" : {"name" : "createERFilterNM1FromFile"} },
+            "(ERFilter*)createERFilterNM2:(NSString*)filename minProbability:(float)minProbability" : { "createERFilterNM2" : {"name" : "createERFilterNM2FromFile"} }
+        },
+        "OCRBeamSearchDecoder" : {
+            "(OCRBeamSearchDecoder*)create:(NSString*)filename vocabulary:(NSString*)vocabulary transition_probabilities_table:(Mat*)transition_probabilities_table emission_probabilities_table:(Mat*)emission_probabilities_table mode:(decoder_mode)mode beam_size:(int)beam_size" : { "create" : {"name" : "createFromFile"} },
+            "create" : { "mode" : {"ctype" : "decoder_mode",
+                                   "defval" : ""
+            } }
+        },
+        "OCRHMMDecoder" : {
+            "(OCRHMMDecoder*)create:(NSString*)filename vocabulary:(NSString*)vocabulary transition_probabilities_table:(Mat*)transition_probabilities_table emission_probabilities_table:(Mat*)emission_probabilities_table mode:(decoder_mode)mode classifier:(int)classifier" : { "create" : {"name" : "createFromFile"} },
+            "create" : { "mode" : {"ctype" : "decoder_mode"} }
+        },
+        "OCRTesseract" : {
+            "create" : { "oem" : {"ctype" : "ocr_engine_mode"},
+                         "psmode" : {"ctype" : "page_seg_mode"} }
+        }
+    }
+}

--- a/modules/tracking/CMakeLists.txt
+++ b/modules/tracking/CMakeLists.txt
@@ -1,3 +1,3 @@
 set(the_description "Tracking API")
-ocv_define_module(tracking opencv_imgproc opencv_core opencv_video opencv_plot OPTIONAL opencv_dnn opencv_datasets WRAP java python)
+ocv_define_module(tracking opencv_imgproc opencv_core opencv_video opencv_plot OPTIONAL opencv_dnn opencv_datasets WRAP java python objc)
 ocv_warnings_disable(CMAKE_CXX_FLAGS -Wno-shadow /wd4458)

--- a/modules/tracking/misc/objc/gen_dict.json
+++ b/modules/tracking/misc/objc/gen_dict.json
@@ -1,0 +1,8 @@
+{
+    "const_fix" : {
+        "TrackerKCF" : { "MODE": { "CUSTOM": "MODE_CUSTOM" } }
+    },
+    "AdditionalImports" : {
+        "*" : [ "\"tracking.hpp\"" ]
+    }
+}

--- a/modules/xfeatures2d/CMakeLists.txt
+++ b/modules/xfeatures2d/CMakeLists.txt
@@ -3,7 +3,7 @@ set(the_description "Contributed/Experimental Algorithms for Salient 2D Features
 if(HAVE_CUDA)
   ocv_warnings_disable(CMAKE_CXX_FLAGS -Wundef)
 endif()
-ocv_define_module(xfeatures2d opencv_core opencv_imgproc opencv_features2d opencv_calib3d OPTIONAL opencv_shape opencv_ml opencv_cudaarithm WRAP python java)
+ocv_define_module(xfeatures2d opencv_core opencv_imgproc opencv_features2d opencv_calib3d OPTIONAL opencv_shape opencv_ml opencv_cudaarithm WRAP python java objc)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/download_vgg.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/download_boostdesc.cmake)

--- a/modules/xfeatures2d/misc/objc/gen_dict.json
+++ b/modules/xfeatures2d/misc/objc/gen_dict.json
@@ -1,0 +1,20 @@
+{
+    "class_ignore_list" : [
+        "SURF_CUDA"
+    ],
+    "const_fix" : {
+        "PCTSignatures" : { "SimilarityFunction": { "GAUSSIAN": "SIMFUN_GAUSSIAN" } }
+    },
+    "AdditionalImports" : {
+        "*" : [ "\"xfeatures2d.hpp\"" ]
+    },
+    "func_arg_fix" : {
+        "DAISY" : {
+            "create" : { "norm" : { "ctype" : "NormalizationType",
+                                    "defval" : "cv::xfeatures2d::DAISY::NRM_NONE"} }
+        },
+        "PCTSignatures" : {
+            "(PCTSignatures*)create:(NSArray<Point2f*>*)initSamplingPoints initSeedCount:(int)initSeedCount" : { "create" : {"name" : "create2"} }
+        }
+    }
+}

--- a/modules/ximgproc/CMakeLists.txt
+++ b/modules/ximgproc/CMakeLists.txt
@@ -1,2 +1,2 @@
 set(the_description "Extended image processing module. It includes edge-aware filters and etc.")
-ocv_define_module(ximgproc opencv_core opencv_imgproc opencv_calib3d opencv_imgcodecs opencv_video WRAP python java)
+ocv_define_module(ximgproc opencv_core opencv_imgproc opencv_calib3d opencv_imgcodecs opencv_video WRAP python java objc)

--- a/modules/ximgproc/misc/objc/gen_dict.json
+++ b/modules/ximgproc/misc/objc/gen_dict.json
@@ -1,0 +1,28 @@
+{
+    "AdditionalImports" : {
+        "*" : [ "\"ximgproc.hpp\"" ]
+    },
+    "missing_consts" : {
+        "Ximgproc" : {
+            "private" : [],
+            "public" : [
+                ["RO_IGNORE_BORDERS", 1], ["RO_STRICT", 0]
+            ]
+        }
+    },
+    "func_arg_fix" : {
+        "Ximgproc" : {
+            "niBlackThreshold" : { "binarizationMethod" : {"ctype" : "LocalBinarizationMethods"} },
+            "HoughPoint2Line" : { "angleRange" : {"ctype" : "AngleRangeOption"},
+                                  "makeSkew" : {"ctype" : "HoughDeskewOption"} },
+            "weightedMedianFilter" : { "weightType" : {"ctype" : "WMFWeightType"} },
+            "createDTFilter" : { "mode" : {"ctype" : "EdgeAwareFiltersList"} },
+            "dtFilter" : { "mode" : {"ctype" : "EdgeAwareFiltersList"} },
+            "thinning" : { "thinningType" : {"ctype" : "ThinningTypes"} },
+            "FastHoughTransform" : { "angleRange" : {"ctype" : "AngleRangeOption"},
+                                     "makeSkew" : {"ctype" : "HoughDeskewOption"},
+                                     "op" : {"ctype" : "HoughOp"} },
+            "createSuperpixelSLIC" : { "algorithm" : {"ctype" : "SLICType"} }
+        }
+    }
+}

--- a/modules/xphoto/CMakeLists.txt
+++ b/modules/xphoto/CMakeLists.txt
@@ -1,2 +1,2 @@
 set(the_description "Addon to basic photo module")
-ocv_define_module(xphoto opencv_core opencv_imgproc opencv_photo WRAP python java)
+ocv_define_module(xphoto opencv_core opencv_imgproc opencv_photo WRAP python java objc)

--- a/modules/xphoto/misc/objc/gen_dict.json
+++ b/modules/xphoto/misc/objc/gen_dict.json
@@ -1,0 +1,5 @@
+{
+    "AdditionalImports" : {
+        "*" : [ "\"xphoto.hpp\"" ]
+    }
+}


### PR DESCRIPTION
**Main PR**: https://github.com/opencv/opencv/pull/17882

07ba8bd

resolves #2608 
resolves https://github.com/opencv/opencv/issues/17881

Changes in this PR
 - add `objc` to the WRAP clause of the relevant `CMakeLists.txt` files
 - add relevant argument/constant fix-ups, import config for each module in `gen_dict.json `

<cut/>

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
