### PR TITLE
Merge 3.4

### DIFF
--- a/modules/cudaarithm/src/core.cpp
+++ b/modules/cudaarithm/src/core.cpp
@@ -163,7 +163,7 @@ void cv::cuda::flip(InputArray _src, OutputArray _dst, int flipCode, Stream& str
 
     _dst.create(src.size(), src.type());
     GpuMat dst = getOutputMat(_dst, src.size(), src.type(), stream);
-    bool isInplace = (src.data == dst.data) || (src.refcount == dst.refcount);
+    bool isInplace = (src.data == dst.data);
     bool isSizeOdd = (src.cols & 1) == 1 || (src.rows & 1) == 1;
     if (isInplace && isSizeOdd)
         CV_Error(Error::BadROISize, "In-place version of flip only accepts even width/height");


### PR DESCRIPTION
moved opencv/opencv#19823 from alalek:issue_contrib_2895

Main PR: https://github.com/opencv/opencv/pull/19835
Previous "Merge 3.4": #2898

<cut/>


<details>

```
force_builders=Custom,Win64 OpenCL
buildworker:Custom=linux-4,linux-6
build_image:Custom=ubuntu-cuda:18.04
buildworker:Win64 OpenCL=windows-2
build_image:Win64 OpenCL=msvs2019
```

</details>
