### PR TITLE
ovis: consistently use 0..1 value range for colors

### DIFF
--- a/modules/ovis/src/ovis.cpp
+++ b/modules/ovis/src/ovis.cpp
@@ -168,12 +168,10 @@ static SceneNode& _getSceneNode(SceneManager* sceneMgr, const String& name)
     return *mo->getParentSceneNode();
 }
 
+/// BGR to RGB 0..1
 static ColourValue convertColor(const Scalar& val)
 {
-    // BGR 0..255 (uchar) to RGB 0..1
-    ColourValue ret = ColourValue(val[2], val[1], val[0]) / 255;
-    ret.saturate();
-    return ret;
+    return ColourValue(val[2], val[1], val[0]).saturateCopy();
 }
 
 class WindowSceneImpl;
@@ -614,9 +612,8 @@ public:
                            const Scalar& specularColour) CV_OVERRIDE
     {
         Light* light = sceneMgr->createLight(name);
-        // convert to BGR
-        light->setDiffuseColour(ColourValue(diffuseColour[2], diffuseColour[1], diffuseColour[0]));
-        light->setSpecularColour(ColourValue(specularColour[2], specularColour[1], specularColour[0]));
+        light->setDiffuseColour(convertColor(diffuseColour));
+        light->setSpecularColour(convertColor(specularColour));
 
         Quaternion q;
         Vector3 t;


### PR DESCRIPTION
matches Ogre and makes more sense given float render targets are possible.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
