### PR TITLE
deltaCIEDE2000_ fix into the MCC module

### DIFF
--- a/modules/mcc/src/distance.cpp
+++ b/modules/mcc/src/distance.cpp
@@ -139,7 +139,8 @@ double deltaCIEDE2000_(const Vec3d& lab1, const Vec3d& lab2, const double& kL,
     double sC = 1.0 + 0.045 * C_bar_apo;
     double sH = 1.0 + 0.015 * C_bar_apo * T;
     double sL = 1.0 + ((0.015 * pow(l_bar_apo - 50.0, 2.0)) / sqrt(20.0 + pow(l_bar_apo - 50.0, 2.0)));
-    double RT = -2.0 * G * sin(toRad(60.0) * exp(-pow((H_bar_apo - toRad(275.0)) / toRad(25.0), 2.0)));
+    double R_C = 2.0 * sqrt(pow(C_bar_apo, 7.0) / (pow(C_bar_apo, 7.0) + pow(25, 7)));
+    double RT = -sin(toRad(60.0) * exp(-pow((H_bar_apo - toRad(275.0)) / toRad(25.0), 2.0))) * R_C;
     double res = (pow(delta_L_apo / (kL * sL), 2.0) + pow(delta_C_apo / (kC * sC), 2.0) + pow(delta_H_apo / (kH * sH), 2.0) + RT * (delta_C_apo / (kC * sC)) * (delta_H_apo / (kH * sH)));
     return res > 0 ? sqrt(res) : 0;
 }

--- a/modules/mcc/test/test_ccm.cpp
+++ b/modules/mcc/test/test_ccm.cpp
@@ -99,9 +99,9 @@ TEST(CV_ccmRunColorCorrection, test_model)
 
 
     Mat ccm = (Mat_<double>(3, 3) <<
-				0.37408717, 0.02066172, 0.05796725,
-				0.12684056, 0.77364991, -0.01566532,
-				-0.27464866, 0.00652140, 2.74593262);
+				0.37406520, 0.02066507, 0.05804047,
+				0.12719672, 0.77389268, -0.01569404,
+				-0.27627010, 0.00603427, 2.74272981);
     ASSERT_MAT_NEAR(model.getCCM(), ccm, 1e-4);
 }
 TEST(CV_ccmRunColorCorrection, test_masks_weights_1)


### PR DESCRIPTION
# DeltaE CIEDE2000 function fix into MCC module

This function did not pass the test case 17 and 19 of [Gaurav Sharma's test data](http://www2.ece.rochester.edu/~gsharma/ciede2000/).

This was due to a mistake into the "RT" value, it was computed with the value ![image](https://user-images.githubusercontent.com/40139622/106273537-247da400-6233-11eb-9532-ae1ce13627b1.png) instead of ![image](https://user-images.githubusercontent.com/40139622/106273627-4414cc80-6233-11eb-9e01-52ffe648cec8.png).

Sources :
 - [Wikipedia](https://en.wikipedia.org/wiki/Color_difference) ;
 - [The CIEDE2000 Color-Difference Formula : Implementation Notes, Supplementary Test Data, and Mathematical Observations](http://www2.ece.rochester.edu/~gsharma/ciede2000/ciede2000noteCRNA.pdf).

And now i have a little question about this module, why color conversion and color distances classes are not exposed to the API ?
They are really useful because, at the moment, OpenCV can't convert sRGB D65 2° to CIELAB D50 2° or perform any CIE color comparison.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [X] There is reference to original bug report and related work
- [X] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X] The feature is well documented and sample code can be built with the project CMake
