### PR TITLE
cudaoptflow: disable Optical Flow SDK when CUDA version is insufficient

### DIFF
--- a/modules/cudaoptflow/CMakeLists.txt
+++ b/modules/cudaoptflow/CMakeLists.txt
@@ -8,21 +8,23 @@ ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4127 /wd4324 /wd4512 -Wundef -Wmissing-d
 
 ocv_define_module(cudaoptflow opencv_video opencv_optflow opencv_cudaarithm opencv_cudawarping opencv_cudaimgproc OPTIONAL opencv_cudalegacy WRAP python)
 
-set(NVIDIA_OPTICAL_FLOW_2_0_HEADERS_COMMIT "edb50da3cf849840d680249aa6dbef248ebce2ca")
-set(NVIDIA_OPTICAL_FLOW_2_0_HEADERS_MD5 "a73cd48b18dcc0cc8933b30796074191")
-set(NVIDIA_OPTICAL_FLOW_2_0_HEADERS_PATH "${OpenCV_BINARY_DIR}/3rdparty/NVIDIAOpticalFlowSDK_2_0_Headers")
-ocv_download(FILENAME "${NVIDIA_OPTICAL_FLOW_2_0_HEADERS_COMMIT}.zip"
-               HASH ${NVIDIA_OPTICAL_FLOW_2_0_HEADERS_MD5}
-               URL
-                 "https://github.com/NVIDIA/NVIDIAOpticalFlowSDK/archive/"
-               DESTINATION_DIR "${NVIDIA_OPTICAL_FLOW_2_0_HEADERS_PATH}"
-               STATUS NVIDIA_OPTICAL_FLOW_2_0_HEADERS_DOWNLOAD_SUCCESS
-               ID "NVIDIA_OPTICAL_FLOW"
-               UNPACK RELATIVE_URL)
+if(NOT CUDA_VERSION VERSION_LESS "10.0")
+  set(NVIDIA_OPTICAL_FLOW_2_0_HEADERS_COMMIT "edb50da3cf849840d680249aa6dbef248ebce2ca")
+  set(NVIDIA_OPTICAL_FLOW_2_0_HEADERS_MD5 "a73cd48b18dcc0cc8933b30796074191")
+  set(NVIDIA_OPTICAL_FLOW_2_0_HEADERS_PATH "${OpenCV_BINARY_DIR}/3rdparty/NVIDIAOpticalFlowSDK_2_0_Headers")
+  ocv_download(FILENAME "${NVIDIA_OPTICAL_FLOW_2_0_HEADERS_COMMIT}.zip"
+                 HASH ${NVIDIA_OPTICAL_FLOW_2_0_HEADERS_MD5}
+                 URL "https://github.com/NVIDIA/NVIDIAOpticalFlowSDK/archive/"
+                 DESTINATION_DIR "${NVIDIA_OPTICAL_FLOW_2_0_HEADERS_PATH}"
+                 STATUS NVIDIA_OPTICAL_FLOW_2_0_HEADERS_DOWNLOAD_SUCCESS
+                 ID "NVIDIA_OPTICAL_FLOW"
+                 UNPACK RELATIVE_URL)
 
-if(NOT NVIDIA_OPTICAL_FLOW_2_0_HEADERS_DOWNLOAD_SUCCESS)
-  message(STATUS "Failed to download NVIDIA_Optical_Flow_2_0 Headers")
-else()
-  add_definitions(-DHAVE_NVIDIA_OPTFLOW=1)
-  ocv_include_directories(SYSTEM "${NVIDIA_OPTICAL_FLOW_2_0_HEADERS_PATH}/NVIDIAOpticalFlowSDK-${NVIDIA_OPTICAL_FLOW_2_0_HEADERS_COMMIT}")
+  if(NOT NVIDIA_OPTICAL_FLOW_2_0_HEADERS_DOWNLOAD_SUCCESS)
+    message(STATUS "Failed to download NVIDIA_Optical_Flow_2_0 Headers")
+  else()
+    message(STATUS "Building with NVIDIA Optical Flow API 2.0")
+    add_definitions(-DHAVE_NVIDIA_OPTFLOW=2)
+    ocv_include_directories(SYSTEM "${NVIDIA_OPTICAL_FLOW_2_0_HEADERS_PATH}/NVIDIAOpticalFlowSDK-${NVIDIA_OPTICAL_FLOW_2_0_HEADERS_COMMIT}")
+  endif()
 endif()

