### PR TITLE
Do not use = 0 for a cv::Mat.

### DIFF
--- a/modules/alphamat/src/cm.cpp
+++ b/modules/alphamat/src/cm.cpp
@@ -90,9 +90,9 @@ void lle(my_vector_of_vectors_t& indm, my_vector_of_vectors_t& samples, float ep
     Mat ptDotN(20, 1, DataType<float>::type), imd(20, 1, DataType<float>::type);
     Mat Cones(20, 1, DataType<float>::type), Cinv(20, 1, DataType<float>::type);
     float alpha, beta, lagrangeMult;
-    Cones = 1;
+    Cones.setTo(cv::Scalar::all(1));
 
-    C = 0;
+    C.setTo(cv::Scalar::all(0));
     rhs = 1;
 
     int i, ind = 0;


### PR DESCRIPTION
There are several operator= overloads and some compilers can be confused.

This is similar to opencv/opencv#20304 and https://github.com/opencv/opencv_contrib/pull/2987 but for opencv_contrib master.


- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
