### PR TITLE
Remove normalization in cv::stereo::QuasiDenseStereo getDisparity().

### DIFF
--- a/modules/stereo/include/opencv2/stereo/quasi_dense_stereo.hpp
+++ b/modules/stereo/include/opencv2/stereo/quasi_dense_stereo.hpp
@@ -176,13 +176,12 @@ public:
 
     /**
      * @brief Compute and return the disparity map based on the correspondences found in the "process" method.
-     * @param[in] disparityLvls The level of detail in output disparity image.
      * @note Default level is 50
      * @return cv::Mat containing a the disparity image in grayscale.
      * @sa computeDisparity
      * @sa quantizeDisparity
      */
-    CV_WRAP virtual cv::Mat getDisparity(uint8_t disparityLvls=50) = 0;
+    CV_WRAP virtual cv::Mat getDisparity() = 0;
 
 
     CV_WRAP static cv::Ptr<QuasiDenseStereo> create(cv::Size monoImgSize, cv::String paramFilepath = cv::String());

--- a/modules/stereo/samples/dense_disparity.cpp
+++ b/modules/stereo/samples/dense_disparity.cpp
@@ -31,9 +31,8 @@ int main()
 
 
 //!     [disp]
-    uint8_t displvl = 80;
     cv::Mat disp;
-    disp = stereo->getDisparity(displvl);
+    disp = stereo->getDisparity();
     cv::namedWindow("disparity map");
     cv::imshow("disparity map", disp);
 //!     [disp]

--- a/modules/stereo/samples/sample_quasi_dense.py
+++ b/modules/stereo/samples/sample_quasi_dense.py
@@ -8,7 +8,7 @@ frame_size = leftImg.shape[0:2];
 
 stereo = cv.stereo.QuasiDenseStereo_create(frame_size[::-1])
 stereo.process(left_img, right_img)
-disp = stereo.getDisparity(80)
+disp = stereo.getDisparity()
 cv.imshow("disparity", disp)
 cv.waitKey()
 dense_matches = stereo.getDenseMatches()

--- a/modules/stereo/src/quasi_dense_stereo.cpp
+++ b/modules/stereo/src/quasi_dense_stereo.cpp
@@ -34,7 +34,6 @@ public:
         ssum1 = cv::Mat_<double>(integralSize);
         // the disparity image.
         disparity = cv::Mat_<float>(monoImgSize);
-        disparityImg = cv::Mat_<uchar>(monoImgSize);
         // texture images.
         textureDescLeft = cv::Mat_<int> (monoImgSize);
         textureDescRight = cv::Mat_<int> (monoImgSize);
@@ -55,7 +54,6 @@ public:
         ssum1.release();
         // the disparity image.
         disparity.release();
-        disparityImg.release();
         // texture images.
         textureDescLeft.release();
         textureDescRight.release();
@@ -248,7 +246,6 @@ public:
      * @param[in] matchMap A matrix of points, the same size as the left channel. Each cell of this
      * matrix stores the location of the corresponding point in the right image.
      * @param[out] dispMat The disparity map.
-     * @sa quantizeDisparity
      * @sa getDisparity
      */
     void computeDisparity(const cv::Mat_<cv::Point2i> &matchMap,
@@ -262,7 +259,7 @@ public:
 
                 if (matchMap.at<cv::Point2i>(tmpPoint) == NO_MATCH)
                 {
-                    dispMat.at<float>(tmpPoint) = 200;
+                    dispMat.at<float>(tmpPoint) = NAN;
                     continue;
                 }
                 //if a match is found, compute the difference in location of the match and current
@@ -274,37 +271,6 @@ public:
             }
         }
     }
