### PR TITLE
Added some helper function in 'mcc'

### DIFF
--- a/modules/mcc/include/opencv2/mcc/checker_model.hpp
+++ b/modules/mcc/include/opencv2/mcc/checker_model.hpp
@@ -82,17 +82,29 @@ public:
 
     CV_WRAP virtual void setTarget(TYPECHART _target)  = 0;
     CV_WRAP virtual void setBox(std::vector<Point2f> _box) = 0;
+    CV_WRAP virtual void setPerPatchCosts(std::vector<Point2f> _patchCosts) = 0;
+
+    // Detected directly by the detector or found using geometry, useful to determine if a patch is occluded
+    CV_WRAP virtual void setBoxDetectionType(std::vector<std::vector<Point2f>> detectionType) = 0;
     CV_WRAP virtual void setChartsRGB(Mat _chartsRGB) = 0;
     CV_WRAP virtual void setChartsYCbCr(Mat _chartsYCbCr) = 0;
     CV_WRAP virtual void setCost(float _cost) = 0;
     CV_WRAP virtual void setCenter(Point2f _center) = 0;
+    CV_WRAP virtual void setPatchCenters(std::vector<Point2f> _patchCenters) = 0;
+    CV_WRAP virtual void setPatchBoundingBoxes(std::vector<Point2f> _patchBoundingBoxes) = 0;
 
     CV_WRAP virtual TYPECHART getTarget() = 0;
     CV_WRAP virtual std::vector<Point2f> getBox() = 0;
+    CV_WRAP virtual std::vector<Point2f> getPerPatchCosts() = 0;
+    CV_WRAP virtual std::vector<std::vector<Point2f>> getBoxDetectionType() = 0;
     CV_WRAP virtual Mat getChartsRGB() = 0;
     CV_WRAP virtual Mat getChartsYCbCr() = 0;
     CV_WRAP virtual float getCost() = 0;
     CV_WRAP virtual Point2f getCenter() = 0;
+    CV_WRAP virtual std::vector<Point2f> getPatchCenters() = 0;
+    CV_WRAP virtual std::vector<Point2f> getPatchBoundingBoxes(float sideRatio=0.5) =0;
+
+    CV_WRAP virtual bool calculate() = 0; ///< Return false if some error occured, true otherwise
 };
 
 /** \brief checker draw
@@ -115,10 +127,16 @@ class CV_EXPORTS_W CCheckerDraw
 public:
     virtual ~CCheckerDraw() {}
     /** \brief Draws the checker to the given image.
-    * \param img image in color space BGR
+    * \param img image in color space BGR, original image gets modified
+    * \param sideRatio ratio between the side length of drawed boxes, and the actual side of squares
+    *                  keeping sideRatio = 1.0 is not recommended as the border can be a bit inaccurate
+    *                  in detection, for best output keep it at less than 1.0
+    * \param drawActualDetection draw the actually detected patch,i.e,, the non occuled ones,
+    *                            useful for debugging, default (false)
     * \return void
     */
-    CV_WRAP virtual void draw(InputOutputArray img) = 0;
+    CV_WRAP virtual void draw(InputOutputArray img, float sideRatio = 0.5,
+                              bool drawActualDetection = false) = 0;
     /** \brief Create a new CCheckerDraw object.
     * \param pChecker The checker which will be drawn by this object.
     * \param color The color by with which the squares of the checker
@@ -132,6 +150,20 @@ public:
                                             int thickness = 2);
 };
 
+
+/** @brief draws a single mcc::ColorChecker on the given image
+ *         This is a functional version of the CCheckerDraw class, provided for convenience
+ * \param img image in color space BGR, it gets changed by this call
+ * \param pChecker pointer to the CChecker, which contains the detection
+ * \param color color used for drawing
+ * \param thickness thickness of the boxes drawed
+ * \param sideRatio ratio between the side length of drawed boxes, and the actual side of squares
+ *                  keeping sideRatio = 1.0 is not recommended as the border can be a bit inaccurate
+ *                  in detection, for best output keep it at less than 1.0
+ */
+CV_EXPORTS_W void drawColorChecker(InputOutputArray img, Ptr<CChecker> pChecker,
+                                  cv::Scalar color = CV_RGB(0, 255, 0), int thickness = 2, float sideRatio = 0.5,
+                                 bool drawActualDetection = false);
 //! @} mcc
 } // namespace mcc
 } // namespace cv

--- a/modules/mcc/samples/chart_detection.cpp
+++ b/modules/mcc/samples/chart_detection.cpp
@@ -40,6 +40,7 @@ int main(int argc, char *argv[])
     if (!parser.check())
     {
         parser.printErrors();
+        parser.printMessage();
         return 0;
     }
 

