### PR TITLE
Implement cv::cuda::inRange (Fixes OpenCV #6295)

### DIFF
--- a/modules/cudaarithm/include/opencv2/cudaarithm.hpp
+++ b/modules/cudaarithm/include/opencv2/cudaarithm.hpp
@@ -358,6 +358,31 @@ threshold types are not supported.
  */
 CV_EXPORTS_W double threshold(InputArray src, OutputArray dst, double thresh, double maxval, int type, Stream& stream = Stream::Null());
 
+/** @brief  Checks if array elements lie between two scalars.
+
+The function checks the range as follows:
+-   For every element of a single-channel input array:
+    \f[\texttt{dst} (I)= \texttt{lowerb}_0  \leq \texttt{src} (I)_0 \leq  \texttt{upperb}_0\f]
+-   For two-channel arrays:
+    \f[\texttt{dst} (I)= \texttt{lowerb}_0  \leq \texttt{src} (I)_0 \leq  \texttt{upperb}_0  \land \texttt{lowerb}_1  \leq \texttt{src} (I)_1 \leq  \texttt{upperb}_1\f]
+-   and so forth.
+
+That is, dst (I) is set to 255 (all 1 -bits) if src (I) is within the
+specified 1D, 2D, 3D, ... box and 0 otherwise.
+
+Note that unlike the CPU inRange, this does NOT accept an array for lowerb or
+upperb, only a cv::Scalar.
+
+@param src first input array.
+@param lowerb inclusive lower boundary cv::Scalar.
+@param upperb inclusive upper boundary cv::Scalar.
+@param dst output array of the same size as src and CV_8U type.
+@param stream Stream for the asynchronous version.
+
+@sa cv::inRange
+ */
+CV_EXPORTS_W void inRange(InputArray src, const Scalar& lowerb, const Scalar& upperb, OutputArray dst, Stream& stream = Stream::Null());
+
 /** @brief Computes magnitudes of complex matrix elements.
 
 @param xy Source complex matrix in the interleaved format ( CV_32FC2 ).

--- a/modules/cudaarithm/misc/python/test/test_cudaarithm.py
+++ b/modules/cudaarithm/misc/python/test/test_cudaarithm.py
@@ -174,5 +174,24 @@ class cudaarithm_test(NewOpenCVTests):
         self.assertTrue(np.allclose(cuMatDst.download(),
                     cv.filter2D(npMat,-1,kernel,anchor=(-1,-1))[iS[0]:iE[0]+1,iS[1]:iE[1]+1]))
 
+    def test_inrange(self):
+        npMat = (np.random.random((128, 128, 3)) * 255).astype(np.float32)
+
+        bound1 = np.random.random((4,)) * 255
+        bound2 = np.random.random((4,)) * 255
+        lowerb = np.minimum(bound1, bound2).tolist()
+        upperb = np.maximum(bound1, bound2).tolist()
+
+        cuMat = cv.cuda_GpuMat()
+        cuMat.upload(npMat)
+
+        self.assertTrue((cv.cuda.inRange(cuMat, lowerb, upperb).download() ==
+                         cv.inRange(npMat, np.array(lowerb), np.array(upperb))).all())
+
+        cuMatDst = cv.cuda_GpuMat(cuMat.size(), cv.CV_8UC1)
+        cv.cuda.inRange(cuMat, lowerb, upperb, cuMatDst)
+        self.assertTrue((cuMatDst.download() ==
+                         cv.inRange(npMat, np.array(lowerb), np.array(upperb))).all())
+
 if __name__ == '__main__':
     NewOpenCVTests.bootstrap()

--- a/modules/cudaarithm/perf/perf_element_operations.cpp
+++ b/modules/cudaarithm/perf/perf_element_operations.cpp
@@ -1501,4 +1501,41 @@ PERF_TEST_P(Sz_Depth_Op, Threshold,
     }
 }
 
+//////////////////////////////////////////////////////////////////////
+// InRange
+
+PERF_TEST_P(Sz_Depth_Cn, InRange,
+            Combine(CUDA_TYPICAL_MAT_SIZES,
+            Values(CV_8U, CV_16U, CV_32F, CV_64F),
+            CUDA_CHANNELS_1_3_4))
+{
+    const cv::Size size = GET_PARAM(0);
+    const int depth = GET_PARAM(1);
+    const int channels = GET_PARAM(2);
+
+    cv::Mat src(size, CV_MAKE_TYPE(depth, channels));
+    declare.in(src, WARMUP_RNG);
+
+    const cv::Scalar lowerb(10, 50, 100);
+    const cv::Scalar upperb(70, 85, 200);
+
+    if (PERF_RUN_CUDA())
+    {
+        const cv::cuda::GpuMat d_src(src);
+        cv::cuda::GpuMat dst;
+
+        TEST_CYCLE() cv::cuda::inRange(d_src, lowerb, upperb, dst);
+
+        CUDA_SANITY_CHECK(dst, 0);
+    }
+    else
+    {
+        cv::Mat dst;
+
+        TEST_CYCLE() cv::inRange(src, lowerb, upperb, dst);
+
+        CPU_SANITY_CHECK(dst);
+    }
+}
+
 }} // namespace

--- a/modules/cudaarithm/src/cuda/in_range.cu
+++ b/modules/cudaarithm/src/cuda/in_range.cu
@@ -1,0 +1,99 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "opencv2/opencv_modules.hpp"
+
+#ifndef HAVE_OPENCV_CUDEV
+
+#error "opencv_cudev is required"
+
+#else
+
+#include "opencv2/core/private.cuda.hpp"
+#include "opencv2/cudaarithm.hpp"
+#include "opencv2/cudev.hpp"
+
+using namespace cv;
+using namespace cv::cuda;
+using namespace cv::cudev;
+
+namespace {
+
+template <typename T, int cn>
+void inRangeImpl(const GpuMat& src,
+                 const Scalar& lowerb,
+                 const Scalar& upperb,
+                 GpuMat& dst,
+                 Stream& stream) {
+    gridTransformUnary(globPtr<typename MakeVec<T, cn>::type>(src),
+                       globPtr<uchar>(dst),
+                       InRangeFunc<T, cn>(lowerb, upperb),
+                       stream);
+}
+
+}  // namespace
+
+void cv::cuda::inRange(InputArray _src,
+                       const Scalar& _lowerb,
+                       const Scalar& _upperb,
+                       OutputArray _dst,
+                       Stream& stream) {
+    const GpuMat src = getInputMat(_src, stream);
+
+    typedef void (*func_t)(const GpuMat& src,
+                           const Scalar& lowerb,
+                           const Scalar& upperb,
+                           GpuMat& dst,
+                           Stream& stream);
+
+    // Note: We cannot support 16F with the current implementation because we
+    // use a CUDA vector (e.g. int3) to store the bounds, and there is no CUDA
+    // vector type for float16
+    static constexpr const int MAX_CHANNELS = 4;
+    static constexpr const int NUM_DEPTHS = CV_64F + 1;
+
+    static const std::array<std::array<func_t, NUM_DEPTHS>, MAX_CHANNELS>
+            funcs = {std::array<func_t, NUM_DEPTHS>{inRangeImpl<uchar, 1>,
+                                                    inRangeImpl<schar, 1>,
+                                                    inRangeImpl<ushort, 1>,
+                                                    inRangeImpl<short, 1>,
+                                                    inRangeImpl<int, 1>,
+                                                    inRangeImpl<float, 1>,
+                                                    inRangeImpl<double, 1>},
+                     std::array<func_t, NUM_DEPTHS>{inRangeImpl<uchar, 2>,
+                                                    inRangeImpl<schar, 2>,
+                                                    inRangeImpl<ushort, 2>,
+                                                    inRangeImpl<short, 2>,
+                                                    inRangeImpl<int, 2>,
+                                                    inRangeImpl<float, 2>,
+                                                    inRangeImpl<double, 2>},
+                     std::array<func_t, NUM_DEPTHS>{inRangeImpl<uchar, 3>,
+                                                    inRangeImpl<schar, 3>,
+                                                    inRangeImpl<ushort, 3>,
+                                                    inRangeImpl<short, 3>,
+                                                    inRangeImpl<int, 3>,
+                                                    inRangeImpl<float, 3>,
+                                                    inRangeImpl<double, 3>},
+                     std::array<func_t, NUM_DEPTHS>{inRangeImpl<uchar, 4>,
+                                                    inRangeImpl<schar, 4>,
+                                                    inRangeImpl<ushort, 4>,
+                                                    inRangeImpl<short, 4>,
+                                                    inRangeImpl<int, 4>,
+                                                    inRangeImpl<float, 4>,
+                                                    inRangeImpl<double, 4>}};
+
+    CV_CheckLE(src.channels(), MAX_CHANNELS, "Src must have <= 4 channels");
+    CV_CheckLE(src.depth(),
+               CV_64F,
+               "Src must have depth 8U, 8S, 16U, 16S, 32S, 32F, or 64F");
+
+    GpuMat dst = getOutputMat(_dst, src.size(), CV_8UC1, stream);
+
+    const func_t func = funcs.at(src.channels() - 1).at(src.depth());
+    func(src, _lowerb, _upperb, dst, stream);
+
+    syncOutput(dst, _dst, stream);
+}
+
+#endif

--- a/modules/cudaarithm/src/element_operations.cpp
+++ b/modules/cudaarithm/src/element_operations.cpp
@@ -77,6 +77,8 @@ void cv::cuda::addWeighted(InputArray, double, InputArray, double, double, Outpu
 
 double cv::cuda::threshold(InputArray, OutputArray, double, double, int, Stream&) {throw_no_cuda(); return 0.0;}
 
+void cv::cuda::inRange(InputArray, const Scalar&, const Scalar&, OutputArray, Stream&) { throw_no_cuda(); }
+
 void cv::cuda::magnitude(InputArray, OutputArray, Stream&) { throw_no_cuda(); }
 void cv::cuda::magnitude(InputArray, InputArray, OutputArray, Stream&) { throw_no_cuda(); }
 void cv::cuda::magnitudeSqr(InputArray, OutputArray, Stream&) { throw_no_cuda(); }


### PR DESCRIPTION
**Merge with extra**: https://github.com/opencv/opencv_extra/pull/834

resolves https://github.com/opencv/opencv/issues/6295

Implementation of `cv::cuda::inRange`, as requested in [this issue](https://github.com/opencv/opencv/issues/6295).  It's not a complete implementation of `cv::inRange`; my implementation supports `cv::Scalar` for the upper and lower bounds, which seems like the most common use case by far, but the CPU version does also support `Mat`s for the bounds as well, which mine does not.  It seemed like more of a challenge to support that as well, but if you don't want to merge this without full feature parity I might be able to spend more time on it to figure that out.

Some questions -
1. Wasn't sure about whether the base branch should be `master` or `3.4`, happy to rebase to `3.4` if desired.  I do use `std::array`, but I think that's the only C++11 feature I'm using and it'd be easily removed.
2. Wasn't sure if I need to do anything special for performance test data - I followed the instructions [here](https://github.com/opencv/opencv/wiki/HowToUsePerfTests) to update the values for my new test only ([PR in opencv_extra](https://github.com/opencv/opencv_extra/pull/834)), but I didn't know how your performance test system deals with the fact that this should perform very differently depending on the GPU (I tested on a GeForce 750M).
3. I added Doxygen comments in the code; if there's more documentation or sample code needed I can do that as well
4. I had to use some recursive templates in `functional.hpp` to copy and compare CUDA vectors; if CUDA or OpenCV already has utilities somewhere to do this I can switch to make that simpler

<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch - see comment below
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake - see comment below


```
force_builders=Custom
buildworker:Custom=linux-5
build_image:Custom=ubuntu-cuda:18.04
```