### PR TITLE
Update cudacodec to work with Nvidia Video Codec SDK 11.0

### DIFF
--- a/modules/cudacodec/include/opencv2/cudacodec.hpp
+++ b/modules/cudacodec/include/opencv2/cudacodec.hpp
@@ -255,6 +255,7 @@ enum Codec
     HEVC,
     VP8,
     VP9,
+    AV1,
     NumCodecs,
 
     Uncompressed_YUV420 = (('I'<<24)|('Y'<<16)|('U'<<8)|('V')),   //!< Y,U,V (4:2:0)

--- a/modules/cudacodec/src/video_decoder.cpp
+++ b/modules/cudacodec/src/video_decoder.cpp
@@ -78,6 +78,7 @@ void cv::cudacodec::detail::VideoDecoder::create(const FormatInfo& videoFormat)
 #if  ((CUDART_VERSION == 7500) || (CUDART_VERSION >= 9000))
     codecSupported |=       cudaVideoCodec_VP8      == _codec ||
                             cudaVideoCodec_VP9      == _codec ||
+                            cudaVideoCodec_AV1      == _codec ||
                             cudaVideoCodec_YUV420   == _codec;
 #endif
 #endif


### PR DESCRIPTION
Nvidia only allows users to download the most recent version of the Nvidia Video Codec SDK.  As a result cudacodec has been broken since the release of v 11.0 when the AV1 codec was added.

This small fix should allow cudacodec to pass the inbuilt tests again.


```
buildworker:Custom=linux-4
build_image:Custom=ubuntu-cuda:18.04
```