### PR TITLE
Add letterbox resize feature

### DIFF
--- a/modules/ximgproc/README.md
+++ b/modules/ximgproc/README.md
@@ -16,3 +16,4 @@ Extended Image Processing
 - Pei&Lin Normalization
 - Ridge Detection Filter
 - Binary morphology on run-length encoded images
+- Letterbox resize

--- a/modules/ximgproc/include/opencv2/ximgproc.hpp
+++ b/modules/ximgproc/include/opencv2/ximgproc.hpp
@@ -60,6 +60,7 @@
 #include "ximgproc/run_length_morphology.hpp"
 #include "ximgproc/edgepreserving_filter.hpp"
 #include "ximgproc/color_match.hpp"
+#include "ximgproc/letterbox_resize.hpp"
 
 
 /** @defgroup ximgproc Extended Image Processing
@@ -207,6 +208,22 @@ CV_EXPORTS_W void thinning( InputArray src, OutputArray dst, int thinningType = 
  @param niters The number of iterations
 */
 CV_EXPORTS_W void anisotropicDiffusion(InputArray src, OutputArray dst, float alpha, float K, int niters );
+
+
+/** @brief Performs letterbox resize of an image 
+
+The function resizes the input image by maintaining its aspect ratio. It then pads the image using the specified
+padding method to change it to the specified output size.  
+
+@param src               Source image
+@param dst               Destination image
+@param dSize             Size of the destination image
+@param interpolation     Interpolation method, see cv::InterpolationFlags
+@param borderType        Border type, see cv::BorderTypes
+@param value             Border value if borderType == BORDER_CONSTANT 
+*/
+
+CV_EXPORTS_W void letterboxResize(InputArray _src, OutputArray _dst, Size dSize, int interpolation, int borderType, Scalar value);
 
 //! @}
 

--- a/modules/ximgproc/include/opencv2/ximgproc/letterbox_resize.hpp
+++ b/modules/ximgproc/include/opencv2/ximgproc/letterbox_resize.hpp
@@ -1,0 +1,16 @@
+#ifndef __OPENCV_XIMGPROC_LETTERBOXRESIZE_HPP__
+#define __OPENCV_XIMGPROC_LETTERBOXRESIZE_HPP__
+
+#include <opencv2/core.hpp>
+
+namespace cv 
+{ 
+  namespace ximgproc 
+  {
+
+    void letterboxResize(InputArray _src, OutputArray _dst, Size dsize, int interpolation, int paddingMethod, int blueChannelValue, int greenChannelValue, int redChannelValue);  
+
+  }
+}
+
+#endif

--- a/modules/ximgproc/samples/letterbox_resize.py
+++ b/modules/ximgproc/samples/letterbox_resize.py
@@ -1,0 +1,13 @@
+import cv2
+
+# Read the image
+img = cv2.imread('opencv-4.5.2/samples/data/fruits.jpg')
+
+# Execute letterbox resize
+test = cv2.ximgproc.letterboxResize(img, (300, 600), 1, 0, (128, 0, 0))
+
+# Display the image
+cv2.imshow('test', test)
+
+# Wait till keypress
+cv2.waitKey(0)

