### PR TITLE
Added edge input feature to fast_line_detector

### DIFF
--- a/modules/ximgproc/include/opencv2/ximgproc/fast_line_detector.hpp
+++ b/modules/ximgproc/include/opencv2/ximgproc/fast_line_detector.hpp
@@ -42,7 +42,8 @@ public:
       brighter side is on their left.
       @param is_edge If true, image will be considerd as edge and negrect the canny parameters.
       */
-    CV_WRAP virtual void detect(InputArray _image, OutputArray _lines, bool is_edge) = 0;
+    CV_WRAP virtual void detect(InputArray _image, OutputArray _lines,
+            bool is_edge = false) = 0;
 
     /** @brief Draws the line segments on a given image.
       @param _image The image, where the lines will be drawn. Should be bigger

--- a/modules/ximgproc/include/opencv2/ximgproc/fast_line_detector.hpp
+++ b/modules/ximgproc/include/opencv2/ximgproc/fast_line_detector.hpp
@@ -40,8 +40,9 @@ public:
       and ending point of a line.  Where Vec4f is (x1, y1, x2, y2), point
       1 is the start, point 2 - end. Returned lines are directed so that the
       brighter side is on their left.
+      @param is_edge If true, image will be considerd as edge and negrect the canny parameters.
       */
-    CV_WRAP virtual void detect(InputArray _image, OutputArray _lines) = 0;
+    CV_WRAP virtual void detect(InputArray _image, OutputArray _lines, bool is_edge) = 0;
 
     /** @brief Draws the line segments on a given image.
       @param _image The image, where the lines will be drawn. Should be bigger

--- a/modules/ximgproc/include/opencv2/ximgproc/fast_line_detector.hpp
+++ b/modules/ximgproc/include/opencv2/ximgproc/fast_line_detector.hpp
@@ -65,17 +65,16 @@ public:
                                          hysteresis procedure in Canny()
 @param _canny_th2           50         - Second threshold for
                                          hysteresis procedure in Canny()
-@param _canny_aperture_size 3          - Aperturesize for the sobel
-                                         operator in Canny()
+@param _canny_aperture_size 3          - Aperturesize for the sobel operator in Canny().
+                                         If zero, Canny() is not applied and the input
+                                         image is taken as an edge image.
 @param _do_merge            false      - If true, incremental merging of segments
                                          will be perfomred
-@param _input_edge          false      - If true, input image will be considerd as
-                                         edge and ignore the canny parameters
 */
 CV_EXPORTS_W Ptr<FastLineDetector> createFastLineDetector(
         int _length_threshold = 10, float _distance_threshold = 1.414213562f,
         double _canny_th1 = 50.0, double _canny_th2 = 50.0, int _canny_aperture_size = 3,
-        bool _do_merge = false, bool _input_edge = false);
+        bool _do_merge = false);
 
 //! @} ximgproc_fast_line_detector
 }

--- a/modules/ximgproc/include/opencv2/ximgproc/fast_line_detector.hpp
+++ b/modules/ximgproc/include/opencv2/ximgproc/fast_line_detector.hpp
@@ -40,10 +40,8 @@ public:
       and ending point of a line.  Where Vec4f is (x1, y1, x2, y2), point
       1 is the start, point 2 - end. Returned lines are directed so that the
       brighter side is on their left.
-      @param is_edge If true, image will be considerd as edge and negrect the canny parameters.
       */
-    CV_WRAP virtual void detect(InputArray _image, OutputArray _lines,
-            bool is_edge = false) = 0;
+    CV_WRAP virtual void detect(InputArray _image, OutputArray _lines) = 0;
 
     /** @brief Draws the line segments on a given image.
       @param _image The image, where the lines will be drawn. Should be bigger
@@ -71,11 +69,13 @@ public:
                                          operator in Canny()
 @param _do_merge            false      - If true, incremental merging of segments
                                          will be perfomred
+@param _input_edge          false      - If true, input image will be considerd as 
+                                         edge and ignore the canny parameters
 */
 CV_EXPORTS_W Ptr<FastLineDetector> createFastLineDetector(
         int _length_threshold = 10, float _distance_threshold = 1.414213562f,
         double _canny_th1 = 50.0, double _canny_th2 = 50.0, int _canny_aperture_size = 3,
-        bool _do_merge = false);
+        bool _do_merge = false, bool _input_edge = false);
 
 //! @} ximgproc_fast_line_detector
 }

--- a/modules/ximgproc/include/opencv2/ximgproc/fast_line_detector.hpp
+++ b/modules/ximgproc/include/opencv2/ximgproc/fast_line_detector.hpp
@@ -69,7 +69,7 @@ public:
                                          operator in Canny()
 @param _do_merge            false      - If true, incremental merging of segments
                                          will be perfomred
