### PR TITLE
Do not use = 0 for a cv::Mat.

### DIFF
--- a/modules/bgsegm/src/synthetic_seq.cpp
+++ b/modules/bgsegm/src/synthetic_seq.cpp
@@ -206,7 +206,7 @@ void SyntheticSequenceGenerator::getNextFrame(OutputArray _frame, OutputArray _g
 
     _gtMask.create(sz, CV_8U);
     Mat gtMask = _gtMask.getMat();
-    gtMask = 0;
+    gtMask.setTo(cv::Scalar::all(0));
     gtMask(Rect(Point2i(pos), objSz)) = 255;
 
     pos += dir * objspeed;

--- a/modules/img_hash/src/radial_variance_hash.cpp
+++ b/modules/img_hash/src/radial_variance_hash.cpp
@@ -276,9 +276,9 @@ public:
         //Different with PHash, this part reverse the row size and col size,
         //because cv::Mat is row major but not column major
         projections_.create(numOfAngelLine_, D, CV_8U);
-        projections_ = 0;
+        projections_.setTo(cv::Scalar::all(0));
         pixPerLine_.create(1, numOfAngelLine_, CV_32S);
-        pixPerLine_ = 0;
+        pixPerLine_.setTo(cv::Scalar::all(0));
         int const xOff = createOffSet(input.cols);
         int const yOff = createOffSet(input.rows);
 

--- a/modules/text/src/erfilter.cpp
+++ b/modules/text/src/erfilter.cpp
@@ -4030,8 +4030,8 @@ void MSERsToERStats(InputArray image, vector<vector<Point> > &contours, vector<v
       mser_regions[1].push_back(cser);
     }
 
-    mask(cser.rect) = 0;
-    mtmp(cser.rect) = 0;
+    mask(cser.rect).setTo(cv::Scalar::all(0));
+    mtmp(cser.rect).setTo(cv::Scalar::all(0));
   }
 }
 

--- a/modules/xfeatures2d/src/pct_signatures/pct_clusterizer.cpp
+++ b/modules/xfeatures2d/src/pct_signatures/pct_clusterizer.cpp
@@ -146,10 +146,10 @@ namespace cv
                     {
                         // Prepare space for new centroid values.
                         Mat tmpCentroids(clusters.size(), clusters.type());
-                        tmpCentroids = 0;
+                        tmpCentroids.setTo(cv::Scalar::all(0));
 
                         // Clear weights for new iteration.
-                        clusters(Rect(WEIGHT_IDX, 0, 1, clusters.rows)) = 0;
+                        clusters(Rect(WEIGHT_IDX, 0, 1, clusters.rows)).setTo(cv::Scalar::all(0));
 
                         // Compute affiliation of points and sum new coordinates for centroids.
                         for (int iSample = 0; iSample < samples.rows; iSample++)

--- a/modules/ximgproc/src/fast_line_detector.cpp
+++ b/modules/ximgproc/src/fast_line_detector.cpp
@@ -513,8 +513,8 @@ void FastLineDetectorImpl::lineDetection(const Mat& src, std::vector<SEGMENT>& s
     {
         Canny(src, canny, canny_th1, canny_th2, canny_aperture_size);
     }
-    canny.colRange(0,6).rowRange(0,6) = 0;
-    canny.colRange(src.cols-5,src.cols).rowRange(src.rows-5,src.rows) = 0;
+    canny.colRange(0,6).rowRange(0,6).setTo(cv::Scalar::all(0));
+    canny.colRange(src.cols-5,src.cols).rowRange(src.rows-5,src.rows).setTo(cv::Scalar::all(0));
 
     SEGMENT seg, seg1, seg2;
 


### PR DESCRIPTION
There are several operator= overloads and some compilers can be confused.

This is similar to https://github.com/opencv/opencv/pull/20304 but for opencv_contrib

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work