### PR TITLE
Fix omnidir::undistortPoints

### DIFF
--- a/modules/ccalib/src/omnidir.cpp
+++ b/modules/ccalib/src/omnidir.cpp
@@ -330,7 +330,7 @@ void cv::omnidir::undistortPoints( InputArray distorted, OutputArray undistorted
         Vec3d Xs = Xw / cv::norm(Xw);
 
         // reproject to camera plane
-        Vec3d ppu = Vec3d(Xs[0]/(Xs[2]+_xi), Xs[1]/(Xs[2]+_xi), 1.0);
+        Vec3d ppu = Vec3d(Xs[0]/Xs[2], Xs[1]/Xs[2], 1.0);
         if (undistorted.depth() == CV_32F)
         {
             dstf[i] = Vec2f((float)ppu[0], (float)ppu[1]);


### PR DESCRIPTION
The relevant bug was reported in https://github.com/opencv/opencv_contrib/issues/1612

The _xi was erroneously applied at points re-projection to camera plane.
_xi parameter was already taken in use while projection of points to unit sphere.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
