### PR TITLE
Fix matching::maxDisparity value when calling StereoBinarySGBM::setNu…

### DIFF
--- a/modules/stereo/src/stereo_binary_sgbm.cpp
+++ b/modules/stereo/src/stereo_binary_sgbm.cpp
@@ -725,7 +725,8 @@ namespace cv
             void setMinDisparity(int minDisparity) CV_OVERRIDE {CV_Assert(minDisparity >= 0); params.minDisparity = minDisparity; }
 
             int getNumDisparities() const CV_OVERRIDE { return params.numDisparities; }
-            void setNumDisparities(int numDisparities) CV_OVERRIDE { CV_Assert(numDisparities > 0); params.numDisparities = numDisparities; }
+            void setNumDisparities(int numDisparities) CV_OVERRIDE { CV_Assert(numDisparities > 0); params.numDisparities = numDisparities;
+                                                                     Matching::setMaxDisparity(numDisparities /*- params.minDisparity*/);}
 
             int getBlockSize() const CV_OVERRIDE { return params.kernelSize; }
             void setBlockSize(int blockSize) CV_OVERRIDE {CV_Assert(blockSize % 2 != 0); params.kernelSize = blockSize; }


### PR DESCRIPTION
…mDisparities after ctor

Note that it considers maxDisparity==numDisparities, and so minDisparity as being 0

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
