### PR TITLE
vtkCocoaInteractorFix.mm: explicity include vtkVersion.h

### DIFF
--- a/modules/viz/src/vtk/vtkCocoaInteractorFix.mm
+++ b/modules/viz/src/vtk/vtkCocoaInteractorFix.mm
@@ -49,6 +49,7 @@
 #include <vtkCocoaRenderWindowInteractor.h>
 #include <vtkObjectFactory.h>
 #include <vtkSmartPointer.h>
+#include <vtkVersion.h>
 
 namespace cv { namespace viz {
     vtkSmartPointer<vtkRenderWindowInteractor> vtkCocoaRenderWindowInteractorNew();


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

In attempting to build VTK 9 for macOS as part of Homebrew, opencv fails to build. Building locally on macOS 10.15 with the new VTK, without any changes to the existing code, the following error is output:

```
/Users/username/open/opencv/opencv_contrib/modules/viz/src/vtk/vtkCocoaInteractorFix.mm:58:7: warning: 'VTK_MAJOR_VERSION' is not defined, evaluates to 0 [-Wundef]
#if ((VTK_MAJOR_VERSION < 6) || ((VTK_MAJOR_VERSION == 6) && (VTK_MINOR_VERSION < 2)))
      ^
/Users/username/open/opencv/opencv_contrib/modules/viz/src/vtk/vtkCocoaInteractorFix.mm:128:50: warning: 'NSApplicationDefined' is deprecated: first deprecated in macOS 10.12 [-Wdeprecated-declarations]
    NSEvent *event = [NSEvent otherEventWithType:NSApplicationDefined
                                                 ^~~~~~~~~~~~~~~~~~~~
                                                 NSEventTypeApplicationDefined
/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/AppKit.framework/Headers/NSEvent.h:78:26: note: 'NSApplicationDefined' has been explicitly marked deprecated here
static const NSEventType NSApplicationDefined   API_DEPRECATED_WITH_REPLACEMENT("NSEventTypeApplicationDefined", macos(10.0,10.12)) = NSEventTypeApplicationDefined;
                         ^
/Users/username/open/opencv/opencv_contrib/modules/viz/src/vtk/vtkCocoaInteractorFix.mm:193:81: error: no member named 'GetCocoaServer' in 'cv::viz::vtkCocoaRenderWindowInteractorFix'
        vtkCocoaServerFix *server = reinterpret_cast<vtkCocoaServerFix*> (this->GetCocoaServer ());
                                                                          ~~~~  ^
/Users/username/open/opencv/opencv_contrib/modules/viz/src/vtk/vtkCocoaInteractorFix.mm:194:20: error: no member named 'GetCocoaServer' in 'cv::viz::vtkCocoaRenderWindowInteractorFix'
        if (!this->GetCocoaServer ())
             ~~~~  ^
/Users/username/open/opencv/opencv_contrib/modules/viz/src/vtk/vtkCocoaInteractorFix.mm:197:19: error: no member named 'SetCocoaServer' in 'cv::viz::vtkCocoaRenderWindowInteractorFix'
            this->SetCocoaServer (reinterpret_cast<void*> (server));
            ~~~~  ^
/Users/username/open/opencv/opencv_contrib/modules/viz/src/vtk/vtkCocoaInteractorFix.mm:209:81: error: no member named 'GetCocoaServer' in 'cv::viz::vtkCocoaRenderWindowInteractorFix'
        vtkCocoaServerFix *server = reinterpret_cast<vtkCocoaServerFix*> (this->GetCocoaServer ());
                                                                          ~~~~  ^
2 warnings and 4 errors generated.
```

After explicitly including `vtkVersion.h`, `vtkCocoaInteractorFix.mm` compiles successfully.