### PR TITLE
Update detector_params.yml

### DIFF
--- a/modules/aruco/samples/detector_params.yml
+++ b/modules/aruco/samples/detector_params.yml
@@ -8,7 +8,7 @@ adaptiveThreshConstant: 7
 minMarkerPerimeterRate: 0.03
 maxMarkerPerimeterRate: 4.0
 polygonalApproxAccuracyRate: 0.05
-minCornerDistanceRate: 10.0
+minCornerDistanceRate: 0.05
 minDistanceToBorder: 3
 minMarkerDistance: 10.0
 minMarkerDistanceRate: 0.05


### PR DESCRIPTION
Related to https://github.com/opencv/opencv_contrib/pull/3026, I found this value is too large so that an aruco board will not be detected.
A default value is 0.05 according to https://docs.opencv.org/master/d1/dcd/structcv_1_1aruco_1_1DetectorParameters.html .

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [*] I agree to contribute to the project under Apache 2 License.
- [*] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [*] The PR is proposed to proper branch
- [*] There is reference to original bug report and related work
- [*] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [*] The feature is well documented and sample code can be built with the project CMake
