### PR TITLE
[ximgproc::rl::createRLEImage] make 'runs' parameter as const

### DIFF
--- a/modules/ximgproc/include/opencv2/ximgproc/run_length_morphology.hpp
+++ b/modules/ximgproc/include/opencv2/ximgproc/run_length_morphology.hpp
@@ -94,7 +94,7 @@ CV_EXPORTS bool isRLMorphologyPossible(InputArray rlStructuringElement);
 * @param   size   image size (to be used if an "on" boundary should be used in erosion, using the default
 *                  means that the size is computed from the extension of the input)
 */
-CV_EXPORTS void createRLEImage(std::vector<cv::Point3i>& runs, OutputArray res, Size size = Size(0, 0));
+CV_EXPORTS void createRLEImage(const std::vector<cv::Point3i>& runs, OutputArray res, Size size = Size(0, 0));
 
 /**
 * @brief   Applies a morphological operation to a run-length encoded binary image.

--- a/modules/ximgproc/src/run_length_morphology.cpp
+++ b/modules/ximgproc/src/run_length_morphology.cpp
@@ -700,13 +700,13 @@ CV_EXPORTS bool isRLMorphologyPossible(InputArray rlStructuringElement)
   return true;
 }
 
-CV_EXPORTS void createRLEImage(std::vector<cv::Point3i>& runs, OutputArray res, Size size)
+CV_EXPORTS void createRLEImage(const std::vector<cv::Point3i>& runs, OutputArray res, Size size)
 {
     size_t nRuns = runs.size();
     rlVec runsConverted(nRuns);
     for (size_t i = 0u; i < nRuns; ++i)
     {
-        Point3i &curIn = runs[i];
+        const Point3i &curIn = runs[i];
         runsConverted[i] = rlType(curIn.x, curIn.y, curIn.z);
     }
     sortChords(runsConverted);


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
