### PR TITLE
phase_unwrapping: add asserts, documentation for input types

### DIFF
--- a/modules/phase_unwrapping/include/opencv2/phase_unwrapping/phase_unwrapping.hpp
+++ b/modules/phase_unwrapping/include/opencv2/phase_unwrapping/phase_unwrapping.hpp
@@ -58,9 +58,9 @@ public:
     /**
      * @brief Unwraps a 2D phase map.
 
-     * @param wrappedPhaseMap The wrapped phase map that needs to be unwrapped.
+     * @param wrappedPhaseMap The wrapped phase map of type CV_32FC1 that needs to be unwrapped.
      * @param unwrappedPhaseMap The unwrapped phase map.
-     * @param shadowMask Optional parameter used when some pixels do not hold any phase information in the wrapped phase map.
+     * @param shadowMask Optional CV_8UC1 mask image used when some pixels do not hold any phase information in the wrapped phase map.
      */
     CV_WRAP
     virtual void unwrapPhaseMap( InputArray wrappedPhaseMap, OutputArray unwrappedPhaseMap,

--- a/modules/phase_unwrapping/src/histogramphaseunwrapping.cpp
+++ b/modules/phase_unwrapping/src/histogramphaseunwrapping.cpp
@@ -402,6 +402,9 @@ void HistogramPhaseUnwrapping_Impl::unwrapPhaseMap( InputArray wrappedPhaseMap,
         temp.copyTo(mask);
     }
 
+    CV_CheckTypeEQ(wPhaseMap.type(), CV_32FC1, "");
+    CV_CheckTypeEQ(mask.type(), CV_8UC1, "");
+
     computePixelsReliability(wPhaseMap, mask);
     computeEdgesReliabilityAndCreateHistogram();
 


### PR DESCRIPTION
related to #2746

<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

