### PR TITLE
Brisque accel

### DIFF
--- a/modules/quality/src/qualitybrisque.cpp
+++ b/modules/quality/src/qualitybrisque.cpp
@@ -49,7 +49,7 @@ namespace
     // brisque intermediate calculation type
     //  Linux+Mat:  CV_64F is 3X slower than CV_32F
     //  Win32+Mat:  CV_64F is 2X slower than CV_32F
-    static constexpr const int BRISQUE_CALC_MAT_TYPE = CV_32F;
+    static constexpr const int BRISQUE_CALC_MAT_TYPE = CV_64F;
     // brisque intermediate matrix element type.  float if BRISQUE_CALC_MAT_TYPE == CV_32F, double if BRISQUE_CALC_MAT_TYPE == CV_64F
     using brisque_calc_element_type = float;
 

--- a/modules/quality/src/qualitybrisque.cpp
+++ b/modules/quality/src/qualitybrisque.cpp
@@ -81,25 +81,21 @@ namespace
     {
         long int poscount = 0, negcount = 0;
         double possqsum = 0, negsqsum = 0, abssum = 0;
-        for (int i = 0; i < structdis.rows; i++)
-        {
-            for (int j = 0; j < structdis.cols; j++)
-            {
-                double pt = structdis.at<brisque_calc_element_type>(i, j);
-                if (pt > 0)
-                {
-                    poscount++;
-                    possqsum += pt * pt;
-                    abssum += pt;
-                }
-                else if (pt < 0)
-                {
-                    negcount++;
-                    negsqsum += pt * pt;
-                    abssum -= pt;
-                }
-            }
-        }
+        
+        brisque_mat_type posmat = cv::max(structdis, 0);
+        brisque_mat_type negmat = cv::min(structdis, 0);
+        brisque_mat_type possqmat, negsqmat, absmat;
+
+        absmat = cv::abs(structdis);
+        cv::patchNaNs(absmat, 0);
+        cv::multiply(posmat, posmat, possqmat);
+        cv::multiply(negmat, negmat, negsqmat);
+
+        possqsum = cv::sum(possqmat)[0];
+        negsqsum = cv::sum(negsqmat)[0];
+        abssum = cv::sum(absmat)[0];
+        poscount = cv::countNonZero(posmat);
+        negcount = cv::countNonZero(negmat);
 
         lsigma_best = cv::pow(negsqsum / negcount, 0.5);
         rsigma_best = cv::pow(possqsum / poscount, 0.5);

--- a/modules/quality/src/qualitybrisque.cpp
+++ b/modules/quality/src/qualitybrisque.cpp
@@ -181,20 +181,20 @@ namespace
                 brisque_mat_type shifted_structdis(imdist_scaled.size(), BRISQUE_CALC_MAT_TYPE); //(imdist_scaled.size(), CV_64FC1, 1);
 
                 // create pair-wise product for the given orientation (reqshift)
-                for (int i = 0; i < structdis.rows; i++)
+                Range colRangesrc = Range(reqshift[1], structdis.cols);
+                Range rowRangesrc = Range(reqshift[0], structdis.rows);
+                Range colRangedst = Range(0, structdis.cols - reqshift[1]);
+                Range rowRangedst = Range(0, structdis.rows - reqshift[0]);
+                if (reqshift[0] == -1)
                 {
-                    for (int j = 0; j < structdis.cols; j++)
-                    {
-                        if (i + reqshift[0] >= 0 && i + reqshift[0] < structdis.rows && j + reqshift[1] >= 0 && j + reqshift[1] < structdis.cols)
-                        {
-                            shifted_structdis.at<brisque_calc_element_type>(i,j) = structdis.at<brisque_calc_element_type>(i + reqshift[0], j + reqshift[1]);
-                        }
-                        else
-                        {
-                            shifted_structdis.at<brisque_calc_element_type>(i, j) = (brisque_calc_element_type) 0;
-                        }
-                    }
+                    rowRangesrc = Range(0, structdis.rows - 1);
+                    rowRangedst = Range(1, structdis.rows);
                 }
+
+                //select maximum allowed cols
+                //copy the 2nd row to the 6th row  max allowed cols
+                structdis(rowRangesrc, colRangesrc).copyTo(shifted_structdis(rowRangedst, colRangedst));
+                
 
                 // calculate the products of the pairs
                 cv::multiply(structdis, shifted_structdis, shifted_structdis);


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

This PR proposes changes in the two most expensive loops found in the algorithm. It basically replaces with OpenCV's native functions:
* Iterative calls to shifted_structdis.at(i,j) function in the generation of the shifted matrices
* Iterative calls to pixel locations for the computation of the AGGDfit parameters.

Performance tests were conducted, showing a 2.5 times faster running code in a 32 core machine.