### PR TITLE
Merge 3.4

### DIFF
--- a/modules/cudaarithm/src/lut.cpp
+++ b/modules/cudaarithm/src/lut.cpp
@@ -4,8 +4,6 @@
 
 #include "precomp.hpp"
 
-#include "lut.hpp"
-
 using namespace cv;
 using namespace cv::cuda;
 
@@ -14,6 +12,9 @@ using namespace cv::cuda;
 Ptr<LookUpTable> cv::cuda::createLookUpTable(InputArray) { throw_no_cuda(); return Ptr<LookUpTable>(); }
 
 #else /* !defined (HAVE_CUDA) || defined (CUDA_DISABLER) */
+
+// lut.hpp includes cuda_runtime.h and can only be included when we have CUDA
+#include "lut.hpp"
 
 Ptr<LookUpTable> cv::cuda::createLookUpTable(InputArray lut)
 {


### PR DESCRIPTION
moved opencv/opencv#18641 from rtimpe:fix_cuda_stubs

Main PR: https://github.com/opencv/opencv/pull/18662
Previous "Merge 3.4": #2688

<cut/>

```
force_builders=Custom,Win64 OpenCL
buildworker:Custom=linux-4
build_image:Custom=ubuntu-cuda:18.04
buildworker:Win64 OpenCL=windows-2
build_image:Win64 OpenCL=msvs2019
```
