### PR TITLE
fixed /modules/text/textdetection.py sample

### DIFF
--- a/modules/text/samples/textdetection.py
+++ b/modules/text/samples/textdetection.py
@@ -17,29 +17,29 @@ if (len(sys.argv) < 2):
 
 pathname = os.path.dirname(sys.argv[0])
 
-
 img      = cv.imread(str(sys.argv[1]))
 # for visualization
 vis      = img.copy()
 
 
 # Extract channels to be processed individually
-channels = cv.text.computeNMChannels(img)
+channels = list(cv.text.computeNMChannels(img))
 # Append negative channels to detect ER- (bright regions over dark background)
 cn = len(channels)-1
 for c in range(0,cn):
-  channels.append((255-channels[c]))
+  channels.append(255-channels[c])
 
 # Apply the default cascade classifier to each independent channel (could be done in parallel)
+
+erc1 = cv.text.loadClassifierNM1('trained_classifierNM1.xml')
+er1 = cv.text.createERFilterNM1(erc1,16,0.00015,0.13,0.2,True,0.1)
+
+erc2 = cv.text.loadClassifierNM2('trained_classifierNM2.xml')
+er2 = cv.text.createERFilterNM2(erc2,0.5)
+
 print("Extracting Class Specific Extremal Regions from "+str(len(channels))+" channels ...")
 print("    (...) this may take a while (...)")
 for channel in channels:
-
-  erc1 = cv.text.loadClassifierNM1(pathname+'/trained_classifierNM1.xml')
-  er1 = cv.text.createERFilterNM1(erc1,16,0.00015,0.13,0.2,True,0.1)
-
-  erc2 = cv.text.loadClassifierNM2(pathname+'/trained_classifierNM2.xml')
-  er2 = cv.text.createERFilterNM2(erc2,0.5)
 
   regions = cv.text.detectRegions(channel,er1,er2)
 
@@ -47,11 +47,9 @@ for channel in channels:
   #rects = cv.text.erGrouping(img,channel,[x.tolist() for x in regions], cv.text.ERGROUPING_ORIENTATION_ANY,'../../GSoC2014/opencv_contrib/modules/text/samples/trained_classifier_erGrouping.xml',0.5)
 
   #Visualization
-  for r in range(0,np.shape(rects)[0]):
-    rect = rects[r]
+  for rect in rects:
     cv.rectangle(vis, (rect[0],rect[1]), (rect[0]+rect[2],rect[1]+rect[3]), (0, 0, 0), 2)
     cv.rectangle(vis, (rect[0],rect[1]), (rect[0]+rect[2],rect[1]+rect[3]), (255, 255, 255), 1)
-
 
 #Visualization
 cv.imshow("Text detection result", vis)


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ Y] I agree to contribute to the project under Apache 2 License.
- [ Y] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ Y] The PR is proposed to proper branch
- [ N] There is reference to original bug report and related work
- [ N] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ N] The feature is well documented and sample code can be built with the project CMake

The sample python code `opencv/opencv_contrib/modules/text/sample/textdetection.py` contained errors and could not be be run. Moreover, the code was not optimized. This pull request fixes both issues.

What caused errors:
In line (old) 27, cv.text.computeNMChannels(img) returns a tuple containing extracted image channels. There is an attempt to append negative channels which results in error as tuples are not mutable.

Fix
converted the returned tuple to list
Removed extra bracket pair in line 30 which could also be causing errors.
Also changed the loading path to `trained_classifierNM1.xml` for classifiers because my system was not able to detect the older path
````
pathname+'/trained_classifierNM1.xml'
````

Performance Optimization

Issue:
From line 38 to 43 in the old code, the classifiers are loaded inside a for loop repeatedly. They need to be loaded only once to provide same results. 

Fix:
Moved the classifiers loading outside the for block (line 33-39 in PR)

I have tested that the python file is now working