### PR TITLE
Fix: undefined reference to `cv::imread

### DIFF
--- a/modules/sfm/CMakeLists.txt
+++ b/modules/sfm/CMakeLists.txt
@@ -154,7 +154,7 @@ endif()
 #include_directories(${OCV_TARGET_INCLUDE_DIRS_${the_module}})
 add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/src/libmv_light" "${CMAKE_CURRENT_BINARY_DIR}/src/libmv")
 
-ocv_target_link_libraries(${the_module} ${LIBMV_LIGHT_LIBS})
+ocv_target_link_libraries(${the_module} ${LIBMV_LIGHT_LIBS} opencv_imgcodecs)
 
 
 ### CREATE OPENCV SFM TESTS ###


### PR DESCRIPTION
F:/msys64/mingw32/bin/../lib/gcc/i686-w64-mingw32/10.3.0/../../../../i686-w64-mingw32/bin/ld.exe: ../../lib/libcorrespondence.a(nRobustViewMatching.cc.obj):nRobustViewMatching.cc:(.text$_ZN5libmv14correspondence19nRobustViewMatching11computeDataERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE+0x3b): undefined reference to `cv::imread(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int)'

The sfm uses imread, but opencv_imgcodecs was not added to it's CMakeLists.txt

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
