### PR TITLE
remove default stream sync in cuda TVL1 optical flow

### DIFF
--- a/modules/cudaoptflow/src/tvl1flow.cpp
+++ b/modules/cudaoptflow/src/tvl1flow.cpp
@@ -162,7 +162,9 @@ namespace
         GpuMat p32_buf;
 
         GpuMat diff_buf;
-        GpuMat norm_buf;
+
+        GpuMat diff_sum_dev;
+        Mat diff_sum_host;
     };
 
     void OpticalFlowDual_TVL1_Impl::calc(InputArray _frame0, InputArray _frame1, InputOutputArray _flow, Stream& stream)
@@ -361,8 +363,11 @@ namespace
                 estimateU(I1wx, I1wy, grad, rho_c, p11, p12, p21, p22, p31, p32, u1, u2, u3, diff, l_t, static_cast<float>(theta_), gamma_, calcError, stream);
                 if (calcError)
                 {
+                    cuda::calcSum(diff, diff_sum_dev, cv::noArray(), _stream);
+                    diff_sum_dev.download(diff_sum_host, _stream);
                     _stream.waitForCompletion();
-                    error = cuda::sum(diff, norm_buf)[0];
+
+                    error = diff_sum_host.at<double>(0,0);
                     prevError = error;
                 }
                 else


### PR DESCRIPTION
This is an optimization in the cuda TVL1 optical flow implementation.

It moves a summation reduction off of the default cuda stream, preventing a device sync. It also eliminates a slow cudaHostAlloc and  cudaHostFree.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
build_worker:Custom=linux-4,linux-6
build_image:Custom=ubuntu-cuda:18.04
```