--- a/modules/ximgproc/src/letterbox_resize.cpp
+++ b/modules/ximgproc/src/letterbox_resize.cpp
@@ -1,0 +1,107 @@
+/*
+ *  By downloading, copying, installing or using the software you agree to this license.
+ *  If you do not agree to this license, do not download, install,
+ *  copy or use the software.
+ *  
+ *  
+ *  License Agreement
+ *  For Open Source Computer Vision Library
+ *  (3 - clause BSD License)
+ *  
+ *  Redistribution and use in source and binary forms, with or without modification,
+ *  are permitted provided that the following conditions are met :
+ *  
+ *  * Redistributions of source code must retain the above copyright notice,
+ *  this list of conditions and the following disclaimer.
+ *  
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and / or other materials provided with the distribution.
+ *  
+ *  * Neither the names of the copyright holders nor the names of the contributors
+ *  may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *  
+ *  This software is provided by the copyright holders and contributors "as is" and
+ *  any express or implied warranties, including, but not limited to, the implied
+ *  warranties of merchantability and fitness for a particular purpose are disclaimed.
+ *  In no event shall copyright holders or contributors be liable for any direct,
+ *  indirect, incidental, special, exemplary, or consequential damages
+ *  (including, but not limited to, procurement of substitute goods or services;
+ *  loss of use, data, or profits; or business interruption) however caused
+ *  and on any theory of liability, whether in contract, strict liability,
+ *  or tort(including negligence or otherwise) arising in any way out of
+ *  the use of this software, even if advised of the possibility of such damage.
+ */
+
+#include "precomp.hpp"
+
+namespace cv{
+  namespace ximgproc{
+
+    // Function prototype
+    void letterboxResize(InputArray _src, OutputArray _dst, Size dSize, int interpolation, int borderType, Scalar value);
+
+    // Function implementation
+    void letterboxResize(InputArray _src, OutputArray _dst, Size dSize, int interpolation, int borderType, Scalar value)
+    {
+ 
+      double scale       = 0;
+      int    dWidth       = 0;
+      int    dHeight      = 0;
+      int    sWidth       = 0;
+      int    sHeight      = 0;
+      int    newWidth    = 0;
+      int    newHeight   = 0;
+      int    deltaWidth  = 0;
+      int    deltaHeight = 0;
+      int    top         = 0;
+      int    bottom      = 0;
+      int    left        = 0;
+      int    right       = 0;
+
+      CV_Assert( !dSize.empty() );
+      dWidth = dSize.width;
+      dHeight = dSize.height;
+
+      Size ssize = _src.size();
+      CV_Assert( !ssize.empty() );
+      sWidth = ssize.width;
+      sHeight = ssize.height;
+
+      // Calculate scale as minimum of width/matWidth and height/matHeight
+      scale = (double) dWidth / sWidth;
+      if (scale > (double) dHeight / sHeight)
+      {
+        scale = (double) dHeight / sHeight;
+      }
+
+      // Calculate new width and height using scale
+      newWidth = (int) (scale * sWidth);
+      newHeight = (int) (scale * sHeight);
+
+      Size rsize = Size(newWidth, newHeight);
+
+      // Resize image to newWidth and newHeight
+      Mat src = _src.getMat();
+
+      cv::resize( src, src, rsize, 0, 0, interpolation ); 
+
+      // Calculate border sizes
+      deltaWidth = dWidth - newWidth;
+      deltaHeight = dHeight - newHeight;
+
+      top = floor(deltaHeight / 2);
+      bottom = deltaHeight - top;
+
+      left = floor(deltaWidth / 2);
+      right = deltaWidth - left;
+
+      _dst.create(dSize, src.type());
+      Mat dst = _dst.getMat();
+      
+      cv::copyMakeBorder( src, dst, top, bottom, left, right, borderType, value );
+
+    }
+  }
+}

--- a/modules/ximgproc/test/test_letterbox_resize.cpp
+++ b/modules/ximgproc/test/test_letterbox_resize.cpp
@@ -1,0 +1,33 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+#include "test_precomp.hpp"
+
+namespace opencv_test { namespace {
+
+TEST(ximgproc_letterboxResize, regression)
+{
+    string img_path = string(cvtest::TS::ptr()->get_data_path()) + "fruits.jpg";
+
+    Mat original = imread(img_path, IMREAD_COLOR);
+
+    ASSERT_FALSE(original.empty()) << "Could not load input image " << img_path;
+
+    Mat result;
+    Size dsize;
+    dsize.width = 400;
+    dsize.height = 200;
+
+    int interpolation = 0;
+    int borderType = 0;
+    Scalar value = {128, 128, 128};
+
+    ximgproc::letterboxResize(original, result, dsize, interpolation, borderType, value);
+
+    Size rsize = result.size();
+
+    ASSERT_TRUE(rsize.width == dsize.width);
+    ASSERT_TRUE(rsize.height == dsize.height);
+}
+
+}} // namespace


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [X] There is reference to original bug report and related work
- [X] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X] The feature is well documented and sample code can be built with the project CMake

--

This PR adds a new letterbox resize function in ximgproc. For machine learning models, images often need to be resized to specific dimensions (width x height). In many cases, it is important to maintain the aspect ratio of an image while resizing. The image then needs to be padded either horizontally or vertically to change it to the specified size. See this page for an example: https://en.wikipedia.org/wiki/Letterboxing_(filming)

The new letterboxResize function performs resize while maintaining the aspect ratio, and pads (adds border to) the image to change it to the specified size.
