### PR TITLE
cudaoptflow: fix build failure when CUDA >= 10.0

### DIFF
--- a/modules/cudaoptflow/src/cuda/nvidiaOpticalFlow.cu
+++ b/modules/cudaoptflow/src/cuda/nvidiaOpticalFlow.cu
@@ -22,7 +22,7 @@ typedef   signed int    int32_t;
 #define SMEM_COLS  ((BLOCKDIM_X)/2)
 #define SMEM_ROWS  ((BLOCKDIM_Y)/2)
 
-#ifdef HAVE_NVIDIA_OPTFLOW
+#if defined(__CUDACC_VER_MAJOR__) && (10 <= __CUDACC_VER_MAJOR__)
 namespace cv { namespace cuda { namespace device { namespace optflow_nvidia
 {
 static const char *_cudaGetErrorEnum(cudaError_t error) { return cudaGetErrorName(error); }
@@ -96,6 +96,6 @@ void FlowUpsample(void* srcDevPtr, uint32_t nSrcWidth, uint32_t nSrcPitch, uint3
 
         checkCudaErrors(cudaGetLastError());
 }}}}}
-#endif //HAVE_NVIDIA_OPTFLOW
+#endif //defined(__CUDACC_VER_MAJOR__) && (10 <= __CUDACC_VER_MAJOR__)
 
 #endif


### PR DESCRIPTION
closes #2834 

 - `HAVE_NVIDIA_OPTFLOW` doesn't arrive to `cu` file, so switch off directly based on CUDA version 

<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


```
force_builders=Custom
buildworker:Custom=linux-4
build_image:Custom=ubuntu-cuda:16.04
```
