### PR TITLE
(4.x) Merge 3.4

### DIFF
--- a/modules/cnn_3dobj/CMakeLists.txt
+++ b/modules/cnn_3dobj/CMakeLists.txt
@@ -1,4 +1,7 @@
 set(BUILD_opencv_cnn_3dobj_INIT OFF)  # Must be disabled by default - requires custom build of Caffe.
+if(NOT BUILD_opencv_cnn_3dobj)
+  return()
+endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR})
 


### PR DESCRIPTION
#2924 from alalek:cmake_completelly_disable_cnn_3dobj

Main PR: https://github.com/opencv/opencv/pull/19916
Previous "Merge 3.4": #2917

<cut/>


<details>

```
force_builders=Custom,Win64 OpenCL
buildworker:Custom=linux-4,linux-6
build_image:Custom=ubuntu-cuda:18.04
buildworker:Win64 OpenCL=windows-2
build_image:Win64 OpenCL=msvs2019
```

</details>
