### PR TITLE
Sanity check tutorial_charuco_create_detect.cpp::readCameraParameters()

### DIFF
--- a/modules/aruco/samples/tutorial_charuco_create_detect.cpp
+++ b/modules/aruco/samples/tutorial_charuco_create_detect.cpp
@@ -21,7 +21,7 @@ static bool readCameraParameters(std::string filename, cv::Mat& camMatrix, cv::M
         return false;
     fs["camera_matrix"] >> camMatrix;
     fs["distortion_coefficients"] >> distCoeffs;
-    return camMatrix.size() == Size(5, 3);
+    return (camMatrix.size() == cv::Size(3, 3)) && (distCoeffs.size() == cv::Size(1,5));
 }
 
 void createBoard()

--- a/modules/aruco/samples/tutorial_charuco_create_detect.cpp
+++ b/modules/aruco/samples/tutorial_charuco_create_detect.cpp
@@ -21,7 +21,7 @@ static bool readCameraParameters(std::string filename, cv::Mat& camMatrix, cv::M
         return false;
     fs["camera_matrix"] >> camMatrix;
     fs["distortion_coefficients"] >> distCoeffs;
-    return (camMatrix.size() == cv::Size(3,3) && distCoeffs.size() == cv::Size(5,1));
+    return (camMatrix.size() == cv::Size(3,3)) ;
 }
 
 void createBoard()

--- a/modules/aruco/samples/tutorial_charuco_create_detect.cpp
+++ b/modules/aruco/samples/tutorial_charuco_create_detect.cpp
@@ -21,7 +21,7 @@ static bool readCameraParameters(std::string filename, cv::Mat& camMatrix, cv::M
         return false;
     fs["camera_matrix"] >> camMatrix;
     fs["distortion_coefficients"] >> distCoeffs;
-    return true;
+    return camMatrix.size() == Size(5, 3);
 }
 
 void createBoard()

--- a/modules/aruco/samples/tutorial_charuco_create_detect.cpp
+++ b/modules/aruco/samples/tutorial_charuco_create_detect.cpp
@@ -21,7 +21,7 @@ static bool readCameraParameters(std::string filename, cv::Mat& camMatrix, cv::M
         return false;
     fs["camera_matrix"] >> camMatrix;
     fs["distortion_coefficients"] >> distCoeffs;
-    return (camMatrix.size() == cv::Size(3, 3)) && (distCoeffs.size() == cv::Size(1,5));
+    return (camMatrix.size().width == 3) && (distCoeffs.size().width == 5);
 }
 
 void createBoard()

--- a/modules/aruco/samples/tutorial_charuco_create_detect.cpp
+++ b/modules/aruco/samples/tutorial_charuco_create_detect.cpp
@@ -21,7 +21,7 @@ static bool readCameraParameters(std::string filename, cv::Mat& camMatrix, cv::M
         return false;
     fs["camera_matrix"] >> camMatrix;
     fs["distortion_coefficients"] >> distCoeffs;
-    return (camMatrix.size().width == 3) && (distCoeffs.size().width == 5);
+    return (camMatrix.size() == cv::Size(3,3) && distCoeffs.size() == cv::Size(5,1));
 }
 
 void createBoard()


### PR DESCRIPTION
Check for successful read of `camera_matrix` and `distortion_coefficients` parameters in readCameraParameters()

If the filename exists, but the values are not read, the routine used to return true with empty matricies.  This changes to check if each matrix has a reasonable dimension.

The tutorial file should be robust against bad inputs and help learners recognize and identify problems.

This should solve https://github.com/opencv/opencv_contrib/issues/2949

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
