### PR TITLE
Do not use = 0 for a cv::Mat.

### DIFF
--- a/modules/img_hash/src/radial_variance_hash.cpp
+++ b/modules/img_hash/src/radial_variance_hash.cpp
@@ -266,7 +266,7 @@ public:
         }
         else
         {
-            hash = 0;
+            hash.setTo(cv::Scalar::all(0));
         }
     }
 


### PR DESCRIPTION
There are several operator= overloads and some compilers can be confused.
This is a leftover from https://github.com/opencv/opencv_contrib/pull/2987

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
