### PR TITLE
TSDF preCalculation pixNorm

### DIFF
--- a/modules/rgbd/src/opencl/tsdf.cl
+++ b/modules/rgbd/src/opencl/tsdf.cl
@@ -29,11 +29,13 @@ static inline float tsdfToFloat(TsdfType num)
 
 __kernel void preCalculationPixNorm (__global float * pixNorms,
                                      __global float * xx,
-                                     __global float * yy)
+                                     __global float * yy,
+                                     int height)
 {    
     int i = get_global_id(0);
     int j = get_global_id(1);
-    int idx = i*480 + j;
+    //int idx = i*480 + j;
+    int idx = i*height + j;
     pixNorms[idx] = sqrt(xx[j] * xx[j] + yy[i] * yy[i] + 1.0f);
 }
 
@@ -161,7 +163,7 @@ __kernel void integrate(__global const char * depthptr,
         if(v == 0)
             continue;
 
-        int idx = projected.x * 480 + projected.y;
+        int idx = projected.x * depth_rows + projected.y;
         float pixNorm = pixNorms[idx];
         //float pixNorm = length(camPixVec);
 

--- a/modules/rgbd/src/opencl/tsdf.cl
+++ b/modules/rgbd/src/opencl/tsdf.cl
@@ -28,13 +28,12 @@ static inline float tsdfToFloat(TsdfType num)
 }
 
 __kernel void preCalculationPixNorm (__global float * pixNorms,
-                                     __global float * xx,
-                                     __global float * yy,
+                                     const __global float * xx,
+                                     const __global float * yy,
                                      int width)
 {    
     int i = get_global_id(0);
     int j = get_global_id(1);
-    //int idx = i*480 + j;
     int idx = i*width + j;
     pixNorms[idx] = sqrt(xx[j] * xx[j] + yy[i] * yy[i] + 1.0f);
 }
@@ -52,7 +51,7 @@ __kernel void integrate(__global const char * depthptr,
                         const float dfac,
                         const float truncDist,
                         const int maxWeight,
-                        __global float * pixNorms)
+                        const __global float * pixNorms)
 {
     int x = get_global_id(0);
     int y = get_global_id(1);

--- a/modules/rgbd/src/opencl/tsdf.cl
+++ b/modules/rgbd/src/opencl/tsdf.cl
@@ -30,12 +30,12 @@ static inline float tsdfToFloat(TsdfType num)
 __kernel void preCalculationPixNorm (__global float * pixNorms,
                                      __global float * xx,
                                      __global float * yy,
-                                     int height)
+                                     int width)
 {    
     int i = get_global_id(0);
     int j = get_global_id(1);
     //int idx = i*480 + j;
-    int idx = i*height + j;
+    int idx = i*width + j;
     pixNorms[idx] = sqrt(xx[j] * xx[j] + yy[i] * yy[i] + 1.0f);
 }
 

--- a/modules/rgbd/src/opencl/tsdf.cl
+++ b/modules/rgbd/src/opencl/tsdf.cl
@@ -163,7 +163,7 @@ __kernel void integrate(__global const char * depthptr,
         if(v == 0)
             continue;
 
-        int idx = projected.x * depth_rows + projected.y;
+        int idx = projected.y * depth_rows + projected.x;
         float pixNorm = pixNorms[idx];
         //float pixNorm = length(camPixVec);
 

--- a/modules/rgbd/src/tsdf.cpp
+++ b/modules/rgbd/src/tsdf.cpp
@@ -1202,8 +1202,7 @@ void TSDFVolumeGPU::reset()
     volume.setTo(Scalar(0, 0));
 }
 
-UMat preCalculationPixNormGPU(int depth_rows, int depth_cols,
-    Vec2f fxy, Vec2f cxy, Point3i volResolution)
+static cv::UMat preCalculationPixNormGPU(int depth_rows, int depth_cols, Vec2f fxy, Vec2f cxy)
 {
     Mat x(1, depth_cols, CV_32F);
     Mat y(1, depth_rows, CV_32F);
@@ -1275,7 +1274,7 @@ void TSDFVolumeGPU::integrate(InputArray _depth, float depthFactor,
         frameParams[2] = intrinsics.fx;     frameParams[3] = intrinsics.fy;
         frameParams[4] = intrinsics.cx;     frameParams[5] = intrinsics.cy;
 
-        pixNorms = preCalculationPixNormGPU(depth.rows, depth.cols, fxy, cxy, volResolution);
+        pixNorms = preCalculationPixNormGPU(depth.rows, depth.cols, fxy, cxy);
     }
 
     // TODO: optimization possible

--- a/modules/rgbd/src/tsdf.cpp
+++ b/modules/rgbd/src/tsdf.cpp
@@ -1231,7 +1231,8 @@ static cv::UMat preCalculationPixNormGPU(int depth_rows, int depth_cols, Vec2f f
 
     kk.args(ocl::KernelArg::PtrReadWrite(tmp1),
         ocl::KernelArg::PtrReadWrite(xx),
-        ocl::KernelArg::PtrReadWrite(yy));
+        ocl::KernelArg::PtrReadWrite(yy),
+        depth_rows);
 
     size_t globalSize[2];
     globalSize[0] = depth_cols;

--- a/modules/rgbd/src/tsdf.cpp
+++ b/modules/rgbd/src/tsdf.cpp
@@ -1232,11 +1232,11 @@ static cv::UMat preCalculationPixNormGPU(int depth_rows, int depth_cols, Vec2f f
     kk.args(ocl::KernelArg::PtrReadWrite(tmp1),
         ocl::KernelArg::PtrReadWrite(xx),
         ocl::KernelArg::PtrReadWrite(yy),
-        depth_rows);
+        depth_cols);
 
     size_t globalSize[2];
-    globalSize[0] = depth_cols;
-    globalSize[1] = depth_rows;
+    globalSize[0] = depth_rows;
+    globalSize[1] = depth_cols;
 
     if (!kk.run(2, globalSize, NULL, true))
         throw std::runtime_error("Failed to run kernel");

--- a/modules/rgbd/src/tsdf.cpp
+++ b/modules/rgbd/src/tsdf.cpp
@@ -331,7 +331,13 @@ struct IntegrateInvoker : ParallelLoopBody
                     }
 
                     // norm(camPixVec) produces double which is too slow
