### PR TITLE
Resolve issue 2796 ric interpolation

### DIFF
--- a/modules/ximgproc/include/opencv2/ximgproc/sparse_match_interpolator.hpp
+++ b/modules/ximgproc/include/opencv2/ximgproc/sparse_match_interpolator.hpp
@@ -57,12 +57,12 @@ public:
     @param from_image first of the two matched images, 8-bit single-channel or three-channel.
 
     @param from_points points of the from_image for which there are correspondences in the
-    to_image (Point2f vector, size shouldn't exceed 32767)
+    to_image (Point2f vector or Mat of depth CV_32F)
 
     @param to_image second of the two matched images, 8-bit single-channel or three-channel.
 
     @param to_points points in the to_image corresponding to from_points
-    (Point2f vector, size shouldn't exceed 32767)
+    (Point2f vector or Mat of depth CV_32F)
 
     @param dense_flow output dense matching (two-channel CV_32F image)
      */

--- a/modules/ximgproc/misc/python/test/test_sparse_match_interpolator.py
+++ b/modules/ximgproc/misc/python/test/test_sparse_match_interpolator.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+import numpy as np
+import cv2 as cv
+
+from tests_common import NewOpenCVTests
+
+class Interpolator_test(NewOpenCVTests):
+    def test_edgeaware_interpolator(self):
+        # readGT
+        MAX_DIF = 1.0
+        MAX_MEAN_DIF = 1.0 / 256.0
+
+        src = cv.imread(self.find_file("cv/optflow/RubberWhale1.png"), cv.IMREAD_COLOR)
+        self.assertFalse(src is None)
+
+        ref_flow = cv.readOpticalFlow(self.find_file("cv/sparse_match_interpolator/RubberWhale_reference_result.flo"))
+        self.assertFalse(ref_flow is None)
+
+        matches = np.genfromtxt(self.find_file("cv/sparse_match_interpolator/RubberWhale_sparse_matches.txt")).astype(np.float32)
+        from_points = matches[:,0:2]
+        to_points = matches[:,2:4]
+        interpolator = cv.ximgproc.createEdgeAwareInterpolator()
+        interpolator.setK(128)
+        interpolator.setSigma(0.05)
+        interpolator.setUsePostProcessing(True)
+        interpolator.setFGSLambda(500.0)
+        interpolator.setFGSSigma(1.5)
+
+        dense_flow = interpolator.interpolate(src, from_points, src, to_points)
+
+        self.assertTrue(cv.norm(dense_flow, ref_flow, cv.NORM_INF) <= MAX_DIF)
+        self.assertTrue(cv.norm(dense_flow, ref_flow, cv.NORM_L1) <= (MAX_MEAN_DIF * dense_flow.shape[0] * dense_flow.shape[1]))
+
+    def test_ric_interpolator(self):
+        # readGT
+        MAX_DIF = 6.0
+        MAX_MEAN_DIF = 60.0 / 256.0
+
+        src0 = cv.imread(self.find_file("cv/optflow/RubberWhale1.png"), cv.IMREAD_COLOR)
+        self.assertFalse(src0 is None)
+
+        src1 = cv.imread(self.find_file("cv/optflow/RubberWhale2.png"), cv.IMREAD_COLOR)
+        self.assertFalse(src1 is None)
+
+        ref_flow = cv.readOpticalFlow(self.find_file("cv/sparse_match_interpolator/RubberWhale_reference_result.flo"))
+        self.assertFalse(ref_flow is None)
+
+        matches = np.genfromtxt(self.find_file("cv/sparse_match_interpolator/RubberWhale_sparse_matches.txt")).astype(np.float32)
+        from_points = matches[:,0:2]
+        to_points = matches[:,2:4]
+
+        interpolator = cv.ximgproc.createRICInterpolator()
+        interpolator.setK(32)
+        interpolator.setSuperpixelSize(15)
+        interpolator.setSuperpixelNNCnt(150)
+        interpolator.setSuperpixelRuler(15.0)
+        interpolator.setSuperpixelMode(cv.ximgproc.SLIC)
+        interpolator.setAlpha(0.7)
+        interpolator.setModelIter(4)
+        interpolator.setRefineModels(True)
+        interpolator.setMaxFlow(250)
+        interpolator.setUseVariationalRefinement(True)
+        interpolator.setUseGlobalSmootherFilter(True)
+        interpolator.setFGSLambda(500.0)
+        interpolator.setFGSSigma(1.5)
+        dense_flow = interpolator.interpolate(src0, from_points, src1, to_points)
+        self.assertTrue(cv.norm(dense_flow, ref_flow, cv.NORM_INF) <= MAX_DIF)
+        self.assertTrue(cv.norm(dense_flow, ref_flow, cv.NORM_L1) <= (MAX_MEAN_DIF * dense_flow.shape[0] * dense_flow.shape[1]))
+
+if __name__ == '__main__':
+    NewOpenCVTests.bootstrap()

--- a/modules/ximgproc/test/test_sparse_match_interpolator.cpp
+++ b/modules/ximgproc/test/test_sparse_match_interpolator.cpp
@@ -93,6 +93,14 @@ TEST(InterpolatorTest, ReferenceAccuracy)
 
     EXPECT_LE(cv::norm(res_flow, ref_flow, NORM_INF), MAX_DIF);
     EXPECT_LE(cv::norm(res_flow, ref_flow, NORM_L1) , MAX_MEAN_DIF*res_flow.total());
+
+    Mat from_point_mat(from_points);
+    Mat to_points_mat(to_points);
+    interpolator->interpolate(src,from_point_mat,Mat(),to_points_mat,res_flow);
+
+    EXPECT_LE(cv::norm(res_flow, ref_flow, NORM_INF), MAX_DIF);
+    EXPECT_LE(cv::norm(res_flow, ref_flow, NORM_L1) , MAX_MEAN_DIF*res_flow.total());
+
 }
 
 TEST(InterpolatorTest, RICReferenceAccuracy)
@@ -141,6 +149,13 @@ TEST(InterpolatorTest, RICReferenceAccuracy)
 
     EXPECT_LE(cv::norm(res_flow, ref_flow, NORM_INF), MAX_DIF);
     EXPECT_LE(cv::norm(res_flow, ref_flow, NORM_L1), MAX_MEAN_DIF*res_flow.total());
+
+    Mat from_point_mat(from_points);
+    Mat to_points_mat(to_points);
+    interpolator->interpolate(src, from_point_mat, src1, to_points_mat, res_flow);
+
+    EXPECT_LE(cv::norm(res_flow, ref_flow, NORM_INF), MAX_DIF);
+    EXPECT_LE(cv::norm(res_flow, ref_flow, NORM_L1) , MAX_MEAN_DIF*res_flow.total());
 }
 
 TEST_P(InterpolatorTest, MultiThreadReproducibility)


### PR DESCRIPTION
Pull request to solve issue #2796.

Problem was that python wrapper puts a Mat object into from_points and to_points function parameters of type InputArray. 
The old verision only allows vector to be packed into InputArray.

New version allows vectors and Mat to be packed into the InputArray arguments.

C++ tests have been updated.

Python tests have been added for the EdgeAwareInterpolator and RICInteroplator classes.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ x] I agree to contribute to the project under Apache 2 License.
- [ x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x ] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
