### PR TITLE
Prefiltering for cuda::stereoBM

### DIFF
--- a/modules/cudastereo/src/stereobm.cpp
+++ b/modules/cudastereo/src/stereobm.cpp
@@ -57,6 +57,7 @@ namespace cv { namespace cuda { namespace device
     {
         void stereoBM_CUDA(const PtrStepSzb& left, const PtrStepSzb& right, const PtrStepSzb& disp, int ndisp, int winsz, const PtrStepSz<unsigned int>& minSSD_buf, cudaStream_t & stream);
         void prefilter_xsobel(const PtrStepSzb& input, const PtrStepSzb& output, int prefilterCap /*= 31*/, cudaStream_t & stream);
+        void prefilter_norm(const PtrStepSzb& input, const PtrStepSzb& output, int prefilterCap, int winsize, cudaStream_t & stream);
         void postfilter_textureness(const PtrStepSzb& input, int winsz, float avgTexturenessThreshold, const PtrStepSzb& disp, cudaStream_t & stream);
     }
 }}}
@@ -92,8 +93,8 @@ namespace
         int getPreFilterType() const { return preset_; }
         void setPreFilterType(int preFilterType) { preset_ = preFilterType; }
 
-        int getPreFilterSize() const { return 0; }
-        void setPreFilterSize(int /*preFilterSize*/) {}
+        int getPreFilterSize() const { return preFilterSize_; }
+        void setPreFilterSize(int preFilterSize) { preFilterSize_ = preFilterSize; }
 
         int getPreFilterCap() const { return preFilterCap_; }
         void setPreFilterCap(int preFilterCap) { preFilterCap_ = preFilterCap; }
@@ -119,12 +120,13 @@ namespace
         int winSize_;
         int preFilterCap_;
         float avergeTexThreshold_;
+        int preFilterSize_;
 
         GpuMat minSSD_, leBuf_, riBuf_;
     };
 
     StereoBMImpl::StereoBMImpl(int numDisparities, int blockSize)
-        : preset_(0), ndisp_(numDisparities), winSize_(blockSize), preFilterCap_(31), avergeTexThreshold_(3)
+        : preset_(-1), ndisp_(numDisparities), winSize_(blockSize), preFilterCap_(31), avergeTexThreshold_(3), preFilterSize_(9)
     {
     }
 
@@ -165,6 +167,17 @@ namespace
 
             prefilter_xsobel( left, leBuf_, preFilterCap_, stream);
             prefilter_xsobel(right, riBuf_, preFilterCap_, stream);
+
+            le_for_bm = leBuf_;
+            ri_for_bm = riBuf_;
+        }
+        else if(preset_ == cv::StereoBM::PREFILTER_NORMALIZED_RESPONSE)
+        {
+            cuda::ensureSizeIsEnough(left.size(), left.type(), leBuf_);
+            cuda::ensureSizeIsEnough(right.size(), right.type(), riBuf_);
+
+            prefilter_norm( left, leBuf_, preFilterCap_, preFilterSize_, stream);
+            prefilter_norm(right, riBuf_, preFilterCap_, preFilterSize_, stream);
 
             le_for_bm = leBuf_;
             ri_for_bm = riBuf_;

--- a/modules/cudastereo/test/test_stereo.cpp
+++ b/modules/cudastereo/test/test_stereo.cpp
@@ -79,6 +79,49 @@ CUDA_TEST_P(StereoBM, Regression)
     EXPECT_MAT_NEAR(disp_gold, disp, 0.0);
 }
 
+CUDA_TEST_P(StereoBM, PrefilterXSobelRegression)
+{
+    cv::Mat left_image  = readImage("stereobm/aloe-L.png", cv::IMREAD_GRAYSCALE);
+    cv::Mat right_image = readImage("stereobm/aloe-R.png", cv::IMREAD_GRAYSCALE);
+    cv::Mat disp_gold   = readImage("stereobm/aloe-disp-prefilter-xsobel.png", cv::IMREAD_GRAYSCALE);
+
+    ASSERT_FALSE(left_image.empty());
+    ASSERT_FALSE(right_image.empty());
+    ASSERT_FALSE(disp_gold.empty());
+
+    cv::Ptr<cv::StereoBM> bm = cv::cuda::createStereoBM(128, 19);
+    cv::cuda::GpuMat disp;
+
+    bm->setPreFilterType(cv::StereoBM::PREFILTER_XSOBEL);
+    bm->compute(loadMat(left_image), loadMat(right_image), disp);
+
+    EXPECT_MAT_NEAR(disp_gold, disp, 0.0);
+}
+
+CUDA_TEST_P(StereoBM, PrefilterNormRegression)
+{
+    cv::Mat left_image  = readImage("stereobm/aloe-L.png", cv::IMREAD_GRAYSCALE);
+    cv::Mat right_image = readImage("stereobm/aloe-R.png", cv::IMREAD_GRAYSCALE);
+    cv::Mat disp_gold   = readImage("stereobm/aloe-disp-prefilter-norm.png", cv::IMREAD_GRAYSCALE);
+
+    ASSERT_FALSE(left_image.empty());
+    ASSERT_FALSE(right_image.empty());
+    ASSERT_FALSE(disp_gold.empty());
+
+    cv::Ptr<cv::StereoBM> bm = cv::cuda::createStereoBM(128, 19);
+    cv::cuda::GpuMat disp;
+
+    bm->setPreFilterType(cv::StereoBM::PREFILTER_NORMALIZED_RESPONSE);
+    bm->setPreFilterSize(9);
+    bm->compute(loadMat(left_image), loadMat(right_image), disp);
+
+    cv::Mat disp_cpu;
+    disp.download(disp_cpu);
+    cv::imwrite("aloe-disp-prefilter-norm.png", disp_cpu);
+
+    EXPECT_MAT_NEAR(disp_gold, disp, 0.0);
+}
+
 INSTANTIATE_TEST_CASE_P(CUDA_Stereo, StereoBM, ALL_DEVICES);
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- Got rid of texture unit for xSobel mode;
- Implemented NORMALIZED_RESPONSE mode.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
buildworker:Custom=linux-4,linux-6
build_image:Custom=ubuntu-cuda:16.04
Xbuild_image:Custom=ubuntu-cuda:18.04
```