### PR TITLE
Do conversion to grayscale after face detection.

### DIFF
--- a/modules/face/src/facemarkLBF.cpp
+++ b/modules/face/src/facemarkLBF.cpp
@@ -535,13 +535,14 @@ Rect FacemarkLBFImpl::getBBox(Mat &img, const Mat_<double> shape) {
 void FacemarkLBFImpl::prepareTrainingData(Mat img, std::vector<Point2f> facePoints,
     std::vector<Mat> & cropped, std::vector<Mat> & shapes, std::vector<BBox> &boxes)
 {
+    Mat shape;
+    Mat _shape = Mat(facePoints).reshape(1);
+    Rect box = getBBox(img, _shape);
+
     if(img.channels()>1){
         cvtColor(img,img,COLOR_BGR2GRAY);
     }
 
-    Mat shape;
-    Mat _shape = Mat(facePoints).reshape(1);
-    Rect box = getBBox(img, _shape);
     if(box.x != -1){
         _shape.convertTo(shape, CV_64FC1);
         Mat sx = shape.col(0);


### PR DESCRIPTION
#2129

The proposed change would convert the training image to grayscale AFTER running the face detector. The default face detector already converts the images to grayscale and a custom detector should be able to decide if it want to use grayscale/color images.

I've kept the conversion itself as I'm not sure if the actual training requires grayscale images.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
