### PR TITLE
Fix build failure in rgbd's test

### DIFF
--- a/modules/rgbd/test/test_dynafu.cpp
+++ b/modules/rgbd/test/test_dynafu.cpp
@@ -41,11 +41,11 @@ static const bool display = false;
 
 void flyTest(bool hiDense, bool inequal)
 {
-    Ptr<dynafu::Params> params;
+    Ptr<kinfu::Params> params;
     if(hiDense)
-        params = dynafu::Params::defaultParams();
+        params = kinfu::Params::defaultParams();
     else
-        params = dynafu::Params::coarseParams();
+        params = kinfu::Params::coarseParams();
 
     if(inequal)
     {


### PR DESCRIPTION
relates #2619
resolves #2715

Fixes the following compiler error:

```
  rgbd/test/test_dynafu.cpp:44:17: error: 'Params' is not a member of 'cv::dynafu'
     44 |     Ptr<dynafu::Params> params;
        |                 ^~~~~~
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
