### PR TITLE
fixed bad shape of markers (1x4) in several cases and added tests

### DIFF
--- a/modules/aruco/src/aruco.cpp
+++ b/modules/aruco/src/aruco.cpp
@@ -1486,7 +1486,7 @@ void refineDetectedMarkers(InputArray _image, const Ptr<Board> &_board,
     _convertToGrey(_image, grey);
 
     // vector of final detected marker corners and ids
-    vector< Mat > finalAcceptedCorners;
+    vector<vector<Point2f> > finalAcceptedCorners;
     vector< int > finalAcceptedIds;
     // fill with the current markers
     finalAcceptedCorners.resize(_detectedCorners.total());
@@ -1597,38 +1597,18 @@ void refineDetectedMarkers(InputArray _image, const Ptr<Board> &_board,
 
     // parse output
     if(finalAcceptedIds.size() != _detectedIds.total()) {
-        _detectedCorners.clear();
-        _detectedIds.clear();
-
         // parse output
         Mat(finalAcceptedIds).copyTo(_detectedIds);
-
-        _detectedCorners.create((int)finalAcceptedCorners.size(), 1, CV_32FC2);
-        for(unsigned int i = 0; i < finalAcceptedCorners.size(); i++) {
-            _detectedCorners.create(4, 1, CV_32FC2, i, true);
-            for(int j = 0; j < 4; j++) {
-                _detectedCorners.getMat(i).ptr< Point2f >()[j] =
-                    finalAcceptedCorners[i].ptr< Point2f >()[j];
-            }
-        }
+        _copyVector2Output(finalAcceptedCorners, _detectedCorners);
 
         // recalculate _rejectedCorners based on alreadyIdentified
-        vector< Mat > finalRejected;
+        vector<vector<Point2f> > finalRejected;
         for(unsigned int i = 0; i < alreadyIdentified.size(); i++) {
             if(!alreadyIdentified[i]) {
                 finalRejected.push_back(_rejectedCorners.getMat(i).clone());
             }
         }
-
-        _rejectedCorners.clear();
-        _rejectedCorners.create((int)finalRejected.size(), 1, CV_32FC2);
-        for(unsigned int i = 0; i < finalRejected.size(); i++) {
-            _rejectedCorners.create(4, 1, CV_32FC2, i, true);
-            for(int j = 0; j < 4; j++) {
-                _rejectedCorners.getMat(i).ptr< Point2f >()[j] =
-                    finalRejected[i].ptr< Point2f >()[j];
-            }
-        }
+        _copyVector2Output(finalRejected, _rejectedCorners);
 
         if(_recoveredIdxs.needed()) {
             Mat(recoveredIdxs).copyTo(_recoveredIdxs);

--- a/modules/aruco/test/test_charucodetection.cpp
+++ b/modules/aruco/test/test_charucodetection.cpp
@@ -793,4 +793,35 @@ TEST(CV_ArucoTutorial, can_find_diamondmarkers)
     EXPECT_EQ(counterGoldCornersIds, counterRes); // check the number of ArUco markers
 }
 
+TEST(Charuco, issue_14014)
+{
+    string imgPath = cvtest::findDataFile("aruco/recover.png");
+    Mat img = imread(imgPath);
+
+    Ptr<aruco::Dictionary> dict = aruco::getPredefinedDictionary(aruco::PREDEFINED_DICTIONARY_NAME(cv::aruco::DICT_7X7_250));
+    Ptr<aruco::CharucoBoard> board = aruco::CharucoBoard::create(8, 5, 0.03455f, 0.02164f, dict);
+    Ptr<aruco::DetectorParameters> detectorParams = aruco::DetectorParameters::create();
+    detectorParams->cornerRefinementMethod = aruco::CORNER_REFINE_SUBPIX;
+    detectorParams->cornerRefinementMinAccuracy = 0.01;
+
+    vector<Mat> corners, rejectedPoints;
+    vector<int> ids;
+
+    aruco::detectMarkers(img, dict, corners, ids, detectorParams, rejectedPoints);
+
+    ASSERT_EQ(corners.size(), 19ull);
+    EXPECT_EQ(Size(4, 1), corners[0].size()); // check dimension of detected corners
+
+    ASSERT_EQ(rejectedPoints.size(), 21ull);
+    EXPECT_EQ(Size(4, 1), rejectedPoints[0].size()); // check dimension of detected corners
+
+    aruco::refineDetectedMarkers(img, board, corners, ids, rejectedPoints);
+
+    ASSERT_EQ(corners.size(), 20ull);
+    EXPECT_EQ(Size(4, 1), corners[0].size()); // check dimension of rejected corners after successfully refine
+
+    ASSERT_EQ(rejectedPoints.size(), 20ull);
+    EXPECT_EQ(Size(4, 1), rejectedPoints[0].size()); // check dimension of rejected corners after successfully refine
+}
+
 }} // namespace


### PR DESCRIPTION
**Merge with extra**: https://github.com/opencv/opencv_extra/pull/935

Fixes https://github.com/opencv/opencv/issues/14014
Problem:

- `detectMarkers()` and `refineDetectedMarkers()` returns `OutputArrayOfArrays corners` and `rejectedCorners` with different dimensions (for similar cases).
- This problem is only relevant for vector<Mat> input.
- In this case `detectMarkers()` **always** returns `corners` and `rejectedCorners` as `vector<Mat>`, with Mat dimension **4x1**.
- In this case `refineDetectedMarkers()` works **differently**, if it finds a new marker. Then the dimension of Mats inside the `vector<Mat>` **changes** from **4x1** to **1x4**.
- The reason for the problem is that `detectMarkers()` and `refineDetectedMarkers()` create `corners` and `rejectedCorners` with different ways.
- Current tests show no errors because they use `vector<vector<Point2f> >` for  `corners` and `rejectedCorners`. Also, the current tests only check the number of refined corners (dimension and value are not checked).

In this PR `refineDetectedMarkers()` for create `OutputArrayOfArrays corners` and `rejectedCorners` uses `_copyVector2Output()`, just like `detectMarkers()`.

`opencv_extra=fix_refineDetectedMarkers_shape`

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
