### PR TITLE
HashTSDF fixes backported

### DIFF
--- a/modules/rgbd/src/hash_tsdf.cpp
+++ b/modules/rgbd/src/hash_tsdf.cpp
@@ -1685,7 +1685,7 @@ void HashTSDFVolumeGPU::fetchPointsNormals(OutputArray _points, OutputArray _nor
                             {
                                 Point3f point = base_point + volume.voxelCoordToVolume(voxelIdx);
 
-                                localPoints.push_back(toPtype(this->pose * normal));
+                                localPoints.push_back(toPtype(this->pose * point));
                                 if (needNormals)
                                 {
                                     Point3f normal = volume.getNormalVoxel(point);

--- a/modules/rgbd/src/hash_tsdf.cpp
+++ b/modules/rgbd/src/hash_tsdf.cpp
@@ -796,11 +796,11 @@ void HashTSDFVolumeCPU::fetchPointsNormals(OutputArray _points, OutputArray _nor
                                 if (voxel.tsdf != -128 && voxel.weight != 0)
                                 {
                                     Point3f point = base_point + volume.voxelCoordToVolume(voxelIdx);
-                                    localPoints.push_back(toPtype(point));
+                                    localPoints.push_back(toPtype(this->pose * point));
                                     if (needNormals)
                                     {
                                         Point3f normal = volume.getNormalVoxel(point);
-                                        localNormals.push_back(toPtype(normal));
+                                        localNormals.push_back(toPtype(this->pose.rotation() * normal));
                                     }
                                 }
                             }
@@ -1685,11 +1685,11 @@ void HashTSDFVolumeGPU::fetchPointsNormals(OutputArray _points, OutputArray _nor
                             {
                                 Point3f point = base_point + volume.voxelCoordToVolume(voxelIdx);
 
-                                localPoints.push_back(toPtype(point));
+                                localPoints.push_back(toPtype(this->pose * normal));
                                 if (needNormals)
                                 {
                                     Point3f normal = volume.getNormalVoxel(point);
-                                    localNormals.push_back(toPtype(normal));
+                                    localNormals.push_back(toPtype(this->pose.rotation() * normal));
                                 }
                             }
                         }


### PR DESCRIPTION
Backport to 4.x from https://github.com/opencv/opencv/pull/21018

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
