### PR TITLE
EdgeDrawing: Add output of segment index for line detection

### DIFF
--- a/modules/ximgproc/include/opencv2/ximgproc/edge_drawing.hpp
+++ b/modules/ximgproc/include/opencv2/ximgproc/edge_drawing.hpp
@@ -67,7 +67,13 @@ public:
     CV_WRAP virtual void getEdgeImage(OutputArray dst) = 0;
     CV_WRAP virtual void getGradientImage(OutputArray dst) = 0;
 
+    /** @brief Returns std::vector<std::vector<Point>> of detected edge segments, see detectEdges()
+     */
     CV_WRAP virtual std::vector<std::vector<Point> > getSegments() = 0;
+
+    /** @brief Returns for each line found in detectLines() its edge segment index in getSegments()
+     */
+    CV_WRAP virtual std::vector<int> getSegmentIndicesOfLines() const = 0;
 
     /** @brief Detects lines.
 

--- a/modules/ximgproc/src/edge_drawing.cpp
+++ b/modules/ximgproc/src/edge_drawing.cpp
@@ -109,6 +109,7 @@ public:
     void getGradientImage(OutputArray dst) CV_OVERRIDE;
 
     vector<vector<Point> > getSegments() CV_OVERRIDE;
+    vector<int> getSegmentIndicesOfLines() const CV_OVERRIDE;
     void detectLines(OutputArray lines) CV_OVERRIDE;
     void detectEllipses(OutputArray ellipses) CV_OVERRIDE;
 
@@ -120,6 +121,7 @@ protected:
     int height;       // height of source image
     uchar *srcImg;
     vector<vector<Point> > segmentPoints;
+    vector<int> segmentIndicesOfLines;
     Mat smoothImage;
     uchar *edgeImg;   // pointer to edge image data
     uchar *smoothImg; // pointer to smoothed image data
@@ -438,6 +440,11 @@ void EdgeDrawingImpl::getGradientImage(OutputArray _dst)
 std::vector<std::vector<Point> > EdgeDrawingImpl::getSegments()
 {
     return segmentPoints;
+}
+
+std::vector<int> EdgeDrawingImpl::getSegmentIndicesOfLines() const
+{
+    return segmentIndicesOfLines;
 }
 
 void EdgeDrawingImpl::ComputeGradient()
@@ -1312,12 +1319,15 @@ void EdgeDrawingImpl::detectLines(OutputArray _lines)
     for (int i = 1; i <= size - linesNo; i++)
         lines.pop_back();
 
+    segmentIndicesOfLines.clear();
     for (int i = 0; i < linesNo; i++)
     {
         Vec4f line((float)lines[i].sx, (float)lines[i].sy, (float)lines[i].ex, (float)lines[i].ey);
         linePoints.push_back(line);
+        segmentIndicesOfLines.push_back(lines[i].segmentNo);
     }
     Mat(linePoints).copyTo(_lines);
+
     delete[] x;
     delete[] y;
 }


### PR DESCRIPTION
Simply adds an optional output to EdgeDrawing lineDetect() for getting the edge segment each line lies on.  
I need this for porting the [STag](https://github.com/bbenligiray/stag) library

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
