### PR TITLE
Properly disable xfeatures2d if extra files cannot be downloaded

### DIFF
--- a/modules/xfeatures2d/CMakeLists.txt
+++ b/modules/xfeatures2d/CMakeLists.txt
@@ -3,7 +3,6 @@ set(the_description "Contributed/Experimental Algorithms for Salient 2D Features
 if(HAVE_CUDA)
   ocv_warnings_disable(CMAKE_CXX_FLAGS -Wundef)
 endif()
-ocv_define_module(xfeatures2d opencv_core opencv_imgproc opencv_features2d opencv_calib3d OPTIONAL opencv_shape opencv_ml opencv_cudaarithm WRAP python java objc)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/download_vgg.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/download_boostdesc.cmake)
@@ -13,6 +12,8 @@ download_vgg_descriptors("${DOWNLOAD_DIR}" vgg_status)
 if(NOT boost_status OR NOT vgg_status)
   ocv_module_disable(xfeatures2d)
 endif()
+
+ocv_define_module(xfeatures2d opencv_core opencv_imgproc opencv_features2d opencv_calib3d OPTIONAL opencv_shape opencv_ml opencv_cudaarithm WRAP python java objc)
 
 ocv_module_include_directories("${DOWNLOAD_DIR}")
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
