### PR TITLE
sfm: link with Glog_LIBS

### DIFF
--- a/modules/sfm/CMakeLists.txt
+++ b/modules/sfm/CMakeLists.txt
@@ -84,6 +84,7 @@ set(LIBMV_LIGHT_LIBS
   multiview
   numeric
   ${GLOG_LIBRARIES}
+  ${Glog_LIBS}
   ${GFLAGS_LIBRARIES}
 )
 


### PR DESCRIPTION
* in 4.5.0 there was explicit linkage with GLOG_LIBRARY, but since 4.5.1 with:
  https://github.com/opencv/opencv_contrib/commit/23ee62a19b7a3e50d6dbf295359d8b1aff2e03fd

  it's gone, probably because Glog_FOUND is already set from Ceres,
  but then GLOG_LIBRARIES is empty in LIBMV_LIGHT_LIBS and build with gold fails:

FAILED: bin/example_tutorial_perspective_correction
: && TOPDIR/tmp-glibc/work/core2-64-oe-linux/opencv/4.5.2-r0/recipe-sysroot-native/usr/bin/x86_64-oe-linux/x86_64-oe-linux-g++ -m64 -march=core2 -mtune=core2 -msse3 -mfpmath=sse -ITOPDIR/tmp-glibc/work/core2-64-oe-linux/opencv/4.5.2-r0/git/include  -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security  --sysroot=TOPDIR/tmp-glibc/work/core2-64-oe-linux/opencv/4.5.2-r0/recipe-sysroot  -O2 -pipe -g -feliminate-unused-debug-types -fmacro-prefix-map=TOPDIR/tmp-glibc/work/core2-64-oe-linux/opencv/4.5.2-r0=/usr/src/debug/opencv/4.5.2-r0                      -fdebug-prefix-map=TOPDIR/tmp-glibc/work/core2-64-oe-linux/opencv/4.5.2-r0=/usr/src/debug/opencv/4.5.2-r0                      -fdebug-prefix-map=TOPDIR/tmp-glibc/work/core2-64-oe-linux/opencv/4.5.2-r0/recipe-sysroot=                      -fdebug-prefix-map=TOPDIR/tmp-glibc/work/core2-64-oe-linux/opencv/4.5.2-r0/recipe-sysroot-native=  -fvisibility-inlines-hidden  -m64 -march=core2 -mtune=core2 -msse3 -mfpmath=sse -ITOPDIR/tmp-glibc/work/core2-64-oe-linux/opencv/4.5.2-r0/git/include  -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security  --sysroot=TOPDIR/tmp-glibc/work/core2-64-oe-linux/opencv/4.5.2-r0/recipe-sysroot   -fsigned-char -W -Wall -Werror=return-type -Werror=non-virtual-dtor -Werror=address -Werror=sequence-point -Wformat -Werror=format-security -Wmissing-declarations -Wundef -Winit-self -Wpointer-arith -Wshadow -Wsign-promo -Wuninitialized -Wsuggest-override -Wno-delete-non-virtual-dtor -Wno-comment -Wimplicit-fallthrough=3 -Wno-strict-overflow -fdiagnostics-show-option -Wno-long-long -pthread -fomit-frame-pointer -ffunction-sections -fdata-sections  -msse -msse2 -msse3 -mssse3 -DNDEBUG  -DNDEBUG  -m64 -march=core2 -mtune=core2 -msse3 -mfpmath=sse -ITOPDIR/tmp-glibc/work/core2-64-oe-linux/opencv/4.5.2-r0/git/include  -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security  --sysroot=TOPDIR/tmp-glibc/work/core2-64-oe-linux/opencv/4.5.2-r0/recipe-sysroot  -O2 -pipe -g -feliminate-unused-debug-types -fmacro-prefix-map=TOPDIR/tmp-glibc/work/core2-64-oe-linux/opencv/4.5.2-r0=/usr/src/debug/opencv/4.5.2-r0                      -fdebug-prefix-map=TOPDIR/tmp-glibc/work/core2-64-oe-linux/opencv/4.5.2-r0=/usr/src/debug/opencv/4.5.2-r0                      -fdebug-prefix-map=TOPDIR/tmp-glibc/work/core2-64-oe-linux/opencv/4.5.2-r0/recipe-sysroot=                      -fdebug-prefix-map=TOPDIR/tmp-glibc/work/core2-64-oe-linux/opencv/4.5.2-r0/recipe-sysroot-native=  -fvisibility-inlines-hidden  -m64 -march=core2 -mtune=core2 -msse3 -mfpmath=sse -ITOPDIR/tmp-glibc/work/core2-64-oe-linux/opencv/4.5.2-r0/git/include  -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security  --sysroot=TOPDIR/tmp-glibc/work/core2-64-oe-linux/opencv/4.5.2-r0/recipe-sysroot -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed -Wl,-z,relro,-z,now -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed -Wl,-z,relro,-z,now  -Wl,--gc-sections -Wl,--as-needed samples/cpp/CMakeFiles/example_tutorial_perspective_correction.dir/tutorial_code/features2D/Homography/perspective_correction.cpp.o -o bin/example_tutorial_perspective_correction  -ldl  -lm  -lpthread  -lrt  lib/libopencv_gapi.so.4.5.2  lib/libopencv_stitching.so.4.5.2  lib/libopencv_ts.so.4.5.2  lib/libopencv_alphamat.so.4.5.2  lib/libopencv_aruco.so.4.5.2  lib/libopencv_bgsegm.so.4.5.2  lib/libopencv_bioinspired.so.4.5.2  lib/libopencv_ccalib.so.4.5.2  lib/libopencv_dnn_objdetect.so.4.5.2  lib/libopencv_dnn_superres.so.4.5.2  lib/libopencv_dpm.so.4.5.2  lib/libopencv_face.so.4.5.2  lib/libopencv_fuzzy.so.4.5.2  lib/libopencv_hfs.so.4.5.2  lib/libopencv_img_hash.so.4.5.2  lib/libopencv_intensity_transform.so.4.5.2  lib/libopencv_line_descriptor.so.4.5.2  lib/libopencv_mcc.so.4.5.2  lib/libopencv_quality.so.4.5.2  lib/libopencv_rapid.so.4.5.2  lib/libopencv_reg.so.4.5.2  lib/libopencv_rgbd.so.4.5.2  lib/libopencv_saliency.so.4.5.2  lib/libopencv_sfm.so.4.5.2  lib/libopencv_stereo.so.4.5.2  lib/libopencv_structured_light.so.4.5.2  lib/libopencv_superres.so.4.5.2  lib/libopencv_surface_matching.so.4.5.2  lib/libopencv_tracking.so.4.5.2  lib/libopencv_videostab.so.4.5.2  lib/libopencv_wechat_qrcode.so.4.5.2  lib/libopencv_xfeatures2d.so.4.5.2  lib/libopencv_xobjdetect.so.4.5.2  lib/libopencv_xphoto.so.4.5.2  lib/libopencv_shape.so.4.5.2  lib/libopencv_highgui.so.4.5.2  lib/libopencv_datasets.so.4.5.2  lib/libopencv_ml.so.4.5.2  lib/libopencv_plot.so.4.5.2  lib/libopencv_phase_unwrapping.so.4.5.2  lib/libopencv_optflow.so.4.5.2  lib/libopencv_ximgproc.so.4.5.2  lib/libopencv_videoio.so.4.5.2  lib/libopencv_video.so.4.5.2  lib/libopencv_dnn.so.4.5.2  lib/libopencv_imgcodecs.so.4.5.2  lib/libopencv_objdetect.so.4.5.2  lib/libopencv_calib3d.so.4.5.2  lib/libopencv_features2d.so.4.5.2  lib/libopencv_flann.so.4.5.2  lib/libopencv_photo.so.4.5.2  lib/libopencv_imgproc.so.4.5.2  lib/libopencv_core.so.4.5.2  -Wl,-rpath-link,TOPDIR/tmp-glibc/work/core2-64-oe-linux/opencv/4.5.2-r0/build/lib && :
lib/libopencv_sfm.so.4.5.2: error: undefined reference to 'google::LogMessage::LogMessage(char const*, int)'
lib/libopencv_sfm.so.4.5.2: error: undefined reference to 'google::LogMessage::stream()'
lib/libopencv_sfm.so.4.5.2: error: undefined reference to 'google::LogMessage::~LogMessage()'
lib/libopencv_sfm.so.4.5.2: error: undefined reference to 'google::kLogSiteUninitialized'
lib/libopencv_sfm.so.4.5.2: error: undefined reference to 'fLI::FLAGS_v'
lib/libopencv_sfm.so.4.5.2: error: undefined reference to 'google::InitVLOG3__(int**, int*, char const*, int)'
lib/libopencv_sfm.so.4.5.2: error: undefined reference to 'google::LogMessageFatal::LogMessageFatal(char const*, int)'
lib/libopencv_sfm.so.4.5.2: error: undefined reference to 'google::LogMessageFatal::~LogMessageFatal()'
collect2: error: ld returned 1 exit status

  Add Glog_LIBS which is set to the same value as GLOG_LIBRARIES used to be.

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
