### PR TITLE
Fix CV_FOURCC identifier not found while compiling

### DIFF
--- a/modules/cudacodec/perf/perf_video.cpp
+++ b/modules/cudacodec/perf/perf_video.cpp
@@ -140,7 +140,7 @@ PERF_TEST_P(FileName, VideoWriter, VIDEO_SRC)
             ASSERT_FALSE(frame.empty());
 
             if (!writer.isOpened())
-                writer.open(outputFile, CV_FOURCC('X', 'V', 'I', 'D'), FPS, frame.size());
+                writer.open(outputFile, VideoWriter::fourcc('X', 'V', 'I', 'D'), FPS, frame.size());
 
             startTimer(); next();
             writer.write(frame);


### PR DESCRIPTION
OpenCV version: 4.5.3
Platform: Windows 10
Compiler: Visual Studio 2019
Cuda: 11.4
Nvidia Video SDK: 11.1.5

Description:
I compiled with Cuda, nvcuvid, tbb, mkl and got an error "CV_FOURCC identifier not found". Change CV_FOURCC to VideoWriter::fourcc solved the problem

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
