### PR TITLE
Merge 3.4

### DIFF
--- a/modules/cudaarithm/test/test_element_operations.cpp
+++ b/modules/cudaarithm/test/test_element_operations.cpp
@@ -2778,7 +2778,7 @@ CUDA_TEST_P(PolarToCart, Accuracy)
 {
     cv::Mat magnitude = randomMat(size, type);
     cv::Mat angle = randomMat(size, type);
-    const double tol = (type == CV_32FC1 ? 1.6e-4 : 1e-4) * (angleInDegrees ? 1.0 : 19.0);
+    const double tol = (type == CV_32FC1 ? 1.6e-4 : 1e-4) * (angleInDegrees ? 1.0 : 19.47);
 
     cv::cuda::GpuMat x = createMat(size, type, useRoi);
     cv::cuda::GpuMat y = createMat(size, type, useRoi);


### PR DESCRIPTION
moved opencv/opencv#17943 from tomoaki0705:fixPolarToCartRounding

Main PR: https://github.com/opencv/opencv/pull/17970
Previous "Merge 3.4": #2602

<cut/>

```
force_builders=Custom
buildworker:Custom=linux-4
build_image:Custom=ubuntu-cuda:18.04
```
