### PR TITLE
fuzzy: fix memleaks

### DIFF
--- a/modules/fuzzy/src/fuzzy_F0_math.cpp
+++ b/modules/fuzzy/src/fuzzy_F0_math.cpp
@@ -122,9 +122,13 @@ void ft::FT02D_FL_process(InputArray matrix, const int radius, OutputArray outpu
     int output_height = matrix.rows();
     int output_width = matrix.cols();
 
-    uchar *img_r = new uchar[output_height * output_width];
-    uchar *img_g = new uchar[output_height * output_width];
-    uchar *img_b = new uchar[output_height * output_width];
+    Mat compR(output_height, output_width, CV_8UC1);
+    Mat compG(output_height, output_width, CV_8UC1);
+    Mat compB(output_height, output_width, CV_8UC1);
+
+    uchar *img_r = compR.ptr();
+    uchar *img_g = compG.ptr();
+    uchar *img_b = compB.ptr();
 
     for (int y = 0; y < output_height; y++)
     {
@@ -157,10 +161,6 @@ void ft::FT02D_FL_process(InputArray matrix, const int radius, OutputArray outpu
             pos_iFT++;
         }
     }
-
-    Mat compR(output_height, output_width, CV_8UC1, img_r);
-    Mat compG(output_height, output_width, CV_8UC1, img_g);
-    Mat compB(output_height, output_width, CV_8UC1, img_b);
 
     std::vector<Mat> oComp;
 
@@ -250,9 +250,13 @@ void ft::FT02D_FL_process_float(InputArray matrix, const int radius, OutputArray
     int output_height = matrix.rows();
     int output_width = matrix.cols();
 
-    float *img_r = new float[output_height * output_width];
-    float *img_g = new float[output_height * output_width];
-    float *img_b = new float[output_height * output_width];
+    Mat compR(output_height, output_width, CV_32FC1);
+    Mat compG(output_height, output_width, CV_32FC1);
+    Mat compB(output_height, output_width, CV_32FC1);
+
+    float *img_r = compR.ptr<float>();
+    float *img_g = compG.ptr<float>();
+    float *img_b = compB.ptr<float>();
 
     for (int y = 0; y < output_height; y++)
     {
@@ -285,10 +289,6 @@ void ft::FT02D_FL_process_float(InputArray matrix, const int radius, OutputArray
             pos_iFT++;
         }
     }
-
-    Mat compR(output_height, output_width, CV_32FC1, img_r);
-    Mat compG(output_height, output_width, CV_32FC1, img_g);
-    Mat compB(output_height, output_width, CV_32FC1, img_b);
 
     std::vector<Mat> oComp;
 


### PR DESCRIPTION
resolves #2977 

using cv::Mat instead of the prev. `new` allocations, since we need Mat later for cv::merge()

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