-@param _input_edge          false      - If true, input image will be considerd as 
+@param _input_edge          false      - If true, input image will be considerd as
                                          edge and ignore the canny parameters
 */
 CV_EXPORTS_W Ptr<FastLineDetector> createFastLineDetector(

--- a/modules/ximgproc/samples/fld_lines.cpp
+++ b/modules/ximgproc/samples/fld_lines.cpp
@@ -41,7 +41,7 @@ int main(int argc, char** argv)
     //                                     operator in Canny()
     // do_merge            false         - If true, incremental merging of segments
     //                                     will be perfomred
-    // input_edge          false         - If true, input image will be considerd as 
+    // input_edge          false         - If true, input image will be considerd as
     //                                     edge and ignore the canny parameters
     int length_threshold = 10;
     float distance_threshold = 1.41421356f;

--- a/modules/ximgproc/samples/fld_lines.cpp
+++ b/modules/ximgproc/samples/fld_lines.cpp
@@ -41,15 +41,18 @@ int main(int argc, char** argv)
     //                                     operator in Canny()
     // do_merge            false         - If true, incremental merging of segments
     //                                     will be perfomred
+    // input_edge          false         - If true, input image will be considerd as 
+    //                                     edge and ignore the canny parameters
     int length_threshold = 10;
     float distance_threshold = 1.41421356f;
     double canny_th1 = 50.0;
     double canny_th2 = 50.0;
     int canny_aperture_size = 3;
     bool do_merge = false;
+    bool input_edge = false;
     Ptr<FastLineDetector> fld = createFastLineDetector(length_threshold,
             distance_threshold, canny_th1, canny_th2, canny_aperture_size,
-            do_merge);
+            do_merge, input_edge);
     vector<Vec4f> lines_fld;
 
     // Because of some CPU's power strategy, it seems that the first running of

--- a/modules/ximgproc/samples/fld_lines.cpp
+++ b/modules/ximgproc/samples/fld_lines.cpp
@@ -37,22 +37,20 @@ int main(int argc, char** argv)
     //                                     hysteresis procedure in Canny()
     // canny_th2           50            - Second threshold for
     //                                     hysteresis procedure in Canny()
-    // canny_aperture_size 3             - Aperturesize for the sobel
-    //                                     operator in Canny()
+    // canny_aperture_size 3            - Aperturesize for the sobel operator in Canny().
+    //                                     If zero, Canny() is not applied and the input
+    //                                     image is taken as an edge image.
     // do_merge            false         - If true, incremental merging of segments
     //                                     will be perfomred
-    // input_edge          false         - If true, input image will be considerd as
-    //                                     edge and ignore the canny parameters
     int length_threshold = 10;
     float distance_threshold = 1.41421356f;
     double canny_th1 = 50.0;
     double canny_th2 = 50.0;
     int canny_aperture_size = 3;
     bool do_merge = false;
-    bool input_edge = false;
     Ptr<FastLineDetector> fld = createFastLineDetector(length_threshold,
             distance_threshold, canny_th1, canny_th2, canny_aperture_size,
-            do_merge, input_edge);
+            do_merge);
     vector<Vec4f> lines_fld;
 
     // Because of some CPU's power strategy, it seems that the first running of

--- a/modules/ximgproc/src/fast_line_detector.cpp
+++ b/modules/ximgproc/src/fast_line_detector.cpp
@@ -33,7 +33,7 @@ class FastLineDetectorImpl : public FastLineDetector
          *                                          If zero, Canny() is not applied and the input
          *                                          image is taken as an edge image.
          * @param _do_merge            false      - If true, incremental merging of segments
