### PR TITLE
fixed redefinition error on clang 7.0.1 with musl

### DIFF
--- a/modules/wechat_qrcode/src/zxing/common/bitarray.cpp
+++ b/modules/wechat_qrcode/src/zxing/common/bitarray.cpp
@@ -15,12 +15,6 @@ using zxing::BitArray;
 using zxing::ErrorHandler;
 using zxing::Ref;
 
-#if __WORDSIZE == 64
-// typedef long int int64_t;
-#else
-typedef long long int int64_t;
-#endif
-
 BitArray::BitArray(int size_) : size(size_), bits(size_), nextSets(size_), nextUnSets(size_) {}
 
 void BitArray::setUnchar(int i, unsigned char newBits) { bits[i] = newBits; }


### PR DESCRIPTION
Currently, it is not possible compile OpenCV 4.5.4 using Clang 7.0.1 + musl due to `__WORDSIZE` not being defined. As a consequence, the following error is issued:
```
opencv_contrib/modules/wechat_qrcode/src/zxing/common/bitarray.cpp:18:5: warning: '__WORDSIZE' is not defined, evaluates to 0 [-Wundef]
#if __WORDSIZE == 64
    ^
opencv_contrib/modules/wechat_qrcode/src/zxing/common/bitarray.cpp:21:23: error: typedef redefinition with different types ('long long' vs 'long')
typedef long long int int64_t;
                      ^
<...>/sysroots/core2-64-<snip>-linux-musl/usr/include/bits/alltypes.h:152:25: note: previous definition is here
typedef signed _Int64   int64_t;
                        ^
1 warning and 1 error generated.
```
Since the `int64_t` typedef is unused in the translation unit anyway, we can simply remove the definition.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
build_image:Custom=ubuntu32:16.04
buildworker:Custom=linux-4,linux-6
```