### PR TITLE
Fix array out of range when too many line segments extracted

### DIFF
--- a/modules/line_descriptor/src/binary_descriptor.cpp
+++ b/modules/line_descriptor/src/binary_descriptor.cpp
@@ -2467,6 +2467,11 @@ int BinaryDescriptor::EDLineDetector::EDline( cv::Mat &image, LineChains &lines 
           offsetInLineArray = pLineSID[numOfLines];         // line was not accepted, the offset is set back
         }
       }
+      // Avoid array out of range
+      if(numOfLines >= lines.sId.size()) {
+        lines.sId.push_back(offsetInLineArray);
+        pLineSID = &lines.sId.front();
+      }
       //Extract line segments from the remaining pixel; Current chain has been shortened already.
     }
   }         //end for(unsigned int edgeID=0; edgeID<edges.numOfEdges; edgeID++)


### PR DESCRIPTION
When extracted line segments number over given size of `lines.sId`(default: `5 * edges.numOfEdges`), it will result in array out of range, which further cause a segment fault as below. This is a small probability event, but it did happen in practical use.
```bash
*** Aborted at 1641264940 (unix time) try "date -d @1641264940" if you are using GNU date ***
PC: @                0x0 (unknown)
*** SIGABRT (@0x3e800001cc8) received by PID 7368 (TID 0x7ff538ff8700) from PID 7368; stack trace: ***
    @     0x7ff56ff71390 (unknown)
    @     0x7ff56e57e428 gsignal
    @     0x7ff56e58002a abort
    @     0x7ff56e5c07ea (unknown)
    @     0x7ff56e5c79dc (unknown)
    @     0x7ff56e5c9678 (unknown)
    @     0x7ff56e5cd53c cfree
    @     0x7ff56fb2787d cv::line_descriptor::BinaryDescriptor::EDLineDetector::~EDLineDetector()
    @     0x7ff56fb3386a cv::detail::PtrOwnerImpl<>::deleteSelf()
    @     0x7ff56fb25ffb cv::line_descriptor::BinaryDescriptor::~BinaryDescriptor()
    @     0x7ff56fb26059 cv::line_descriptor::BinaryDescriptor::~BinaryDescriptor()
    @     0x7ff56fb33453 cv::detail::PtrOwnerImpl<>::deleteSelf()
```