--- a/modules/mcc/samples/chart_detection_with_network.cpp
+++ b/modules/mcc/samples/chart_detection_with_network.cpp
@@ -58,6 +58,7 @@ int main(int argc, char *argv[])
     if (!parser.check())
     {
         parser.printErrors();
+        parser.printMessage();
         return 0;
     }
 

--- a/modules/mcc/src/checker_detector.cpp
+++ b/modules/mcc/src/checker_detector.cpp
@@ -193,7 +193,8 @@ bool CCheckerDetectorImpl::
                     //-------------------------------------------------------------------
 
                     std::vector<std::vector<cv::Point2f>> colorCharts;
-                    checkerRecognize(img_bgr, detectedCharts, G, chartType, colorCharts, params);
+                    std::vector<std::vector<CChart>> groupedCharts;
+                    checkerRecognize(img_bgr, detectedCharts, G, chartType, colorCharts,groupedCharts, params);
 
                     if (colorCharts.empty())
                         continue;
@@ -219,7 +220,7 @@ bool CCheckerDetectorImpl::
                     // checker color analysis
                     //-------------------------------------------------------------------
                     std::vector<Ptr<CChecker>> checkers;
-                    checkerAnalysis(img_rgb_f, chartType, nc, colorCharts, checkers, asp, params,
+                    checkerAnalysis(img_rgb_f, chartType, nc, colorCharts, groupedCharts, checkers, asp, params,
                                     img_rgb_org, img_ycbcr_org, rgb_planes, ycbcr_planes);
 
 #ifdef MCC_DEBUG
@@ -236,6 +237,10 @@ bool CCheckerDetectorImpl::
                     {
                         for (cv::Point2f &corner : checker->getBox())
                             corner += static_cast<cv::Point2f>(region.tl());
+
+                        for (std::vector<cv::Point2f> &corners : checker->getBoxDetectionType())
+                            for (cv::Point2f & corner: corners)
+                                corner += static_cast<cv::Point2f>(region.tl());
 
                         mtx.lock(); // push_back is not thread safe
                         m_checkers.push_back(checker);
@@ -414,7 +419,8 @@ bool CCheckerDetectorImpl::
                             //-------------------------------------------------------------------
 
                             std::vector<std::vector<cv::Point2f>> colorCharts;
-                            checkerRecognize(img_bgr, detectedCharts, G, chartType, colorCharts, params);
+                            std::vector<std::vector<CChart>> groupedCharts;
+                            checkerRecognize(img_bgr, detectedCharts, G, chartType, colorCharts, groupedCharts, params);
 
                             if (colorCharts.empty())
                                 continue;
@@ -440,7 +446,7 @@ bool CCheckerDetectorImpl::
                             // checker color analysis
                             //-------------------------------------------------------------------
                             std::vector<Ptr<CChecker>> checkers;
-                            checkerAnalysis(img_rgb_f, chartType, nc, colorCharts, checkers, asp, params,
+                            checkerAnalysis(img_rgb_f, chartType, nc, colorCharts,groupedCharts, checkers, asp, params,
                                             img_rgb_org, img_ycbcr_org, rgb_planes, ycbcr_planes);
 #ifdef MCC_DEBUG
                             cv::Mat image_checker;
@@ -456,6 +462,10 @@ bool CCheckerDetectorImpl::
                             {
                                 for (cv::Point2f &corner : checker->getBox())
                                     corner += static_cast<cv::Point2f>(region.tl() + innerRegion.tl());
+                                for (std::vector<cv::Point2f> &corners : checker->getBoxDetectionType())
+                                    for (cv::Point2f & corner: corners)
+                                        corner += static_cast<cv::Point2f>(region.tl() + innerRegion.tl());
+                                checker->calculate();
                                 mtx.lock(); // push_back is not thread safe
                                 m_checkers.push_back(checker);
                                 mtx.unlock();
@@ -756,6 +766,7 @@ void CCheckerDetectorImpl::
         const std::vector<int> &G,
         const TYPECHART chartType,
         std::vector<std::vector<cv::Point2f>> &colorChartsOut,
+        std::vector<std::vector<CChart>> &groupedCharts,
         const Ptr<DetectorParameters> &params)
 {
     std::vector<int> gU;
@@ -775,7 +786,7 @@ void CCheckerDetectorImpl::
         for (size_t i = 0; i < Ncc; i++)
             if (G[i] == (int)g)
                 chartSub.push_back(detectedCharts[i]);
-
+        std::vector<CChart> chartSubCopy = chartSub;
         size_t Nsc = chartSub.size();
         if (Nsc < params->minGroupSize)
             continue;
@@ -958,6 +969,7 @@ void CCheckerDetectorImpl::
             mcc::polyclockwise(ibox);
         // circshift(ibox, 4 - iTheta);
         colorCharts.push_back(ibox);
+        groupedCharts.push_back(chartSubCopy);
     }
 
     // return
@@ -970,6 +982,7 @@ void CCheckerDetectorImpl::
         const TYPECHART chartType,
         const unsigned int nc,
         const std::vector<std::vector<cv::Point2f>> &colorCharts,
+        const std::vector<std::vector<CChart>> &groupedCharts,
         std::vector<Ptr<CChecker>> &checkers,
         float asp,
         const Ptr<DetectorParameters> &params,
@@ -993,10 +1006,11 @@ void CCheckerDetectorImpl::
 
     N = colorCharts.size();
     std::vector<float> J(N);
+    std::vector<Point2f> perPatchCost(N);
     for (size_t i = 0; i < N; i++)
     {
         ibox = colorCharts[i];
-        J[i] = cost_function(img_f, mask, lab, ibox, chartType);
+        J[i] = cost_function(img_f, mask, lab, perPatchCost, ibox, chartType);
     }
 
     std::vector<int> idx;
@@ -1020,14 +1034,28 @@ void CCheckerDetectorImpl::
         get_profile(ibox, chartType, charts_rgb, charts_ycbcr, img_rgb_org,
                     img_ycbcr_org, rgb_planes, ycbcr_planes);
 
+        std::vector<std::vector<Point2f>> directlyDetectedPatches;
+        for(auto chart : groupedCharts[idx[i]])
+        {
+            for(auto &corners: chart.corners)
+                corners *= invAsp;
+            directlyDetectedPatches.push_back(chart.corners);
+        }
+
+
+
         // result
         Ptr<CChecker> checker = CChecker::create();
         checker->setBox(ibox);
+        checker->setBoxDetectionType(directlyDetectedPatches);
+
         checker->setTarget(chartType);
         checker->setChartsRGB(charts_rgb);
         checker->setChartsYCbCr(charts_ycbcr);
         checker->setCenter(mace_center(ibox));
         checker->setCost(J[i]);
+        checker->calculate(); //does some precomputation based on the inputs,
+                              //mainly used to keep the code a bit clean
 
         checkers.push_back(checker);
     }
@@ -1179,38 +1207,6 @@ void CCheckerDetectorImpl::
 }
 
 void CCheckerDetectorImpl::
-    transform_points_forward(InputArray T, const std::vector<cv::Point2f> &X, std::vector<cv::Point2f> &Xt)
-{
-    size_t N = X.size();
-    if (N == 0)
-        return;
-
-    Xt.clear();
-    Xt.resize(N);
-    cv::Matx31f p, xt;
-    cv::Point2f pt;
-
-    cv::Matx33f _T = T.getMat();
-    for (int i = 0; i < (int)N; i++)
-    {
-        p(0, 0) = X[i].x;
-        p(1, 0) = X[i].y;
-        p(2, 0) = 1;
-        xt = _T * p;
-        pt.x = xt(0, 0) / xt(2, 0);
-        pt.y = xt(1, 0) / xt(2, 0);
-        Xt[i] = pt;
-    }
-}
-
-void CCheckerDetectorImpl::
-    transform_points_inverse(InputArray T, const std::vector<cv::Point2f> &X, std::vector<cv::Point2f> &Xt)
-{
-    cv::Matx33f _T = T.getMat();
-    cv::Matx33f Tinv = _T.inv();
-    transform_points_forward(Tinv, X, Xt);
-}
-void CCheckerDetectorImpl::
     get_profile(
         const std::vector<cv::Point2f> &ibox,
         const TYPECHART chartType,
@@ -1330,6 +1326,7 @@ void CCheckerDetectorImpl::
 
 float CCheckerDetectorImpl::
     cost_function(InputArray im_rgb, InputOutputArray mask, InputArray lab,
+                  std::vector<Point2f> &perPatchCost,
                   const std::vector<cv::Point2f> &ibox, const TYPECHART chartType)
 {
     CChartModel cccm(chartType);
@@ -1341,6 +1338,8 @@ float CCheckerDetectorImpl::
     std::vector<cv::Point2f> bch(4), bcht(4);
 
     int N = (int)(cellchart.size() / 4);
+
+    perPatchCost.assign(N, {-1, -1}); //-1 for patches outside the image
 
     cv::Mat _lab = lab.getMat();
     cv::Mat _im_rgb = im_rgb.getMat();
@@ -1376,10 +1375,11 @@ float CCheckerDetectorImpl::
             // cos error
             float costh;
             costh = (float)(mu.dot(cv::Scalar(r)) / (norm(mu) * norm(r) + FLT_EPSILON));
-            ec += (1 - (1 + costh) / 2);
+            perPatchCost[i]  = {1 - (1 + costh)/2, (float)st.dot(st)};
+            ec += perPatchCost[i].x;
 
             // standar desviation
-            es += (float)st.dot(st);
+            es += perPatchCost[i].y;
         }
     }
 

--- a/modules/mcc/src/checker_detector.hpp
+++ b/modules/mcc/src/checker_detector.hpp
@@ -130,8 +130,10 @@ protected: // methods pipeline
     * \param[out] colorChartsOut
     */
     virtual void
-    checkerRecognize(InputArray img, const std::vector<CChart> &detectedCharts, const std::vector<int> &G,
-                     const TYPECHART chartType, std::vector<std::vector<cv::Point2f>> &colorChartsOut,
+    checkerRecognize(InputArray img, const std::vector<CChart> &detectedCharts,
+                     const std::vector<int> &G, const TYPECHART chartType,
+                     std::vector<std::vector<cv::Point2f>> &colorChartsOut,
+                     std::vector<std::vector<CChart>> &groupedCharts,
                      const Ptr<DetectorParameters> &params);
 
     /// checkerAnalysis
@@ -146,6 +148,7 @@ protected: // methods pipeline
     checkerAnalysis(InputArray img_rgb_f,
                     const TYPECHART chartType, const unsigned int nc,
                     const std::vector<std::vector<cv::Point2f>> &colorCharts,
+                    const std::vector<std::vector<CChart>> &groupedCharts,
                     std::vector<Ptr<CChecker>> &checkers, float asp,
                     const Ptr<DetectorParameters> &params,
                     const cv::Mat &img_rgb_org,
@@ -172,16 +175,6 @@ private: // methods aux
         std::vector<float> &x_new,
         float tol);
 
-    void transform_points_forward(
-        InputArray T,
-        const std::vector<cv::Point2f> &X,
-        std::vector<cv::Point2f> &Xt);
-
-    void transform_points_inverse(
-        InputArray T,
-        const std::vector<cv::Point2f> &X,
-        std::vector<cv::Point2f> &Xt);
-
     void get_profile(
         const std::vector<cv::Point2f> &ibox,
         const TYPECHART chartType,
@@ -197,6 +190,7 @@ private: // methods aux
      *                   + \sum_k || \sigma_{k,p} ||^2
      */
     float cost_function(InputArray img, InputOutputArray mask, InputArray lab,
+                        std::vector<cv::Point2f> &perPatchCost,
                         const std::vector<cv::Point2f> &ibox,
                         const TYPECHART chartType);
 };

--- a/modules/mcc/src/checker_model.hpp
+++ b/modules/mcc/src/checker_model.hpp
@@ -130,25 +130,42 @@ public:
 
     void setTarget(TYPECHART _target)  CV_OVERRIDE;
     void setBox(std::vector<Point2f> _box) CV_OVERRIDE;
+    void setPerPatchCosts(std::vector<Point2f> cost) CV_OVERRIDE;
+
+    // Detected directly by the detector or found using geometry, useful to determine if a patch is occluded
+    void setBoxDetectionType(std::vector<std::vector<Point2f>> detectionType) CV_OVERRIDE;
     void setChartsRGB(Mat _chartsRGB) CV_OVERRIDE;
     void setChartsYCbCr(Mat _chartsYCbCr) CV_OVERRIDE;
     void setCost(float _cost) CV_OVERRIDE;
     void setCenter(Point2f _center) CV_OVERRIDE;
+    void setPatchCenters(std::vector<Point2f> _patchCenters) CV_OVERRIDE;
+    void setPatchBoundingBoxes(std::vector<Point2f> _patchBoundingBoxes) CV_OVERRIDE;
 
     TYPECHART getTarget() CV_OVERRIDE;
     std::vector<Point2f> getBox() CV_OVERRIDE;
+    std::vector<Point2f> getPerPatchCosts() CV_OVERRIDE;
+    std::vector<std::vector<Point2f>> getBoxDetectionType() CV_OVERRIDE;
     Mat getChartsRGB() CV_OVERRIDE;
     Mat getChartsYCbCr() CV_OVERRIDE;
     float getCost() CV_OVERRIDE;
     Point2f getCenter() CV_OVERRIDE;
+    std::vector<Point2f> getPatchCenters() CV_OVERRIDE;
+    std::vector<Point2f> getPatchBoundingBoxes(float sideRatio=0.5) CV_OVERRIDE;
+
+    bool calculate() CV_OVERRIDE;//basic precomp
 
 private:
     TYPECHART target;             ///< type of checkercolor
     std::vector<cv::Point2f> box; ///< positions of the corners
+    std::vector<cv::Point2f> perPatchCost; ///< Cost of each patch in chart
+    std::vector<cv::Point2f> patchBoundingBoxes; ///< Bounding box of the patches
+    std::vector<cv::Point2f> patchCenters; ///< Centers of all the patches
+    std::vector<std::vector<cv::Point2f>> boxDetectionType; ///< contours of patches directly dectected, not using geometry
     cv::Mat chartsRGB;             ///< charts profile in rgb color space
     cv::Mat chartsYCbCr;         ///< charts profile in YCbCr color space
     float cost;                     ///< cost to aproximate
     cv::Point2f center;             ///< center of the chart.
+    float defaultSideRatio = 0.5;   ///< ratio of side of patchBoundingBox and actual patch size
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -167,19 +184,13 @@ public:
         CV_Assert(pChecker);
     }
 
-    void draw(InputOutputArray img) CV_OVERRIDE;
+    void draw(InputOutputArray img, float sideRatio =0.5,bool drawActualDetection=false) CV_OVERRIDE;
 
 private:
     Ptr<CChecker> m_pChecker;
     cv::Scalar m_color;
     int m_thickness;
 
-private:
-    /** \brief transformation perspetive*/
-    void transform_points_forward(
-        InputArray T,
-        const std::vector<cv::Point2f> &X,
-        std::vector<cv::Point2f> &Xt);
 };
 // @}
 

