### PR TITLE
rlof optflow: fix crash when no match are found

### DIFF
--- a/modules/optflow/include/opencv2/optflow/rlofflow.hpp
+++ b/modules/optflow/include/opencv2/optflow/rlofflow.hpp
@@ -227,6 +227,7 @@ public:
  * @note If the grid size is set to (1,1) and the forward backward threshold <= 0 than pixelwise dense optical flow field is
  * computed by RLOF without using interpolation.
  *
+ * @note Note that in output, if no correspondences are found between \a I0 and \a I1, the \a flow is set to 0.
  * @see optflow::calcOpticalFlowDenseRLOF(), optflow::RLOFOpticalFlowParameter
 */
 class CV_EXPORTS_W DenseRLOFOpticalFlow : public DenseOpticalFlow
@@ -493,6 +494,7 @@ public:
  * computed with the RLOF.
  *
  * @note SIMD parallelization is only available when compiling with SSE4.1.
+ * @note Note that in output, if no correspondences are found between \a I0 and \a I1, the \a flow is set to 0.
  *
  * @sa optflow::DenseRLOFOpticalFlow, optflow::RLOFOpticalFlowParameter
 */

--- a/modules/optflow/src/rlofflow.cpp
+++ b/modules/optflow/src/rlofflow.cpp
@@ -203,7 +203,11 @@ public:
             filtered_prevPoints = prevPoints;
             filtered_currPoints = currPoints;
         }
-
+        // Interpolators below expect non empty matches
+        if (filtered_prevPoints.empty()) {
+            flow.setTo(0);
+            return;
+        }
         if (interp_type == InterpolationType::INTERP_EPIC)
         {
             Ptr<ximgproc::EdgeAwareInterpolator> gd = ximgproc::createEdgeAwareInterpolator();


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X ] I agree to contribute to the project under Apache 2 License.
- [ X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ X] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X ] The feature is well documented and sample code can be built with the project CMake
