### PR TITLE
Viz3d sample fixes for python (sample 02 and 03) 

### DIFF
--- a/modules/viz/samples/viz_sample_02.py
+++ b/modules/viz/samples/viz_sample_02.py
@@ -3,15 +3,15 @@ import cv2 as cv
 
 my_window = cv.viz_Viz3d("Coordinate Frame")
 
-axe = cv.viz_PyWCoordinateSystem()
-axis = cv.viz_PyWLine((-1.0,-1.0,-1.0), (1.0,1.0,1.0), cv.viz_PyColor().green())
+axe = cv.viz_WCoordinateSystem()
+axis = cv.viz_WLine((-1.0,-1.0,-1.0), (1.0,1.0,1.0), cv.viz_Color().green())
 axis.setRenderingProperty(cv.viz.LINE_WIDTH, 4.0);
 my_window.showWidget("axe",axis)
-plan = cv.viz_PyWPlane((-1.0,-1.0,-1.0), (1.0,.0,.0), (-.0,.0,-1.0))
+plan = cv.viz_WPlane((-1.0,-1.0,-1.0), (1.0,.0,.0), (-.0,.0,-1.0))
 #my_window.showWidget("plan", plan)
-cube = cv.viz_PyWCube((0.5,0.5,0.0), (0.0,0.0,-0.5), True, cv.viz_PyColor().blue())
+cube = cv.viz_WCube((0.5,0.5,0.0), (0.0,0.0,-0.5), True, cv.viz_Color().blue())
 
-#my_window.showWidget("Cube Widget",cube)
+my_window.showWidget("Cube Widget",cube)
 pi = np.arccos(-1)
 print("First event loop is over")
 my_window.spin()
@@ -27,7 +27,8 @@ while not my_window.wasStopped():
     rot_vec[0, 2] += np.pi * 0.01
     translation_phase += pi * 0.01
     translation = np.sin(translation_phase)
-    pose = cv.viz_PyAffine3(rot_vec, (translation, translation, translation))
-    my_window.setWidgetPosePy("Cube Widget", pose)
-    my_window.spinOnce(1, True)
+    pose = cv.viz_Affine3d(rot_vec, (translation, translation, translation))
+    my_window.setWidgetPose("Cube Widget",pose)
+    my_window.spinOnce(1, True);
+
 print("Last event loop is over")

--- a/modules/viz/samples/viz_sample_03.py
+++ b/modules/viz/samples/viz_sample_03.py
@@ -2,7 +2,7 @@ import numpy as np
 import cv2 as cv
 
 def load_bunny():
-    with open(cv.samples.findFile("viz/bunny.ply"), 'r') as f:
+    with open(cv.samples.findFile("../viz/data/bunny.ply"), 'r') as f:
         s = f.read()
     ligne = s.split('\n')
     if len(ligne) == 5753:
@@ -13,28 +13,28 @@ def load_bunny():
             d = ligne[idx].split(' ')
             pts3d[0,idx-12,:] = (float(d[0]), float(d[1]), float(d[2]))
     pts3d = 5 * pts3d
-    return cv.viz_PyWCloud(pts3d)
+    return cv.viz_WCloud(pts3d)
 
 myWindow = cv.viz_Viz3d("Coordinate Frame")
-axe = cv.viz_PyWCoordinateSystem()
+axe = cv.viz_WCoordinateSystem()
 myWindow.showWidget("axe",axe)
 
 cam_pos =  (3.0, 3.0, 3.0)
 cam_focal_point = (3.0,3.0,2.0)
 cam_y_dir = (-1.0,0.0,0.0)
-cam_pose = cv.viz.makeCameraPosePy(cam_pos, cam_focal_point, cam_y_dir)
+cam_pose = cv.viz.makeCameraPose(cam_pos, cam_focal_point, cam_y_dir)
 print("OK")
-transform = cv.viz.makeTransformToGlobalPy((0.0,-1.0,0.0), (-1.0,0.0,0.0), (0.0,0.0,-1.0), cam_pos)
+transform = cv.viz.makeTransformToGlobal((0.0,-1.0,0.0), (-1.0,0.0,0.0), (0.0,0.0,-1.0), cam_pos)
 pw_bunny = load_bunny()
-cloud_pose = cv.viz_PyAffine3()
+cloud_pose = cv.viz_Affine3d()
 cloud_pose = cloud_pose.translate((0, 0, 3))
 cloud_pose_global = transform.product(cloud_pose)
 
-cpw = cv.viz_PyWCameraPosition(0.5)
-cpw_frustum = cv.viz_PyWCameraPosition(0.3)
+cpw = cv.viz_WCameraPosition(0.5)
+cpw_frustum = cv.viz_WCameraPosition(0.3)
 myWindow.showWidget("CPW", cpw);
 myWindow.showWidget("CPW_FRUSTUM", cpw_frustum)
-myWindow.setViewerPosePy(cam_pose)
+myWindow.setViewerPose(cam_pose)
 myWindow.showWidget("bunny", pw_bunny, cloud_pose_global)
 #myWindow.setWidgetPosePy("bunny")
 myWindow.spin();


### PR DESCRIPTION
- Fixes multiple old viz function into new name
- Fix opencv bunny path for viz sample 3
- Fix viz sample 2 for proper cube rotation and example video is in here[1]

[1]: https://docs.opencv.org/4.5.3/d8/df0/tutorial_widget_pose.html

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
