### PR TITLE
rename the database names in or_mnist.cpp

### DIFF
--- a/modules/datasets/src/or_mnist.cpp
+++ b/modules/datasets/src/or_mnist.cpp
@@ -127,12 +127,12 @@ void OR_mnistImp::loadDataset(const string &path)
     test.push_back(vector< Ptr<Object> >());
     validation.push_back(vector< Ptr<Object> >());
 
-    string trainImagesFile(path + "train-images.idx3-ubyte");
-    string trainLabelsFile(path + "train-labels.idx1-ubyte");
+    string trainImagesFile(path + "train-images-idx3-ubyte");
+    string trainLabelsFile(path + "train-labels-idx1-ubyte");
     loadDatasetPart(trainImagesFile, trainLabelsFile, 60000, train.back());
 
-    string testImagesFile(path + "t10k-images.idx3-ubyte");
-    string testLabelsFile(path + "t10k-labels.idx1-ubyte");
+    string testImagesFile(path + "t10k-images-idx3-ubyte");
+    string testLabelsFile(path + "t10k-labels-idx1-ubyte");
     loadDatasetPart(testImagesFile, testLabelsFile, 10000, test.back());
 }
 


### PR DESCRIPTION
The files from http://yann.lecun.com/exdb/mnist/ are
train-images-idx3-ubyte.gz
train-labels-idx1-ubyte.gz
t10k-images-idx3-ubyte.gz
t10k-labels-idx1-ubyte.gz

after unpacking, ther default names are like xxxx-idxn-ubyte

but the names in the code are
train-images.idx3-ubyte
train-labels.idx1-ubyte
t10k-images.idx3-ubyte
t10k-labels.idx1-ubyte

'-' is replaced by '.' , this cause a segmentation fault when do as the instructions in dataset.hpp:
./opencv/build/bin/example_datasets_or_mnist -p=/home/user/path_to_unpacked_files/