-
-
-    /**
-     * @brief Disparity map normalization for display purposes. If needed specify the quantization
-     * level as input argument.
-     * @param[in] dispMat The disparity Map.
-     * @param[in] lvls The quantization level of the output disparity map.
-     * @return Disparity image.
-     * @note Stores the output in the disparityImage class variable.
-     * @sa computeDisparity
-     * @sa getDisparity
-     */
-    cv::Mat quantiseDisparity(const cv::Mat_<float> &dispMat, const int lvls)
-   {
-       float tmpPixelVal ;
-       double min, max;
-//	   minMaxLoc(disparity, &min, &max);
-       min = 0;
-       max = lvls;
-       for(int row=0; row<height; row++)
-       {
-           for(int col=0; col<width; col++)
-           {
-               tmpPixelVal = dispMat.at<float>(row, col);
-               tmpPixelVal = (float) (255. - 255.0*(tmpPixelVal-min)/(max-min));
-
-               disparityImg.at<uchar>(row, col) =  (uint8_t) tmpPixelVal;
-           }
-       }
-       return disparityImg;
-   }
 
 
     /**
@@ -635,10 +601,10 @@ public:
         return refMap.at<cv::Point2i>(y, x);
     }
 
-    cv::Mat getDisparity(uint8_t disparityLvls) override
+    cv::Mat getDisparity() override
     {
         computeDisparity(refMap, disparity);
-        return quantiseDisparity(disparity, disparityLvls);
+        return disparity;
     }
 
     // Variables used at sparse feature extraction.
@@ -663,8 +629,6 @@ public:
     cv::Mat_<double> ssum1;
     // Container to store the disparity un-normalized
     cv::Mat_<float> disparity;
-    // Container to store the disparity image.
-    cv::Mat_<uchar> disparityImg;
     // Containers to store textures descriptors.
     cv::Mat_<int> textureDescLeft;
     cv::Mat_<int> textureDescRight;

--- a/modules/stereo/test/test_block_matching.cpp
+++ b/modules/stereo/test/test_block_matching.cpp
@@ -166,7 +166,7 @@ void CV_SGBlockMatchingTest::run(int )
     image2 = imread(ts->get_data_path() + "stereomatching/datasets/tsukuba/im6.png", IMREAD_GRAYSCALE);
     gt = imread(ts->get_data_path() + "stereomatching/datasets/tsukuba/disp2.png", IMREAD_GRAYSCALE);
 
-
+    ts->printf(cvtest::TS::LOG,(ts->get_data_path() + "stereomatching/datasets/tsukuba/im2.png").c_str());
     if(image1.empty() || image2.empty() || gt.empty())
     {
         ts->printf(cvtest::TS::LOG, "Wrong input data \n");

--- a/modules/stereo/test/test_qds_matching.cpp
+++ b/modules/stereo/test/test_qds_matching.cpp
@@ -1,77 +1,27 @@
-/*M///////////////////////////////////////////////////////////////////////////////////////
-//
-//  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
-//
-//  By downloading, copying, installing or using the software you agree to this license.
-//  If you do not agree to this license, do not download, install,
-//  copy or use the software.
-//
-//
-//                        Intel License Agreement
-//                For Open Source Computer Vision Library
-//
-// Copyright (C) 2000, Intel Corporation, all rights reserved.
-// Third party copyrights are property of their respective owners.
-//
-// Redistribution and use in source and binary forms, with or without modification,
-// are permitted provided that the following conditions are met:
-//
-//   * Redistribution's of source code must retain the above copyright notice,
-//     this list of conditions and the following disclaimer.
-//
-//   * Redistribution's in binary form must reproduce the above copyright notice,
-//     this list of conditions and the following disclaimer in the documentation
-//     and/or other materials provided with the distribution.
-//
-//   * The name of Intel Corporation may not be used to endorse or promote products
-//     derived from this software without specific prior written permission.
-//
-// This software is provided by the copyright holders and contributors "as is" and
-// any express or implied warranties, including, but not limited to, the implied
-// warranties of merchantability and fitness for a particular purpose are disclaimed.
-// In no event shall the Intel Corporation or contributors be liable for any direct,
-// indirect, incidental, special, exemplary, or consequential damages
-// (including, but not limited to, procurement of substitute goods or services;
-// loss of use, data, or profits; or business interruption) however caused
-// and on any theory of liability, whether in contract, strict liability,
-// or tort (including negligence or otherwise) arising in any way out of
-// the use of this software, even if advised of the possibility of such damage.
-//
-//M*/
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
 
 #include "test_precomp.hpp"
 
 namespace opencv_test { namespace {
 
-class CV_QdsMatchingTest : public cvtest::BaseTest
-{
-public:
-    CV_QdsMatchingTest();
-    ~CV_QdsMatchingTest();
-protected:
-    void run(int /* idx */);
-};
-
-CV_QdsMatchingTest::CV_QdsMatchingTest(){}
-CV_QdsMatchingTest::~CV_QdsMatchingTest(){}
 
 static float disparity_MAE(const Mat &reference, const Mat &estimation)
 {
     int elems=0;
     float error=0;
     float ref_invalid=0;
-    for (int row=0; row< reference.rows; row++)
-    {
-        for (int col=0; col<reference.cols; col++)
-        {
+    for (int row=0; row< reference.rows; row++){
+        for (int col=0; col<reference.cols; col++){
             float ref_val = reference.at<float>(row, col);
             float estimated_val = estimation.at<float>(row, col);
             if (ref_val == 0){
                 ref_invalid++;
             }
             // filter out pixels with unknown reference value and pixels whose disparity did not get estimated.
-            if (estimated_val == 0 || ref_val == 0 || std::isnan(estimated_val))
-            {
+            if (estimated_val == 0 || ref_val == 0 || std::isnan(estimated_val)){
                 continue;
             }
             else{
@@ -84,31 +34,22 @@ static float disparity_MAE(const Mat &reference, const Mat &estimation)
 }
 
 
-void CV_QdsMatchingTest::run(int)
+// void CV_QdsMatchingTest::run(int)
+TEST(qds_getDisparity, accuracy)
 {
     //load data
     Mat image1, image2, gt;
-    image1 = imread(ts->get_data_path() + "stereomatching/datasets/cones/im2.png", IMREAD_GRAYSCALE);
-    image2 = imread(ts->get_data_path() + "stereomatching/datasets/cones/im6.png", IMREAD_GRAYSCALE);
-    gt = imread(ts->get_data_path() + "stereomatching/datasets/cones/disp2.png", IMREAD_GRAYSCALE);
+    image1 = imread(cvtest::TS::ptr()->get_data_path() + "stereomatching/datasets/cones/im2.png", IMREAD_GRAYSCALE);
+    image2 = imread(cvtest::TS::ptr()->get_data_path() + "stereomatching/datasets/cones/im6.png", IMREAD_GRAYSCALE);
+    gt = imread(cvtest::TS::ptr()->get_data_path() + "stereomatching/datasets/cones/disp2.png", IMREAD_GRAYSCALE);
 
     // reference scale factor is based on this https://github.com/opencv/opencv_extra/blob/master/testdata/cv/stereomatching/datasets/datasets.xml
     gt.convertTo(gt, CV_32F);
     gt =gt/4;
 
     //test inputs
-    if(image1.empty() || image2.empty() || gt.empty())
-    {
-        ts->printf(cvtest::TS::LOG, "Wrong input data \n");
-        ts->set_failed_test_info(cvtest::TS::FAIL_INVALID_TEST_DATA);
-        return;
-    }
-    if(image1.rows != image2.rows || image1.cols != image2.cols || gt.cols != image1.cols || gt.rows != image1.rows)
-    {
-        ts->printf(cvtest::TS::LOG, "Wrong input / output dimension \n");
-        ts->set_failed_test_info(cvtest::TS::FAIL_INVALID_TEST_DATA);
-        return;
-    }
+    ASSERT_FALSE(image1.empty() || image2.empty() || gt.empty()) << "Issue with input data";
+
     //configure disparity algorithm
     cv::Size frameSize = image1.size();
     Ptr<stereo::QuasiDenseStereo> qds_matcher = stereo::QuasiDenseStereo::create(frameSize);
@@ -118,27 +59,11 @@ void CV_QdsMatchingTest::run(int)
     qds_matcher->process(image1, image2);
     Mat outDisp = qds_matcher->getDisparity();
 
-
     // test input output size consistency
-    if(gt.rows != outDisp.rows || gt.cols != outDisp.cols)
-    {
-        ts->printf(cvtest::TS::LOG, "Missmatch input output dimension \n");
-        ts->set_failed_test_info(cvtest::TS::FAIL_INVALID_OUTPUT);
-        return;
-    }
-
-    // test error level, for this sample/hyperparameters, EPE(MAE) should be ~1.1 in version 4.5.1
-    double error_mae = disparity_MAE(gt, outDisp);
-    if(error_mae > 2)
-    {
-        ts->printf( cvtest::TS::LOG,("Disparity Mean Absolute Error: "+std::to_string(error_mae)+" pixels > 2\n").c_str());
-        ts->set_failed_test_info(cvtest::TS::FAIL_BAD_ACCURACY);
-        return;
-    }
+    ASSERT_EQ(gt.size(), outDisp.size()) << "Mismatch input/output dimensions";
+    ASSERT_LT(disparity_MAE(gt, outDisp),2) << "EPE should be 1.1053 for this sample/hyperparamters (Tested on version 4.5.1)";
 }
 
-
-TEST(qds_matching_simple_test, accuracy) { CV_QdsMatchingTest test; test.safe_run(); }
 
 
 }} // namespace

--- a/modules/stereo/test/test_qds_matching.cpp
+++ b/modules/stereo/test/test_qds_matching.cpp
@@ -1,0 +1,144 @@
+/*M///////////////////////////////////////////////////////////////////////////////////////
+//
+//  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
+//
+//  By downloading, copying, installing or using the software you agree to this license.
+//  If you do not agree to this license, do not download, install,
+//  copy or use the software.
+//
+//
+//                        Intel License Agreement
+//                For Open Source Computer Vision Library
+//
+// Copyright (C) 2000, Intel Corporation, all rights reserved.
+// Third party copyrights are property of their respective owners.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//   * Redistribution's of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//   * Redistribution's in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//   * The name of Intel Corporation may not be used to endorse or promote products
+//     derived from this software without specific prior written permission.
+//
+// This software is provided by the copyright holders and contributors "as is" and
+// any express or implied warranties, including, but not limited to, the implied
+// warranties of merchantability and fitness for a particular purpose are disclaimed.
+// In no event shall the Intel Corporation or contributors be liable for any direct,
+// indirect, incidental, special, exemplary, or consequential damages
+// (including, but not limited to, procurement of substitute goods or services;
+// loss of use, data, or profits; or business interruption) however caused
+// and on any theory of liability, whether in contract, strict liability,
+// or tort (including negligence or otherwise) arising in any way out of
+// the use of this software, even if advised of the possibility of such damage.
+//
+//M*/
+
+#include "test_precomp.hpp"
+
+namespace opencv_test { namespace {
+
+class CV_QdsMatchingTest : public cvtest::BaseTest
+{
+public:
+    CV_QdsMatchingTest();
+    ~CV_QdsMatchingTest();
+protected:
+    void run(int /* idx */);
+};
+
+CV_QdsMatchingTest::CV_QdsMatchingTest(){}
+CV_QdsMatchingTest::~CV_QdsMatchingTest(){}
+
+static float disparity_MAE(const Mat &reference, const Mat &estimation)
+{
+    int elems=0;
+    float error=0;
+    float ref_invalid=0;
+    for (int row=0; row< reference.rows; row++)
+    {
+        for (int col=0; col<reference.cols; col++)
+        {
+            float ref_val = reference.at<float>(row, col);
+            float estimated_val = estimation.at<float>(row, col);
+            if (ref_val == 0){
+                ref_invalid++;
+            }
+            // filter out pixels with unknown reference value and pixels whose disparity did not get estimated.
+            if (estimated_val == 0 || ref_val == 0 || std::isnan(estimated_val))
+            {
+                continue;
+            }
+            else{
+                error+=abs(ref_val - estimated_val);
+                elems+=1;
+            }
+        }
+    }
+    return error/elems;
+}
+
+
+void CV_QdsMatchingTest::run(int)
+{
+    //load data
+    Mat image1, image2, gt;
+    image1 = imread(ts->get_data_path() + "stereomatching/datasets/cones/im2.png", IMREAD_GRAYSCALE);
+    image2 = imread(ts->get_data_path() + "stereomatching/datasets/cones/im6.png", IMREAD_GRAYSCALE);
+    gt = imread(ts->get_data_path() + "stereomatching/datasets/cones/disp2.png", IMREAD_GRAYSCALE);
+
+    // reference scale factor is based on this https://github.com/opencv/opencv_extra/blob/master/testdata/cv/stereomatching/datasets/datasets.xml
+    gt.convertTo(gt, CV_32F);
+    gt =gt/4;
+
+    //test inputs
+    if(image1.empty() || image2.empty() || gt.empty())
+    {
+        ts->printf(cvtest::TS::LOG, "Wrong input data \n");
+        ts->set_failed_test_info(cvtest::TS::FAIL_INVALID_TEST_DATA);
+        return;
+    }
+    if(image1.rows != image2.rows || image1.cols != image2.cols || gt.cols != image1.cols || gt.rows != image1.rows)
+    {
+        ts->printf(cvtest::TS::LOG, "Wrong input / output dimension \n");
+        ts->set_failed_test_info(cvtest::TS::FAIL_INVALID_TEST_DATA);
+        return;
+    }
+    //configure disparity algorithm
+    cv::Size frameSize = image1.size();
+    Ptr<stereo::QuasiDenseStereo> qds_matcher = stereo::QuasiDenseStereo::create(frameSize);
+
+
+    //compute disparity
+    qds_matcher->process(image1, image2);
+    Mat outDisp = qds_matcher->getDisparity();
+
+
+    // test input output size consistency
+    if(gt.rows != outDisp.rows || gt.cols != outDisp.cols)
+    {
+        ts->printf(cvtest::TS::LOG, "Missmatch input output dimension \n");
+        ts->set_failed_test_info(cvtest::TS::FAIL_INVALID_OUTPUT);
+        return;
+    }
+
+    // test error level, for this sample/hyperparameters, EPE(MAE) should be ~1.1 in version 4.5.1
+    double error_mae = disparity_MAE(gt, outDisp);
+    if(error_mae > 2)
+    {
+        ts->printf( cvtest::TS::LOG,("Disparity Mean Absolute Error: "+std::to_string(error_mae)+" pixels > 2\n").c_str());
+        ts->set_failed_test_info(cvtest::TS::FAIL_BAD_ACCURACY);
+        return;
+    }
+}
+
+
+TEST(qds_matching_simple_test, accuracy) { CV_QdsMatchingTest test; test.safe_run(); }
+
+
+}} // namespace


### PR DESCRIPTION
This addresses user comments made in #1941 and #2819. The getDisparity function, of QuasiDenseStereo, originally returned a disparity image normalized to span the full range between 0 and 255, which was improper and understandably confused users.

I've made the following changes:
- getDisparity now returns proper CV_32F disparity maps with nan values for unknown matches. 
- included an accuracy test.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
