### PR TITLE
fix: aruco test tries to pass 2d numpy array as std::vector<int>

### DIFF
--- a/modules/aruco/misc/python/test/test_aruco.py
+++ b/modules/aruco/misc/python/test/test_aruco.py
@@ -13,19 +13,19 @@ class aruco_test(NewOpenCVTests):
 
     def test_idsAccessibility(self):
 
-        ids = np.array([[elem] for elem in range(17)])
-        rev_ids = np.array(list(reversed(ids)))
+        ids = np.arange(17)
+        rev_ids = ids[::-1]
 
         aruco_dict  = cv.aruco.Dictionary_get(cv.aruco.DICT_5X5_250)
         board = cv.aruco.CharucoBoard_create(7, 5, 1, 0.5, aruco_dict)
 
-        self.assertTrue(np.equal(board.ids, ids).all())
+        np.testing.assert_array_equal(board.ids.squeeze(), ids)
 
         board.ids = rev_ids
-        self.assertTrue(np.equal(board.ids, rev_ids).all())
+        np.testing.assert_array_equal(board.ids.squeeze(), rev_ids)
 
         board.setIds(ids)
-        self.assertTrue(np.equal(board.ids, ids).all())
+        np.testing.assert_array_equal(board.ids.squeeze(), ids)
 
         with self.assertRaises(cv.error):
             board.setIds(np.array([0]))


### PR DESCRIPTION
Test utilize error-prone behavior when 2d array is flattened. 

Merge before https://github.com/opencv/opencv/pull/20618 , but without this PR indices shape `squeeze` is required because `std::vector<int>` is returned as 2d Mat `[[1], [2], ...]`  

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
