### PR TITLE
wechat_qr: disable iconv dependancy for mingw

### DIFF
--- a/modules/wechat_qrcode/src/zxing/zxing.hpp
+++ b/modules/wechat_qrcode/src/zxing/zxing.hpp
@@ -27,7 +27,7 @@
 #define USE_ONED_WRITER 1
 #endif
 
-#if defined(__ANDROID_API__)
+#if defined(__ANDROID_API__) || defined(_MSC_VER) || defined(__MINGW32__) || defined(__MINGW64__)
 
 #ifndef NO_ICONV
 #define NO_ICONV
@@ -51,15 +51,6 @@ typedef unsigned char boolean;
 }  // namespace zxing
 
 #include <limits>
-
-#if defined(_MSC_VER)
-
-#ifndef NO_ICONV
-#define NO_ICONV
-#endif
-
-#endif
-
 #include <cmath>
 
 namespace zxing {


### PR DESCRIPTION
resolves #2862

this also collapses all `#if defined(XXX)` blocks to disable iconv support into a single one

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x ] I agree to contribute to the project under Apache 2 License.
- [x ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x ] The PR is proposed to proper branch
- [x ] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
