### PR TITLE
ovis: add software-renderer based unit testing

### DIFF
--- a/modules/ovis/misc/python/test_ovis.py
+++ b/modules/ovis/misc/python/test_ovis.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+import os
+import numpy as np
+import cv2 as cv
+
+from tests_common import NewOpenCVTests
+#from unittest import TestCase as NewOpenCVTests
+
+
+class ovis_contrib_test(NewOpenCVTests):
+
+    def setUp(self):
+        super().setUp()
+        # use software rendering
+        os.environ["OPENCV_OVIS_RENDERSYSTEM"] = "Tiny Rendering Subsystem"
+        # in case something goes wrong
+        os.environ["OPENCV_OVIS_VERBOSE_LOG"] = "1"
+
+    def test_multiWindow(self):
+        win0 = cv.ovis.createWindow("main", (1, 1))
+        win1 = cv.ovis.createWindow("other", (1, 1))
+        del win1
+        win1 = cv.ovis.createWindow("other", (1, 1))
+        del win1
+
+    def test_addResourceLocation(self):
+        win0 = cv.ovis.createWindow("main", (1, 1))
+        with self.assertRaises(cv.error):
+            # must be called before the first createWindow
+            cv.ovis.addResourceLocation(".")
+
+    def test_texStride(self):
+        win = cv.ovis.createWindow("main", (1, 1))
+        data = np.zeros((200, 200), dtype=np.uint8)
+        cv.ovis.createPlaneMesh("plane", (1, 1), data[50:-50, 50:-50])
+
+
+if __name__ == '__main__':
+    NewOpenCVTests.bootstrap()


### PR DESCRIPTION
the last Ogre release added a self-contained Software Rendering backend, which eases testing:
https://www.ogre3d.org/2021/02/12/ogre-1-12-11-released#Software_RenderSystem

this adds unit-tests for the last two bugs I fixed in ovis. If Ogre will be installed on the runners, they could also be executed as part of the opencv test-suite.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- n/a There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
