### PR TITLE
Pose Graph rewritten without Ceres

### DIFF
--- a/modules/rgbd/CMakeLists.txt
+++ b/modules/rgbd/CMakeLists.txt
@@ -1,15 +1,3 @@
 set(the_description "RGBD algorithms")
 
-find_package(Ceres QUIET)
 ocv_define_module(rgbd opencv_core opencv_calib3d opencv_imgproc OPTIONAL opencv_viz WRAP python)
-
-if(Ceres_FOUND)
-  ocv_target_compile_definitions(${the_module} PUBLIC CERES_FOUND)
-  ocv_target_link_libraries(${the_module} ${CERES_LIBRARIES})
-  if(Ceres_VERSION VERSION_LESS 2.0.0)
-    ocv_include_directories("${CERES_INCLUDE_DIRS}")
-  endif()
-  add_definitions(/DGLOG_NO_ABBREVIATED_SEVERITIES)  # avoid ERROR macro conflict in glog (ceres dependency)
-else()
-  message(STATUS "rgbd: CERES support is disabled. Ceres Solver is Required for Posegraph optimization")
-endif()

--- a/modules/rgbd/CMakeLists.txt
+++ b/modules/rgbd/CMakeLists.txt
@@ -1,3 +1,7 @@
 set(the_description "RGBD algorithms")
 
 ocv_define_module(rgbd opencv_core opencv_calib3d opencv_imgproc OPTIONAL opencv_viz WRAP python)
+
+if(NOT HAVE_EIGEN)
+  message(STATUS "rgbd: Eigen support is disabled. Eigen is Required for Posegraph optimization")
+endif()

--- a/modules/rgbd/include/opencv2/rgbd.hpp
+++ b/modules/rgbd/include/opencv2/rgbd.hpp
@@ -14,6 +14,7 @@
 #include "opencv2/rgbd/kinfu.hpp"
 #include "opencv2/rgbd/dynafu.hpp"
 #include "opencv2/rgbd/large_kinfu.hpp"
+#include "opencv2/rgbd/detail/pose_graph.hpp"
 
 
 /** @defgroup rgbd RGB-Depth Processing

--- a/modules/rgbd/include/opencv2/rgbd/detail/pose_graph.hpp
+++ b/modules/rgbd/include/opencv2/rgbd/detail/pose_graph.hpp
@@ -18,7 +18,10 @@ namespace cv
 {
 namespace kinfu
 {
+namespace detail
+{
 
+// TODO: text about unstable API
 class PoseGraph
 {
 public:
@@ -171,16 +174,17 @@ public:
 
    public:
 
-    void optimize();
+    void optimize(const cv::TermCriteria& tc);
 
     // used during optimization
     // nodes is a set of parameters to be used instead of contained in the graph
     double calcEnergy(const std::map<size_t, Node>& newNodes) const;
 
+//TODO: pImpl
     std::map<size_t, Node> nodes;
     std::vector<Edge>   edges;
 };
-
+}  // namespace detail
 }  // namespace kinfu
 }  // namespace cv
 #endif /* ifndef OPENCV_RGBD_GRAPH_NODE_H */

--- a/modules/rgbd/include/opencv2/rgbd/detail/pose_graph.hpp
+++ b/modules/rgbd/include/opencv2/rgbd/detail/pose_graph.hpp
@@ -1,5 +1,9 @@
-#ifndef OPENCV_RGBD_GRAPH_NODE_H
-#define OPENCV_RGBD_GRAPH_NODE_H
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
+
+#ifndef OPENCV_RGBD_POSE_GRAPH_HPP
+#define OPENCV_RGBD_POSE_GRAPH_HPP
 
 #include "opencv2/core/affine.hpp"
 #include "opencv2/core/quaternion.hpp"
@@ -55,4 +59,4 @@ public:
 }  // namespace detail
 }  // namespace kinfu
 }  // namespace cv
-#endif /* ifndef OPENCV_RGBD_GRAPH_NODE_H */
+#endif /* ifndef OPENCV_RGBD_POSE_GRAPH_HPP */

--- a/modules/rgbd/include/opencv2/rgbd/detail/pose_graph.hpp
+++ b/modules/rgbd/include/opencv2/rgbd/detail/pose_graph.hpp
@@ -1,17 +1,7 @@
 #ifndef OPENCV_RGBD_GRAPH_NODE_H
 #define OPENCV_RGBD_GRAPH_NODE_H
 
-#include <map>
-#include <unordered_map>
-
 #include "opencv2/core/affine.hpp"
-#if defined(HAVE_EIGEN)
-#include <Eigen/Core>
-#include <Eigen/Geometry>
-#include "opencv2/core/eigen.hpp"
-#endif
-
-#include "sparse_block_matrix.hpp"
 #include "opencv2/core/quaternion.hpp"
 
 namespace cv
@@ -32,15 +22,15 @@ namespace detail
 class CV_EXPORTS_W PoseGraph
 {
 public:
-    CV_WRAP static Ptr<PoseGraph> create();
-    virtual ~PoseGraph() = 0;
+    static Ptr<PoseGraph> create();
+    virtual ~PoseGraph();
 
     // Node may have any id >= 0
     virtual void addNode(size_t _nodeId, const Affine3d& _pose, bool fixed) = 0;
     virtual bool isNodeExist(size_t nodeId) const = 0;
     virtual bool setNodeFixed(size_t nodeId, bool fixed) = 0;
-    virtual bool isNodeFixed(size_t nodeId) = 0;
-    virtual Affine3d getNodePose(size_t nodeId) = 0;
+    virtual bool isNodeFixed(size_t nodeId) const = 0;
+    virtual Affine3d getNodePose(size_t nodeId) const = 0;
     virtual std::vector<size_t> getNodesIds() const = 0;
     virtual size_t getNumNodes() const = 0;
 

--- a/modules/rgbd/src/fast_icp.cpp
+++ b/modules/rgbd/src/fast_icp.cpp
@@ -504,7 +504,7 @@ void ICPImpl::getAb<Mat>(const Mat& oldPts, const Mat& oldNrm, const Mat& newPts
     const Normals np(newPts), nn(newNrm);
     GetAbInvoker invoker(sumAB, mutex, op, on, np, nn, pose,
                          intrinsics.scale(level).makeProjector(),
-                         distanceThreshold*distanceThreshold, cos(angleThreshold));
+                         distanceThreshold*distanceThreshold, std::cos(angleThreshold));
     Range range(0, newPts.rows);
     const int nstripes = -1;
     parallel_for_(range, invoker, nstripes);
@@ -590,7 +590,7 @@ void ICPImpl::getAb<UMat>(const UMat& oldPts, const UMat& oldNrm, const UMat& ne
                                     sizeof(pose.matrix.val)),
            fxy.val, cxy.val,
            distanceThreshold*distanceThreshold,
-           cos(angleThreshold),
+           std::cos(angleThreshold),
            ocl::KernelArg::Local(lsz),
            ocl::KernelArg::WriteOnlyNoSize(groupedSumGpu)
            );

--- a/modules/rgbd/src/large_kinfu.cpp
+++ b/modules/rgbd/src/large_kinfu.cpp
@@ -225,14 +225,14 @@ bool LargeKinfuImpl<MatType>::updateT(const MatType& _depth)
                        params.bilateral_sigma_depth, params.bilateral_sigma_spatial, params.bilateral_kernel_size,
                        params.truncateThreshold);
 
-    std::cout << "Current frameID: " << frameCounter << "\n";
+    CV_LOG_INFO(NULL, "Current frameID: " << frameCounter);
     for (const auto& it : submapMgr->activeSubmaps)
     {
         int currTrackingId = it.first;
         auto submapData = it.second;
         Ptr<Submap<MatType>> currTrackingSubmap = submapMgr->getSubmap(currTrackingId);
         Affine3f affine;
-        std::cout << "Current tracking ID: " << currTrackingId << std::endl;
+        CV_LOG_INFO(NULL, "Current tracking ID: " << currTrackingId);
 
         if(frameCounter == 0) //! Only one current tracking map
         {
@@ -249,7 +249,7 @@ bool LargeKinfuImpl<MatType>::updateT(const MatType& _depth)
             currTrackingSubmap->composeCameraPose(affine);
         else
         {
-            std::cout << "Tracking failed" << std::endl;
+            CV_LOG_INFO(NULL, "Tracking failed");
             continue;
         }
 
@@ -268,8 +268,8 @@ bool LargeKinfuImpl<MatType>::updateT(const MatType& _depth)
 
         currTrackingSubmap->updatePyrPointsNormals(params.pyramidLevels);
 
-        std::cout << "Submap: " << currTrackingId << " Total allocated blocks: " << currTrackingSubmap->getTotalAllocatedBlocks() << "\n";
-        std::cout << "Submap: " << currTrackingId << " Visible blocks: " << currTrackingSubmap->getVisibleBlocks(frameCounter) << "\n";
+        CV_LOG_INFO(NULL, "Submap: " << currTrackingId << " Total allocated blocks: " << currTrackingSubmap->getTotalAllocatedBlocks());
+        CV_LOG_INFO(NULL, "Submap: " << currTrackingId << " Visible blocks: " << currTrackingSubmap->getVisibleBlocks(frameCounter));
 
     }
     //4. Update map
@@ -278,8 +278,8 @@ bool LargeKinfuImpl<MatType>::updateT(const MatType& _depth)
     if(isMapUpdated)
     {
         // TODO: Convert constraints to posegraph
-        std::cout << "Created posegraph\n";
         Ptr<kinfu::detail::PoseGraph> poseGraph = submapMgr->MapToPoseGraph();
+        CV_LOG_INFO(NULL, "Created posegraph");
         int iters = poseGraph->optimize();
         if (iters < 0)
         {
@@ -290,7 +290,7 @@ bool LargeKinfuImpl<MatType>::updateT(const MatType& _depth)
         submapMgr->PoseGraphToMap(poseGraph);
 
     }
-    std::cout << "Number of submaps: " << submapMgr->submapList.size() << "\n";
+    CV_LOG_INFO(NULL, "Number of submaps: " << submapMgr->submapList.size());
 
     frameCounter++;
     return true;

--- a/modules/rgbd/src/large_kinfu.cpp
+++ b/modules/rgbd/src/large_kinfu.cpp
@@ -208,6 +208,7 @@ bool LargeKinfuImpl<UMat>::update(InputArray _depth)
     }
 }
 
+
 template<typename MatType>
 bool LargeKinfuImpl<MatType>::updateT(const MatType& _depth)
 {
@@ -279,7 +280,7 @@ bool LargeKinfuImpl<MatType>::updateT(const MatType& _depth)
         // TODO: Convert constraints to posegraph
         PoseGraph poseGraph = submapMgr->MapToPoseGraph();
         std::cout << "Created posegraph\n";
-        Optimizer::optimize(poseGraph);
+        poseGraph.optimize();
         submapMgr->PoseGraphToMap(poseGraph);
 
     }

--- a/modules/rgbd/src/large_kinfu.cpp
+++ b/modules/rgbd/src/large_kinfu.cpp
@@ -278,9 +278,15 @@ bool LargeKinfuImpl<MatType>::updateT(const MatType& _depth)
     if(isMapUpdated)
     {
         // TODO: Convert constraints to posegraph
-        PoseGraph poseGraph = submapMgr->MapToPoseGraph();
         std::cout << "Created posegraph\n";
-        poseGraph.optimize();
+        Ptr<kinfu::detail::PoseGraph> poseGraph = submapMgr->MapToPoseGraph();
+        int iters = poseGraph->optimize();
+        if (iters < 0)
+        {
+            CV_LOG_INFO(NULL, "Failed to perform pose graph optimization");
+            return false;
+        }
+
         submapMgr->PoseGraphToMap(poseGraph);
 
     }

--- a/modules/rgbd/src/nonrigid_icp.cpp
+++ b/modules/rgbd/src/nonrigid_icp.cpp
@@ -350,7 +350,7 @@ bool ICPImpl::estimateWarpNodes(WarpField& currentWarp, const Affine3f &pose,
 
             Vec3f diff = oldPoints.at<Vec3f>(y, x) - Vec3f(newP);
             if(diff.dot(diff) > 0.0004f) continue;
-            if(abs(newN.dot(oldNormals.at<Point3f>(y, x))) < cos((float)CV_PI / 2)) continue;
+            if(abs(newN.dot(oldNormals.at<Point3f>(y, x))) < std::cos((float)CV_PI / 2)) continue;
 
             float rd = newN.dot(diff);
 

--- a/modules/rgbd/src/pose_graph.cpp
+++ b/modules/rgbd/src/pose_graph.cpp
@@ -467,9 +467,7 @@ static inline void doJacobiScaling(BlockSparseMat<double, 6, 6>& jtj, std::vecto
 
 void PoseGraph::optimize()
 {
-#if !defined(HAVE_EIGEN)
-    CV_Error(Error::StsNotImplemented, "Eigen library required for matrix solve, dense solver is not implemented");
-#endif
+    #if defined(HAVE_EIGEN)
 
     if (!isValid())
     {
@@ -797,6 +795,10 @@ void PoseGraph::optimize()
     for (const auto& t : txtFlags)
         std::cout << " " << t;
     std::cout << " )" << std::endl;
+
+#else
+    CV_Error(Error::StsNotImplemented, "Eigen library required for matrix solve, dense solver is not implemented");
+#endif
 }
 
 }  // namespace kinfu

--- a/modules/rgbd/src/pose_graph.cpp
+++ b/modules/rgbd/src/pose_graph.cpp
@@ -228,14 +228,11 @@ void Optimizer::createOptimizationProblem(PoseGraph& poseGraph, ceres::Problem& 
         Pose3d& sourcePose = poseGraph.nodes.at(sourceNodeId).se3Pose;
         Pose3d& targetPose = poseGraph.nodes.at(targetNodeId).se3Pose;
 
-        ceres::CostFunction* costFunction = Pose3dAnalyticCostFunction::create(
-            Vec3d(currEdge.transformation.translation()),
-            Quatd::createFromRotMat(Matx33d(currEdge.transformation.rotation())),
-            currEdge.information);
+        ceres::CostFunction* costFunction = Pose3dAnalyticCostFunction::create(Vec3d(currEdge.pose.t), currEdge.pose.getQuat(), currEdge.information);
 
         problem.AddResidualBlock(costFunction, lossFunction,
-            sourcePose.t.val, sourcePose.vq.val,
-            targetPose.t.val, targetPose.vq.val);
+                                 sourcePose.t.val, sourcePose.vq.val,
+                                 targetPose.t.val, targetPose.vq.val);
         problem.SetParameterization(sourcePose.vq.val, quatLocalParameterization);
         problem.SetParameterization(targetPose.vq.val, quatLocalParameterization);
     }

--- a/modules/rgbd/src/pose_graph.cpp
+++ b/modules/rgbd/src/pose_graph.cpp
@@ -43,6 +43,9 @@ static inline cv::Matx44d m_right(cv::Quatd q)
              z,  y, -x,  w };
 }
 
