### PR TITLE
surface_matching/PPF3DDetector::match : fix memory leak

### DIFF
--- a/modules/surface_matching/src/ppf_match_3d.cpp
+++ b/modules/surface_matching/src/ppf_match_3d.cpp
@@ -583,9 +583,7 @@ void PPF3DDetector::match(const Mat& pc, std::vector<Pose3DPtr>& results, const 
       poseList.push_back(pose);
     }
 
-#if defined (_OPENMP)
     free(accumulator);
-#endif
   }
 
   // TODO : Make the parameters relative if not arguments.


### PR DESCRIPTION
I think the define guards are wrong, the accumulator is allocated with `calloc` regardless of  `_OPENMP`, so it should be freed in any case.