### PR TITLE
fix: VS compatibility with unicode strings

### DIFF
--- a/modules/cvv/src/stfl/stringutils.cpp
+++ b/modules/cvv/src/stfl/stringutils.cpp
@@ -248,15 +248,16 @@ void unescapeCommas(QString &str)
 
 QString shortenString(QString &str, int maxLength, bool cutEnd, bool fill)
 {
+    const auto horizontalEllipsis = u8"\xE2\x80\xA6"; // u8"…"
     if (str.size() > maxLength)
     {
         if (cutEnd)
         {
-            str = str.mid(0, maxLength - 1) + u8"…";
+            str = str.mid(0, maxLength - 1) + horizontalEllipsis;
         }
         else
         {
-            str = u8"…" +
+            str = horizontalEllipsis +
                   str.mid(str.size() + 1 - maxLength, str.size());
         }
     }


### PR DESCRIPTION
The UTF-8 string u8"…" causes following errors when building under VS2019:
C2001  newline in constant
C2143 syntax error: missing ';' before '}'
C2146 syntax error: missing ';' before identifier 'str'

#### Referenced Issues

#2001 

#### Steps to reproduce

Build under VS2017/2019

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
