### PR TITLE
Fix mistake between 0x11 and 0b11 and change |=1 for +=1, increasing …

### DIFF
--- a/modules/stereo/src/descriptor.hpp
+++ b/modules/stereo/src/descriptor.hpp
@@ -114,20 +114,11 @@ namespace cv
                 CV_UNUSED(w2);
                 for(int i = 0; i < imageStop; i++)
                 {
+                    c[i] <<= 2;
                     if (image[i][rrWidth + jj] > image[i][rWidth + j] + t)
-                    {
-                        c[i] <<= 2;
-                        c[i] |= 0x11;
-                    }
+                        c[i] += 3;
                     else if (image[i][rrWidth + jj] > image[i][rWidth + j] - t)
-                    {
-                        c[i] <<= 2;
-                        c[i] |= 0x01;
-                    }
-                    else
-                    {
-                        c[i] <<= 2;
-                    }
+                        c[i] += 1;
                 }
             }
         };


### PR DESCRIPTION
…chance compiler will use ++

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
