### PR TITLE
sfm: disable `min`/`max` macros under win32

### DIFF
--- a/modules/sfm/CMakeLists.txt
+++ b/modules/sfm/CMakeLists.txt
@@ -117,6 +117,11 @@ ocv_add_module(sfm
 
 add_definitions(/DGLOG_NO_ABBREVIATED_SEVERITIES)  # avoid ERROR macro conflict in glog (ceres dependency)
 
+if(WIN32)
+  # Avoid error due to min/max being already defined as a macro
+  add_definitions(-DNOMINMAX)
+endif(WIN32)
+
 ocv_warnings_disable(CMAKE_CXX_FLAGS
   -Wundef
   -Wshadow


### PR DESCRIPTION
Using Visual Studio 2017, I observe in the `sfm` module errors such as
```console
opencv_contrib\modules\sfm\src\libmv_light\libmv/correspondence/matches.h(234): error C2589: '(': illegal token on right side of '::'
```
caused by `min`/`max` being defined as macros. This PR adds the `NOMINMAX` define to the `sfm` module to avoid the macro definitions.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
