### PR TITLE
Python viz

### DIFF
--- a/modules/viz/include/opencv2/viz/viz3d.hpp
+++ b/modules/viz/include/opencv2/viz/viz3d.hpp
@@ -127,6 +127,12 @@ namespace cv
              */
             void setWidgetPose(const String &id, const Affine3d &pose);
 
+            /** @brief Sets pose of a widget in the window.
+
+            @widget full info for the widget whose pose will be set.
+             */
+            CV_WRAP void setWidgetPose(CV_IN_OUT ParamWidget &widget);
+
             /** @brief Updates pose of a widget in the window by pre-multiplying its current pose.
 
             @param id The id of the widget whose pose will be updated. @param pose The pose that the current

--- a/modules/viz/include/opencv2/viz/viz3d.hpp
+++ b/modules/viz/include/opencv2/viz/viz3d.hpp
@@ -64,9 +64,10 @@ namespace cv
 
         /** @brief The Viz3d class represents a 3D visualizer window. This class is implicitly shared.
         */
-        class CV_EXPORTS Viz3d
+        class CV_EXPORTS_W Viz3d
         {
         public:
+            CV_WRAP static cv::Ptr<Viz3d> create(const String& window_name = String());
             typedef cv::viz::Color Color;
             typedef void (*KeyboardCallback)(const KeyboardEvent&, void*);
             typedef void (*MouseCallback)(const MouseEvent&, void*);
@@ -75,10 +76,10 @@ namespace cv
 
             @param window_name Name of the window.
              */
-            Viz3d(const String& window_name = String());
+            CV_WRAP Viz3d(const String& window_name = String());
             Viz3d(const Viz3d&);
             Viz3d& operator=(const Viz3d&);
-            ~Viz3d();
+            CV_WRAP ~Viz3d();
 
             /** @brief Shows a widget in the window.
 
@@ -87,11 +88,18 @@ namespace cv
              */
             void showWidget(const String &id, const Widget &widget, const Affine3d &pose = Affine3d::Identity());
 
+            /** @brief Shows a widget in the window.
+
+            @param id A unique id for the widget. @param widget The widget to be displayed in the window.
+            @param pose Pose of the widget.
+             */
+            CV_WRAP void showWidget(CV_IN_OUT ParamWidget &widget);
+
             /** @brief Removes a widget from the window.
 
             @param id The id of the widget that will be removed.
              */
-            void removeWidget(const String &id);
+            CV_WRAP void removeWidget(const String &id);
 
             /** @brief Retrieves a widget from the window.
 
@@ -104,7 +112,7 @@ namespace cv
 
             /** @brief Removes all widgets from the window.
             */
-            void removeAllWidgets();
+            CV_WRAP void removeAllWidgets();
 
             /** @brief Removed all widgets and displays image scaled to whole window area.
 
@@ -220,14 +228,14 @@ namespace cv
 
             /** @brief The window renders and starts the event loop.
             */
-            void spin();
+            CV_WRAP void spin();
 
             /** @brief Starts the event loop for a given time.
 
             @param time Amount of time in milliseconds for the event loop to keep running.
             @param force_redraw If true, window renders.
              */
-            void spinOnce(int time = 1, bool force_redraw = false);
+            CV_WRAP void spinOnce(int time = 1, bool force_redraw = false);
 
             /** @brief Create a window in memory instead of on the screen.
              */
@@ -252,7 +260,7 @@ namespace cv
 
             /** @brief Returns whether the event loop has been stopped.
             */
-            bool wasStopped() const;
+            CV_WRAP bool wasStopped() const;
             void close();
 
             /** @brief Sets keyboard handler.
@@ -339,7 +347,7 @@ namespace cv
             struct VizImpl;
             VizImpl* impl_;
 
-            void create(const String &window_name);
+            void create_internal(const String &window_name);
             void release();
 
             friend class VizStorage;

--- a/modules/viz/include/opencv2/viz/widgets.hpp
+++ b/modules/viz/include/opencv2/viz/widgets.hpp
@@ -55,6 +55,43 @@ namespace cv
 
 //! @addtogroup viz_widget
 //! @{
+        enum WidgetId{
+            WIDGET_WArrow,
+            WIDGET_WLine,
+            WIDGET_WCube,
+            WIDGET_WCoordinateSystem,
+
+        };
+
+        struct CV_EXPORTS_W_SIMPLE ParamWidget {
+            CV_PROP_RW cv::Point3d p1;
+            CV_PROP_RW cv::Point3d p2;
+            CV_PROP_RW double thickness;
+            CV_PROP_RW double   blue;
+            CV_PROP_RW double   green;
+            CV_PROP_RW double   red;
+            CV_PROP_RW int widget_type;
+            CV_PROP_RW String widget_name;
+            CV_PROP_RW Mat  rot_vec; //  Mat::zeros(1,3,CV_32F);
+            CV_PROP_RW Mat  trans_vec; //  Vec3f must be compatible with Affine3 (const Mat3 &R, const Vec3 &t=Vec3::all(0))
+            CV_WRAP ParamWidget(cv::Point3d p_ini= cv::Point3d(), cv::Point3d p_fin= cv::Point3d(),
+                                double thick=0.3, double b=255, double g = 255, double r = 255,
+                                int type= WIDGET_WCoordinateSystem, const String name="", Mat r_vec=Mat(), Mat t_vec=Mat())
+            {
+                p1 = p_ini;
+                p2 = p_fin;
+                thickness = thick;
+                blue = b;
+                green = g;
+                red = r;
+                widget_type = type;
+                widget_name = name;
+                rot_vec = r_vec;
+                trans_vec = t_vec;
+
+
+            }
+        };
 
         /////////////////////////////////////////////////////////////////////////////
         /// Widget rendering properties

--- a/modules/viz/include/opencv2/viz/widgets.hpp
+++ b/modules/viz/include/opencv2/viz/widgets.hpp
@@ -74,6 +74,7 @@ namespace cv
             CV_PROP_RW String widget_name;
             CV_PROP_RW Mat  rot_vec; //  Mat::zeros(1,3,CV_32F);
             CV_PROP_RW Mat  trans_vec; //  Vec3f must be compatible with Affine3 (const Mat3 &R, const Vec3 &t=Vec3::all(0))
+            CV_PROP_RW Mat  pose; //  Vec3f must be compatible with Affine3 (const Mat3 &R, const Vec3 &t=Vec3::all(0))
             CV_WRAP ParamWidget(cv::Point3d p_ini= cv::Point3d(), cv::Point3d p_fin= cv::Point3d(),
                                 double thick=0.3, double b=255, double g = 255, double r = 255,
                                 int type= WIDGET_WCoordinateSystem, const String name="", Mat r_vec=Mat(), Mat t_vec=Mat())

--- a/modules/viz/samples/viz_sample_01.py
+++ b/modules/viz/samples/viz_sample_01.py
@@ -1,0 +1,20 @@
+import os
+os.add_dll_directory(r'G:\Lib\install\opencv\x64\vc15\bin')
+os.add_dll_directory(r'G:\Lib\install\vtk\bin')
+os.add_dll_directory(r'G:\Lib\install\ceres-solver\bin')
+os.add_dll_directory(r'G:\Lib\install\glog\bin')
+os.add_dll_directory(r'F:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.2\bin')
+os.add_dll_directory(r'F:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.2')
+
+import cv2 as cv
+import numpy as np
+
+v = cv.viz.Viz3d_create("Viz Demo")
+
+print("First event loop is over")
+v.spin()
+print("Second event loop is over")
+v.spinOnce(1, True)
+while not v.wasStopped():
+    v.spinOnce(1, True)
+print("Last event loop is over")

--- a/modules/viz/samples/viz_sample_02.py
+++ b/modules/viz/samples/viz_sample_02.py
@@ -1,0 +1,47 @@
+import os
+os.add_dll_directory(r'G:\Lib\install\opencv\x64\vc15\bin')
+os.add_dll_directory(r'G:\Lib\install\vtk\bin')
+os.add_dll_directory(r'G:\Lib\install\ceres-solver\bin')
+os.add_dll_directory(r'G:\Lib\install\glog\bin')
+os.add_dll_directory(r'F:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.2\bin')
+os.add_dll_directory(r'F:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.2')
+
+import cv2 as cv
+import numpy as np
+
+v = cv.viz_Viz3d("Coordinate Frame")
+
+pw = cv.viz_ParamWidget()
+pw.p1 = (-1.0,-1.0,-1.0)
+pw.p2 = (1.0,1.0,1.0)
+pw.thickness = 0.2
+pw.widget_type = cv.viz.WIDGET_WCoordinateSystem
+pw.blue = 255
+pw.green = 192
+pw.red = 128
+pw.widget_name = "Coordinate Widget"
+pw.rot_vec = np.zeros(shape=(3,1),dtype=np.float64)
+pw.trans_vec=np.zeros(shape=(3,1),dtype=np.float64)
+v.showWidget(pw)
+
+p_cube = cv.viz_ParamWidget()
+p_cube.p1 = (0.5,0.5,0.0)
+p_cube.p2 = (0.0,0.0,-0.5)
+p_cube.thickness = 4.0
+p_cube.widget_type = cv.viz.WIDGET_WCube
+p_cube.blue = 255
+p_cube.green = 0
+p_cube.red = 0
+p_cube.widget_name = "Cube Widget"
+p_cube.rot_vec = np.zeros(shape=(1,3),dtype=np.float64)
+p_cube.trans_vec= np.zeros(shape=(3,1),dtype=np.float64)
+p_cube.trans_vec[0,0]=2
+v.showWidget(p_cube)
+
+print("First event loop is over")
+v.spin()
+print("Second event loop is over")
+v.spinOnce(1, True)
+while not v.wasStopped():
+    v.spinOnce(1, True)
+print("Last event loop is over")

--- a/modules/viz/samples/viz_sample_02.py
+++ b/modules/viz/samples/viz_sample_02.py
@@ -33,15 +33,25 @@ p_cube.blue = 255
 p_cube.green = 0
 p_cube.red = 0
 p_cube.widget_name = "Cube Widget"
-p_cube.rot_vec = np.zeros(shape=(1,3),dtype=np.float64)
-p_cube.trans_vec= np.zeros(shape=(3,1),dtype=np.float64)
+p_cube.rot_vec = np.zeros(shape=(1,3),dtype=np.float32)
+p_cube.trans_vec= np.zeros(shape=(3,1),dtype=np.float32)
 p_cube.trans_vec[0,0]=2
 v.showWidget(p_cube)
-
-print("First event loop is over")
-v.spin()
-print("Second event loop is over")
-v.spinOnce(1, True)
+pi = np.arccos(-1)
+translation_phase = 0.0
+translation = 0.0
+rot_mat = np.zeros(shape=(3, 3), dtype=np.float32)
+p_cube.pose = np.zeros(shape=(4, 4), dtype=np.float32)
+p_cube.pose[3, 3] = 1
 while not v.wasStopped():
+    p_cube.rot_vec[0, 0] += pi * 0.01
+    p_cube.rot_vec[0, 1] += pi * 0.01
+    p_cube.rot_vec[0, 2] += pi * 0.01
+    translation_phase += pi * 0.01
+    translation = np.sin(translation_phase)
+    cv.Rodrigues(p_cube.rot_vec, rot_mat)
+    p_cube.pose[0:3,0:3] = rot_mat
+    p_cube.pose[0:3,3] = translation
+    v.setWidgetPose(p_cube)
     v.spinOnce(1, True)
 print("Last event loop is over")

--- a/modules/viz/samples/widget_pose.cpp
+++ b/modules/viz/samples/widget_pose.cpp
@@ -52,6 +52,26 @@ int main()
     /// Rodrigues vector
     Mat rot_vec = Mat::zeros(1,3,CV_32F);
     float translation_phase = 0.0, translation = 0.0;
+
+    rot_vec.at<float>(0, 0) += (float)CV_PI * 0.01f;
+    rot_vec.at<float>(0, 1) += (float)CV_PI * 0.01f;
+    rot_vec.at<float>(0, 2) += (float)CV_PI * 0.01f;
+
+    /// Shift on (1,1,1)
+    translation_phase += (float)CV_PI * 0.01f;
+    translation = sin(translation_phase);
+
+    Mat rot_mat;
+    Rodrigues(rot_vec, rot_mat);
+    cout << "rot_mat = " << rot_mat << endl;
+    /// Construct pose
+    Affine3f pose(rot_mat, Vec3f(translation, translation, translation));
+    Affine3f pose2(pose.matrix);
+    cout << "pose = " << pose.matrix << endl;
+    cout << "pose = " << pose2.matrix << endl;
+
+
+
     while(!myWindow.wasStopped())
     {
         /* Rotation using rodrigues */

--- a/modules/viz/src/viz3d.cpp
+++ b/modules/viz/src/viz3d.cpp
@@ -150,6 +150,13 @@ void cv::viz::Viz3d::removeAllWidgets() { impl_->removeAllWidgets(); }
 void cv::viz::Viz3d::showImage(InputArray image, const Size& window_size) { impl_->showImage(image, window_size); }
 
 void cv::viz::Viz3d::setWidgetPose(const String &id, const Affine3d &pose) { impl_->setWidgetPose(id, pose); }
+
+void cv::viz::Viz3d::setWidgetPose(ParamWidget &widget)
+{
+    Affine3f pose(widget.pose);
+    impl_->setWidgetPose(widget.widget_name, pose);
+}
+
 void cv::viz::Viz3d::updateWidgetPose(const String &id, const Affine3d &pose) { impl_->updateWidgetPose(id, pose); }
 cv::Affine3d cv::viz::Viz3d::getWidgetPose(const String &id) const { return impl_->getWidgetPose(id); }
 

--- a/modules/viz/src/viz3d.cpp
+++ b/modules/viz/src/viz3d.cpp
@@ -45,7 +45,12 @@
 
 #include "precomp.hpp"
 
-cv::viz::Viz3d::Viz3d(const String& window_name) : impl_(0) { create(window_name); }
+cv::Ptr<cv::viz::Viz3d> cv::viz::Viz3d::Viz3d::create(const String& window_name)
+{
+    return cv::makePtr<cv::viz::Viz3d>(window_name);
+}
+
+cv::viz::Viz3d::Viz3d(const String& window_name) : impl_(0) { create_internal(window_name); }
 
 cv::viz::Viz3d::Viz3d(const Viz3d& other) : impl_(other.impl_)
 {
@@ -67,7 +72,7 @@ cv::viz::Viz3d& cv::viz::Viz3d::operator=(const Viz3d& other)
 
 cv::viz::Viz3d::~Viz3d() { release(); }
 
-void cv::viz::Viz3d::create(const String &window_name)
+void cv::viz::Viz3d::create_internal(const String &window_name)
 {
     if (impl_)
         release();
@@ -115,6 +120,29 @@ void cv::viz::Viz3d::registerMouseCallback(MouseCallback callback, void* cookie)
 { impl_->registerMouseCallback(callback, cookie); }
 
 void cv::viz::Viz3d::showWidget(const String &id, const Widget &widget, const Affine3d &pose) { impl_->showWidget(id, widget, pose); }
+
+void cv::viz::Viz3d::showWidget(ParamWidget &widget)
+{
+    if (widget.widget_type == WIDGET_WArrow)
+    {
+        WArrow w(widget.p1, widget.p2, widget.thickness, Color(widget.blue, widget.green, widget.red));
+        CV_Assert(widget.rot_vec.rows == 3 && widget.rot_vec.cols == 1);
+        Affine3d pose(widget.rot_vec, widget.trans_vec);
+        impl_->showWidget(widget.widget_name, w, pose);
+    }
+    if (widget.widget_type == WIDGET_WCoordinateSystem)
+    {
+        WCoordinateSystem w;
+        impl_->showWidget(widget.widget_name, w);
+    }
+    if (widget.widget_type == WIDGET_WCube)
+    {
+        WCube w(widget.p1, widget.p2, true, Color(widget.blue, widget.green, widget.red));
+        w.setRenderingProperty(viz::LINE_WIDTH, widget.thickness);
+        impl_->showWidget(widget.widget_name, w);
+    }
+}
+
 void cv::viz::Viz3d::removeWidget(const String &id) { impl_->removeWidget(id); }
 cv::viz::Widget cv::viz::Viz3d::getWidget(const String &id) const { return impl_->getWidget(id); }
 void cv::viz::Viz3d::removeAllWidgets() { impl_->removeAllWidgets(); }


### PR DESCRIPTION
Python binding for viz module

This PR is not finished but I need advice about method


relative to https://github.com/opencv/opencv/issues/19490

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake




I am not able to make python binding for affine3 and widget. Affine3  and widget parameters are hidding in a new structure [ParamWidget](https://github.com/opencv/opencv_contrib/pull/2872/files#diff-5c3da8e855194d6c6fd9ade23507ac047993c3107649e8127480adf9e77733e1R66-R95)
This structure is used in all called function showWidget and setWidgetPose

I wrote two examples in[ python](https://github.com/LaurentBerger/opencv_contrib/tree/python_viz/modules/viz/samples) to test binding

force_builders=Linux x64