### PR TITLE
ximgproc: tolerate the rounding error

### DIFF
--- a/modules/ximgproc/test/test_fld.cpp
+++ b/modules/ximgproc/test/test_fld.cpp
@@ -292,7 +292,8 @@ TEST_F(ximgproc_ED, ManySmallCircles)
     size_t lines_size = 6264;
     size_t ellipses_size = 2449;
     EXPECT_EQ(detector->getSegments().size(), segments_size);
-    EXPECT_EQ(lines.size(), lines_size);
+    EXPECT_GE(lines.size(), lines_size);
+    EXPECT_LE(lines.size(), lines_size + 2);
     EXPECT_EQ(ellipses.size(), ellipses_size);
 }
 }} // namespace


### PR DESCRIPTION
  * edge drawing is NOT bit-exact

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

On some platforms such as Jetson Nano or Rapsberry Pi 3/4, this test `ximgproc_ED.ManySmallCircles` fails with following message

```
[ RUN      ] ximgproc_ED.ManySmallCircles
/opencv_contrib/modules/ximgproc/test/test_fld.cpp:295: Failure
Expected equality of these values:
  lines.size()
    Which is: 6266
  lines_size
    Which is: 6264
[  FAILED  ] ximgproc_ED.ManySmallCircles (486 ms)
```

This is caused due to the rounding error

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