+// precaution against "unused function" warning when there's no Eigen
+#if defined(HAVE_EIGEN)
+// jacobian of quaternionic (exp(x)*q) : R_3 -> H near x == 0
 static inline cv::Matx43d expQuatJacobian(cv::Quatd q)
 {
     double w = q.w, x = q.x, y = q.y, z = q.z;
@@ -51,6 +54,7 @@ static inline cv::Matx43d expQuatJacobian(cv::Quatd q)
                        -z,  w,  x,
                         y, -x,  w);
 }
+#endif
 
 // concatenate matrices vertically
 template<typename _Tp, int m, int n, int k> static inline

--- a/modules/rgbd/src/pose_graph.cpp
+++ b/modules/rgbd/src/pose_graph.cpp
@@ -467,8 +467,6 @@ static inline void doJacobiScaling(BlockSparseMat<double, 6, 6>& jtj, std::vecto
 
 void PoseGraph::optimize()
 {
-    #if defined(HAVE_EIGEN)
-
     if (!isValid())
     {
         CV_Error(Error::StsBadArg,
@@ -676,7 +674,7 @@ void PoseGraph::optimize()
 
             // use double or convert everything to float
             std::vector<double> x;
-            bool solved = kinfu::sparseSolve(jtj, jtb, x, false);
+            bool solved = jtj.sparseSolve(jtb, x, false);
 
             std::cout << (solved ? "OK" : "FAIL") << std::endl;
 
@@ -795,10 +793,6 @@ void PoseGraph::optimize()
     for (const auto& t : txtFlags)
         std::cout << " " << t;
     std::cout << " )" << std::endl;
-
-#else
-    CV_Error(Error::StsNotImplemented, "Eigen library required for matrix solve, dense solver is not implemented");
-#endif
 }
 
 }  // namespace kinfu

--- a/modules/rgbd/src/pose_graph.cpp
+++ b/modules/rgbd/src/pose_graph.cpp
@@ -736,7 +736,7 @@ void PoseGraph::optimize()
                 lambdaLevMarq *= lmUpFactor;
                 lmUpFactor *= 2.0;
 
-                CV_LOG_INFO(NULL, "LM up: " << lambdaLevMarq << ", old energy = " << oldEnergy);
+                CV_LOG_INFO(NULL, "LM goes up, lambda: " << lambdaLevMarq << ", old energy: " << oldEnergy);
             }
             else
             {
@@ -756,7 +756,7 @@ void PoseGraph::optimize()
 
                 oldEnergy = energy;
 
-                CV_LOG_INFO(NULL, "LM down: " << lambdaLevMarq << " step quality: " << stepQuality);
+                CV_LOG_INFO(NULL, "LM goes down, lambda: " << lambdaLevMarq << " step quality: " << stepQuality);
             }
 
             iter++;

--- a/modules/rgbd/src/pose_graph.cpp
+++ b/modules/rgbd/src/pose_graph.cpp
@@ -10,6 +10,10 @@
 #include <unordered_set>
 #include <vector>
 
+// a very stupid workaround against unreachable code warning
+#if defined(_MSC_VER)
+#pragma warning(disable : 4702)
+#endif
 
 namespace cv
 {

--- a/modules/rgbd/src/pose_graph.cpp
+++ b/modules/rgbd/src/pose_graph.cpp
@@ -129,7 +129,7 @@ void PoseGraph::readG2OFile(const std::string& g2oFileName)
     nodes.clear(); edges.clear();
 
     // for debugging purposes
-    int minId = 0, maxId = 1 << 30;
+    size_t minId = 0, maxId = 1 << 30;
 
     std::ifstream infile(g2oFileName.c_str());
     if (!infile)

--- a/modules/rgbd/src/pose_graph.cpp
+++ b/modules/rgbd/src/pose_graph.cpp
@@ -4,10 +4,6 @@
 
 #include "precomp.hpp"
 
-#include <fstream>
-#include <limits>
-#include <unordered_set>
-#include <vector>
 #include "sparse_block_matrix.hpp"
 
 // matrix form of conjugation

--- a/modules/rgbd/src/pose_graph.cpp
+++ b/modules/rgbd/src/pose_graph.cpp
@@ -37,7 +37,7 @@ static inline cv::Matx66d llt6(Matx66d m)
     return L;
 }
 
-PoseGraph::Edge::Edge(int _sourceNodeId, int _targetNodeId, const Affine3f& _transformation,
+PoseGraph::Edge::Edge(size_t _sourceNodeId, size_t _targetNodeId, const Affine3f& _transformation,
                       const Matx66f& _information) :
                       sourceNodeId(_sourceNodeId),
                       targetNodeId(_targetNodeId),
@@ -47,10 +47,10 @@ PoseGraph::Edge::Edge(int _sourceNodeId, int _targetNodeId, const Affine3f& _tra
 
 bool PoseGraph::isValid() const
 {
-    int numNodes = getNumNodes();
-    int numEdges = getNumEdges();
+    size_t numNodes = getNumNodes();
+    size_t numEdges = getNumEdges();
 
-    if (numNodes <= 0 || numEdges <= 0)
+    if (!numNodes || !numEdges)
         return false;
 
     std::unordered_set<size_t> nodesVisited;
@@ -65,10 +65,10 @@ bool PoseGraph::isValid() const
         nodesToVisit.pop_back();
         nodesVisited.insert(currNodeId);
         // Since each node does not maintain its neighbor list
-        for (int i = 0; i < numEdges; i++)
+        for (size_t i = 0; i < numEdges; i++)
         {
             const Edge& potentialEdge = edges.at(i);
-            int nextNodeId                     = -1;
+            size_t nextNodeId = (size_t)(-1);
 
             if (potentialEdge.getSourceNodeId() == currNodeId)
             {
@@ -78,7 +78,7 @@ bool PoseGraph::isValid() const
             {
                 nextNodeId = potentialEdge.getSourceNodeId();
             }
-            if (nextNodeId != -1)
+            if (nextNodeId != (size_t)(-1))
             {
                 if (nodesVisited.count(nextNodeId) == 0)
                 {
@@ -88,11 +88,11 @@ bool PoseGraph::isValid() const
         }
     }
 
-    isGraphConnected = (int(nodesVisited.size()) == numNodes);
+    isGraphConnected = (nodesVisited.size() == numNodes);
     //std::cout << "nodesVisited: " << nodesVisited.size();
     //std::cout << " IsGraphConnected: " << isGraphConnected << std::endl;
     bool invalidEdgeNode = false;
-    for (int i = 0; i < numEdges; i++)
+    for (size_t i = 0; i < numEdges; i++)
     {
         const Edge& edge = edges.at(i);
         // edges have spurious source/target nodes
@@ -144,7 +144,7 @@ void PoseGraph::readG2OFile(const std::string& g2oFileName)
         infile >> data_type;
         if (data_type == "VERTEX_SE3:QUAT")
         {
-            int id;
+            size_t id;
             infile >> id;
             Affine3d pose = readAffine(infile);
 
@@ -169,7 +169,7 @@ void PoseGraph::readG2OFile(const std::string& g2oFileName)
         }
         else if (data_type == "EDGE_SE3:QUAT")
         {
-            int startId, endId;
+            size_t startId, endId;
             infile >> startId >> endId;
             Affine3d pose = readAffine(infile);
 
@@ -213,7 +213,7 @@ void PoseGraph::writeToObjFile(const std::string& fname) const
     }
     for (const auto& e : edges)
     {
-        int sid = e.sourceNodeId, tid = e.targetNodeId;
+        size_t sid = e.sourceNodeId, tid = e.targetNodeId;
         of << "l " << sid + 1 << " " << tid + 1 << std::endl;
     }
     of.close();
@@ -474,8 +474,8 @@ void PoseGraph::optimize()
         return;
     }
 
-    int numNodes = getNumNodes();
-    int numEdges = getNumEdges();
+    size_t numNodes = getNumNodes();
+    size_t numEdges = getNumEdges();
 
     // Allocate indices for nodes
     std::vector<size_t> placesIds;
@@ -564,7 +564,7 @@ void PoseGraph::optimize()
         // fill jtj and jtb
         for (const auto& e : edges)
         {
-            int srcId = e.getSourceNodeId(), dstId = e.getTargetNodeId();
+            size_t srcId = e.getSourceNodeId(), dstId = e.getTargetNodeId();
             const Node& srcNode = nodes.at(srcId);
             const Node& dstNode = nodes.at(dstId);
 

--- a/modules/rgbd/src/pose_graph.cpp
+++ b/modules/rgbd/src/pose_graph.cpp
@@ -267,7 +267,7 @@ void writePg(const PoseGraph& pg, std::string fname)
 };
 
 
-void Optimizer::MyOptimize(PoseGraph& poseGraph)
+void Optimizer::optimize(PoseGraph& poseGraph)
 {
     //TODO: no copying
     PoseGraph poseGraphOriginal = poseGraph;
@@ -544,9 +544,6 @@ void Optimizer::MyOptimize(PoseGraph& poseGraph)
                 lmDiag[i] = ld;
 
                 jtj.refElem(i, i) = v + ld;
-
-                //DEBUG
-                //std::cout << jtj.refElem(i, i) << " ";
             }
 
             std::cout << std::endl;
@@ -671,14 +668,23 @@ void Optimizer::MyOptimize(PoseGraph& poseGraph)
     if (!found)
         std::cout << " not";
     std::cout << " found" << std::endl;
+    std::vector < std::string > txtFlags;
+    if (smallGradient)
+        txtFlags.push_back("smallGradient");
+    if (smallStep)
+        txtFlags.push_back("smallStep");
+    if (smallEnergyDelta)
+        txtFlags.push_back("smallEnergyDelta");
+    if (tooLong)
+        txtFlags.push_back("tooLong");
 
-    std::cout << "smallGradient: "    << (smallGradient    ? "true" : "false") << std::endl;
-    std::cout << "smallStep: "        << (smallStep        ? "true" : "false") << std::endl;
-    std::cout << "smallEnergyDelta: " << (smallEnergyDelta ? "true" : "false") << std::endl;
-    std::cout << "tooLong: "          << (tooLong          ? "true" : "false") << std::endl;
+    std::cout << "(";
+    for (const auto& t : txtFlags)
+        std::cout << " " << t;
+    std::cout << ")" << std::endl;
 }
 
-void Optimizer::optimize(PoseGraph& poseGraph)
+void Optimizer::CeresOptimize(PoseGraph& poseGraph)
 {
     PoseGraph poseGraphOriginal = poseGraph;
 

--- a/modules/rgbd/src/pose_graph.cpp
+++ b/modules/rgbd/src/pose_graph.cpp
@@ -162,12 +162,10 @@ class PoseGraphImpl : public detail::PoseGraph
     {
     public:
         explicit Node(size_t _nodeId, const Affine3d& _pose)
-            : nodeId(_nodeId), isFixed(false), pose(_pose.rotation(), _pose.translation())
+            : id(_nodeId), isFixed(false), pose(_pose.rotation(), _pose.translation())
         { }
-        virtual ~Node() = default;
 
-        size_t getId() const { return nodeId; }
-        inline Affine3d getPose() const
+        Affine3d getPose() const
         {
             return pose.getAffine();
         }
@@ -175,15 +173,9 @@ class PoseGraphImpl : public detail::PoseGraph
         {
             pose = Pose3d(_pose.rotation(), _pose.translation());
         }
-        void setPose(const Pose3d& _pose)
-        {
-            pose = _pose;
-        }
-        void setFixed(bool val = true) { isFixed = val; }
-        bool isPoseFixed() const { return isFixed; }
 
     public:
-        size_t nodeId;
+        size_t id;
         bool isFixed;
         Pose3d pose;
     };
@@ -196,18 +188,13 @@ class PoseGraphImpl : public detail::PoseGraph
     struct Edge
     {
     public:
-        Edge(size_t _sourceNodeId, size_t _targetNodeId, const Affine3f& _transformation,
-            const Matx66f& _information = Matx66f::eye());
-
-        virtual ~Edge() = default;
-
-        size_t getSourceNodeId() const { return sourceNodeId; }
-        size_t getTargetNodeId() const { return targetNodeId; }
+        explicit Edge(size_t _sourceNodeId, size_t _targetNodeId, const Affine3f& _transformation,
+                      const Matx66f& _information = Matx66f::eye());
 
         bool operator==(const Edge& edge)
         {
-            if ((edge.getSourceNodeId() == sourceNodeId && edge.getTargetNodeId() == targetNodeId) ||
-                (edge.getSourceNodeId() == targetNodeId && edge.getTargetNodeId() == sourceNodeId))
+            if ((edge.sourceNodeId == sourceNodeId && edge.targetNodeId == targetNodeId) ||
+                (edge.sourceNodeId == targetNodeId && edge.targetNodeId == sourceNodeId))
                 return true;
             return false;
         }
@@ -359,12 +346,12 @@ static inline cv::Matx66d llt6(Matx66d m)
     return L;
 }
 
-PoseGraph::Edge::Edge(size_t _sourceNodeId, size_t _targetNodeId, const Affine3f& _transformation,
-                      const Matx66f& _information) :
-                      sourceNodeId(_sourceNodeId),
-                      targetNodeId(_targetNodeId),
-                      pose(_transformation.rotation(), _transformation.translation()),
-                      sqrtInfo(llt6(_information))
+PoseGraphImpl::Edge::Edge(size_t _sourceNodeId, size_t _targetNodeId, const Affine3f& _transformation,
+                          const Matx66f& _information) :
+                          sourceNodeId(_sourceNodeId),
+                          targetNodeId(_targetNodeId),
+                          pose(_transformation.rotation(), _transformation.translation()),
+                          sqrtInfo(llt6(_information))
 { }
 
 bool PoseGraph::isValid() const

--- a/modules/rgbd/src/pose_graph.cpp
+++ b/modules/rgbd/src/pose_graph.cpp
@@ -10,11 +10,6 @@
 #include <unordered_set>
 #include <vector>
 
-// a very stupid workaround against unreachable code warning
-#if defined(_MSC_VER)
-#pragma warning(disable : 4702)
-#endif
-
 namespace cv
 {
 namespace kinfu
@@ -471,6 +466,7 @@ static inline void doJacobiScaling(BlockSparseMat<double, 6, 6>& jtj, std::vecto
 
 void PoseGraph::optimize()
 {
+#if defined(HAVE_EIGEN)
     if (!isValid())
     {
         CV_Error(Error::StsBadArg,
@@ -797,7 +793,11 @@ void PoseGraph::optimize()
     for (const auto& t : txtFlags)
         std::cout << " " << t;
     std::cout << " )" << std::endl;
+#else
+    CV_Error(Error::StsNotImplemented, "Eigen library required for sparse matrix solve during pose graph optimization, dense solver is not implemented");
+#endif
 }
+
 
 }  // namespace kinfu
 }  // namespace cv

--- a/modules/rgbd/src/pose_graph.cpp
+++ b/modules/rgbd/src/pose_graph.cpp
@@ -467,6 +467,10 @@ static inline void doJacobiScaling(BlockSparseMat<double, 6, 6>& jtj, std::vecto
 
 void PoseGraph::optimize()
 {
+#if !defined(HAVE_EIGEN)
+    CV_Error(Error::StsNotImplemented, "Eigen library required for matrix solve, dense solver is not implemented");
+#endif
+
     if (!isValid())
     {
         CV_Error(Error::StsBadArg,

--- a/modules/rgbd/src/pose_graph.cpp
+++ b/modules/rgbd/src/pose_graph.cpp
@@ -507,7 +507,7 @@ void PoseGraph::optimize()
     size_t nVars = nVarNodes * 6;
     BlockSparseMat<double, 6, 6> jtj(nVarNodes);
     std::vector<double> jtb(nVars);
- 
+
     double energy = calcEnergy(nodes);
     double oldEnergy = energy;
 

--- a/modules/rgbd/src/pose_graph.hpp
+++ b/modules/rgbd/src/pose_graph.hpp
@@ -262,7 +262,7 @@ class PoseGraph
 namespace Optimizer
 {
 
-void MyOptimize(PoseGraph& poseGraph);
+void CeresOptimize(PoseGraph& poseGraph);
 
 void optimize(PoseGraph& poseGraph);
 

--- a/modules/rgbd/src/pose_graph.hpp
+++ b/modules/rgbd/src/pose_graph.hpp
@@ -261,6 +261,9 @@ class PoseGraph
 
 namespace Optimizer
 {
+
+void MyOptimize(PoseGraph& poseGraph);
+
 void optimize(PoseGraph& poseGraph);
 
 #if defined(CERES_FOUND)

--- a/modules/rgbd/src/pose_graph.hpp
+++ b/modules/rgbd/src/pose_graph.hpp
@@ -15,6 +15,10 @@
 #include <ceres/ceres.h>
 #endif
 
+#include "sparse_block_matrix.hpp"
+
+#include "opencv2/core/dualquaternion.hpp"
+
 namespace cv
 {
 namespace kinfu
@@ -24,76 +28,51 @@ namespace kinfu
  *
  *  Detailed description
  */
-#if defined(HAVE_EIGEN)
+
 struct Pose3d
 {
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    Vec3d t;
+    Vec4d vq;
 
-    Eigen::Vector3d t;
-    Eigen::Quaterniond r;
-
-    Pose3d()
-    {
-        t.setZero();
-        r.setIdentity();
-    };
-    Pose3d(const Eigen::Matrix3d& rotation, const Eigen::Vector3d& translation)
-        : t(translation), r(Eigen::Quaterniond(rotation))
-    {
-        normalizeRotation();
-    }
+    Pose3d() : t(), vq(1, 0, 0, 0) { }
 
     Pose3d(const Matx33d& rotation, const Vec3d& translation)
+        : t(translation)
     {
-        Eigen::Matrix3d R;
-        cv2eigen(rotation, R);
-        cv2eigen(translation, t);
-        r = Eigen::Quaterniond(R);
-        normalizeRotation();
+        vq = Quatd::createFromRotMat(rotation).normalize().toVec();
     }
 
-    explicit Pose3d(const Matx44f& pose)
-    {
-        Matx33d rotation(pose.val[0], pose.val[1], pose.val[2], pose.val[4], pose.val[5],
-                         pose.val[6], pose.val[8], pose.val[9], pose.val[10]);
-        Vec3d translation(pose.val[3], pose.val[7], pose.val[11]);
-        Pose3d(rotation, translation);
-    }
+    explicit Pose3d(const Matx44d& pose) :
+        Pose3d(pose.get_minor<3, 3>(0, 0), Vec3d(pose(0, 3), pose(1, 3), pose(2, 3)))
+    { }
 
     // NOTE: Eigen overloads quaternion multiplication appropriately
     inline Pose3d operator*(const Pose3d& otherPose) const
     {
         Pose3d out(*this);
-        out.t += r * otherPose.t;
-        out.r *= otherPose.r;
-        out.normalizeRotation();
+        out.t += Quatd(vq).toRotMat3x3() * otherPose.t;
+        out.vq = (Quatd(out.vq) * Quatd(otherPose.vq)).toVec();
         return out;
     }
 
-    inline Pose3d& operator*=(const Pose3d& otherPose)
+    Affine3d getAffine() const
     {
-        t += otherPose.t;
-        r *= otherPose.r;
-        normalizeRotation();
-        return *this;
+        return Affine3d(Quatd(vq).toRotMat3x3(), t);
     }
 
     inline Pose3d inverse() const
     {
         Pose3d out;
-        out.r = r.conjugate();
-        out.t = out.r * (t * -1.0);
+        out.vq = Quatd(vq).conjugate().toVec();
+        out.t = - (Quatd(out.vq).toRotMat3x3(QUAT_ASSUME_UNIT) * t);
         return out;
     }
 
     inline void normalizeRotation()
     {
-        if (r.w() < 0)
-            r.coeffs() *= -1.0;
-        r.normalize();
+        vq = Quatd(vq).normalize().toVec();
     }
 };
-#endif
 
 struct PoseGraphNode
 {
@@ -101,9 +80,7 @@ struct PoseGraphNode
     explicit PoseGraphNode(int _nodeId, const Affine3f& _pose)
         : nodeId(_nodeId), isFixed(false), pose(_pose)
     {
-#if defined(HAVE_EIGEN)
         se3Pose = Pose3d(_pose.rotation(), _pose.translation());
-#endif
     }
     virtual ~PoseGraphNode() = default;
 
@@ -115,24 +92,13 @@ struct PoseGraphNode
     void setPose(const Affine3f& _pose)
     {
         pose = _pose;
-#if defined(HAVE_EIGEN)
         se3Pose = Pose3d(pose.rotation(), pose.translation());
-#endif
     }
-#if defined(HAVE_EIGEN)
     void setPose(const Pose3d& _pose)
     {
         se3Pose = _pose;
-        const Eigen::Matrix3d& rotation    = se3Pose.r.toRotationMatrix();
-        const Eigen::Vector3d& translation = se3Pose.t;
-        Matx33d rot;
-        Vec3d trans;
-        eigen2cv(rotation, rot);
-        eigen2cv(translation, trans);
-        Affine3d poseMatrix(rot, trans);
-        pose = poseMatrix;
+        pose = Affine3d(Quatd(se3Pose.vq).toRotMat3x3(QUAT_ASSUME_UNIT), se3Pose.t);
     }
-#endif
     void setFixed(bool val = true) { isFixed = val; }
     bool isPoseFixed() const { return isFixed; }
 
@@ -140,9 +106,7 @@ struct PoseGraphNode
     int nodeId;
     bool isFixed;
     Affine3f pose;
-#if defined(HAVE_EIGEN)
     Pose3d se3Pose;
-#endif
 };
 
 /*! \class PoseGraphEdge
@@ -221,24 +185,41 @@ struct PoseGraphEdge
 class PoseGraph
 {
    public:
-    typedef std::vector<PoseGraphNode> NodeVector;
-    typedef std::vector<PoseGraphEdge> EdgeVector;
+       typedef std::map<int, PoseGraphNode> Nodes;
+       //typedef std::vector<PoseGraphNode> NodeVector;
+       typedef std::vector<PoseGraphEdge> EdgeVector;
 
-    explicit PoseGraph(){};
+    explicit PoseGraph() {};
     virtual ~PoseGraph() = default;
 
     //! PoseGraph can be copied/cloned
     PoseGraph(const PoseGraph&) = default;
     PoseGraph& operator=(const PoseGraph&) = default;
 
-    void addNode(const PoseGraphNode& node) { nodes.push_back(node); }
+    void addNode(const PoseGraphNode& node)
+    {
+        int id = node.getId();
+        const auto& it = nodes.find(id);
+        if (it != nodes.end())
+        {
+            std::cout << "duplicated node, id=" << id << std::endl;
+            nodes.insert(it, { id, node });
+        }
+        else
+        {
+            nodes.insert({ id, node });
+        }
+    }
     void addEdge(const PoseGraphEdge& edge) { edges.push_back(edge); }
 
     bool nodeExists(int nodeId) const
     {
+        return (nodes.find(nodeId) != nodes.end());
+        /*
         return std::find_if(nodes.begin(), nodes.end(), [nodeId](const PoseGraphNode& currNode) {
                    return currNode.getId() == nodeId;
                }) != nodes.end();
+        */
     }
 
     bool isValid() const;
@@ -247,7 +228,7 @@ class PoseGraph
     int getNumEdges() const { return int(edges.size()); }
 
    public:
-    NodeVector nodes;
+    Nodes nodes;
     EdgeVector edges;
 };
 
@@ -280,20 +261,36 @@ class Pose3dErrorFunctor
     {
         Eigen::Map<const Eigen::Matrix<T, 3, 1>> sourceTrans(_pSourceTrans);
         Eigen::Map<const Eigen::Matrix<T, 3, 1>> targetTrans(_pTargetTrans);
-        Eigen::Map<const Eigen::Quaternion<T>> sourceQuat(_pSourceQuat);
-        Eigen::Map<const Eigen::Quaternion<T>> targetQuat(_pTargetQuat);
+
+        //Eigen::Quaternion<T> sourceQuat(_pSourceQuat[3], _pSourceQuat[0], _pSourceQuat[1], _pSourceQuat[2]);
+        //Eigen::Quaternion<T> targetQuat(_pTargetQuat[3], _pTargetQuat[0], _pTargetQuat[1], _pTargetQuat[2]);
+        Eigen::Quaternion<T> sourceQuat(_pSourceQuat[0], _pSourceQuat[1], _pSourceQuat[2], _pSourceQuat[3]);
+        Eigen::Quaternion<T> targetQuat(_pTargetQuat[0], _pTargetQuat[1], _pTargetQuat[2], _pTargetQuat[3]);
+        
         Eigen::Map<Eigen::Matrix<T, 6, 1>> residual(_pResidual);
 
-        Eigen::Quaternion<T> targetQuatInv = targetQuat.conjugate();
+        //Eigen::Quaternion<T> targetQuatInv = targetQuat.conjugate();
 
-        Eigen::Quaternion<T> relativeQuat    = targetQuatInv * sourceQuat;
-        Eigen::Matrix<T, 3, 1> relativeTrans = targetQuatInv * (targetTrans - sourceTrans);
+        //Eigen::Quaternion<T> relativeQuat    = targetQuatInv * sourceQuat;
+        //Eigen::Matrix<T, 3, 1> relativeTrans = targetQuatInv * (targetTrans - sourceTrans);
+
+        Eigen::Quaternion<T> sourceQuatInv = sourceQuat.conjugate();
+
+        Eigen::Quaternion<T> relativeQuat = sourceQuatInv * targetQuat;
+        Eigen::Matrix<T, 3, 1> relativeTrans = sourceQuatInv * (targetTrans - sourceTrans);
 
         //! Definition should actually be relativeQuat * poseMeasurement.r.conjugate()
-        Eigen::Quaternion<T> deltaRot =
-            poseMeasurement.r.template cast<T>() * relativeQuat.conjugate();
+        Eigen::Quaternion<T> pmr(T(poseMeasurement.vq[0]), T(poseMeasurement.vq[1]), T(poseMeasurement.vq[2]), T(poseMeasurement.vq[3]));
+        
+        //DEBUG
+        //Eigen::Quaternion<T> deltaRot = pmr * relativeQuat.conjugate();
+        Eigen::Quaternion<T> deltaRot = relativeQuat.conjugate() * pmr;
 
-        residual.template block<3, 1>(0, 0) = relativeTrans - poseMeasurement.t.template cast<T>();
+        //DEBUG
+        //deltaRot = (deltaRot.w() < T(0)) ? deltaRot * Eigen::Quaternion<T>(T(-1), T(0), T(0), T(0)) : deltaRot;
+
+        Eigen::Matrix<T, 3, 1> pmt(T(poseMeasurement.t[0]), T(poseMeasurement.t[1]), T(poseMeasurement.t[2]));
+        residual.template block<3, 1>(0, 0) = relativeTrans -  pmt;
         residual.template block<3, 1>(3, 0) = T(2.0) * deltaRot.vec();
 
         residual.applyOnTheLeft(sqrtInfo.template cast<T>());
@@ -312,6 +309,249 @@ class Pose3dErrorFunctor
     const Pose3d poseMeasurement;
     Eigen::Matrix<double, 6, 6> sqrtInfo;
 };
+
+// matrix form of Im(a)
+const Matx44d M_Im{ 0, 0, 0, 0,
+                    0, 1, 0, 0,
+                    0, 0, 1, 0,
+                    0, 0, 0, 1 };
+
+// matrix form of conjugation
+const Matx44d M_Conj{ 1,  0,  0,  0,
+                      0, -1,  0,  0,
+                      0,  0, -1,  0,
+                      0,  0,  0, -1 };
+
+// matrix form of quaternion multiplication from left side
+inline Matx44d m_left(Quatd q)
+{
+    // M_left(a)* V(b) =
+    //    = (I_4 * a0 + [ 0 | -av    [    0 | 0_1x3
+    //                   av | 0_3] +  0_3x1 | skew(av)]) * V(b)
+
+    float w = q.w, x = q.x, y = q.y, z = q.z;
+    return { w, -x, -y, -z,
+             x,  w, -z,  y,
+             y,  z,  w, -x,
+             z, -y,  x,  w };
+}
+
+// matrix form of quaternion multiplication from right side
+inline Matx44d m_right(Quatd q)
+{
+    // M_right(b)* V(a) =
+    //    = (I_4 * b0 + [ 0 | -bv    [    0 | 0_1x3
+    //                   bv | 0_3] +  0_3x1 | skew(-bv)]) * V(a)
+
+    float w = q.w, x = q.x, y = q.y, z = q.z;
+    return { w, -x, -y, -z,
+             x,  w,  z, -y,
+             y, -z,  w,  x,
+             z,  y, -x,  w };
+}
+
+// concatenate matrices vertically
+template<typename _Tp, int m, int n, int k> static inline
+Matx<_Tp, m + k, n> concatVert(const Matx<_Tp, m, n>& a, const Matx<_Tp, k, n>& b)
+{
+    Matx<_Tp, m + k, n> res;
+    for (int i = 0; i < m; i++)
+    {
+        for (int j = 0; j < n; j++)
+        {
+            res(i, j) = a(i, j);
+        }
+    }
+    for (int i = 0; i < k; i++)
+    {
+        for (int j = 0; j < n; j++)
+        {
+            res(m + i, j) = b(i, j);
+        }
+    }
+    return res;
+}
+
+// concatenate matrices horizontally
+template<typename _Tp, int m, int n, int k> static inline
+Matx<_Tp, m, n + k> concatHor(const Matx<_Tp, m, n>& a, const Matx<_Tp, m, k>& b)
+{
+    Matx<_Tp, m, n + k> res;
+
+    for (int i = 0; i < m; i++)
+    {
+        for (int j = 0; j < n; j++)
+        {
+            res(i, j) = a(i, j);
+        }
+    }
+    for (int i = 0; i < m; i++)
+    {
+        for (int j = 0; j < k; j++)
+        {
+            res(i, n + j) = b(i, j);
+        }
+    }
+    return res;
+}
+
+
+class Pose3dAnalyticCostFunction : public ceres::SizedCostFunction<6, 3, 4, 3, 4>
+{
+public:
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+    Pose3dAnalyticCostFunction(Vec3d _transMeasured, Quatd _rotMeasured, Matx66d _infoMatrix) :
+        transMeasured(_transMeasured), rotMeasured(_rotMeasured), infoMatrix(_infoMatrix),
+        sqrtInfoMatrix(llt6(infoMatrix))
+    { }
+
+    static Matx66d llt6(Matx66d m)
+    {
+        Matx66d L;
+        for (int i = 0; i < 6; i++)
+        {
+            for (int j = 0; j < (i + 1); j++)
+            {
+                double sum = 0;
+                for (int k = 0; k < j; k++)
+                    sum += L(i, k) * L(j, k);
+
+                if (i == j)
+                    L(i, i) = sqrt(m(i, i) - sum);
+                else
+                    L(i, j) = (1.0 / L(j, j) * (m(i, j) - sum));
+            }
+        }
+        return L;
+    }
+
+    bool Evaluate(double const* const* parameters,
+                  double* residuals,
+                  double** jacobians) const override
+    {
+        Vec3d sourceTrans(parameters[0]);
+        Vec4d p1(parameters[1]);
+        Quatd sourceQuat(p1);
+        Vec3d targetTrans(parameters[2]);
+        Vec4d p3(parameters[3]);
+        Quatd targetQuat(p3);
+
+        // err_r = 2*Im(conj(rel_r) * measure_r) = 2*Im(conj(target_r) * source_r * measure_r)
+        // err_t = conj(source_r) * (target_t - source_t) * source_r - measure_t
+
+        Vec6d res;
+
+        Quatd sourceQuatInv = sourceQuat.conjugate();
+        Vec3d deltaTrans = targetTrans - sourceTrans;
+
+        Quatd relativeQuat = sourceQuatInv * targetQuat;
+        Vec3d relativeTrans = sourceQuatInv.toRotMat3x3(cv::QUAT_ASSUME_UNIT) * deltaTrans;
+
+        //! Definition should actually be relativeQuat * rotMeasured.conjugate()
+        Quatd deltaRot = relativeQuat.conjugate() * rotMeasured;
+
+        Vec3d terr = relativeTrans - transMeasured;
+        Vec3d rerr = 2.0 * Vec3d(deltaRot.x, deltaRot.y, deltaRot.z);
+        Vec6d rterr(terr[0], terr[1], terr[2], rerr[0], rerr[1], rerr[2]);
+
+        res = sqrtInfoMatrix * rterr;
+
+        if (jacobians)
+        {
+            Matx<double, 6, 3> stj, ttj;
+            Matx<double, 6, 4> sqj, tqj;
+
+            // d(err_r) = 2*Im(d(conj(target_r) * source_r * measure_r)) = < measure_r is constant > =
+            // 2*Im((conj(d(target_r)) * source_r + conj(target_r) * d(source_r)) * measure_r)
+            // d(target_r) == 0:
+            //  # d(err_r) = 2*Im(conj(target_r) * d(source_r) * measure_r)
+            //  # V(d(err_r)) = 2 * M_Im * M_right(measure_r) * M_left(conj(target_r)) * V(d(source_r))
+            //  # d(err_r) / d(source_r) = 2 * M_Im * M_right(measure_r) * M_left(conj(target_r))
+            Matx34d drdsq = 2.0 * (m_right(rotMeasured) * m_left(targetQuat.conjugate())).get_minor<3, 4>(1, 0);
+
+            // d(source_r) == 0:
+            //  # d(err_r) = 2*Im(conj(d(target_r)) * source_r * measure_r)
+            //  # V(d(err_r)) = 2 * M_Im * M_right(source_r * measure_r) * M_Conj * V(d(target_r))
+            //  # d(err_r) / d(target_r) = 2 * M_Im * M_right(source_r * measure_r) * M_Conj
+            Matx34d drdtq = 2.0 * (m_right(sourceQuat * rotMeasured) * M_Conj).get_minor<3, 4>(1, 0);
+
+            // d(err_t) = d(conj(source_r) * (target_t - source_t) * source_r) =
+            // conj(source_r) * (d(target_t) - d(source_t)) * source_r +
+            // conj(d(source_r)) * (target_t - source_t) * source_r +
+            // conj(source_r) * (target_t - source_t) * d(source_r) =
+            // <conj(a*b) == conj(b)*conj(a), conj(target_t - source_t) = - (target_t - source_t), 2 * Im(x) = (x - conj(x))>
+            // conj(source_r) * (d(target_t) - d(source_t)) * source_r +
+            // 2 * Im(conj(source_r) * (target_t - source_t) * d(source_r))
+            // d(*_t) == 0:
+            //  # d(err_t) = 2 * Im(conj(source_r) * (target_t - source_t) * d(source_r))
+            //  # V(d(err_t)) = 2 * M_Im * M_left(conj(source_r) * (target_t - source_t)) * V(d(source_r))
+            //  # d(err_t) / d(source_r) = 2 * M_Im * M_left(conj(source_r) * (target_t - source_t))
+            Vec3d td = targetTrans - sourceTrans;
+            Matx34d dtdsq = 2 * m_left(sourceQuatInv * Quatd(0, deltaTrans[0], deltaTrans[1], deltaTrans[2])).get_minor<3, 4>(1, 0);
+            // deltaTrans is rotated by sourceQuatInv, so the jacobian is rot matrix of sourceQuatInv by +1 or -1
+            Matx33d dtdtt = sourceQuatInv.toRotMat3x3(QUAT_ASSUME_UNIT);
+            Matx33d dtdst = - dtdtt;
+
+            Matx33d z;
+            sqj = concatVert(dtdsq, drdsq);
+            tqj = concatVert(Matx34d(), drdtq);
+            stj = concatVert(dtdst, z);
+            ttj = concatVert(dtdtt, z);
+
+            stj = sqrtInfoMatrix * stj;
+            ttj = sqrtInfoMatrix * ttj;
+            sqj = sqrtInfoMatrix * sqj;
+            tqj = sqrtInfoMatrix * tqj;
+
+            // sourceTrans
+            if (jacobians[0])
+            {
+                for (int i = 0; i < 6 * 3; i++)
+                    jacobians[0][i] = stj.val[i];
+            }
+            
+            // sourceQuat
+            if (jacobians[1])
+            {
+                for (int i = 0; i < 6 * 4; i++)
+                    jacobians[1][i] = sqj.val[i];
+            }
+
+            // targetTrans
+            if (jacobians[2])
+            {
+                for (int i = 0; i < 6 * 3; i++)
+                    jacobians[2][i] = ttj.val[i];
+            }
+
+            // targetQuat
+            if (jacobians[3])
+            {
+                for (int i = 0; i < 6 * 4; i++)
+                    jacobians[3][i] = tqj.val[i];
+            }
+        }
+
+        for (int i = 0; i < 6; i++)
+            residuals[i] = res[i];
+
+        return true;
+    }
+
+    static ceres::CostFunction* create(Vec3d _transMeasured, Quatd _rotMeasured, Matx66d _infoMatrix)
+    {
+        return new Pose3dAnalyticCostFunction(_transMeasured, _rotMeasured, _infoMatrix);
+    }
+
+    Vec3d transMeasured;
+    Quatd rotMeasured;
+    Matx66d infoMatrix;
+    Matx66d sqrtInfoMatrix;
+};
+
+
 #endif
 
 }  // namespace Optimizer

--- a/modules/rgbd/src/pose_graph.hpp
+++ b/modules/rgbd/src/pose_graph.hpp
@@ -18,133 +18,118 @@ namespace cv
 {
 namespace kinfu
 {
-/*! \class GraphNode
- *  \brief Defines a node/variable that is optimizable in a posegraph
- *
- *  Detailed description
- */
-
-
-
-// TODO: put it to PoseGraph as a subtype
-struct Pose3d
-{
-    Vec3d t;
-    Vec4d vq;
-
-    Pose3d() : t(), vq(1, 0, 0, 0) { }
-
-    Pose3d(const Matx33d& rotation, const Vec3d& translation)
-        : t(translation)
-    {
-        vq = Quatd::createFromRotMat(rotation).normalize().toVec();
-    }
-
-    explicit Pose3d(const Matx44d& pose) :
-        Pose3d(pose.get_minor<3, 3>(0, 0), Vec3d(pose(0, 3), pose(1, 3), pose(2, 3)))
-    { }
-
-    // NOTE: Eigen overloads quaternion multiplication appropriately
-    inline Pose3d operator*(const Pose3d& otherPose) const
-    {
-        Pose3d out(*this);
-        out.t += Quatd(vq).toRotMat3x3(QUAT_ASSUME_UNIT) * otherPose.t;
-        out.vq = (Quatd(out.vq) * Quatd(otherPose.vq)).toVec();
-        return out;
-    }
-
-    Affine3d getAffine() const
-    {
-        return Affine3d(Quatd(vq).toRotMat3x3(QUAT_ASSUME_UNIT), t);
-    }
-
-    Quatd getQuat() const
-    {
-        return Quatd(vq);
-    }
-
-    inline Pose3d inverse() const
-    {
-        Pose3d out;
-        out.vq = Quatd(vq).conjugate().toVec();
-        out.t = - (Quatd(out.vq).toRotMat3x3(QUAT_ASSUME_UNIT) * t);
-        return out;
-    }
-
-    inline void normalizeRotation()
-    {
-        vq = Quatd(vq).normalize().toVec();
-    }
-};
-
-// TODO: put it to PoseGraph as a subtype
-struct PoseGraphNode
-{
-   public:
-    explicit PoseGraphNode(int _nodeId, const Affine3d& _pose)
-        : nodeId(_nodeId), isFixed(false)
-    {
-        se3Pose = Pose3d(_pose.rotation(), _pose.translation());
-    }
-    virtual ~PoseGraphNode() = default;
-
-    int getId() const { return nodeId; }
-    inline Affine3d getPose() const
-    {
-        return se3Pose.getAffine();
-    }
-    void setPose(const Affine3d& _pose)
-    {
-        se3Pose = Pose3d(_pose.rotation(), _pose.translation());
-    }
-    void setPose(const Pose3d& _pose)
-    {
-        se3Pose = _pose;
-    }
-    void setFixed(bool val = true) { isFixed = val; }
-    bool isPoseFixed() const { return isFixed; }
-
-   public:
-    int nodeId;
-    bool isFixed;
-    Pose3d se3Pose;
-};
-
-// TODO: put it to PoseGraph as a subtype
-/*! \class PoseGraphEdge
- *  \brief Defines the constraints between two PoseGraphNodes
- *
- *  Detailed description
- */
-struct PoseGraphEdge
-{
-   public:
-    PoseGraphEdge(int _sourceNodeId, int _targetNodeId, const Affine3f& _transformation,
-                  const Matx66f& _information = Matx66f::eye());
-
-    virtual ~PoseGraphEdge() = default;
-
-    int getSourceNodeId() const { return sourceNodeId; }
-    int getTargetNodeId() const { return targetNodeId; }
-
-    bool operator==(const PoseGraphEdge& edge)
-    {
-        if ((edge.getSourceNodeId() == sourceNodeId && edge.getTargetNodeId() == targetNodeId) ||
-            (edge.getSourceNodeId() == targetNodeId && edge.getTargetNodeId() == sourceNodeId))
-            return true;
-        return false;
-    }
-
-   public:
-    int sourceNodeId;
-    int targetNodeId;
-    Pose3d pose;
-    Matx66f information;
-    Matx66f sqrtInfo;
-};
 
 class PoseGraph
 {
+public:
+    struct Pose3d
+    {
+        Vec3d t;
+        Quatd q;
+
+        Pose3d() : t(), q(1, 0, 0, 0) { }
+
+        Pose3d(const Matx33d& rotation, const Vec3d& translation)
+            : t(translation), q(Quatd::createFromRotMat(rotation).normalize())
+        { }
+
+        explicit Pose3d(const Matx44d& pose) :
+            Pose3d(pose.get_minor<3, 3>(0, 0), Vec3d(pose(0, 3), pose(1, 3), pose(2, 3)))
+        { }
+
+        inline Pose3d operator*(const Pose3d& otherPose) const
+        {
+            Pose3d out(*this);
+            out.t += q.toRotMat3x3(QUAT_ASSUME_UNIT) * otherPose.t;
+            out.q = out.q * otherPose.q;
+            return out;
+        }
+
+        Affine3d getAffine() const
+        {
+            return Affine3d(q.toRotMat3x3(QUAT_ASSUME_UNIT), t);
+        }
+
+        inline Pose3d inverse() const
+        {
+            Pose3d out;
+            out.q = q.conjugate();
+            out.t = -(out.q.toRotMat3x3(QUAT_ASSUME_UNIT) * t);
+            return out;
+        }
+
+        inline void normalizeRotation()
+        {
+            q = q.normalize();
+        }
+    };
+
+    /*! \class GraphNode
+     *  \brief Defines a node/variable that is optimizable in a posegraph
+     *
+     *  Detailed description
+     */
+    struct Node
+    {
+    public:
+        explicit Node(int _nodeId, const Affine3d& _pose)
+            : nodeId(_nodeId), isFixed(false), pose(_pose.rotation(), _pose.translation())
+        { }
+        virtual ~Node() = default;
+
+        int getId() const { return nodeId; }
+        inline Affine3d getPose() const
+        {
+            return pose.getAffine();
+        }
+        void setPose(const Affine3d& _pose)
+        {
+            pose = Pose3d(_pose.rotation(), _pose.translation());
+        }
+        void setPose(const Pose3d& _pose)
+        {
+            pose = _pose;
+        }
+        void setFixed(bool val = true) { isFixed = val; }
+        bool isPoseFixed() const { return isFixed; }
+
+    public:
+        int nodeId;
+        bool isFixed;
+        Pose3d pose;
+    };
+
+    /*! \class PoseGraphEdge
+     *  \brief Defines the constraints between two PoseGraphNodes
+     *
+     *  Detailed description
+     */
+    struct Edge
+    {
+    public:
+        Edge(int _sourceNodeId, int _targetNodeId, const Affine3f& _transformation,
+             const Matx66f& _information = Matx66f::eye());
+
+        virtual ~Edge() = default;
+
+        int getSourceNodeId() const { return sourceNodeId; }
+        int getTargetNodeId() const { return targetNodeId; }
+
+        bool operator==(const Edge& edge)
+        {
+            if ((edge.getSourceNodeId() == sourceNodeId && edge.getTargetNodeId() == targetNodeId) ||
+                (edge.getSourceNodeId() == targetNodeId && edge.getTargetNodeId() == sourceNodeId))
+                return true;
+            return false;
+        }
+
+    public:
+        int sourceNodeId;
+        int targetNodeId;
+        Pose3d pose;
+        Matx66f sqrtInfo;
+    };
+
    public:
     explicit PoseGraph() {};
     virtual ~PoseGraph() = default;
@@ -158,7 +143,7 @@ class PoseGraph
     void readG2OFile(const std::string& g2oFileName);
     void writeToObjFile(const std::string& objFname) const;
 
-    void addNode(const PoseGraphNode& node)
+    void addNode(const Node& node)
     {
         int id = node.getId();
         const auto& it = nodes.find(id);
@@ -172,7 +157,7 @@ class PoseGraph
             nodes.insert({ id, node });
         }
     }
-    void addEdge(const PoseGraphEdge& edge) { edges.push_back(edge); }
+    void addEdge(const Edge& edge) { edges.push_back(edge); }
 
     bool nodeExists(int nodeId) const
     {
@@ -190,10 +175,10 @@ class PoseGraph
 
     // used during optimization
     // nodes is a set of parameters to be used instead of contained in the graph
-    double calcEnergy(const std::map<int, PoseGraphNode>& newNodes) const;
+    double calcEnergy(const std::map<int, Node>& newNodes) const;
 
-    std::map<int, PoseGraphNode> nodes;
-    std::vector<PoseGraphEdge>   edges;
+    std::map<int, Node> nodes;
+    std::vector<Edge>   edges;
 };
 
 }  // namespace kinfu

--- a/modules/rgbd/src/pose_graph.hpp
+++ b/modules/rgbd/src/pose_graph.hpp
@@ -12,7 +12,7 @@
 #endif
 
 #include "sparse_block_matrix.hpp"
-#include "opencv2/core/dualquaternion.hpp"
+#include "opencv2/core/quaternion.hpp"
 
 namespace cv
 {
@@ -175,9 +175,9 @@ public:
 
     // used during optimization
     // nodes is a set of parameters to be used instead of contained in the graph
-    double calcEnergy(const std::map<int, Node>& newNodes) const;
+    double calcEnergy(const std::map<size_t, Node>& newNodes) const;
 
-    std::map<int, Node> nodes;
+    std::map<size_t, Node> nodes;
     std::vector<Edge>   edges;
 };
 

--- a/modules/rgbd/src/pose_graph.hpp
+++ b/modules/rgbd/src/pose_graph.hpp
@@ -72,12 +72,12 @@ public:
     struct Node
     {
     public:
-        explicit Node(int _nodeId, const Affine3d& _pose)
+        explicit Node(size_t _nodeId, const Affine3d& _pose)
             : nodeId(_nodeId), isFixed(false), pose(_pose.rotation(), _pose.translation())
         { }
         virtual ~Node() = default;
 
-        int getId() const { return nodeId; }
+        size_t getId() const { return nodeId; }
         inline Affine3d getPose() const
         {
             return pose.getAffine();
@@ -94,7 +94,7 @@ public:
         bool isPoseFixed() const { return isFixed; }
 
     public:
-        int nodeId;
+        size_t nodeId;
         bool isFixed;
         Pose3d pose;
     };
@@ -107,13 +107,13 @@ public:
     struct Edge
     {
     public:
-        Edge(int _sourceNodeId, int _targetNodeId, const Affine3f& _transformation,
+        Edge(size_t _sourceNodeId, size_t _targetNodeId, const Affine3f& _transformation,
              const Matx66f& _information = Matx66f::eye());
 
         virtual ~Edge() = default;
 
-        int getSourceNodeId() const { return sourceNodeId; }
-        int getTargetNodeId() const { return targetNodeId; }
+        size_t getSourceNodeId() const { return sourceNodeId; }
+        size_t getTargetNodeId() const { return targetNodeId; }
 
         bool operator==(const Edge& edge)
         {
@@ -124,8 +124,8 @@ public:
         }
 
     public:
-        int sourceNodeId;
-        int targetNodeId;
+        size_t sourceNodeId;
+        size_t targetNodeId;
         Pose3d pose;
         Matx66f sqrtInfo;
     };
@@ -145,7 +145,7 @@ public:
 
     void addNode(const Node& node)
     {
-        int id = node.getId();
+        size_t id = node.getId();
         const auto& it = nodes.find(id);
         if (it != nodes.end())
         {
@@ -159,15 +159,15 @@ public:
     }
     void addEdge(const Edge& edge) { edges.push_back(edge); }
 
-    bool nodeExists(int nodeId) const
+    bool nodeExists(size_t nodeId) const
     {
         return (nodes.find(nodeId) != nodes.end());
     }
 
     bool isValid() const;
 
-    int getNumNodes() const { return int(nodes.size()); }
-    int getNumEdges() const { return int(edges.size()); }
+    size_t getNumNodes() const { return nodes.size(); }
+    size_t getNumEdges() const { return edges.size(); }
 
    public:
 

--- a/modules/rgbd/src/pose_graph.hpp
+++ b/modules/rgbd/src/pose_graph.hpp
@@ -11,12 +11,7 @@
 #include "opencv2/core/eigen.hpp"
 #endif
 
-#if defined(CERES_FOUND)
-#include <ceres/ceres.h>
-#endif
-
 #include "sparse_block_matrix.hpp"
-
 #include "opencv2/core/dualquaternion.hpp"
 
 namespace cv
@@ -29,27 +24,9 @@ namespace kinfu
  *  Detailed description
  */
 
-// Cholesky decomposition of symmetrical 6x6 matrix
-inline cv::Matx66d llt6(Matx66d m)
-{
-    Matx66d L;
-    for (int i = 0; i < 6; i++)
-    {
-        for (int j = 0; j < (i + 1); j++)
-        {
-            double sum = 0;
-            for (int k = 0; k < j; k++)
-                sum += L(i, k) * L(j, k);
 
-            if (i == j)
-                L(i, i) = sqrt(m(i, i) - sum);
-            else
-                L(i, j) = (1.0 / L(j, j) * (m(i, j) - sum));
-        }
-    }
-    return L;
-}
 
+// TODO: put it to PoseGraph as a subtype
 struct Pose3d
 {
     Vec3d t;
@@ -100,6 +77,7 @@ struct Pose3d
     }
 };
 
+// TODO: put it to PoseGraph as a subtype
 struct PoseGraphNode
 {
    public:
@@ -132,6 +110,7 @@ struct PoseGraphNode
     Pose3d se3Pose;
 };
 
+// TODO: put it to PoseGraph as a subtype
 /*! \class PoseGraphEdge
  *  \brief Defines the constraints between two PoseGraphNodes
  *
@@ -141,14 +120,8 @@ struct PoseGraphEdge
 {
    public:
     PoseGraphEdge(int _sourceNodeId, int _targetNodeId, const Affine3f& _transformation,
-                  const Matx66f& _information = Matx66f::eye())
-        : sourceNodeId(_sourceNodeId),
-          targetNodeId(_targetNodeId),
-          pose(_transformation.rotation(), _transformation.translation()),
-          information(_information),
-          sqrtInfo(llt6(_information))
-    {
-    }
+                  const Matx66f& _information = Matx66f::eye());
+
     virtual ~PoseGraphEdge() = default;
 
     int getSourceNodeId() const { return sourceNodeId; }
@@ -170,48 +143,9 @@ struct PoseGraphEdge
     Matx66f sqrtInfo;
 };
 
-//! @brief Reference: A tutorial on SE(3) transformation parameterizations and on-manifold
-//! optimization Jose Luis Blanco Compactly represents the jacobian of the SE3 generator
-// clang-format off
-/* static const std::array<Matx44f, 6> generatorJacobian = { */
-/*     // alpha */
-/*     Matx44f(0, 0,  0, 0, */
-/*             0, 0, -1, 0, */
-/*             0, 1,  0, 0, */
-/*             0, 0,  0, 0), */
-/*     // beta */
-/*     Matx44f( 0, 0, 1, 0, */
-/*              0, 0, 0, 0, */
-/*             -1, 0, 0, 0, */
-/*              0, 0, 0, 0), */
-/*     // gamma */
-/*     Matx44f(0, -1, 0, 0, */
-/*             1,  0, 0, 0, */
-/*             0,  0, 0, 0, */
-/*             0,  0, 0, 0), */
-/*     // x */
-/*     Matx44f(0, 0, 0, 1, */
-/*             0, 0, 0, 0, */
-/*             0, 0, 0, 0, */
-/*             0, 0, 0, 0), */
-/*     // y */
-/*     Matx44f(0, 0, 0, 0, */
-/*             0, 0, 0, 1, */
-/*             0, 0, 0, 0, */
-/*             0, 0, 0, 0), */
-/*     // z */
-/*     Matx44f(0, 0, 0, 0, */
-/*             0, 0, 0, 0, */
-/*             0, 0, 0, 1, */
-/*             0, 0, 0, 0) */
-/* }; */
-// clang-format on
-
 class PoseGraph
 {
    public:
-
-
     explicit PoseGraph() {};
     virtual ~PoseGraph() = default;
 
@@ -221,6 +155,8 @@ class PoseGraph
 
     // can be used for debugging
     PoseGraph(const std::string& g2oFileName);
+    void readG2OFile(const std::string& g2oFileName);
+    void writeToObjFile(const std::string& objFname) const;
 
     void addNode(const PoseGraphNode& node)
     {
@@ -241,11 +177,6 @@ class PoseGraph
     bool nodeExists(int nodeId) const
     {
         return (nodes.find(nodeId) != nodes.end());
-        /*
-        return std::find_if(nodes.begin(), nodes.end(), [nodeId](const PoseGraphNode& currNode) {
-                   return currNode.getId() == nodeId;
-               }) != nodes.end();
-        */
     }
 
     bool isValid() const;
@@ -255,256 +186,15 @@ class PoseGraph
 
    public:
 
+    void optimize();
+
+    // used during optimization
+    // nodes is a set of parameters to be used instead of contained in the graph
+    double calcEnergy(const std::map<int, PoseGraphNode>& newNodes) const;
+
     std::map<int, PoseGraphNode> nodes;
     std::vector<PoseGraphEdge>   edges;
 };
-
-namespace Optimizer
-{
-
-void CeresOptimize(PoseGraph& poseGraph);
-
-void optimize(PoseGraph& poseGraph);
-
-#if defined(CERES_FOUND)
-void createOptimizationProblem(PoseGraph& poseGraph, ceres::Problem& problem);
-
-// matrix form of Im(a)
-const Matx44d M_Im{ 0, 0, 0, 0,
-                    0, 1, 0, 0,
-                    0, 0, 1, 0,
-                    0, 0, 0, 1 };
-
-// matrix form of conjugation
-const Matx44d M_Conj{ 1,  0,  0,  0,
-                      0, -1,  0,  0,
-                      0,  0, -1,  0,
-                      0,  0,  0, -1 };
-
-// matrix form of quaternion multiplication from left side
-inline Matx44d m_left(Quatd q)
-{
-    // M_left(a)* V(b) =
-    //    = (I_4 * a0 + [ 0 | -av    [    0 | 0_1x3
-    //                   av | 0_3] +  0_3x1 | skew(av)]) * V(b)
-
-    float w = q.w, x = q.x, y = q.y, z = q.z;
-    return { w, -x, -y, -z,
-             x,  w, -z,  y,
-             y,  z,  w, -x,
-             z, -y,  x,  w };
-}
-
-// matrix form of quaternion multiplication from right side
-inline Matx44d m_right(Quatd q)
-{
-    // M_right(b)* V(a) =
-    //    = (I_4 * b0 + [ 0 | -bv    [    0 | 0_1x3
-    //                   bv | 0_3] +  0_3x1 | skew(-bv)]) * V(a)
-
-    float w = q.w, x = q.x, y = q.y, z = q.z;
-    return { w, -x, -y, -z,
-             x,  w,  z, -y,
-             y, -z,  w,  x,
-             z,  y, -x,  w };
-}
-
-inline Matx43d expQuatJacobian(Quatd q)
-{
-    double w = q.w, x = q.x, y = q.y, z = q.z;
-    return Matx43d(-x, -y, -z,
-                    w,  z, -y,
-                   -z,  w,  x,
-                    y, -x,  w);
-}
-
-
-// concatenate matrices vertically
-template<typename _Tp, int m, int n, int k> static inline
-Matx<_Tp, m + k, n> concatVert(const Matx<_Tp, m, n>& a, const Matx<_Tp, k, n>& b)
-{
-    Matx<_Tp, m + k, n> res;
-    for (int i = 0; i < m; i++)
-    {
-        for (int j = 0; j < n; j++)
-        {
-            res(i, j) = a(i, j);
-        }
-    }
-    for (int i = 0; i < k; i++)
-    {
-        for (int j = 0; j < n; j++)
-        {
-            res(m + i, j) = b(i, j);
-        }
-    }
-    return res;
-}
-
-// concatenate matrices horizontally
-template<typename _Tp, int m, int n, int k> static inline
-Matx<_Tp, m, n + k> concatHor(const Matx<_Tp, m, n>& a, const Matx<_Tp, m, k>& b)
-{
-    Matx<_Tp, m, n + k> res;
-
-    for (int i = 0; i < m; i++)
-    {
-        for (int j = 0; j < n; j++)
-        {
-            res(i, j) = a(i, j);
-        }
-    }
-    for (int i = 0; i < m; i++)
-    {
-        for (int j = 0; j < k; j++)
-        {
-            res(i, n + j) = b(i, j);
-        }
-    }
-    return res;
-}
-
-
-inline double poseError(Quatd sourceQuat, Vec3d sourceTrans, Quatd targetQuat, Vec3d targetTrans,
-                        Quatd rotMeasured, Vec3d transMeasured, Matx66d sqrtInfoMatrix, bool needJacobians,
-                        Matx<double, 6, 4>& sqj, Matx<double, 6, 3>& stj,
-                        Matx<double, 6, 4>& tqj, Matx<double, 6, 3>& ttj,
-                        Vec6d& res)
-{
-    // err_r = 2*Im(conj(rel_r) * measure_r) = 2*Im(conj(target_r) * source_r * measure_r)
-    // err_t = conj(source_r) * (target_t - source_t) * source_r - measure_t
-
-    Quatd sourceQuatInv = sourceQuat.conjugate();
-    Vec3d deltaTrans = targetTrans - sourceTrans;
-
-    Quatd relativeQuat = sourceQuatInv * targetQuat;
-    Vec3d relativeTrans = sourceQuatInv.toRotMat3x3(cv::QUAT_ASSUME_UNIT) * deltaTrans;
-
-    //! Definition should actually be relativeQuat * rotMeasured.conjugate()
-    Quatd deltaRot = relativeQuat.conjugate() * rotMeasured;
-
-    Vec3d terr = relativeTrans - transMeasured;
-    Vec3d rerr = 2.0 * Vec3d(deltaRot.x, deltaRot.y, deltaRot.z);
-    Vec6d rterr(terr[0], terr[1], terr[2], rerr[0], rerr[1], rerr[2]);
-
-    res = sqrtInfoMatrix * rterr;
-
-    if (needJacobians)
-    {
-        // d(err_r) = 2*Im(d(conj(target_r) * source_r * measure_r)) = < measure_r is constant > =
-        // 2*Im((conj(d(target_r)) * source_r + conj(target_r) * d(source_r)) * measure_r)
-        // d(target_r) == 0:
-        //  # d(err_r) = 2*Im(conj(target_r) * d(source_r) * measure_r)
-        //  # V(d(err_r)) = 2 * M_Im * M_right(measure_r) * M_left(conj(target_r)) * V(d(source_r))
-        //  # d(err_r) / d(source_r) = 2 * M_Im * M_right(measure_r) * M_left(conj(target_r))
-        Matx34d drdsq = 2.0 * (m_right(rotMeasured) * m_left(targetQuat.conjugate())).get_minor<3, 4>(1, 0);
-
-        // d(source_r) == 0:
-        //  # d(err_r) = 2*Im(conj(d(target_r)) * source_r * measure_r)
-        //  # V(d(err_r)) = 2 * M_Im * M_right(source_r * measure_r) * M_Conj * V(d(target_r))
-        //  # d(err_r) / d(target_r) = 2 * M_Im * M_right(source_r * measure_r) * M_Conj
-        Matx34d drdtq = 2.0 * (m_right(sourceQuat * rotMeasured) * M_Conj).get_minor<3, 4>(1, 0);
-
-        // d(err_t) = d(conj(source_r) * (target_t - source_t) * source_r) =
-        // conj(source_r) * (d(target_t) - d(source_t)) * source_r +
-        // conj(d(source_r)) * (target_t - source_t) * source_r +
-        // conj(source_r) * (target_t - source_t) * d(source_r) =
-        // <conj(a*b) == conj(b)*conj(a), conj(target_t - source_t) = - (target_t - source_t), 2 * Im(x) = (x - conj(x))>
-        // conj(source_r) * (d(target_t) - d(source_t)) * source_r +
-        // 2 * Im(conj(source_r) * (target_t - source_t) * d(source_r))
-        // d(*_t) == 0:
-        //  # d(err_t) = 2 * Im(conj(source_r) * (target_t - source_t) * d(source_r))
-        //  # V(d(err_t)) = 2 * M_Im * M_left(conj(source_r) * (target_t - source_t)) * V(d(source_r))
-        //  # d(err_t) / d(source_r) = 2 * M_Im * M_left(conj(source_r) * (target_t - source_t))
-        Matx34d dtdsq = 2 * m_left(sourceQuatInv * Quatd(0, deltaTrans[0], deltaTrans[1], deltaTrans[2])).get_minor<3, 4>(1, 0);
-        // deltaTrans is rotated by sourceQuatInv, so the jacobian is rot matrix of sourceQuatInv by +1 or -1
-        Matx33d dtdtt = sourceQuatInv.toRotMat3x3(QUAT_ASSUME_UNIT);
-        Matx33d dtdst = -dtdtt;
-
-        Matx33d z;
-        sqj = concatVert(dtdsq, drdsq);
-        tqj = concatVert(Matx34d(), drdtq);
-        stj = concatVert(dtdst, z);
-        ttj = concatVert(dtdtt, z);
-
-        stj = sqrtInfoMatrix * stj;
-        ttj = sqrtInfoMatrix * ttj;
-        sqj = sqrtInfoMatrix * sqj;
-        tqj = sqrtInfoMatrix * tqj;
-    }
-
-    return res.ddot(res);
-}
-
-
-class Pose3dAnalyticCostFunction : public ceres::SizedCostFunction<6, 3, 4, 3, 4>
-{
-public:
-
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-
-    Pose3dAnalyticCostFunction(Vec3d _transMeasured, Quatd _rotMeasured, Matx66d _infoMatrix) :
-        transMeasured(_transMeasured), rotMeasured(_rotMeasured), infoMatrix(_infoMatrix),
-        sqrtInfoMatrix(llt6(infoMatrix))
-    { }
-
-    
-    bool Evaluate(double const* const* parameters,
-                  double* residuals,
-                  double** jacobians) const override
-    {
-        Vec3d sourceTrans(parameters[0]);
-        Vec4d p1(parameters[1]);
-        Quatd sourceQuat(p1);
-        Vec3d targetTrans(parameters[2]);
-        Vec4d p3(parameters[3]);
-        Quatd targetQuat(p3);
-
-        Vec6d res;
-        Matx<double, 6, 3> stj, ttj;
-        Matx<double, 6, 4> sqj, tqj;
-        poseError(sourceQuat, sourceTrans, targetQuat, targetTrans,
-                  rotMeasured, transMeasured, sqrtInfoMatrix, /* needJacobians = */ (bool)(jacobians),
-                  sqj, stj, tqj, ttj, res);
-
-        if (jacobians)
-        {
-            // source trans, source quat, target trans, target quat
-            double* ptrs[4] = { stj.val, sqj.val, ttj.val, tqj.val };
-            size_t sizes[4] = { 6 * 3, 6 * 4, 6 * 3, 6 * 4 };
-
-            for (int k = 0; k < 4; k++)
-            {
-                if (jacobians[k])
-                {
-                    for (int i = 0; i < sizes[k]; i++)
-                        jacobians[k][i] = ptrs[k][i];
-
-                }
-            }
-        }
-
-        for (int i = 0; i < 6; i++)
-            residuals[i] = res[i];
-
-        return true;
-    }
-
-    static ceres::CostFunction* create(Vec3d _transMeasured, Quatd _rotMeasured, Matx66d _infoMatrix)
-    {
-        return new Pose3dAnalyticCostFunction(_transMeasured, _rotMeasured, _infoMatrix);
-    }
-
-    Vec3d transMeasured;
-    Quatd rotMeasured;
-    Matx66d infoMatrix;
-    Matx66d sqrtInfoMatrix;
-};
-
-
-#endif
-
-}  // namespace Optimizer
 
 }  // namespace kinfu
 }  // namespace cv

--- a/modules/rgbd/src/precomp.hpp
+++ b/modules/rgbd/src/precomp.hpp
@@ -11,8 +11,10 @@
 #define __OPENCV_PRECOMP_H__
 
 #include <iostream>
+#include <vector>
 #include <list>
 #include <set>
+#include <unordered_set>
 #include <limits>
 
 #include "opencv2/core/utility.hpp"

--- a/modules/rgbd/src/sparse_block_matrix.hpp
+++ b/modules/rgbd/src/sparse_block_matrix.hpp
@@ -48,7 +48,7 @@ struct BlockSparseMat
         ijValue.clear();
     }
 
-    MatType& refBlock(size_t i, size_t j)
+    inline MatType& refBlock(size_t i, size_t j)
     {
         Point2i p((int)i, (int)j);
         auto it = ijValue.find(p);
@@ -59,14 +59,14 @@ struct BlockSparseMat
         return it->second;
     }
 
-    _Tp& refElem(size_t i, size_t j)
+    inline _Tp& refElem(size_t i, size_t j)
     {
         Point2i ib((int)(i / blockM), (int)(j / blockN));
         Point2i iv((int)(i % blockM), (int)(j % blockN));
         return refBlock(ib.x, ib.y)(iv.x, iv.y);
     }
 
-    MatType valBlock(size_t i, size_t j) const
+    inline MatType valBlock(size_t i, size_t j) const
     {
         Point2i p((int)i, (int)j);
         auto it = ijValue.find(p);
@@ -76,7 +76,7 @@ struct BlockSparseMat
             return it->second;
     }
 
-    _Tp valElem(size_t i, size_t j) const
+    inline _Tp valElem(size_t i, size_t j) const
     {
         Point2i ib((int)(i / blockM), (int)(j / blockN));
         Point2i iv((int)(i % blockM), (int)(j % blockN));
@@ -124,7 +124,7 @@ struct BlockSparseMat
         return EigenMat;
     }
 #endif
-    size_t nonZeroBlocks() const { return ijValue.size(); }
+    inline size_t nonZeroBlocks() const { return ijValue.size(); }
 
     BlockSparseMat<_Tp, blockM, blockN>& operator+=(const BlockSparseMat<_Tp, blockM, blockN>& other)
     {
@@ -184,11 +184,9 @@ struct BlockSparseMat
         }
     }
 #else
-    bool sparseSolve(InputArray /*B*/, OutputArray /*X*/, bool /*checkSymmetry*/ = true, OutputArray /*predB*/ = cv::noArray())
+    bool sparseSolve(InputArray /*B*/, OutputArray /*X*/, bool /*checkSymmetry*/ = true, OutputArray /*predB*/ = cv::noArray()) const
     {
-        std::cout << "no eigen library" << std::endl;
         CV_Error(Error::StsNotImplemented, "Eigen library required for matrix solve, dense solver is not implemented");
-        return false;
     }
 #endif
 

--- a/modules/rgbd/src/sparse_block_matrix.hpp
+++ b/modules/rgbd/src/sparse_block_matrix.hpp
@@ -146,16 +146,17 @@ struct BlockSparseMat
 //! Function to solve a sparse linear system of equations HX = B
 //! Requires Eigen
 template<typename T>
-static bool sparseSolve(const BlockSparseMat<T, 6, 6>& H, const Mat& B,
-                        OutputArray X, OutputArray predB = cv::noArray())
+static bool sparseSolve(const BlockSparseMat<T, 6, 6>& H, InputArray B,
+                        OutputArray X, bool checkSymmetry = true, OutputArray predB = cv::noArray())
 {
 #if defined(HAVE_EIGEN)
     Eigen::SparseMatrix<T> bigA = H.toEigen();
+    Mat mb = B.getMat().t();
     Eigen::Matrix<T, -1, 1> bigB;
-    cv2eigen(B, bigB);
+    cv2eigen(mb, bigB);
 
     Eigen::SparseMatrix<T> bigAtranspose = bigA.transpose();
-    if(!bigA.isApprox(bigAtranspose))
+    if(checkSymmetry && !bigA.isApprox(bigAtranspose))
     {
         CV_Error(Error::StsBadArg, "H matrix is not symmetrical");
         return false;

--- a/modules/rgbd/src/sparse_block_matrix.hpp
+++ b/modules/rgbd/src/sparse_block_matrix.hpp
@@ -188,6 +188,7 @@ struct BlockSparseMat
     {
         std::cout << "no eigen library" << std::endl;
         CV_Error(Error::StsNotImplemented, "Eigen library required for matrix solve, dense solver is not implemented");
+        return false;
     }
 #endif
 

--- a/modules/rgbd/src/sparse_block_matrix.hpp
+++ b/modules/rgbd/src/sparse_block_matrix.hpp
@@ -105,14 +105,14 @@ struct BlockSparseMat
         {
             int xb = ijv.first.x, yb = ijv.first.y;
             MatType vblock = ijv.second;
-            for (int i = 0; i < blockM; i++)
+            for (size_t i = 0; i < blockM; i++)
             {
-                for (int j = 0; j < blockN; j++)
+                for (size_t j = 0; j < blockN; j++)
                 {
-                    _Tp val = vblock(i, j);
+                    _Tp val = vblock((int)i, (int)j);
                     if (abs(val) >= NON_ZERO_VAL_THRESHOLD)
                     {
-                        tripletList.push_back(Eigen::Triplet<_Tp>(blockM * xb + i, blockN * yb + j, val));
+                        tripletList.push_back(Eigen::Triplet<_Tp>((int)(blockM * xb + i), (int)(blockN * yb + j), val));
                     }
                 }
             }
@@ -143,13 +143,14 @@ struct BlockSparseMat
     IDtoBlockValueMap ijValue;
 };
 
+#if defined(HAVE_EIGEN)
 //! Function to solve a sparse linear system of equations HX = B
 //! Requires Eigen
 template<typename T>
 static bool sparseSolve(const BlockSparseMat<T, 6, 6>& H, InputArray B,
                         OutputArray X, bool checkSymmetry = true, OutputArray predB = cv::noArray())
 {
-#if defined(HAVE_EIGEN)
+
     Eigen::SparseMatrix<T> bigA = H.toEigen();
     Mat mb = B.getMat().t();
     Eigen::Matrix<T, -1, 1> bigB;
@@ -189,10 +190,17 @@ static bool sparseSolve(const BlockSparseMat<T, 6, 6>& H, InputArray B,
             return true;
         }
     }
+
+}
 #else
+template<typename T>
+static bool sparseSolve(const BlockSparseMat<T, 6, 6>& /*H*/, InputArray /*B*/,
+    OutputArray /*X*/, bool /*checkSymmetry*/ = true, OutputArray /*predB*/ = cv::noArray())
+{
     std::cout << "no eigen library" << std::endl;
     CV_Error(Error::StsNotImplemented, "Eigen library required for matrix solve, dense solver is not implemented");
-#endif
 }
+#endif
+
 }  // namespace kinfu
 }  // namespace cv

--- a/modules/rgbd/src/sparse_block_matrix.hpp
+++ b/modules/rgbd/src/sparse_block_matrix.hpp
@@ -7,6 +7,7 @@
 
 #include "opencv2/core/base.hpp"
 #include "opencv2/core/types.hpp"
+#include "opencv2/core/utils/logger.hpp"
 
 #if defined(HAVE_EIGEN)
 #include <Eigen/Core>
@@ -160,7 +161,7 @@ struct BlockSparseMat
         solver.compute(bigA);
         if (solver.info() != Eigen::Success)
         {
-            std::cout << "failed to eigen-decompose" << std::endl;
+            CV_LOG_INFO(NULL, "Failed to eigen-decompose");
             return false;
         }
         else
@@ -168,7 +169,7 @@ struct BlockSparseMat
             Eigen::Matrix<_Tp, -1, 1> solutionX = solver.solve(bigB);
             if (solver.info() != Eigen::Success)
             {
-                std::cout << "failed to eigen-solve" << std::endl;
+                CV_LOG_INFO(NULL, "Failed to eigen-solve");
                 return false;
             }
             else

--- a/modules/rgbd/src/submap.hpp
+++ b/modules/rgbd/src/submap.hpp
@@ -13,7 +13,7 @@
 
 #include "hash_tsdf.hpp"
 #include "opencv2/core/mat.inl.hpp"
-#include "pose_graph.hpp"
+#include "opencv2/rgbd/detail/pose_graph.hpp"
 
 namespace cv
 {
@@ -166,15 +166,15 @@ class SubmapManager
     int estimateConstraint(int fromSubmapId, int toSubmapId, int& inliers, Affine3f& inlierPose);
     bool updateMap(int _frameId, std::vector<MatType> _framePoints, std::vector<MatType> _frameNormals);
 
-    PoseGraph MapToPoseGraph();
-    void PoseGraphToMap(const PoseGraph& updatedPoseGraph);
+    Ptr<detail::PoseGraph> MapToPoseGraph();
+    void PoseGraphToMap(const Ptr<detail::PoseGraph>& updatedPoseGraph);
 
     VolumeParams volumeParams;
 
     std::vector<Ptr<SubmapT>> submapList;
     IdToActiveSubmaps activeSubmaps;
 
-    PoseGraph poseGraph;
+    Ptr<detail::PoseGraph> poseGraph;
 };
 
 template<typename MatType>
@@ -494,9 +494,9 @@ bool SubmapManager<MatType>::updateMap(int _frameId, std::vector<MatType> _frame
 }
 
 template<typename MatType>
-PoseGraph SubmapManager<MatType>::MapToPoseGraph()
+Ptr<detail::PoseGraph> SubmapManager<MatType>::MapToPoseGraph()
 {
-    PoseGraph localPoseGraph;
+    Ptr<detail::PoseGraph> localPoseGraph = detail::PoseGraph::create();
 
     for(const auto& currSubmap : submapList)
     {
@@ -506,32 +506,26 @@ PoseGraph SubmapManager<MatType>::MapToPoseGraph()
             // TODO: Handle case with duplicate constraints A -> B and B -> A
             /* Matx66f informationMatrix = Matx66f::eye() * (currConstraintPair.second.weight/10); */
             Matx66f informationMatrix = Matx66f::eye();
-            PoseGraph::Edge currEdge(currSubmap->id, currConstraintPair.first, currConstraintPair.second.estimatedPose, informationMatrix);
-            localPoseGraph.addEdge(currEdge);
+            localPoseGraph->addEdge(currSubmap->id, currConstraintPair.first, currConstraintPair.second.estimatedPose, informationMatrix);
         }
     }
 
     for(const auto& currSubmap : submapList)
     {
-        PoseGraph::Node currNode(currSubmap->id, currSubmap->pose);
-        if(currSubmap->id == 0)
-        {
-            currNode.setFixed();
-        }
-        localPoseGraph.addNode(currNode);
+        localPoseGraph->addNode(currSubmap->id, currSubmap->pose, (currSubmap->id == 0));
     }
 
     return localPoseGraph;
 }
 
 template <typename MatType>
-void SubmapManager<MatType>::PoseGraphToMap(const PoseGraph &updatedPoseGraph)
+void SubmapManager<MatType>::PoseGraphToMap(const Ptr<detail::PoseGraph>& updatedPoseGraph)
 {
     for(const auto& currSubmap : submapList)
     {
-        const PoseGraph::Node& currNode = updatedPoseGraph.nodes.at(currSubmap->id);
-        if(!currNode.isPoseFixed())
-            currSubmap->pose = currNode.getPose();
+        Affine3d pose = updatedPoseGraph->getNodePose(currSubmap->id);
+        if(!updatedPoseGraph->isNodeFixed(currSubmap->id))
+            currSubmap->pose = pose;
         std::cout << "Current node: " << currSubmap->id << " Updated Pose: \n" << currSubmap->pose.matrix << std::endl;
     }
 }

--- a/modules/rgbd/src/submap.hpp
+++ b/modules/rgbd/src/submap.hpp
@@ -498,7 +498,6 @@ PoseGraph SubmapManager<MatType>::MapToPoseGraph()
 {
     PoseGraph localPoseGraph;
 
-
     for(const auto& currSubmap : submapList)
     {
         const typename SubmapT::Constraints& constraintList = currSubmap->constraints;
@@ -507,22 +506,20 @@ PoseGraph SubmapManager<MatType>::MapToPoseGraph()
             // TODO: Handle case with duplicate constraints A -> B and B -> A
             /* Matx66f informationMatrix = Matx66f::eye() * (currConstraintPair.second.weight/10); */
             Matx66f informationMatrix = Matx66f::eye();
-            PoseGraphEdge currEdge(currSubmap->id, currConstraintPair.first, currConstraintPair.second.estimatedPose, informationMatrix);
+            PoseGraph::Edge currEdge(currSubmap->id, currConstraintPair.first, currConstraintPair.second.estimatedPose, informationMatrix);
             localPoseGraph.addEdge(currEdge);
         }
     }
 
     for(const auto& currSubmap : submapList)
     {
-        PoseGraphNode currNode(currSubmap->id, currSubmap->pose);
+        PoseGraph::Node currNode(currSubmap->id, currSubmap->pose);
         if(currSubmap->id == 0)
         {
             currNode.setFixed();
         }
         localPoseGraph.addNode(currNode);
     }
-
-
 
     return localPoseGraph;
 }
@@ -532,7 +529,7 @@ void SubmapManager<MatType>::PoseGraphToMap(const PoseGraph &updatedPoseGraph)
 {
     for(const auto& currSubmap : submapList)
     {
-        const PoseGraphNode& currNode = updatedPoseGraph.nodes.at(currSubmap->id);
+        const PoseGraph::Node& currNode = updatedPoseGraph.nodes.at(currSubmap->id);
         if(!currNode.isPoseFixed())
             currSubmap->pose = currNode.getPose();
         std::cout << "Current node: " << currSubmap->id << " Updated Pose: \n" << currSubmap->pose.matrix << std::endl;

--- a/modules/rgbd/test/test_pose_graph.cpp
+++ b/modules/rgbd/test/test_pose_graph.cpp
@@ -1,0 +1,55 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
+
+#include "test_precomp.hpp"
+
+namespace opencv_test { namespace {
+
+using namespace cv;
+
+TEST( PoseGraph, sphereG2O )
+{
+    //TODO: add code itself
+
+    //DEBUG
+    cv::utils::logging::setLogLevel(cv::utils::logging::LogLevel::LOG_LEVEL_INFO);
+
+    // The dataset was taken from here: https://lucacarlone.mit.edu/datasets/
+    // Connected paper:
+    // L.Carlone, R.Tron, K.Daniilidis, and F.Dellaert.
+    // Initialization Techniques for 3D SLAM : a Survey on Rotation Estimation and its Use in Pose Graph Optimization.
+    // In IEEE Intl.Conf.on Robotics and Automation(ICRA), pages 4597 - 4604, 2015.
+
+    std::string filename = cvtest::TS::ptr()->get_data_path() + "sphere_bignoise_vertex3.g2o";
+    //std::string filename = "C:\\Users\\rvasilik\\Downloads\\torus3D.g2o";
+    PoseGraph pg(filename);
+
+    //writePg(pg, "C:\\Temp\\g2opt\\in.obj");
+
+    double t0 = cv::getTickCount();
+
+    pg.optimize();
+
+    double t1 = cv::getTickCount();
+
+    std::cout << "time: " << (t1 - t0) / cv::getTickFrequency() << std::endl;
+
+    //writePg(pg, "C:\\Temp\\g2opt\\out.obj");
+
+    viz::Viz3d debug("debug");
+    std::vector<Point3d> sv, dv;
+    for (const auto& e : pg.edges)
+    {
+        size_t sid = e.sourceNodeId, tid = e.targetNodeId;
+        Point3d sp = pg.nodes.at(sid).getPose().translation();
+        Point3d tp = pg.nodes.at(tid).getPose().translation();
+        sv.push_back(sp);
+        dv.push_back(tp - sp);
+    }
+    debug.showWidget("after", viz::WCloudNormals(sv, dv, 1, 1, viz::Color::green()));
+    debug.spin();
+
+}
+
+}} // namespace

--- a/modules/rgbd/test/test_pose_graph.cpp
+++ b/modules/rgbd/test/test_pose_graph.cpp
@@ -97,6 +97,7 @@ static const bool writeToObjFile = false;
 // Turn if off if you don't need log messages
 static const bool verbose = true;
 
+#if !defined _DEBUG
 TEST( PoseGraph, sphereG2O )
 {
     // The dataset was taken from here: https://lucacarlone.mit.edu/datasets/
@@ -144,5 +145,13 @@ TEST( PoseGraph, sphereG2O )
         of.close();
     }
 }
+#else
+TEST(PoseGraph, DISABLED)
+{
+    // Disabled for Debug mode, it takes 400 sec to run test vs 15 sec in Release
+    CV_UNUSED(readG2OFile);
+}
+#endif
+
 
 }} // namespace

--- a/modules/rgbd/test/test_pose_graph.cpp
+++ b/modules/rgbd/test/test_pose_graph.cpp
@@ -143,6 +143,9 @@ TEST( PoseGraph, sphereG2O )
         of.close();
     }
 #else
+    // suppress "unused function" warning
+    (void)(&readG2OFile);
+
     throw SkipTestException("Build with Eigen required for pose graph optimization");
 #endif
 }

--- a/modules/rgbd/test/test_pose_graph.cpp
+++ b/modules/rgbd/test/test_pose_graph.cpp
@@ -92,9 +92,6 @@ static Ptr<kinfu::detail::PoseGraph> readG2OFile(const std::string& g2oFileName)
     return pg;
 }
 
-// Turn it on if you want to see resulting pose graph nodes
-static const bool writeToObjFile = false;
-
 #if !defined(_DEBUG) && defined(HAVE_EIGEN)
 TEST( PoseGraph, sphereG2O )
 {
@@ -119,7 +116,8 @@ TEST( PoseGraph, sphereG2O )
 
     ASSERT_LE(energy, 1.47723e+06); // should converge to 1.47722e+06 or less
 
-    if (writeToObjFile)
+    // Add the "--test_debug" to arguments to see resulting pose graph nodes positions
+    if (cvtest::debugLevel > 0)
     {
         // Write edge-only model of how nodes are located in space
         std::string fname = "pgout.obj";
@@ -146,7 +144,6 @@ TEST(PoseGraph, DISABLED)
 {
     // Disabled for Debug mode, it takes 400 sec to run test vs 15 sec in Release
     (void)(&readG2OFile);
-    CV_UNUSED(writeToObjFile);
 }
 #endif
 

--- a/modules/rgbd/test/test_pose_graph.cpp
+++ b/modules/rgbd/test/test_pose_graph.cpp
@@ -94,30 +94,33 @@ static Ptr<kinfu::detail::PoseGraph> readG2OFile(const std::string& g2oFileName)
 
 // Turn it on if you want to see resulting pose graph nodes
 static const bool writeToObjFile = false;
-
+// Turn if off if you don't need log messages
+static const bool verbose = true;
 
 TEST( PoseGraph, sphereG2O )
 {
-    //TODO: optional
-    cv::utils::logging::setLogLevel(cv::utils::logging::LogLevel::LOG_LEVEL_INFO);
-
     // The dataset was taken from here: https://lucacarlone.mit.edu/datasets/
     // Connected paper:
     // L.Carlone, R.Tron, K.Daniilidis, and F.Dellaert.
     // Initialization Techniques for 3D SLAM : a Survey on Rotation Estimation and its Use in Pose Graph Optimization.
     // In IEEE Intl.Conf.on Robotics and Automation(ICRA), pages 4597 - 4604, 2015.
 
-    std::string filename = cvtest::TS::ptr()->get_data_path() + "sphere_bignoise_vertex3.g2o";
+    std::string filename = cvtest::TS::ptr()->get_data_path() + "rgbd/sphere_bignoise_vertex3.g2o";
     Ptr<kinfu::detail::PoseGraph> pg = readG2OFile(filename);
 
-    double t0 = cv::getTickCount();
+    if (verbose)
+    {
+        cv::utils::logging::setLogLevel(cv::utils::logging::LogLevel::LOG_LEVEL_INFO);
+    }
 
     int iters = pg->optimize();
 
+    ASSERT_GE(iters, 0);
+    ASSERT_LE(iters, 36); // should converge in 36 iterations
 
-    double t1 = cv::getTickCount();
+    double energy = pg->calcEnergy();
 
-    std::cout << "time: " << (t1 - t0) / cv::getTickFrequency() << std::endl;
+    ASSERT_LE(energy, 1.47723e+06); // should converge to 1.47722e+06 or less
 
     if (writeToObjFile)
     {
@@ -140,7 +143,6 @@ TEST( PoseGraph, sphereG2O )
         
         of.close();
     }
-
 }
 
 }} // namespace

--- a/modules/rgbd/test/test_pose_graph.cpp
+++ b/modules/rgbd/test/test_pose_graph.cpp
@@ -95,7 +95,6 @@ static Ptr<kinfu::detail::PoseGraph> readG2OFile(const std::string& g2oFileName)
 
 TEST( PoseGraph, sphereG2O )
 {
-#ifdef HAVE_EIGEN
     // Test takes 15+ sec in Release mode and 400+ sec in Debug mode
     applyTestTag(CV_TEST_TAG_LONG, CV_TEST_TAG_DEBUG_VERYLONG);
 
@@ -108,6 +107,7 @@ TEST( PoseGraph, sphereG2O )
     std::string filename = cvtest::TS::ptr()->get_data_path() + "rgbd/sphere_bignoise_vertex3.g2o";
     Ptr<kinfu::detail::PoseGraph> pg = readG2OFile(filename);
 
+#ifdef HAVE_EIGEN
     // You may change logging level to view detailed optimization report
     // For example, set env. variable like this: OPENCV_LOG_LEVEL=INFO
 
@@ -143,9 +143,6 @@ TEST( PoseGraph, sphereG2O )
         of.close();
     }
 #else
-    // suppress "unused function" warning
-    (void)(&readG2OFile);
-
     throw SkipTestException("Build with Eigen required for pose graph optimization");
 #endif
 }

--- a/modules/rgbd/test/test_pose_graph.cpp
+++ b/modules/rgbd/test/test_pose_graph.cpp
@@ -94,8 +94,6 @@ static Ptr<kinfu::detail::PoseGraph> readG2OFile(const std::string& g2oFileName)
 
 // Turn it on if you want to see resulting pose graph nodes
 static const bool writeToObjFile = false;
-// Turn if off if you don't need log messages
-static const bool verbose = true;
 
 #if !defined(_DEBUG) && defined(HAVE_EIGEN)
 TEST( PoseGraph, sphereG2O )
@@ -109,10 +107,8 @@ TEST( PoseGraph, sphereG2O )
     std::string filename = cvtest::TS::ptr()->get_data_path() + "rgbd/sphere_bignoise_vertex3.g2o";
     Ptr<kinfu::detail::PoseGraph> pg = readG2OFile(filename);
 
-    if (verbose)
-    {
-        cv::utils::logging::setLogLevel(cv::utils::logging::LogLevel::LOG_LEVEL_INFO);
-    }
+    // You may change logging level to view detailed optimization report
+    // For example, set env. variable like this: OPENCV_LOG_LEVEL=INFO
 
     int iters = pg->optimize();
 
@@ -151,7 +147,6 @@ TEST(PoseGraph, DISABLED)
     // Disabled for Debug mode, it takes 400 sec to run test vs 15 sec in Release
     (void)(&readG2OFile);
     CV_UNUSED(writeToObjFile);
-    CV_UNUSED(verbose);
 }
 #endif
 

--- a/modules/rgbd/test/test_pose_graph.cpp
+++ b/modules/rgbd/test/test_pose_graph.cpp
@@ -149,7 +149,7 @@ TEST( PoseGraph, sphereG2O )
 TEST(PoseGraph, DISABLED)
 {
     // Disabled for Debug mode, it takes 400 sec to run test vs 15 sec in Release
-    CV_UNUSED(readG2OFile);
+    (void)(&readG2OFile);
     CV_UNUSED(writeToObjFile);
     CV_UNUSED(verbose);
 }

--- a/modules/rgbd/test/test_pose_graph.cpp
+++ b/modules/rgbd/test/test_pose_graph.cpp
@@ -97,7 +97,7 @@ static const bool writeToObjFile = false;
 // Turn if off if you don't need log messages
 static const bool verbose = true;
 
-#if !defined _DEBUG
+#if !defined(_DEBUG) && defined(HAVE_EIGEN)
 TEST( PoseGraph, sphereG2O )
 {
     // The dataset was taken from here: https://lucacarlone.mit.edu/datasets/

--- a/modules/rgbd/test/test_pose_graph.cpp
+++ b/modules/rgbd/test/test_pose_graph.cpp
@@ -92,9 +92,13 @@ static Ptr<kinfu::detail::PoseGraph> readG2OFile(const std::string& g2oFileName)
     return pg;
 }
 
-#if !defined(_DEBUG) && defined(HAVE_EIGEN)
+
 TEST( PoseGraph, sphereG2O )
 {
+#ifdef HAVE_EIGEN
+    // Test takes 15+ sec in Release mode and 400+ sec in Debug mode
+    applyTestTag(CV_TEST_TAG_LONG, CV_TEST_TAG_DEBUG_VERYLONG);
+
     // The dataset was taken from here: https://lucacarlone.mit.edu/datasets/
     // Connected paper:
     // L.Carlone, R.Tron, K.Daniilidis, and F.Dellaert.
@@ -138,14 +142,10 @@ TEST( PoseGraph, sphereG2O )
 
         of.close();
     }
-}
 #else
-TEST(PoseGraph, DISABLED)
-{
-    // Disabled for Debug mode, it takes 400 sec to run test vs 15 sec in Release
-    (void)(&readG2OFile);
-}
+    throw SkipTestException("Build with Eigen required for pose graph optimization");
 #endif
+}
 
 
 }} // namespace

