### PR TITLE
Link wechat_qrcode with libiconv on MinGW

### DIFF
--- a/modules/wechat_qrcode/CMakeLists.txt
+++ b/modules/wechat_qrcode/CMakeLists.txt
@@ -1,6 +1,14 @@
 set(the_description "WeChat QR code Detector")
 ocv_define_module(wechat_qrcode opencv_core opencv_imgproc opencv_dnn WRAP java objc python js)
 
+# iconv support isn't automatic on some systems
+if(CMAKE_VERSION VERSION_GREATER "3.11")
+  find_package(Iconv QUIET)
+  if(Iconv_FOUND)
+    ocv_target_link_libraries(${the_module} Iconv::Iconv)
+  endif()
+endif()
+
 # need to change
 set(wechat_qrcode_commit_hash "a8b69ccc738421293254aec5ddb38bd523503252")
 set(hash_detect_caffemodel "238e2b2d6f3c18d6c3a30de0c31e23cf")

--- a/modules/wechat_qrcode/CMakeLists.txt
+++ b/modules/wechat_qrcode/CMakeLists.txt
@@ -6,6 +6,8 @@ if(CMAKE_VERSION VERSION_GREATER "3.11")
   find_package(Iconv QUIET)
   if(Iconv_FOUND)
     ocv_target_link_libraries(${the_module} Iconv::Iconv)
+  else()
+    ocv_target_compile_definitions(${the_module} PRIVATE "NO_ICONV=1")
   endif()
 endif()
 

--- a/modules/wechat_qrcode/src/zxing/zxing.hpp
+++ b/modules/wechat_qrcode/src/zxing/zxing.hpp
@@ -27,7 +27,7 @@
 #define USE_ONED_WRITER 1
 #endif
 
-#if defined(__ANDROID_API__) || defined(_MSC_VER) || defined(__MINGW32__) || defined(__MINGW64__)
+#if defined(__ANDROID_API__) || defined(_MSC_VER)
 
 #ifndef NO_ICONV
 #define NO_ICONV


### PR DESCRIPTION
This PR is an alternate approach that fixes #2862, and partially reverts #2916 (with original submitter @berak's approval).

Instead of disabling `wechat_qrcode`'s use of `iconv` in MinGW environments, the module simply needs to be linked with the external library `libiconv`, which is packaged and available as part of the MSYS2 collection.

(On POSIX systems `iconv` is built into libc, but on others it's provided by an external library.)

Fortunately, since CMake 3.11 the standard module `FindIconv.cmake` has been included in the distribution that can handle linking with libiconv if necessary on the target system.

The use of `FindIconv.cmake` is safe on POSIX systems; on my Fedora box it simply noted that iconv is built in to the C library and fell through harmlessly:
```text
-- Performing Test Iconv_IS_BUILT_IN
-- Performing Test Iconv_IS_BUILT_IN - Success
-- wechat_qrcode: Download: detect.caffemodel
-- wechat_qrcode: Download: detect.prototxt
-- wechat_qrcode: Download: sr.caffemodel
-- wechat_qrcode: Download: sr.prototxt
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [X] There is reference to original bug report and related work
#### N/A:
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