--- a/modules/cudaoptflow/src/cuda/nvidiaOpticalFlow.cu
+++ b/modules/cudaoptflow/src/cuda/nvidiaOpticalFlow.cu
@@ -22,6 +22,7 @@ typedef   signed int    int32_t;
 #define SMEM_COLS  ((BLOCKDIM_X)/2)
 #define SMEM_ROWS  ((BLOCKDIM_Y)/2)
 
+#ifdef HAVE_NVIDIA_OPTFLOW
 namespace cv { namespace cuda { namespace device { namespace optflow_nvidia
 {
 static const char *_cudaGetErrorEnum(cudaError_t error) { return cudaGetErrorName(error); }
@@ -95,5 +96,6 @@ void FlowUpsample(void* srcDevPtr, uint32_t nSrcWidth, uint32_t nSrcPitch, uint3
 
         checkCudaErrors(cudaGetLastError());
 }}}}}
+#endif //HAVE_NVIDIA_OPTFLOW
 
 #endif

--- a/modules/cudaoptflow/src/nvidiaOpticalFlow.cpp
+++ b/modules/cudaoptflow/src/nvidiaOpticalFlow.cpp
@@ -9,26 +9,39 @@
 #if !defined HAVE_CUDA || defined(CUDA_DISABLER)
 
 cv::Ptr<cv::cuda::NvidiaOpticalFlow_1_0> cv::cuda::NvidiaOpticalFlow_1_0::create