-                    float pixNorm = sqrt(v_reduce_sum(camPixVec*camPixVec));
+                    // float pixNorm = pixNorms.at<float>();
+                    int _u = (int) projected.get0();
+                    int _v = (int) v_rotate_right<1>(projected).get0();
+                    if (!(_u >= 0 && _u < depth.cols && _v >= 0 && _v < depth.rows))
+                        continue;
+                    float pixNorm = pixNorms.at<float>(_v, _u);
+                    // float pixNorm = sqrt(v_reduce_sum(camPixVec*camPixVec));
                     // difference between distances of point and of surface to camera
                     float sdf = pixNorm*(v*dfac - zCamSpace);
                     // possible alternative is:
@@ -1183,7 +1189,7 @@ void TSDFVolumeCPU::fetchNormals(InputArray _points, OutputArray _normals) const
 
 ///////// GPU implementation /////////
 
-#ifdef HAVE_OPENCL
+#ifdef HAVE_OPENCL_
 TSDFVolumeGPU::TSDFVolumeGPU(float _voxelSize, cv::Matx44f _pose, float _raycastStepFactor, float _truncDist, int _maxWeight,
                              Point3i _resolution) :
     TSDFVolume(_voxelSize, _pose, _raycastStepFactor, _truncDist, _maxWeight, _resolution, false)
@@ -1539,7 +1545,7 @@ void TSDFVolumeGPU::fetchPointsNormals(OutputArray points, OutputArray normals) 
 cv::Ptr<TSDFVolume> makeTSDFVolume(float _voxelSize, cv::Matx44f _pose, float _raycastStepFactor,
                                    float _truncDist, int _maxWeight, Point3i _resolution)
 {
-#ifdef HAVE_OPENCL
+#ifdef HAVE_OPENCL_
     if (cv::ocl::useOpenCL())
         return cv::makePtr<TSDFVolumeGPU>(_voxelSize, _pose, _raycastStepFactor, _truncDist, _maxWeight,
                                           _resolution);

--- a/modules/rgbd/src/tsdf.cpp
+++ b/modules/rgbd/src/tsdf.cpp
@@ -1189,7 +1189,7 @@ void TSDFVolumeCPU::fetchNormals(InputArray _points, OutputArray _normals) const
 
 ///////// GPU implementation /////////
 
-#ifdef HAVE_OPENCL_
+#ifdef HAVE_OPENCL
 TSDFVolumeGPU::TSDFVolumeGPU(float _voxelSize, cv::Matx44f _pose, float _raycastStepFactor, float _truncDist, int _maxWeight,
                              Point3i _resolution) :
     TSDFVolume(_voxelSize, _pose, _raycastStepFactor, _truncDist, _maxWeight, _resolution, false)
@@ -1545,7 +1545,7 @@ void TSDFVolumeGPU::fetchPointsNormals(OutputArray points, OutputArray normals) 
 cv::Ptr<TSDFVolume> makeTSDFVolume(float _voxelSize, cv::Matx44f _pose, float _raycastStepFactor,
                                    float _truncDist, int _maxWeight, Point3i _resolution)
 {
-#ifdef HAVE_OPENCL_
+#ifdef HAVE_OPENCL
     if (cv::ocl::useOpenCL())
         return cv::makePtr<TSDFVolumeGPU>(_voxelSize, _pose, _raycastStepFactor, _truncDist, _maxWeight,
                                           _resolution);

--- a/modules/rgbd/src/tsdf.cpp
+++ b/modules/rgbd/src/tsdf.cpp
@@ -420,9 +420,9 @@ struct IntegrateInvoker : ParallelLoopBody
 
                     int _u = projected.x;
                     int _v = projected.y;
-                    if (!(_u >= 0 && _u < depth.rows && _v >= 0 && _v < depth.cols))
+                    if (!(_u >= 0 && _u < depth.cols && _v >= 0 && _v < depth.rows))
                         continue;
-                    float pixNorm = pixNorms.at<float>(_u, _v);
+                    float pixNorm = pixNorms.at<float>(_v, _u);
 
                     // difference between distances of point and of surface to camera
                     float sdf = pixNorm*(v*dfac - camSpacePt.z);

--- a/modules/rgbd/src/tsdf.hpp
+++ b/modules/rgbd/src/tsdf.hpp
@@ -103,6 +103,8 @@ class TSDFVolumeGPU : public TSDFVolume
 
     virtual void reset() override;
 
+    Vec6f frameParams;
+    UMat pixNorms;
     // See zFirstMemOrder arg of parent class constructor
     // for the array layout info
     // Array elem is CV_32FC2, read as (float, int)


### PR DESCRIPTION
resolves #2675

Results of GPU optimization:
* before:
[ RUN      ] Perf_TSDF.integrate
[ PERFSTAT ]    (samples=72   mean=2.51   median=2.36   min=1.62   stddev=0.54 (21.7%))
* after:
[ RUN      ] Perf_TSDF.integrate
[ PERFSTAT ]    (samples=72   mean=2.21   median=1.90   min=1.33   stddev=0.82 (37.3%))



### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
