### PR TITLE
cmake: completelly disable cnn_3dobj

### DIFF
--- a/modules/cnn_3dobj/CMakeLists.txt
+++ b/modules/cnn_3dobj/CMakeLists.txt
@@ -1,4 +1,7 @@
 set(BUILD_opencv_cnn_3dobj_INIT OFF)  # Must be disabled by default - requires custom build of Caffe.
+if(NOT BUILD_opencv_cnn_3dobj)
+  return()
+endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR})
 


### PR DESCRIPTION
- used FindGlog.cmake has buggy implementation (doesn't follow CMake policies / variable names)

relates #2923