### PR TITLE
Merge 3.4

### DIFF
--- a/modules/cudaarithm/test/test_gpumat.cpp
+++ b/modules/cudaarithm/test/test_gpumat.cpp
@@ -320,6 +320,65 @@ CUDA_TEST_P(GpuMat_ConvertTo, WithScaling)
     }
 }
 
+CUDA_TEST_P(GpuMat_ConvertTo, InplaceWithOutScaling)
+{
+    cv::Mat src = randomMat(size, depth1);
+
+    if ((depth1 == CV_64F || depth2 == CV_64F) && !supportFeature(devInfo, cv::cuda::NATIVE_DOUBLE))
+    {
+        try
+        {
+            cv::cuda::GpuMat d_srcDst = loadMat(src);
+            d_srcDst.convertTo(d_srcDst, depth2);
+        }
+        catch (const cv::Exception& e)
+        {
+            ASSERT_EQ(cv::Error::StsUnsupportedFormat, e.code);
+        }
+    }
+    else
+    {
+        cv::cuda::GpuMat d_srcDst = loadMat(src, useRoi);
+        d_srcDst.convertTo(d_srcDst, depth2);
+
+        cv::Mat dst_gold;
+        src.convertTo(dst_gold, depth2);
+
+        EXPECT_MAT_NEAR(dst_gold, d_srcDst, depth2 < CV_32F ? 1.0 : 1e-4);
+    }
+}
+
+
+CUDA_TEST_P(GpuMat_ConvertTo, InplaceWithScaling)
+{
+    cv::Mat src = randomMat(size, depth1);
+    double a = randomDouble(0.0, 1.0);
+    double b = randomDouble(-10.0, 10.0);
+
+    if ((depth1 == CV_64F || depth2 == CV_64F) && !supportFeature(devInfo, cv::cuda::NATIVE_DOUBLE))
+    {
+        try
+        {
+            cv::cuda::GpuMat d_srcDst = loadMat(src);
+            d_srcDst.convertTo(d_srcDst, depth2, a, b);
+        }
+        catch (const cv::Exception& e)
+        {
+            ASSERT_EQ(cv::Error::StsUnsupportedFormat, e.code);
+        }
+    }
+    else
+    {
+        cv::cuda::GpuMat d_srcDst = loadMat(src, useRoi);
+        d_srcDst.convertTo(d_srcDst, depth2, a, b);
+
+        cv::Mat dst_gold;
+        src.convertTo(dst_gold, depth2, a, b);
+
+        EXPECT_MAT_NEAR(dst_gold, d_srcDst, depth2 < CV_32F ? 1.0 : 1e-4);
+    }
+}
+
 INSTANTIATE_TEST_CASE_P(CUDA, GpuMat_ConvertTo, testing::Combine(
     ALL_DEVICES,
     DIFFERENT_SIZES,

--- a/modules/stereo/src/descriptor.cpp
+++ b/modules/stereo/src/descriptor.cpp
@@ -56,7 +56,7 @@ namespace cv
             CV_Assert(image1.size() == image2.size());
             CV_Assert(kernelSize % 2 != 0);
             CV_Assert(image1.type() == CV_8UC1 && image2.type() == CV_8UC1);
-            CV_Assert(type != CV_DENSE_CENSUS || type != CV_SPARSE_CENSUS);
+            CV_Assert(type == CV_DENSE_CENSUS || type == CV_SPARSE_CENSUS);
             CV_Assert(kernelSize <= ((type == 0) ? 5 : 11));
             int n2 = (kernelSize) / 2;
             uint8_t *images[] = {image1.data, image2.data};
@@ -79,7 +79,7 @@ namespace cv
             CV_Assert(image1.size() == dist1.size());
             CV_Assert(kernelSize % 2 != 0);
             CV_Assert(image1.type() == CV_8UC1);
-            CV_Assert(type != CV_DENSE_CENSUS || type != CV_SPARSE_CENSUS);
+            CV_Assert(type == CV_DENSE_CENSUS || type == CV_SPARSE_CENSUS);
             CV_Assert(kernelSize <= ((type == 0) ? 5 : 11));
             int n2 = (kernelSize) / 2;
             uint8_t *images[] = {image1.data};
@@ -130,7 +130,7 @@ namespace cv
             CV_Assert(img1.size() == img2.size());
             CV_Assert(kernelSize % 2 != 0);
             CV_Assert(img1.type() == CV_8UC1 && img2.type() == CV_8UC1);
-            CV_Assert(type != CV_MODIFIED_CENSUS_TRANSFORM || type != CV_MEAN_VARIATION);
+            CV_Assert(type == CV_MODIFIED_CENSUS_TRANSFORM || type == CV_MEAN_VARIATION);
             CV_Assert(kernelSize <= 9);
             int n2 = (kernelSize - 1) >> 1;
             uint8_t *images[] = {img1.data, img2.data};
@@ -168,7 +168,7 @@ namespace cv
             CV_Assert(img1.size() == dist.size());
             CV_Assert(kernelSize % 2 != 0);
             CV_Assert(img1.type() == CV_8UC1);
-            CV_Assert(type != CV_MODIFIED_CENSUS_TRANSFORM || type != CV_MEAN_VARIATION);
+            CV_Assert(type == CV_MODIFIED_CENSUS_TRANSFORM || type == CV_MEAN_VARIATION);
             CV_Assert(kernelSize <= 9);
             int n2 = (kernelSize - 1) >> 1;
             uint8_t *images[] = {img1.data};
@@ -200,7 +200,7 @@ namespace cv
             CV_Assert(img1.size() ==  img2.size());
             CV_Assert(kernelSize % 2 != 0);
             CV_Assert(img1.type() == CV_8UC1 && img2.type() == CV_8UC1);
-            CV_Assert(type != CV_CS_CENSUS || type != CV_MODIFIED_CS_CENSUS);
+            CV_Assert(type == CV_CS_CENSUS || type == CV_MODIFIED_CS_CENSUS);
             CV_Assert(kernelSize <= 7);
             int n2 = kernelSize >> 1;
             uint8_t *images[] = {img1.data, img2.data};
@@ -222,7 +222,7 @@ namespace cv
             CV_Assert(img1.size() ==  dist1.size());
             CV_Assert(kernelSize % 2 != 0);
             CV_Assert(img1.type() == CV_8UC1);
-            CV_Assert(type != CV_MODIFIED_CS_CENSUS || type != CV_CS_CENSUS);
+            CV_Assert(type == CV_MODIFIED_CS_CENSUS || type == CV_CS_CENSUS);
             CV_Assert(kernelSize <= 7);
             int n2 = kernelSize >> 1;
             uint8_t *images[] = {img1.data};


### PR DESCRIPTION
moved opencv/opencv#17982 from nglee:dev_cudaGpuMatConvertToInplaceFix (test code)
#2632 from pemmanuelviel:pev--fix-descriptor-asserts

Main PR: https://github.com/opencv/opencv/pull/18099
Previous "Merge 3.4": #2618

<cut/>

```
force_builders=Custom
buildworker:Custom=linux-4
build_image:Custom=ubuntu-cuda:18.04
```
