### PR TITLE
Removed check for cascade_face as it is not used.

### DIFF
--- a/modules/face/src/facemarkLBF.cpp
+++ b/modules/face/src/facemarkLBF.cpp
@@ -332,9 +332,9 @@ void FacemarkLBFImpl::training(void* parameters){
         CV_Error(Error::StsBadArg, "Training data is not provided. Consider to add using addTrainingSample() function!");
     }
 
-    if (params.cascade_face.empty() || (params.model_filename.empty() && params.save_model))
+    if (params.model_filename.empty() && params.save_model)
     {
-        CV_Error(Error::StsBadArg, "The parameter cascade_face and model_filename should be set!");
+        CV_Error(Error::StsBadArg, "The parameter model_filename should be set!");
     }
 
     // flip the image and swap the landmark position


### PR DESCRIPTION
Original issue: #2130

The cascade_face parameter is only used by the default face detector, which already complains if the parameter is not set.

## Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

Not sure how to determine the appropriate branch.
There is no applicable testing data in opencv_extra.
