### PR TITLE
Make aruco board ids field accessible from python

### DIFF
--- a/modules/aruco/include/opencv2/aruco.hpp
+++ b/modules/aruco/include/opencv2/aruco.hpp
@@ -281,6 +281,18 @@ class CV_EXPORTS_W Board {
     *
     */
     CV_WRAP static Ptr<Board> create(InputArrayOfArrays objPoints, const Ptr<Dictionary> &dictionary, InputArray ids);
+
+    /**
+    * @brief Set ids vector
+    *
+    * @param ids vector of the identifiers of the markers in the board (should be the same size
+    * as objPoints)
+    *
+    * Recommended way to set ids vector, which will fail if the size of ids does not match size
+     * of objPoints.
+    */
+    CV_WRAP void setIds(InputArray ids);
+
     /// array of object points of all the marker corners in the board
     /// each marker include its 4 corners in CCW order. For M markers, the size is Mx4.
     CV_PROP std::vector< std::vector< Point3f > > objPoints;
@@ -290,7 +302,7 @@ class CV_EXPORTS_W Board {
 
     /// vector of the identifiers of the markers in the board (same size than objPoints)
     /// The identifiers refers to the board dictionary
-    CV_PROP std::vector< int > ids;
+    CV_PROP_RW std::vector< int > ids;
 };
 
 

--- a/modules/aruco/misc/python/test/test_aruco.py
+++ b/modules/aruco/misc/python/test/test_aruco.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+# Python 2/3 compatibility
+from __future__ import print_function
+
+import os, numpy as np
+
+import cv2 as cv
+
+from tests_common import NewOpenCVTests
+
+class aruco_test(NewOpenCVTests):
+
+    def test_idsAccessibility(self):
+
+        ids = np.array([[elem] for elem in range(17)])
+        rev_ids = np.array(list(reversed(ids)))
+
+        aruco_dict  = cv.aruco.Dictionary_get(cv.aruco.DICT_5X5_250)
+        board = cv.aruco.CharucoBoard_create(7, 5, 1, 0.5, aruco_dict)
+
+        self.assertTrue(np.equal(board.ids, ids).all())
+
+        board.ids = rev_ids
+        self.assertTrue(np.equal(board.ids, rev_ids).all())
+
+        board.setIds(ids)
+        self.assertTrue(np.equal(board.ids, ids).all())
+
+        with self.assertRaises(cv.error):
+            board.setIds(np.array([0]))
+
+if __name__ == '__main__':
+    NewOpenCVTests.bootstrap()

--- a/modules/aruco/src/aruco.cpp
+++ b/modules/aruco/src/aruco.cpp
@@ -1661,6 +1661,13 @@ Ptr<Board> Board::create(InputArrayOfArrays objPoints, const Ptr<Dictionary> &di
 
 /**
  */
+void Board::setIds(InputArray ids_) {
+    CV_Assert(objPoints.size() == ids_.total());
+    ids_.copyTo(this->ids);
+}
+
+/**
+ */
 Ptr<GridBoard> GridBoard::create(int markersX, int markersY, float markerLength, float markerSeparation,
                             const Ptr<Dictionary> &dictionary, int firstMarker) {
 


### PR DESCRIPTION
Fixing https://github.com/opencv/opencv-python/issues/451.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [X] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
