### PR TITLE
fix: add a safe score threshold(1E-5) to wechat_qrcode detector

### DIFF
--- a/modules/wechat_qrcode/src/detector/ssd_detector.cpp
+++ b/modules/wechat_qrcode/src/detector/ssd_detector.cpp
@@ -31,7 +31,8 @@ vector<Mat> SSDDetector::forward(Mat img, const int target_width, const int targ
         const float* prob_score = prob.ptr<float>(0, 0, row);
         // prob_score[0] is not used.
         // prob_score[1]==1 stands for qrcode
-        if (prob_score[1] == 1) {
+        if (prob_score[1] == 1 && prob_score[2] > 1E-5) {
+            // add a safe score threshold due to https://github.com/opencv/opencv_contrib/issues/2877
             // prob_score[2] is the probability of the qrcode, which is not used.
             auto point = Mat(4, 2, CV_32FC1);
             float x0 = CLIP(prob_score[3] * img_w, 0.0f, img_w - 1.0f);


### PR DESCRIPTION
resolves #2877

add a safe score threshold due to https://github.com/opencv/opencv_contrib/issues/2877

<cut/>

### Pull Request Readiness Checklist


See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