--- a/modules/mcc/src/common.cpp
+++ b/modules/mcc/src/common.cpp
@@ -86,5 +86,37 @@ mace_center(const std::vector<cv::Point2f> &ps)
     return center;
 }
 
+void transform_points_forward(InputArray T, const std::vector<cv::Point2f> &X,
+                              std::vector<cv::Point2f> &Xt)
+{
+    size_t N = X.size();
+    if (N == 0)
+        return;
+
+    Xt.clear();
+    Xt.resize(N);
+    cv::Matx31f p, xt;
+    cv::Point2f pt;
+
+    cv::Matx33f _T = T.getMat();
+    for (int i = 0; i < (int)N; i++)
+    {
+        p(0, 0) = X[i].x;
+        p(1, 0) = X[i].y;
+        p(2, 0) = 1;
+        xt = _T * p;
+        pt.x = xt(0, 0) / xt(2, 0);
+        pt.y = xt(1, 0) / xt(2, 0);
+        Xt[i] = pt;
+    }
+}
+
+void transform_points_inverse(InputArray T, const std::vector<cv::Point2f> &X,
+                              std::vector<cv::Point2f> &Xt)
+{
+    cv::Matx33f _T = T.getMat();
+    cv::Matx33f Tinv = _T.inv();
+    transform_points_forward(Tinv, X, Xt);
+}
 } // namespace mcc
 } // namespace cv

