### PR TITLE
freetype2: Fix comments in freetype.hpp and README.md

### DIFF
--- a/modules/freetype/README.md
+++ b/modules/freetype/README.md
@@ -1,10 +1,11 @@
 FreeType2 Wrapper Module
-==========================
+========================
 
 This FreeType2 wrapper module allows to draw strings with outlines and bitmaps.
 
-Requested external libraries.
-------------------------------
+Requested external libraries
+----------------------------
+
 harfbuzz is requested to convert UTF8 to gid(GlyphID).
 
 freetype library is requested to rasterize given gid.
@@ -13,7 +14,7 @@ freetype library is requested to rasterize given gid.
 - freetype https://www.freetype.org/
 
 Usage
------------
+-----
 
 ```
 cv::Ptr<cv::freetype::FreeType2> ft2;
@@ -24,7 +25,7 @@ ft2->putText(mat, "hello world", cv::Point(20, 200),
 ```
 
 Option
-------------
+------
 - 2nd argument of loadFontData is used if font file has many font data.
 - 3 drawing mode is available.
     - outline mode is used if lineWidth is larger than 0. (like original putText)

--- a/modules/freetype/README.md
+++ b/modules/freetype/README.md
@@ -1,34 +1,34 @@
-FreeType Module
-===========
+FreeType2 Wrapper Module
+==========================
 
-This FreeType module allows you to draw strings with outlines and bitmaps.
+This FreeType2 wrapper module allows to draw strings with outlines and bitmaps.
 
-Installation
------------
+Requested external libraries.
+------------------------------
 harfbuzz is requested to convert UTF8 to gid(GlyphID).
+
 freetype library is requested to rasterize given gid.
 
-harfbuzz https://www.freedesktop.org/wiki/Software/HarfBuzz/
-freetype https://www.freetype.org/
+- harfbuzz https://www.freedesktop.org/wiki/Software/HarfBuzz/
+- freetype https://www.freetype.org/
 
 Usage
 -----------
-cv::freetype::FreeType2 ft2;
-ft2.loadFontData("your-font.ttf", 0);
-ft2.setSplitNumber( 4 ); // Bezier-line is splited by 4 segment.
-ft2.putText(src, .... )
+
+```
+cv::Ptr<cv::freetype::FreeType2> ft2;
+ft2 = cv::freetype::createFreeType2();
+ft2->loadFontData(ttf_pathname, 0);
+ft2->putText(mat, "hello world", cv::Point(20, 200),
+             30, CV_RGB(0, 0, 0), cv::FILLED, cv::LINE_AA, true);
+```
 
 Option
 ------------
 - 2nd argument of loadFontData is used if font file has many font data.
 - 3 drawing mode is available.
--- outline mode is used if lineWidth is larger than 0. (like original putText)
--- bitmap  mode is used if lineWidth is less than 0.
---- 1bit bitmap mode is used if lineStyle is 4 or 8.
---- gray bitmap mode is used if lineStyle is 16.
+    - outline mode is used if lineWidth is larger than 0. (like original putText)
+    - bitmap  mode is used if lineWidth is less than 0.
+        - 1bit bitmap mode is used if lineStyle is 4 or 8.
+        - gray bitmap mode is used if lineStyle is 16.
 
-Future work
-------------
-- test
--- CJK and ...
-- RTL,LTR,TTB,BTT...

--- a/modules/freetype/README.md
+++ b/modules/freetype/README.md
@@ -31,4 +31,3 @@ Option
     - bitmap  mode is used if lineWidth is less than 0.
         - 1bit bitmap mode is used if lineStyle is 4 or 8.
         - gray bitmap mode is used if lineStyle is 16.
-

--- a/modules/freetype/include/opencv2/freetype.hpp
+++ b/modules/freetype/include/opencv2/freetype.hpp
@@ -99,11 +99,11 @@ If you want to draw small glyph, small is better.
 
 The function putText renders the specified text string in the image. Symbols that cannot be rendered using the specified font are replaced by "Tofu" or non-drawn.
 
-@param img Image.
+@param img Image. (Only 8UC3 image is supported.)
 @param text Text string to be drawn.
 @param org Bottom-left/Top-left corner of the text string in the image.
 @param fontHeight Drawing font size by pixel unit.
-@param color Text color.
+@param color Text color.(Only 3ch 8bit Scalar is supported.)
 @param thickness Thickness of the lines used to draw a text when negative, the glyph is filled. Otherwise, the glyph is drawn with this thickness.
 @param line_type Line type. See the line for details.
 @param bottomLeftOrigin When true, the image data origin is at the bottom-left corner. Otherwise, it is at the top-left corner.

--- a/modules/freetype/include/opencv2/freetype.hpp
+++ b/modules/freetype/include/opencv2/freetype.hpp
@@ -103,7 +103,7 @@ The function putText renders the specified text string in the image. Symbols tha
 @param text Text string to be drawn.
 @param org Bottom-left/Top-left corner of the text string in the image.
 @param fontHeight Drawing font size by pixel unit.
-@param color Text color.(Only 3ch 8bit Scalar is supported.)
+@param color Text color.
 @param thickness Thickness of the lines used to draw a text when negative, the glyph is filled. Otherwise, the glyph is drawn with this thickness.
 @param line_type Line type. See the line for details.
 @param bottomLeftOrigin When true, the image data origin is at the bottom-left corner. Otherwise, it is at the top-left corner.


### PR DESCRIPTION
Fix https://github.com/opencv/opencv_contrib/issues/2771 and related small problems about documentation.

1.  freetype.hpp is fixed.
  - putText() is supported for only 8UC3 image with only 8UC3 color.

2. README.md is fixed.
  - Use correct markdown format.
  - Change document title from "freetype module" to "freetype wrapper module". 
    - This module title was "freetype **module**". 
    - FText primitive in GAPI uses `freetype **library**". 
    - Generally  "module" and "library" in the computer world are similar.
    - So that, I think this module title should be changed to not confuse it.
  - `Installation` is replaced as `Requested external libraries`
  - `Usage` is update to it can be compile in real. 
  - `Future work` is removed. 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [X] There is reference to original bug report and related work
- [X] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X] The feature is well documented and sample code can be built with the project CMake
