### PR TITLE
Date type fixer

### DIFF
--- a/modules/wechat_qrcode/src/zxing/common/unicomblock.cpp
+++ b/modules/wechat_qrcode/src/zxing/common/unicomblock.cpp
@@ -16,8 +16,8 @@ UnicomBlock::~UnicomBlock() {}
 
 void UnicomBlock::Init() {
     if (m_bInit) return;
-    m_vcIndex = std::vector<unsigned short>(m_iHeight * m_iWidth, 0);
-    m_vcCount = std::vector<unsigned short>(m_iHeight * m_iWidth, 0);
+    m_vcIndex = std::vector<unsigned int>(m_iHeight * m_iWidth, 0);
+    m_vcCount = std::vector<unsigned int>(m_iHeight * m_iWidth, 0);
     m_vcMinPnt = std::vector<int>(m_iHeight * m_iWidth, 0);
     m_vcMaxPnt = std::vector<int>(m_iHeight * m_iWidth, 0);
     m_vcQueue = std::vector<int>(m_iHeight * m_iWidth, 0);

--- a/modules/wechat_qrcode/src/zxing/common/unicomblock.hpp
+++ b/modules/wechat_qrcode/src/zxing/common/unicomblock.hpp
@@ -32,10 +32,10 @@ private:
     int m_iHeight;
     int m_iWidth;
 
-    unsigned short m_iNowIdx;
+    unsigned int m_iNowIdx;
     bool m_bInit;
-    std::vector<unsigned short> m_vcIndex;
-    std::vector<unsigned short> m_vcCount;
+    std::vector<unsigned int> m_vcIndex;
+    std::vector<unsigned int> m_vcCount;
     std::vector<int> m_vcMinPnt;
     std::vector<int> m_vcMaxPnt;
     std::vector<int> m_vcQueue;


### PR DESCRIPTION
Fixes #2911

When the hand is covered, there are too many unicomblock, which resulting in a large `m_iNowIdx`, but the data type is`  unsigned short`,  make data overflow to zero.

https://github.com/opencv/opencv_contrib/blob/8eec886808b1352cdb746772ef6e001ff83d2774/modules/wechat_qrcode/src/zxing/common/unicomblock.hpp#L35

and it will fall into an infinite loop:
https://github.com/opencv/opencv_contrib/blob/8eec886808b1352cdb746772ef6e001ff83d2774/modules/wechat_qrcode/src/zxing/common/unicomblock.cpp#L103

so we need modify data type from `unsigned short`  to `unsigned int`.


```
force_builders=linux,docs
```