--- a/modules/rgbd/test/test_pose_graph.cpp
+++ b/modules/rgbd/test/test_pose_graph.cpp
@@ -88,6 +88,8 @@ static Ptr<kinfu::detail::PoseGraph> readG2OFile(const std::string& g2oFileName)
         // Clear any trailing whitespace from the line
         infile >> std::ws;
     }
+
+    return pg;
 }
 
 // Turn it on if you want to see resulting pose graph nodes

--- a/modules/rgbd/test/test_pose_graph.cpp
+++ b/modules/rgbd/test/test_pose_graph.cpp
@@ -141,7 +141,7 @@ TEST( PoseGraph, sphereG2O )
             size_t sid = pg->getEdgeStart(i), tid = pg->getEdgeEnd(i);
             of << "l " << sid + 1 << " " << tid + 1 << std::endl;
         }
-        
+
         of.close();
     }
 }

--- a/modules/rgbd/test/test_pose_graph.cpp
+++ b/modules/rgbd/test/test_pose_graph.cpp
@@ -150,6 +150,8 @@ TEST(PoseGraph, DISABLED)
 {
     // Disabled for Debug mode, it takes 400 sec to run test vs 15 sec in Release
     CV_UNUSED(readG2OFile);
+    CV_UNUSED(writeToObjFile);
+    CV_UNUSED(verbose);
 }
 #endif
 


### PR DESCRIPTION
Pose graph from Large KinFu rewritten using manual analytic differentiation and custom LevMarq solver based on naive block sparse matrix implementation solved by Eigen library.

Connected test data PR: https://github.com/opencv/opencv_extra/pull/869

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
