### PR TITLE
Rename variable name at detector_params.yml since it is differrent from c++ source code

### DIFF
--- a/modules/aruco/samples/detector_params.yml
+++ b/modules/aruco/samples/detector_params.yml
@@ -8,7 +8,7 @@ adaptiveThreshConstant: 7
 minMarkerPerimeterRate: 0.03
 maxMarkerPerimeterRate: 4.0
 polygonalApproxAccuracyRate: 0.05
-minCornerDistance: 10.0
+minCornerDistanceRate: 10.0
 minDistanceToBorder: 3
 minMarkerDistance: 10.0
 minMarkerDistanceRate: 0.05


### PR DESCRIPTION
Renamed a variable name minCornerDistance on a yml to minCornerDistanceRate since it is used as minCornerDistanceRate at https://github.com/opencv/opencv_contrib/blob/907efb966823ea3ca40b70500068866f6bfb8f3a/modules/aruco/samples/detect_markers.cpp#L93 and https://github.com/opencv/opencv_contrib/blob/907efb966823ea3ca40b70500068866f6bfb8f3a/modules/aruco/samples/detect_diamonds.cpp#L94 .

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [*] I agree to contribute to the project under Apache 2 License.
- [*] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [*] The PR is proposed to proper branch
- [*] There is reference to original bug report and related work
- [*] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [*] The feature is well documented and sample code can be built with the project CMake
