### PR TITLE
ximgproc: fix delete calls in edge_drawing_common

### DIFF
--- a/modules/ximgproc/src/edge_drawing_common.hpp
+++ b/modules/ximgproc/src/edge_drawing_common.hpp
@@ -537,7 +537,7 @@ public:
 	}
 
 	~EDArcs() {
-		delete arcs;
+		delete[] arcs;
 	}
 };
 
@@ -552,8 +552,8 @@ struct BufferManager {
 	}
 
 	~BufferManager() {
-		delete x;
-		delete y;
+		delete[] x;
+		delete[] y;
 	}
 
 	double *getX() { return &x[index]; }


### PR DESCRIPTION
add `[]` to array delete calls
(cppcheck found a few: "Mismatching allocation and deallocation" issues)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