--- a/modules/mcc/src/common.hpp
+++ b/modules/mcc/src/common.hpp
@@ -36,6 +36,17 @@ namespace mcc
 
 Rect poly2mask(const std::vector<Point2f> &poly, Size size, InputOutputArray mask);
 
+
+float perimeter(const std::vector<cv::Point2f> &ps);
+
+cv::Point2f mace_center(const std::vector<cv::Point2f> &ps);
+
+void transform_points_forward(InputArray T, const std::vector<cv::Point2f> &X,
+                              std::vector<cv::Point2f> &Xt);
+
+void transform_points_inverse(InputArray T, const std::vector<cv::Point2f> &X,
+                              std::vector<cv::Point2f> &Xt);
+
 template <typename T>
 void circshift(std::vector<T> &A, int shiff)
 {
@@ -52,10 +63,6 @@ void circshift(std::vector<T> &A, int shiff)
 
     A = Tmp;
 }
-
-float perimeter(const std::vector<cv::Point2f> &ps);
-
-cv::Point2f mace_center(const std::vector<cv::Point2f> &ps);
 
 template <typename T>
 void unique(const std::vector<T> &A, std::vector<T> &U)


### PR DESCRIPTION
Earlier the CChecker class only stores the four corners of the chart, others were to be calculated by the user using perspective transform. Now the centers of each squares in the chart, along with a crop of their center is stored, also the loss per patch is also stored, which can be used by user. Also removed some code duplication in transform_points_forward.
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ X ] I agree to contribute to the project under OpenCV (BSD) License.
- [ X ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
