### PR TITLE
julia - Fix type conversion bug

### DIFF
--- a/modules/julia/gen/jl_cxx_files/types_conversion.jl
+++ b/modules/julia/gen/jl_cxx_files/types_conversion.jl
@@ -40,6 +40,17 @@ function julia_to_cpp(var::Array{Vec{T, N}, 1}) where {T, N}
     return ret
 end
 
+function julia_to_cpp(var::Array{T}) where {T}
+    if size(var, 1) == 0
+        return CxxWrap.StdVector{T}()
+    end
+    ret = CxxWrap.StdVector{typeof(julia_to_cpp(var[1]))}()
+    for x in var
+        push!(ret, julia_to_cpp(x))
+    end
+    return ret
+end
+
 function cpp_to_julia(var::CxxWrap.StdVector{T}) where {T <: CxxScalar}
     ret = Array{Scalar, 1}()
     for x in var
@@ -50,6 +61,17 @@ end
 
 function cpp_to_julia(var::CxxWrap.StdVector{CxxVec{T, N}}) where {T, N}
     ret = Array{Vec{T, N}, 1}()
+    for x in var
+        push!(ret, cpp_to_julia(x))
+    end
+    return ret
+end
+
+function cpp_to_julia(var::CxxWrap.StdVector{T}) where {T}
+    if size(var, 1) == 0
+        return Array{T}()
+    end
+    ret = Array{typeof(cpp_to_julia(var[1])), 1}()
     for x in var
         push!(ret, cpp_to_julia(x))
     end


### PR DESCRIPTION
Fix bug in type conversion in Julia bindings. Previously calling certain functions like `imwrite` will result in an error which this fixes.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
