### PR TITLE
Default kernel size of 9 was used instead of the set one

### DIFF
--- a/modules/stereo/src/stereo_binary_bm.cpp
+++ b/modules/stereo/src/stereo_binary_bm.cpp
@@ -393,7 +393,7 @@ namespace cv
                 {
                     starCensusTransform(left,right,params.kernelSize,censusImage[0],censusImage[1]);
                 }
-                hammingDistanceBlockMatching(censusImage[0], censusImage[1], hammingDistance);
+                hammingDistanceBlockMatching(censusImage[0], censusImage[1], hammingDistance, params.kernelSize);
                 costGathering(hammingDistance, partialSumsLR);
                 blockAgregation(partialSumsLR, params.agregationWindowSize, agregatedHammingLRCost);
                 dispartyMapFormation(agregatedHammingLRCost, disp0, 3);

--- a/modules/stereo/src/stereo_binary_sgbm.cpp
+++ b/modules/stereo/src/stereo_binary_sgbm.cpp
@@ -679,7 +679,7 @@ namespace cv
                     starCensusTransform(left,right,params.kernelSize,censusImageLeft,censusImageRight);
                 }
 
-                hammingDistanceBlockMatching(censusImageLeft, censusImageRight, hamDist);
+                hammingDistanceBlockMatching(censusImageLeft, censusImageRight, hamDist, params.kernelSize);
 
                 computeDisparityBinarySGBM( left, right, disp, params, buffer,hamDist);
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under OpenCV (BSD) License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
