### PR TITLE
fixes #2662

### DIFF
--- a/modules/alphamat/src/cm.cpp
+++ b/modules/alphamat/src/cm.cpp
@@ -90,7 +90,7 @@ void lle(my_vector_of_vectors_t& indm, my_vector_of_vectors_t& samples, float ep
     Mat ptDotN(20, 1, DataType<float>::type), imd(20, 1, DataType<float>::type);
     Mat Cones(20, 1, DataType<float>::type), Cinv(20, 1, DataType<float>::type);
     float alpha, beta, lagrangeMult;
-    Cones += 1;
+    Cones = 1;
 
     C = 0;
     rhs = 1;


### PR DESCRIPTION
fixes #2662

This PR fixes the usage of uninitialized memory that can lead to throws and segfaults.

I think the original author wanted to add ones to a zero-initialized Mat object.
I could have used another Constructor for the Mat object, but i chose to make the minimal amount of changes to the code to work as intended.

My proposed change does not change the used algorithm.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
