### PR TITLE
surface matching

### DIFF
--- a/modules/surface_matching/src/ppf_match_3d.cpp
+++ b/modules/surface_matching/src/ppf_match_3d.cpp
@@ -366,6 +366,13 @@ void PPF3DDetector::clusterPoses(std::vector<Pose3DPtr>& poseList, int numPoses,
       tAvg *= 1.0 / wSum;
       qAvg *= 1.0 / wSum;
 
+      // normalize quantonion
+      const double qNorm = cv::norm(qAvg);
+      if (qNorm > EPS)
+      {
+        qAvg *= 1.0 / qNorm;
+      }
+
       curPoses[0]->updatePoseQuat(qAvg, tAvg);
       curPoses[0]->numVotes=curCluster->numVotes;
 
@@ -396,6 +403,13 @@ void PPF3DDetector::clusterPoses(std::vector<Pose3DPtr>& poseList, int numPoses,
 
       tAvg *= 1.0 / curSize;
       qAvg *= 1.0 / curSize;
+
+      // normalize quantonion
+      const double qNorm = cv::norm(qAvg);
+      if (qNorm > EPS)
+      {
+        qAvg *= 1.0 / qNorm;
+      }
 
       curPoses[0]->updatePoseQuat(qAvg, tAvg);
       curPoses[0]->numVotes=curCluster->numVotes;

--- a/modules/surface_matching/src/ppf_match_3d.cpp
+++ b/modules/surface_matching/src/ppf_match_3d.cpp
@@ -365,12 +365,6 @@ void PPF3DDetector::clusterPoses(std::vector<Pose3DPtr>& poseList, int numPoses,
 
       tAvg *= 1.0 / wSum;
       qAvg *= 1.0 / wSum;
-      // normalize quantonion
-      const double qNorm = cv::norm(qAvg);
-      if (qNorm > EPS)
-      {
-        qAvg *= 1.0 / qNorm;
-      }
 
       curPoses[0]->updatePoseQuat(qAvg, tAvg);
       curPoses[0]->numVotes=curCluster->numVotes;
@@ -402,13 +396,6 @@ void PPF3DDetector::clusterPoses(std::vector<Pose3DPtr>& poseList, int numPoses,
 
       tAvg *= 1.0 / curSize;
       qAvg *= 1.0 / curSize;
-
-      // normalize quantonion
-      const double qNorm = cv::norm(qAvg);
-      if (qNorm > EPS)
-      {
-        qAvg *= 1.0 / qNorm;
-      }
 
       curPoses[0]->updatePoseQuat(qAvg, tAvg);
       curPoses[0]->numVotes=curCluster->numVotes;

--- a/modules/surface_matching/src/ppf_match_3d.cpp
+++ b/modules/surface_matching/src/ppf_match_3d.cpp
@@ -365,6 +365,12 @@ void PPF3DDetector::clusterPoses(std::vector<Pose3DPtr>& poseList, int numPoses,
 
       tAvg *= 1.0 / wSum;
       qAvg *= 1.0 / wSum;
+      // normalize quantonion
+      const double qNorm = cv::norm(qAvg);
+      if (qNorm > EPS)
+      {
+        qAvg *= 1.0 / qNorm;
+      }
 
       curPoses[0]->updatePoseQuat(qAvg, tAvg);
       curPoses[0]->numVotes=curCluster->numVotes;
@@ -396,6 +402,13 @@ void PPF3DDetector::clusterPoses(std::vector<Pose3DPtr>& poseList, int numPoses,
 
       tAvg *= 1.0 / curSize;
       qAvg *= 1.0 / curSize;
+
+      // normalize quantonion
+      const double qNorm = cv::norm(qAvg);
+      if (qNorm > EPS)
+      {
+        qAvg *= 1.0 / qNorm;
+      }
 
       curPoses[0]->updatePoseQuat(qAvg, tAvg);
       curPoses[0]->numVotes=curCluster->numVotes;


### PR DESCRIPTION
### normalize quaternion
After weighted average quaternion of poses in the same cluster, the weighted average quaternion should be normalized.


