### PR TITLE
add camera parameters for the tutorial

### DIFF
--- a/modules/aruco/tutorials/aruco_detection/aruco_detection.markdown
+++ b/modules/aruco/tutorials/aruco_detection/aruco_detection.markdown
@@ -267,6 +267,13 @@ The aruco module provides a function to estimate the poses of all the detected m
 
 @code{.cpp}
 cv::Mat cameraMatrix, distCoeffs;
+// To work with examples from the tutorial, you can use these camera parameters:
+// Size imgSize = inputImage.size();
+// cameraMatrix = Mat::eye(3, 3, CV_64FC1);
+// cameraMatrix.at<double>(0, 0) = cameraMatrix.at<double>(1, 1) = 650;
+// cameraMatrix.at<double>(0, 2) = imgSize.width / 2;
+// cameraMatrix.at<double>(1, 2) = imgSize.height / 2;
+// distCoeffs = Mat(5, 1, CV_64FC1, Scalar::all(0));
 ...
 std::vector<cv::Vec3d> rvecs, tvecs;
 cv::aruco::estimatePoseSingleMarkers(markerCorners, 0.05, cameraMatrix, distCoeffs, rvecs, tvecs);


### PR DESCRIPTION
Fixes #3045
For the pose estimation example, the camera parameters are required. To work with examples from the tutorial, default camera parameters were added:
```
Size imgSize = inputImage.size();
cameraMatrix = Mat::eye(3, 3, CV_64FC1);
cameraMatrix.at<double>(0, 0) = cameraMatrix.at<double>(1, 1) = 650;
cameraMatrix.at<double>(0, 2) = imgSize.width / 2;
cameraMatrix.at<double>(1, 2) = imgSize.height / 2;
distCoeffs = Mat(5, 1, CV_64FC1, Scalar::all(0));
```
![aruco_tutorial](https://user-images.githubusercontent.com/22337800/142910209-63ee4093-d13e-43c9-9eba-d3cbcdde8596.png)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
