### PR TITLE
opencv-4.5.4 enable_cvv fixes #3063

### DIFF
--- a/modules/cvv/CMakeLists.txt
+++ b/modules/cvv/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(NOT HAVE_QT5 OR NOT HAVE_CXX11)
+if(NOT HAVE_QT OR NOT HAVE_CXX11 OR QT_VERSION_MAJOR LESS 5)
   ocv_module_disable(cvv)
   return()
 endif()


### PR DESCRIPTION
The cvv module is compiled conditionally on HAVE_QT5. But in opencv commit 87d4970e8b4b3251035fdf4a0101335ee5904a58 this variable was renamed to HAVE_QT, so the module is never compiled.

fixes #3063

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [X] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


```
buildworker:Custom=linux-1,linux-4,linux-6
build_image:Custom=qt:16.04
```