### PR TITLE
Update color_cvt.hpp, fix a potential overflow bug in Lab2BGR func

### DIFF
--- a/modules/cudev/include/opencv2/cudev/functional/detail/color_cvt.hpp
+++ b/modules/cudev/include/opencv2/cudev/functional/detail/color_cvt.hpp
@@ -1083,9 +1083,9 @@ namespace color_cvt_detail
             else
                 Z = Z * Z * Z;
 
-            float B = 0.052891f * X - 0.204043f * Y + 1.151152f * Z;
-            float G = -0.921235f * X + 1.875991f * Y + 0.045244f * Z;
-            float R = 3.079933f * X - 1.537150f * Y - 0.542782f * Z;
+            float B = __saturatef(0.052891f * X - 0.204043f * Y + 1.151152f * Z); //need __saturatef values to (0.0, 1.0)
+            float G = __saturatef(-0.921235f * X + 1.875991f * Y + 0.045244f * Z);
+            float R = __saturatef(3.079933f * X - 1.537150f * Y - 0.542782f * Z);
 
             if (srgb)
             {


### PR DESCRIPTION
fix a potential overflow bug in cv::cuda::cvtColor(cv::COLOR_Lab2BGR) func, which need to clamp on B/G/R.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake


```
force_builders=Custom
buildworker:Custom=linux-4,linux-6
build_image:Custom=ubuntu-cuda:16.04
Xbuild_image:Custom=ubuntu-cuda:18.04
```