-         *                                          will be perfomred
+         *                                          will be performed
          */
         FastLineDetectorImpl(int _length_threshold = 10, float _distance_threshold = 1.414213562f,
                 double _canny_th1 = 50.0, double _canny_th2 = 50.0, int _canny_aperture_size = 3,
@@ -545,9 +545,14 @@ void FastLineDetectorImpl::lineDetection(const Mat& src, std::vector<SEGMENT>& s
     std::vector<Point2i> points;
     std::vector<SEGMENT> segments, segments_tmp;
     Mat canny;
-    if (canny_aperture_size == 0) canny = src;
-    else Canny(src, canny, canny_th1, canny_th2, canny_aperture_size);
-
+    if (canny_aperture_size == 0)
+    {
+        canny = src;
+    }
+    else
+    {
+        Canny(src, canny, canny_th1, canny_th2, canny_aperture_size);
+    }
     canny.colRange(0,6).rowRange(0,6) = 0;
     canny.colRange(src.cols-5,src.cols).rowRange(src.rows-5,src.rows) = 0;
 

--- a/modules/ximgproc/src/fast_line_detector.cpp
+++ b/modules/ximgproc/src/fast_line_detector.cpp
@@ -29,16 +29,15 @@ class FastLineDetectorImpl : public FastLineDetector
          *        _                                 hysteresis procedure in Canny()
          * @param _canny_th2           50         - Second threshold for
          *        _                                 hysteresis procedure in Canny()
-         * @param _canny_aperture_size 3          - Aperturesize for the sobel
-         *        _                                 operator in Canny()
+         * @param _canny_aperture_size 3          - Aperturesize for the sobel operator in Canny().
+         *                                          If zero, Canny() is not applied and the input
+         *                                          image is taken as an edge image.
          * @param _do_merge            false      - If true, incremental merging of segments
-                                                    will be perfomred
-         * @param _input_edge          false      - If true, input image will be considerd as
-                                                    edge and ignore the canny parameters
+         *                                          will be perfomred
          */
         FastLineDetectorImpl(int _length_threshold = 10, float _distance_threshold = 1.414213562f,
                 double _canny_th1 = 50.0, double _canny_th2 = 50.0, int _canny_aperture_size = 3,
-                bool _do_merge = false, bool _input_edge = false);
+                bool _do_merge = false);
 
         /**
          * Detect lines in the input image.
@@ -69,7 +68,6 @@ class FastLineDetectorImpl : public FastLineDetector
         double canny_th1, canny_th2;
         int canny_aperture_size;
         bool do_merge;
-        bool input_edge;
 
         FastLineDetectorImpl& operator= (const FastLineDetectorImpl&); // to quiet MSVC
         template<class T>
@@ -101,22 +99,22 @@ class FastLineDetectorImpl : public FastLineDetector
 
 CV_EXPORTS Ptr<FastLineDetector> createFastLineDetector(
         int _length_threshold, float _distance_threshold,
-        double _canny_th1, double _canny_th2, int _canny_aperture_size, bool _do_merge, bool _input_edge)
+        double _canny_th1, double _canny_th2, int _canny_aperture_size, bool _do_merge)
 {
     return makePtr<FastLineDetectorImpl>(
             _length_threshold, _distance_threshold,
-            _canny_th1, _canny_th2, _canny_aperture_size, _do_merge, _input_edge);
+            _canny_th1, _canny_th2, _canny_aperture_size, _do_merge);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
 FastLineDetectorImpl::FastLineDetectorImpl(int _length_threshold, float _distance_threshold,
-        double _canny_th1, double _canny_th2, int _canny_aperture_size, bool _do_merge, bool _input_edge)
+        double _canny_th1, double _canny_th2, int _canny_aperture_size, bool _do_merge)
     :threshold_length(_length_threshold), threshold_dist(_distance_threshold),
-    canny_th1(_canny_th1), canny_th2(_canny_th2), canny_aperture_size(_canny_aperture_size), do_merge(_do_merge), input_edge(_input_edge)
+    canny_th1(_canny_th1), canny_th2(_canny_th2), canny_aperture_size(_canny_aperture_size), do_merge(_do_merge)
 {
     CV_Assert(_length_threshold > 0 && _distance_threshold > 0 &&
-            _canny_th1 > 0 && _canny_th2 > 0 && _canny_aperture_size > 0);
+            _canny_th1 > 0 && _canny_th2 > 0 && _canny_aperture_size >= 0);
 }
 
 void FastLineDetectorImpl::detect(InputArray _image, OutputArray _lines)
@@ -547,7 +545,7 @@ void FastLineDetectorImpl::lineDetection(const Mat& src, std::vector<SEGMENT>& s
     std::vector<Point2i> points;
     std::vector<SEGMENT> segments, segments_tmp;
     Mat canny;
-    if (input_edge) canny = src;
+    if (canny_aperture_size == 0) canny = src;
     else Canny(src, canny, canny_th1, canny_th2, canny_aperture_size);
 
     canny.colRange(0,6).rowRange(0,6) = 0;

--- a/modules/ximgproc/src/fast_line_detector.cpp
+++ b/modules/ximgproc/src/fast_line_detector.cpp
@@ -33,7 +33,7 @@ class FastLineDetectorImpl : public FastLineDetector
          *        _                                 operator in Canny()
          * @param _do_merge            false      - If true, incremental merging of segments
                                                     will be perfomred
-         * @param _input_edge          false      - If true, input image will be considerd as 
+         * @param _input_edge          false      - If true, input image will be considerd as
                                                     edge and ignore the canny parameters
          */
         FastLineDetectorImpl(int _length_threshold = 10, float _distance_threshold = 1.414213562f,

--- a/modules/ximgproc/test/test_fld.cpp
+++ b/modules/ximgproc/test/test_fld.cpp
@@ -166,7 +166,7 @@ TEST_F(ximgproc_FLD, edgeLines)
     {
         const unsigned int numOfLines = 1;
         GenerateEdgeLines(test_image, numOfLines);
-        Ptr<FastLineDetector> detector = createFastLineDetector(10, 1.414213562f, 50, 50, 3, false, true);
+        Ptr<FastLineDetector> detector = createFastLineDetector(10, 1.414213562f, 50, 50, 0);
         detector->detect(test_image, lines);
         if(numOfLines == lines.size()) ++passedtests;
     }

--- a/modules/ximgproc/test/test_fld.cpp
+++ b/modules/ximgproc/test/test_fld.cpp
@@ -166,8 +166,8 @@ TEST_F(ximgproc_FLD, edgeLines)
     {
         const unsigned int numOfLines = 1;
         GenerateEdgeLines(test_image, numOfLines);
-        Ptr<FastLineDetector> detector = createFastLineDetector();
-        detector->detect(test_image, lines, true); // is_edge = true
+        Ptr<FastLineDetector> detector = createFastLineDetector(10, 1.414213562f, 50, 50, 3, false, true);
+        detector->detect(test_image, lines);
         if(numOfLines == lines.size()) ++passedtests;
     }
     ASSERT_EQ(EPOCHS, passedtests);

--- a/modules/ximgproc/test/test_fld.cpp
+++ b/modules/ximgproc/test/test_fld.cpp
@@ -23,6 +23,7 @@ class FLDBase : public testing::Test
         void GenerateWhiteNoise(Mat& image);
         void GenerateConstColor(Mat& image);
         void GenerateLines(Mat& image, const unsigned int numLines);
+        void GenerateEdgeLines(Mat& image, const unsigned int numLines);
         void GenerateBrokenLines(Mat& image, const unsigned int numLines);
         void GenerateRotatedRect(Mat& image);
         virtual void SetUp();
@@ -47,6 +48,7 @@ void FLDBase::GenerateConstColor(Mat& image)
     image = Mat(img_size, CV_8UC1, Scalar::all(rng.uniform(0, 256)));
 }
 
+
 void FLDBase::GenerateLines(Mat& image, const unsigned int numLines)
 {
     image = Mat(img_size, CV_8UC1, Scalar::all(rng.uniform(0, 128)));
@@ -57,6 +59,19 @@ void FLDBase::GenerateLines(Mat& image, const unsigned int numLines)
         Point p1(y, 10);
         Point p2(y, img_size.height - 10);
         line(image, p1, p2, Scalar(255), 2);
+    }
+}
+
+void FLDBase::GenerateEdgeLines(Mat& image, const unsigned int numLines)
+{
+    image = Mat(img_size, CV_8UC1, Scalar::all(0));
+
+    for(unsigned int i = 0; i < numLines; ++i)
+    {
+        int y = rng.uniform(10, img_size.width - 10);
+        Point p1(y, 10);
+        Point p2(y, img_size.height - 10);
+        line(image, p1, p2, Scalar(255), 1);
     }
 }
 
