### PR TITLE
WIP: KinFu fix on ARM64

### DIFF
--- a/modules/rgbd/test/test_odometry.cpp
+++ b/modules/rgbd/test/test_odometry.cpp
@@ -324,6 +324,8 @@ TEST(RGBD_Odometry_RgbdICP, algorithmic)
 
 TEST(RGBD_Odometry_FastICP, algorithmic)
 {
+    std::cout << "test output to indicate that test runs" << std::endl;
+
     CV_OdometryTest test(cv::rgbd::Odometry::create("FastICPOdometry"), 0.99, 0.99, FLT_EPSILON);
     test.safe_run();
 }


### PR DESCRIPTION
TODO:
- [ ] Reproduce #2817 and #2818 on ARM64 with NEON FP16 enabled
- [ ] Fix them

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
**WIP**
force_builders_only=ARMv8
build_contrib=ON
test_modules=rgbd

build_image:Win64 OpenCL=msvs2019
```