-    (int, int, NVIDIA_OF_PERF_LEVEL, bool, bool, bool, int, Stream&, Stream&) {
+    (cv::Size, NVIDIA_OF_PERF_LEVEL, bool, bool, bool, int, Stream&, Stream&) {
     throw_no_cuda(); return cv::Ptr<cv::cuda::NvidiaOpticalFlow_1_0>(); }
 
 cv::Ptr<cv::cuda::NvidiaOpticalFlow_2_0> cv::cuda::NvidiaOpticalFlow_2_0::create(
-    int, int, NVIDIA_OF_PERF_LEVEL, NVIDIA_OF_OUTPUT_VECTOR_GRID_SIZE, NVIDIA_OF_HINT_VECTOR_GRID_SIZE,
-    bool, int, cv::Rect*, bool, bool, bool, int, Stream&, Stream&) {
+    cv::Size, NVIDIA_OF_PERF_LEVEL, NVIDIA_OF_OUTPUT_VECTOR_GRID_SIZE, NVIDIA_OF_HINT_VECTOR_GRID_SIZE,
+    bool, bool, bool, int, Stream&, Stream&) {
+    throw_no_cuda(); return cv::Ptr<cv::cuda::NvidiaOpticalFlow_2_0>();
+}
+
+cv::Ptr<cv::cuda::NvidiaOpticalFlow_2_0> cv::cuda::NvidiaOpticalFlow_2_0::create(
+    cv::Size, std::vector<Rect>, NVIDIA_OF_PERF_LEVEL, NVIDIA_OF_OUTPUT_VECTOR_GRID_SIZE, NVIDIA_OF_HINT_VECTOR_GRID_SIZE,
+    bool, bool, bool, int, Stream&, Stream&) {
     throw_no_cuda(); return cv::Ptr<cv::cuda::NvidiaOpticalFlow_2_0>();
 }
 
 #elif !defined HAVE_NVIDIA_OPTFLOW
 
 cv::Ptr<cv::cuda::NvidiaOpticalFlow_1_0> cv::cuda::NvidiaOpticalFlow_1_0::create(
-    int, int, NVIDIA_OF_PERF_LEVEL, bool, bool, bool, int, Stream&, Stream&)
+    cv::Size, NVIDIA_OF_PERF_LEVEL, bool, bool, bool, int, Stream&, Stream&)
 {
     CV_Error(cv::Error::HeaderIsNull, "OpenCV was build without NVIDIA OpticalFlow support");
 }
 
 cv::Ptr<cv::cuda::NvidiaOpticalFlow_2_0> cv::cuda::NvidiaOpticalFlow_2_0::create(
-    int, int, NVIDIA_OF_PERF_LEVEL, NVIDIA_OF_OUTPUT_VECTOR_GRID_SIZE, NVIDIA_OF_HINT_VECTOR_GRID_SIZE,
-    bool, int, cv::Rect*, bool, bool, bool, int, , Stream&, Stream&)
+    cv::Size, NVIDIA_OF_PERF_LEVEL, NVIDIA_OF_OUTPUT_VECTOR_GRID_SIZE, NVIDIA_OF_HINT_VECTOR_GRID_SIZE,
+    bool, bool, bool, int, Stream&, Stream&)
+{
+    CV_Error(cv::Error::HeaderIsNull, "OpenCV was build without NVIDIA OpticalFlow support");
+}
+
+cv::Ptr<cv::cuda::NvidiaOpticalFlow_2_0> cv::cuda::NvidiaOpticalFlow_2_0::create(
+    cv::Size, std::vector<Rect>, NVIDIA_OF_PERF_LEVEL, NVIDIA_OF_OUTPUT_VECTOR_GRID_SIZE, NVIDIA_OF_HINT_VECTOR_GRID_SIZE,
+    bool, bool, bool, int, Stream&, Stream&)
 {
     CV_Error(cv::Error::HeaderIsNull, "OpenCV was build without NVIDIA OpticalFlow support");
 }


### PR DESCRIPTION
relates #2807 

Just modifying this line will let the build pass for both CUDA 8.0 and CUDA 10.0

/cc @vchiluka5 
I understand that Optical flow API only supports CUDA 10.0 and later. Thank you for the comment.
Though, I'd like to propose this fix as a quick fix of build.

Eventually, I can add to disable Optical Flow API when CUDA is less than 10.0

 - Before
```
[ 81%] Building NVCC (Device) object modules/cudaoptflow/CMakeFiles/cuda_compile_1.dir/src/cuda/cuda_compile_1_generated_nvidiaOpticalFlow.cu.o
/opencv_contrib/modules/cudaoptflow/src/cuda/nvidiaOpticalFlow.cu(76): error: no instance of overloaded function "surf2Dwrite" matches the argument list
            argument types are: (short2, cudaSurfaceObject_t, unsigned long, int, cudaSurfaceBoundaryMode)

1 error detected in the compilation of "/tmp/tmpxft_00007a2a_00000000-7_nvidiaOpticalFlow.cpp1.ii".
CMake Error at cuda_compile_1_generated_nvidiaOpticalFlow.cu.o.Release.cmake:279 (message):
  Error generating file
  /opencv/build/modules/cudaoptflow/CMakeFiles/cuda_compile_1.dir/src/cuda/./cuda_compile_1_generated_nvidiaOpticalFlow.cu.o
```
 - After
```
[ 82%] Building NVCC (Device) object modules/cudaoptflow/CMakeFiles/cuda_compile_1.dir/src/cuda/cuda_compile_1_generated_nvidiaOpticalFlow.cu.o
 : 
[ 86%] Built target opencv_cudaoptflow
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
buildworker:Custom=linux-4
build_image:Custom=ubuntu-cuda:16.04
```
