### PR TITLE
build warnings

### DIFF
--- a/modules/rgbd/src/pose_graph.hpp
+++ b/modules/rgbd/src/pose_graph.hpp
@@ -228,8 +228,8 @@ class PoseGraph
     virtual ~PoseGraph() = default;
 
     //! PoseGraph can be copied/cloned
-    PoseGraph(const PoseGraph& _poseGraph) = default;
-    PoseGraph& operator=(const PoseGraph& _poseGraph) = default;
+    PoseGraph(const PoseGraph&) = default;
+    PoseGraph& operator=(const PoseGraph&) = default;
 
     void addNode(const PoseGraphNode& node) { nodes.push_back(node); }
     void addEdge(const PoseGraphEdge& edge) { edges.push_back(edge); }


### PR DESCRIPTION
**Main PR**: https://github.com/opencv/opencv/pull/19021

- GCC 4.8.5 / CentOS 7

[Nightly build](http://pullrequest.opencv.org/buildbot/builders/master-contrib_etc-centos-lin64/builds/44).

<cut/>

```
/build/master-contrib_etc-centos-lin64/opencv_contrib/modules/rgbd/src/pose_graph.hpp:231:5: warning: unused parameter '_poseGraph' [-Wunused-parameter]
/build/master-contrib_etc-centos-lin64/opencv_contrib/modules/rgbd/src/pose_graph.hpp:231:5: warning: unused parameter '_poseGraph' [-Wunused-parameter]
```