### PR TITLE
update PR template to match license

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request
 
-- [ ] I agree to contribute to the project under OpenCV (BSD) License.
+- [ ] I agree to contribute to the project under Apache 2 License.
 - [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
 - [ ] The PR is proposed to proper branch
 - [ ] There is reference to original bug report and related work


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

The license for opencv and opencv_contrib was changed to Apache 2: (https://github.com/opencv/opencv/pull/18073, https://github.com/opencv/opencv_contrib/pull/2628) and the PR template for opencv was updated with the new license, but not for opencv_contrib.