@@ -141,6 +156,19 @@ TEST_F(ximgproc_FLD, lines)
         Ptr<FastLineDetector> detector = createFastLineDetector();
         detector->detect(test_image, lines);
         if(numOfLines * 2 == lines.size()) ++passedtests;  // * 2 because of Gibbs effect
+    }
+    ASSERT_EQ(EPOCHS, passedtests);
+}
+
+TEST_F(ximgproc_FLD, edgeLines)
+{
+    for (int i = 0; i < EPOCHS; ++i)
+    {
+        const unsigned int numOfLines = 1;
+        GenerateEdgeLines(test_image, numOfLines);
+        Ptr<FastLineDetector> detector = createFastLineDetector();
+        detector->detect(test_image, lines, true); // is_edge = true
+        if(numOfLines == lines.size()) ++passedtests;
     }
     ASSERT_EQ(EPOCHS, passedtests);
 }


### PR DESCRIPTION
Fixed issue #2667 in opencv/opencv_contrib

Added the `is_edge` option to the `detect` method in `fast_line_detector`.

The Fast Line Detector used to use the canny method for edge detection internally, but `is_edge=true` makes it possible to input the edge image directly. Parameters for the canny method are ignored. The default value is `false`, so it won't break anyone's code.

This feature will provide users with additional flexibility and versatility in FastLineDetector.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
