### PR TITLE
Divide by zero error in SEEDS Superpixels #2935

### DIFF
--- a/modules/ximgproc/src/seeds.cpp
+++ b/modules/ximgproc/src/seeds.cpp
@@ -136,8 +136,8 @@ private:
     //compute initial label for sublevels: level <= seeds_top_level
     //this is an equally sized grid with size nr_h[level]*nr_w[level]
     int computeLabel(int level, int x, int y) {
-        return std::min(y * nr_wh[2 * level + 1] / height), nr_wh[2 * level + 1] - 1) * nr_wh[2 * level]
-            + std::min((x * nr_wh[2 * level] / width)), nr_wh[2 * level] - 1);
+        return std::min(y * nr_wh[2 * level + 1] / height, nr_wh[2 * level + 1] - 1) * nr_wh[2 * level]
+            + std::min(x * nr_wh[2 * level] / width, nr_wh[2 * level] - 1);
     }
     inline int nrLabels(int level) const {
         return nr_wh[2 * level + 1] * nr_wh[2 * level];

--- a/modules/ximgproc/src/seeds.cpp
+++ b/modules/ximgproc/src/seeds.cpp
@@ -136,8 +136,8 @@ private:
     //compute initial label for sublevels: level <= seeds_top_level
     //this is an equally sized grid with size nr_h[level]*nr_w[level]
     int computeLabel(int level, int x, int y) {
-        return std::min(y / (height / nr_wh[2 * level + 1]), nr_wh[2 * level + 1] - 1) * nr_wh[2 * level]
-                + std::min((x / (width / nr_wh[2 * level])), nr_wh[2 * level] - 1);
+        return std::min(y * nr_wh[2 * level + 1] / height), nr_wh[2 * level + 1] - 1) * nr_wh[2 * level]
+            + std::min((x * nr_wh[2 * level] / width)), nr_wh[2 * level] - 1);
     }
     inline int nrLabels(int level) const {
         return nr_wh[2 * level + 1] * nr_wh[2 * level];


### PR DESCRIPTION
resolves #2935

When processing a large number of images, a program crash can occur with a divide by zero error in the above function. Changing the order of multiplication / division avoids a division by zero.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
