### PR TITLE
ximgproc: add python wrappers for disparity functions

### DIFF
--- a/modules/ximgproc/include/opencv2/ximgproc/disparity_filter.hpp
+++ b/modules/ximgproc/include/opencv2/ximgproc/disparity_filter.hpp
@@ -160,7 +160,7 @@ and MPI-Sintel formats. Note that the resulting disparity map is scaled by 16.
 
 @result returns zero if successfully read the ground truth
  */
-CV_EXPORTS
+CV_EXPORTS_W
 int readGT(String src_path,OutputArray dst);
 
 /** @brief Function for computing mean square error for disparity maps
@@ -173,7 +173,7 @@ int readGT(String src_path,OutputArray dst);
 
 @result returns mean square error between GT and src
  */
-CV_EXPORTS
+CV_EXPORTS_W
 double computeMSE(InputArray GT, InputArray src, Rect ROI);
 
 /** @brief Function for computing the percent of "bad" pixels in the disparity map
@@ -189,7 +189,7 @@ double computeMSE(InputArray GT, InputArray src, Rect ROI);
 
 @result returns mean square error between GT and src
  */
-CV_EXPORTS
+CV_EXPORTS_W
 double computeBadPixelPercent(InputArray GT, InputArray src, Rect ROI, int thresh=24/*1.5 pixels*/);
 
 /** @brief Function for creating a disparity map visualization (clamped CV_8U image)
@@ -200,7 +200,7 @@ double computeBadPixelPercent(InputArray GT, InputArray src, Rect ROI, int thres
 
 @param scale disparity map will be multiplied by this value for visualization
  */
-CV_EXPORTS
+CV_EXPORTS_W
 void getDisparityVis(InputArray src,OutputArray dst,double scale=1.0);
 
 //! @}

--- a/modules/ximgproc/misc/python/test/test_disparity.py
+++ b/modules/ximgproc/misc/python/test/test_disparity.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+import cv2 as cv
+import numpy as np
+
+from tests_common import NewOpenCVTests
+
+class disparity_test(NewOpenCVTests):
+    def test_disp(self):
+        # readGT
+        ret,GT = cv.ximgproc.readGT(self.find_file("cv/disparityfilter/GT.png"))
+        self.assertEqual(ret, 0) # returns 0 on success!
+        self.assertFalse(np.shape(GT) == ())
+
+        # computeMSE
+        left = cv.imread(self.find_file("cv/disparityfilter/disparity_left_raw.png"), cv.IMREAD_UNCHANGED)
+        self.assertFalse(np.shape(left) == ())
+        left = np.asarray(left, dtype=np.int16)
+        mse = cv.ximgproc.computeMSE(GT, left, (0, 0, GT.shape[1], GT.shape[0]))
+
+        # computeBadPixelPercent
+        bad = cv.ximgproc.computeBadPixelPercent(GT, left, (0, 0, GT.shape[1], GT.shape[0]), 24)
+
+if __name__ == '__main__':
+    NewOpenCVTests.bootstrap()

--- a/modules/ximgproc/src/disparity_filters.cpp
+++ b/modules/ximgproc/src/disparity_filters.cpp
@@ -420,7 +420,6 @@ void DisparityWLSFilterImpl::ParallelMatOp_ParBody::operator() (const Range& ran
         (wls->*ops[i])(*src[i],*dst[i]);
 }
 
-CV_EXPORTS_W
 Ptr<DisparityWLSFilter> createDisparityWLSFilter(Ptr<StereoMatcher> matcher_left)
 {
     Ptr<DisparityWLSFilter> wls;
@@ -451,7 +450,6 @@ Ptr<DisparityWLSFilter> createDisparityWLSFilter(Ptr<StereoMatcher> matcher_left
     return wls;
 }
 
-CV_EXPORTS_W
 Ptr<StereoMatcher> createRightMatcher(Ptr<StereoMatcher> matcher_left)
 {
     int min_disp = matcher_left->getMinDisparity();
@@ -485,7 +483,6 @@ Ptr<StereoMatcher> createRightMatcher(Ptr<StereoMatcher> matcher_left)
     }
 }
 
-CV_EXPORTS_W
 Ptr<DisparityWLSFilter> createDisparityWLSFilterGeneric(bool use_confidence)
 {
     return Ptr<DisparityWLSFilter>(DisparityWLSFilterImpl::create(use_confidence));


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

questions:
* should the license be changed ?
* does it need a python test ? (there is already a [c++ one here](https://github.com/opencv/opencv_contrib/blob/master/modules/ximgproc/test/test_disparity_wls_filter.cpp#L19))