### PR TITLE
freetype: fix call sequence for Harfbuzz

### DIFF
--- a/modules/freetype/src/freetype.cpp
+++ b/modules/freetype/src/freetype.cpp
@@ -238,16 +238,14 @@ void FreeType2Impl::putTextOutline(
     hb_buffer_t *hb_buffer = hb_buffer_create ();
     CV_Assert( hb_buffer != NULL );
 
-    unsigned int textLen;
-    hb_buffer_guess_segment_properties (hb_buffer);
     hb_buffer_add_utf8 (hb_buffer, _text.c_str(), -1, 0, -1);
-    FT_Vector currentPos = {0,0};
+    hb_buffer_guess_segment_properties (hb_buffer);
+    hb_shape (mHb_font, hb_buffer, NULL, 0);
 
+    unsigned int textLen = 0;
     hb_glyph_info_t *info =
         hb_buffer_get_glyph_infos(hb_buffer,&textLen );
     CV_Assert( info != NULL );
-
-    hb_shape (mHb_font, hb_buffer, NULL, 0);
 
     PathUserData *userData = new PathUserData( _img );
     userData->mColor     = _color;
@@ -256,6 +254,7 @@ void FreeType2Impl::putTextOutline(
     userData->mLine_type = _line_type;
 
     // Initilize currentPosition ( in FreeType coordinates)
+    FT_Vector currentPos = {0,0};
     currentPos.x = _org.x * 64;
     currentPos.y = _org.y * 64;
 
@@ -305,14 +304,14 @@ void FreeType2Impl::putTextBitmapMono(
     hb_buffer_t *hb_buffer = hb_buffer_create ();
     CV_Assert( hb_buffer != NULL );
 
-    unsigned int textLen;
-    hb_buffer_guess_segment_properties (hb_buffer);
     hb_buffer_add_utf8 (hb_buffer, _text.c_str(), -1, 0, -1);
+    hb_buffer_guess_segment_properties (hb_buffer);
+    hb_shape (mHb_font, hb_buffer, NULL, 0);
+
+    unsigned int textLen = 0;
     hb_glyph_info_t *info =
         hb_buffer_get_glyph_infos(hb_buffer,&textLen );
     CV_Assert( info != NULL );
-
-    hb_shape (mHb_font, hb_buffer, NULL, 0);
 
     _org.y += _fontHeight;
     if( _bottomLeftOrigin == true ){
@@ -372,6 +371,7 @@ void FreeType2Impl::putTextBitmapBlend(
    int _fontHeight, Scalar _color,
    int _thickness, int _line_type, bool _bottomLeftOrigin )
 {
+
     CV_Assert( _thickness < 0 );
     CV_Assert( _line_type == 16 );
 
@@ -379,14 +379,14 @@ void FreeType2Impl::putTextBitmapBlend(
     hb_buffer_t *hb_buffer = hb_buffer_create ();
     CV_Assert( hb_buffer != NULL );
 
-    unsigned int textLen;
-    hb_buffer_guess_segment_properties (hb_buffer);
     hb_buffer_add_utf8 (hb_buffer, _text.c_str(), -1, 0, -1);
+    hb_buffer_guess_segment_properties (hb_buffer);
+    hb_shape (mHb_font, hb_buffer, NULL, 0);
+
+    unsigned int textLen = 0;
     hb_glyph_info_t *info =
         hb_buffer_get_glyph_infos(hb_buffer,&textLen );
     CV_Assert( info != NULL );
-
-    hb_shape (mHb_font, hb_buffer, NULL, 0);
 
     _org.y += _fontHeight;
     if( _bottomLeftOrigin == true ){
@@ -461,13 +461,14 @@ Size FreeType2Impl::getTextSize(
     CV_Assert( hb_buffer != NULL );
     FT_Vector currentPos = {0,0};
 
-    unsigned int textLen;
-    hb_buffer_guess_segment_properties (hb_buffer);
     hb_buffer_add_utf8 (hb_buffer, _text.c_str(), -1, 0, -1);
+    hb_buffer_guess_segment_properties (hb_buffer);
+    hb_shape (mHb_font, hb_buffer, NULL, 0);
+
+    unsigned int textLen = 0;
     hb_glyph_info_t *info =
         hb_buffer_get_glyph_infos(hb_buffer,&textLen );
     CV_Assert( info != NULL );
-    hb_shape (mHb_font, hb_buffer, NULL, 0);
 
     // Initilize BoundaryBox ( in OpenCV coordinates )
     int xMin = INT_MAX, yMin = INT_MAX;


### PR DESCRIPTION
Fix #3078

freetype wrapper was calling harfbuzz library in the wrong sequence.  
So incorrect guess which is text will be LTR(Left to Right)is happen.
This patch fix it.  Correct calling sequence is *1.  
This text will be drawn correctly with RTL(Right to Left).

However, it seems that harfbuzz alone is not able to support bidi.  *2
So that freetype wrapper cannot draw text with a mixture of LTR and RTL.

And it is difficult for me to test many languages/fonts/texts.
I could only create a patch that wasn't effective enough. I'm sorry.

*1) https://harfbuzz.github.io/a-simple-shaping-example.html
*2) https://harfbuzz.github.io/what-harfbuzz-doesnt-do.html

<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [X] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


```
force_builders=Custom
build_image:Custom=ubuntu-gapi-freetype:16.04
buildworker:Custom=linux-1
```