### PR TITLE
Correct width/height returned by cudacodec::VideoReader::FormatInfo()

### DIFF
--- a/modules/cudacodec/include/opencv2/cudacodec.hpp
+++ b/modules/cudacodec/include/opencv2/cudacodec.hpp
@@ -282,9 +282,11 @@ struct FormatInfo
 {
     Codec codec;
     ChromaFormat chromaFormat;
-    int nBitDepthMinus8;
-    int width;
-    int height;
+    int nBitDepthMinus8 = -1;
+    int width = 0;//!< Width of the decoded frame returned by nextFrame(frame)
+    int height = 0;//!< Height of the decoded frame returned by nextFrame(frame)
+    Rect displayArea;//!< ROI inside the decoded frame returned by nextFrame(frame), containing the useable video frame.
+    bool valid = false;
 };
 
 /** @brief Video reader interface.
@@ -329,6 +331,10 @@ public:
     /** @brief Returns information about video file format.
     */
     virtual FormatInfo format() const = 0;
+
+    /** @brief Updates the coded width and height inside format.
+    */
+    virtual void updateFormat(const int codedWidth, const int codedHeight) = 0;
 };
 
 /** @brief Creates video reader.

--- a/modules/cudacodec/src/cuvid_video_source.cpp
+++ b/modules/cudacodec/src/cuvid_video_source.cpp
@@ -74,6 +74,8 @@ cv::cudacodec::detail::CuvidVideoSource::CuvidVideoSource(const String& fname)
     format_.nBitDepthMinus8 = vidfmt.bit_depth_luma_minus8;
     format_.width = vidfmt.coded_width;
     format_.height = vidfmt.coded_height;
+    format_.displayArea = Rect(Point(vidfmt.display_area.left, vidfmt.display_area.top), Point(vidfmt.display_area.right, vidfmt.display_area.bottom));
+    format_.valid = true;
 }
 
 cv::cudacodec::detail::CuvidVideoSource::~CuvidVideoSource()
@@ -84,6 +86,13 @@ cv::cudacodec::detail::CuvidVideoSource::~CuvidVideoSource()
 FormatInfo cv::cudacodec::detail::CuvidVideoSource::format() const
 {
     return format_;
+}
+
+void cv::cudacodec::detail::CuvidVideoSource::updateFormat(const int codedWidth, const int codedHeight)
+{
+    format_.width = codedWidth;
+    format_.height = codedHeight;
+    format_.valid = true;
 }
 
 void cv::cudacodec::detail::CuvidVideoSource::start()

--- a/modules/cudacodec/src/cuvid_video_source.hpp
+++ b/modules/cudacodec/src/cuvid_video_source.hpp
@@ -55,6 +55,7 @@ public:
     ~CuvidVideoSource();
 
     FormatInfo format() const CV_OVERRIDE;
+    void updateFormat(const int codedWidth, const int codedHeight);
     void start() CV_OVERRIDE;
     void stop() CV_OVERRIDE;
     bool isStarted() const CV_OVERRIDE;

--- a/modules/cudacodec/src/ffmpeg_video_source.cpp
+++ b/modules/cudacodec/src/ffmpeg_video_source.cpp
@@ -131,6 +131,8 @@ cv::cudacodec::detail::FFmpegVideoSource::FFmpegVideoSource(const String& fname)
     format_.codec = FourccToCodec(codec);
     format_.height = cap.get(CAP_PROP_FRAME_HEIGHT);
     format_.width = cap.get(CAP_PROP_FRAME_WIDTH);
+    format_.displayArea = Rect(0, 0, cap.get(CAP_PROP_FRAME_WIDTH), cap.get(CAP_PROP_FRAME_HEIGHT));
+    format_.valid = false;
     FourccToChromaFormat(pixelFormat, format_.chromaFormat, format_.nBitDepthMinus8);
 }
 
@@ -143,6 +145,13 @@ cv::cudacodec::detail::FFmpegVideoSource::~FFmpegVideoSource()
 FormatInfo cv::cudacodec::detail::FFmpegVideoSource::format() const
 {
     return format_;
+}
+
+void cv::cudacodec::detail::FFmpegVideoSource::updateFormat(const int codedWidth, const int codedHeight)
+{
+    format_.width = codedWidth;
+    format_.height = codedHeight;
+    format_.valid = true;
 }
 
 bool cv::cudacodec::detail::FFmpegVideoSource::getNextPacket(unsigned char** data, size_t* size)

--- a/modules/cudacodec/src/ffmpeg_video_source.cpp
+++ b/modules/cudacodec/src/ffmpeg_video_source.cpp
@@ -131,7 +131,7 @@ cv::cudacodec::detail::FFmpegVideoSource::FFmpegVideoSource(const String& fname)
     format_.codec = FourccToCodec(codec);
     format_.height = cap.get(CAP_PROP_FRAME_HEIGHT);
     format_.width = cap.get(CAP_PROP_FRAME_WIDTH);
-    format_.displayArea = Rect(0, 0, cap.get(CAP_PROP_FRAME_WIDTH), cap.get(CAP_PROP_FRAME_HEIGHT));
+    format_.displayArea = Rect(0, 0, format_.width, format_.height);
     format_.valid = false;
     FourccToChromaFormat(pixelFormat, format_.chromaFormat, format_.nBitDepthMinus8);
 }

--- a/modules/cudacodec/src/ffmpeg_video_source.hpp
+++ b/modules/cudacodec/src/ffmpeg_video_source.hpp
@@ -58,6 +58,9 @@ public:
 
     FormatInfo format() const CV_OVERRIDE;
 
+    void updateFormat(const int codedWidth, const int codedHeight);
+
+
 private:
     FormatInfo format_;
     VideoCapture cap;

--- a/modules/cudacodec/src/video_parser.cpp
+++ b/modules/cudacodec/src/video_parser.cpp
@@ -114,6 +114,7 @@ int CUDAAPI cv::cudacodec::detail::VideoParser::HandleVideoSequence(void* userDa
         newFormat.chromaFormat = static_cast<ChromaFormat>(format->chroma_format);
         newFormat.width = format->coded_width;
         newFormat.height = format->coded_height;
+        newFormat.displayArea = Rect(Point(format->display_area.left, format->display_area.top), Point(format->display_area.right, format->display_area.bottom));
         newFormat.nBitDepthMinus8 = format->bit_depth_luma_minus8;
 
         try

--- a/modules/cudacodec/src/video_reader.cpp
+++ b/modules/cudacodec/src/video_reader.cpp
@@ -148,6 +148,7 @@ namespace
 
             bool isProgressive = displayInfo.progressive_frame != 0;
             const int num_fields = isProgressive ? 1 : 2 + displayInfo.repeat_first_field;
+            videoSource_->updateFormat(videoDecoder_->targetWidth(), videoDecoder_->targetHeight());
 
             for (int active_field = 0; active_field < num_fields; ++active_field)
             {

--- a/modules/cudacodec/src/video_source.cpp
+++ b/modules/cudacodec/src/video_source.cpp
@@ -65,6 +65,11 @@ cv::cudacodec::FormatInfo cv::cudacodec::detail::RawVideoSourceWrapper::format()
     return source_->format();
 }
 
+void cv::cudacodec::detail::RawVideoSourceWrapper::updateFormat(const int codedWidth, const int codedHeight)
+{
+    source_->updateFormat(codedWidth,codedHeight);
+}
+
 void cv::cudacodec::detail::RawVideoSourceWrapper::start()
 {
     stop_ = false;

--- a/modules/cudacodec/src/video_source.hpp
+++ b/modules/cudacodec/src/video_source.hpp
@@ -56,6 +56,7 @@ public:
     virtual ~VideoSource() {}
 
     virtual FormatInfo format() const = 0;
+    virtual void updateFormat(const int codedWidth, const int codedHeight) = 0;
     virtual void start() = 0;
     virtual void stop() = 0;
     virtual bool isStarted() const = 0;
@@ -76,6 +77,7 @@ public:
     RawVideoSourceWrapper(const Ptr<RawVideoSource>& source);
 
     FormatInfo format() const CV_OVERRIDE;
+    void updateFormat(const int codedWidth, const int codedHeight) CV_OVERRIDE;
     void start() CV_OVERRIDE;
     void stop() CV_OVERRIDE;
     bool isStarted() const CV_OVERRIDE;

--- a/modules/cudacodec/test/test_video.cpp
+++ b/modules/cudacodec/test/test_video.cpp
@@ -63,11 +63,14 @@ CUDA_TEST_P(Video, Reader)
 
     std::string inputFile = std::string(cvtest::TS::ptr()->get_data_path()) + "../" + GET_PARAM(1);
     cv::Ptr<cv::cudacodec::VideoReader> reader = cv::cudacodec::createVideoReader(inputFile);
-
+    cv::cudacodec::FormatInfo fmt = reader->format();
     cv::cuda::GpuMat frame;
     for (int i = 0; i < 100; i++)
     {
         ASSERT_TRUE(reader->nextFrame(frame));
+        if(!fmt.valid)
+            fmt = reader->format();
+        ASSERT_TRUE(frame.cols == fmt.width && frame.rows == fmt.height);
         ASSERT_FALSE(frame.empty());
     }
 }


### PR DESCRIPTION
When decoding certain resolutions (e.g. 1080p), the size of the frame returned from `nextFrame()` (1920x**1088**) can be larger than the usable area (1920x**1080**) due to the coded sizes being multiples of n bytes, for efficient coding/decoding.

This causes a problem in cudacodec because currently the values of width and height returned by `cudaCodec::Format()` are different depending on which video source is used.  The two possibilities are FFmpeg and cuvid, with FFmpeg returning the usable width and height (1920x**1080**) and cuvid returning the coded width and height (1920x**1088**).

I think it would make sense for both video sources to return the coded width and height if possible because that corresponds to the dimensions of the frame returned by `nextFrame()`.  Unfortunately in the case of the FFmpeg backend this won't be known for certain until after the first call to `nextFrame()` where the decoder may or may not reconfigure itself based on the coded bit stream.  To avoid changing the internals of cudacodec too much (it needs a re-write to mirror the existing Nvidia sample code anyway) I have included an ugly hack using a flag to signal if the dimensions of width and height can be relied upon.

The accuracy test case has been updated and should fail without this fix.

Additionally I have included the display area so that the frame can be cropped to get the usable area (e.g. 1920x1080 from 1920x1088).
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
buildworker:Custom=linux-4,linux-6
build_image:Custom=ubuntu-cuda:18.04
```