### PR TITLE
sfm: fix build in non-C++11 mode

### DIFF
--- a/modules/sfm/src/libmv_light/libmv/base/vector.h
+++ b/modules/sfm/src/libmv_light/libmv/base/vector.h
@@ -125,7 +125,11 @@ class vector {
       memcpy(data, data_, sizeof(*data)*size_);
 #else
       for (int i = 0; i < size_; ++i)
+#ifdef CV_CXX11
         new (&data[i]) T(std::move(data_[i]));
+#else
+        new (&data[i]) T(data_[i]);
+#endif
       for (int i = 0; i < size_; ++i)
         data_[i].~T();
 #endif


### PR DESCRIPTION
relates #2740

Failed [nightly build](http://pullrequest.opencv.org/buildbot/builders/3_4-contrib-lin64/builds/892).