### PR TITLE
Fixed cache initialization in cuda::stereoBM

### DIFF
--- a/modules/cudastereo/src/cuda/stereobm.cu
+++ b/modules/cudastereo/src/cuda/stereobm.cu
@@ -76,9 +76,8 @@ namespace cv { namespace cuda { namespace device
             {
                 for(int i = 1; i <= RADIUS; i++)
                     cache += col_ssd[i];
-
-                col_ssd_cache[0] = cache;
             }
+            col_ssd_cache[0] = cache;
 
             __syncthreads();
 

--- a/modules/cudastereo/test/test_stereo.cpp
+++ b/modules/cudastereo/test/test_stereo.cpp
@@ -115,10 +115,6 @@ CUDA_TEST_P(StereoBM, PrefilterNormRegression)
     bm->setPreFilterSize(9);
     bm->compute(loadMat(left_image), loadMat(right_image), disp);
 
-    cv::Mat disp_cpu;
-    disp.download(disp_cpu);
-    cv::imwrite("aloe-disp-prefilter-norm.png", disp_cpu);
-
     EXPECT_MAT_NEAR(disp_gold, disp, 0.0);
 }
 
@@ -157,10 +153,6 @@ CUDA_TEST_P(StereoBM, Uniqueness_Regression)
 
     bm->setUniquenessRatio(15);
     bm->compute(loadMat(left_image), loadMat(right_image), disp);
-
-    cv::Mat disp_cpu;
-    disp.download(disp_cpu);
-    cv::imwrite("disp_inq15.png", disp_cpu);
 
     EXPECT_MAT_NEAR(disp_gold, disp, 0.0);
 }


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
buildworker:Custom=linux-4,linux-6
build_image:Custom=ubuntu-cuda:16.04
Xbuild_image:Custom=ubuntu-cuda:18.04
```