### PR TITLE
Feature/aruco speedup (rebased with 4.x)

### DIFF
--- a/modules/aruco/include/opencv2/aruco.hpp
+++ b/modules/aruco/include/opencv2/aruco.hpp
@@ -150,6 +150,7 @@ enum CornerRefineMethod{
  *   Romero-Ramirez et al: Speeded up detection of squared fiducial markers (2018) is, that the binary
  *   code of a marker can be reliably detected if the canonical image (that is used to extract the binary code)
  *   has a size of minSideLengthCanonicalImg (in practice tau_c=16-32 pixels).
+ *   Link to article: https://www.researchgate.net/publication/325787310_Speeded_Up_Detection_of_Squared_Fiducial_Markers
  *   In addition, very small markers are barely useful for pose estimation and thus a we can define a minimum marker size that we
  *   still want to be able to detect (e.g. 50x50 pixel).
  *   To decouple this from the initial image size they propose to resize the input image

--- a/modules/aruco/include/opencv2/aruco.hpp
+++ b/modules/aruco/include/opencv2/aruco.hpp
@@ -146,6 +146,33 @@ enum CornerRefineMethod{
  *   Parameter is the standard deviation in pixels.  Very noisy images benefit from non-zero values (e.g. 0.8). (default 0.0)
  * - detectInvertedMarker: to check if there is a white marker. In order to generate a "white" marker just
  *   invert a normal marker by using a tilde, ~markerImage. (default false)
+ * - useAruco3Detection: to enable the new and faster Aruco detection strategy. The most important observation from the authors of
+ *   Romero-Ramirez et al: Speeded up detection of squared fiducial markers (2018) is, that the binary
+ *   code of a marker can be reliably detected if the canonical image (that is used to extract the binary code)
+ *   has a size of minSideLengthCanonicalImg (in practice tau_c=16-32 pixels).
+ *   In addition, very small markers are barely useful for pose estimation and thus a we can define a minimum marker size that we
+ *   still want to be able to detect (e.g. 50x50 pixel).
+ *   To decouple this from the initial image size they propose to resize the input image
+ *   to (I_w_r, I_h_r) = (tau_c / tau_dot_i) * (I_w, I_h), with tau_dot_i = tau_c + max(I_w,I_h) * tau_i.
+ *   Here tau_i (parameter: minMarkerLengthRatioOriginalImg) is a ratio in the range [0,1].
+ *   If we set this to 0, the smallest marker we can detect
+ *   has a side length of tau_c. If we set it to 1 the marker would fill the entire image.
+ *   For a FullHD video a good value to start with is 0.1.
+ * - minSideLengthCanonicalImg: minimum side length of a marker in the canonical image.
+ *   Latter is the binarized image in which contours are searched.
+ *   So all contours with a size smaller than minSideLengthCanonicalImg*minSideLengthCanonicalImg will omitted from the search.
+ * - minMarkerLengthRatioOriginalImg:  range [0,1], eq (2) from paper
+ * - cameraMotionSpeed: is in the range [0,1]. This parameter (tau_s in the paper) implements the feature proposed
+ *   in Section 3.7. and is particularly useful for video sequences.
+ *   The parameter tau_i has a direct influence on the processing speed. Instead of setting a fixed value for it,
+ *   it can be adjusted at the end of each frame using
+ *   tau_i = (1-tau_s)*P(v_s)/4 (eq. 6 in paper).
+ *   Where P(v_s) is the perimeter of the smallest marker that was detected in the last frame.
+ * - useGlobalThreshold: if we process a video, the assumption is, that the illumination conditions remains
+ *   constant and global instead of adaptive thresholding can be applied, speeding up the binarization step.
+ * - foundGlobalThreshold: internal variable. It is used to cache the variable to the next detector call.
+ * - otsuGlobalThreshold: internal variable. It is used to cache the global otsu threshold to the next detector call.
+ * - foundMarkerInLastFrames: internal variable. It is used to cache if markers were found in the last frame.
  */
 struct CV_EXPORTS_W DetectorParameters {
 
@@ -188,6 +215,19 @@ struct CV_EXPORTS_W DetectorParameters {
 
     // to detect white (inverted) markers
     CV_PROP_RW bool detectInvertedMarker;
+
+    // New Aruco functionality proposed in the paper:
+    // Romero-Ramirez et al: Speeded up detection of squared fiducial markers (2018)
+    CV_PROP_RW bool useAruco3Detection;
+    CV_PROP_RW int minSideLengthCanonicalImg;
+    CV_PROP_RW float minMarkerLengthRatioOriginalImg;
+
+    // New Aruco functionality especially for video
+    CV_PROP_RW float cameraMotionSpeed;
+    CV_PROP_RW bool useGlobalThreshold;
+    CV_PROP_RW bool foundGlobalThreshold;
+    CV_PROP_RW float otsuGlobalThreshold;
+    CV_PROP_RW int foundMarkerInLastFrames;
 };
 
 
@@ -215,12 +255,13 @@ struct CV_EXPORTS_W DetectorParameters {
  * are searched. For each detected marker, it returns the 2D position of its corner in the image
  * and its corresponding identifier.
  * Note that this function does not perform pose estimation.
- * @sa estimatePoseSingleMarkers,  estimatePoseBoard
+ * The function returns an estimate of the parameter minMarkerLengthRatioOriginalImg if useAruco3Detection=1. If not it returns 0.0.
+ * @sa estimatePoseSingleMarkers, estimatePoseBoard
  *
  */
-CV_EXPORTS_W void detectMarkers(InputArray image, const Ptr<Dictionary> &dictionary, OutputArrayOfArrays corners,
-                                OutputArray ids, const Ptr<DetectorParameters> &parameters = DetectorParameters::create(),
-                                OutputArrayOfArrays rejectedImgPoints = noArray(), InputArray cameraMatrix= noArray(), InputArray distCoeff= noArray());
+CV_EXPORTS_W float detectMarkers(InputArray image, const Ptr<Dictionary> &dictionary, OutputArrayOfArrays corners,
+                                 OutputArray ids, const Ptr<DetectorParameters> &parameters = DetectorParameters::create(),
+                                 OutputArrayOfArrays rejectedImgPoints = noArray(), InputArray cameraMatrix= noArray(), InputArray distCoeff= noArray());
 
 
 

--- a/modules/aruco/include/opencv2/aruco.hpp
+++ b/modules/aruco/include/opencv2/aruco.hpp
@@ -163,17 +163,7 @@ enum CornerRefineMethod{
  *   Latter is the binarized image in which contours are searched.
  *   So all contours with a size smaller than minSideLengthCanonicalImg*minSideLengthCanonicalImg will omitted from the search.
  * - minMarkerLengthRatioOriginalImg:  range [0,1], eq (2) from paper
- * - cameraMotionSpeed: is in the range [0,1]. This parameter (tau_s in the paper) implements the feature proposed
- *   in Section 3.7. and is particularly useful for video sequences.
- *   The parameter tau_i has a direct influence on the processing speed. Instead of setting a fixed value for it,
- *   it can be adjusted at the end of each frame using
- *   tau_i = (1-tau_s)*P(v_s)/4 (eq. 6 in paper).
- *   Where P(v_s) is the perimeter of the smallest marker that was detected in the last frame.
- * - useGlobalThreshold: if we process a video, the assumption is, that the illumination conditions remains
- *   constant and global instead of adaptive thresholding can be applied, speeding up the binarization step.
- * - foundGlobalThreshold: internal variable. It is used to cache the variable to the next detector call.
- * - otsuGlobalThreshold: internal variable. It is used to cache the global otsu threshold to the next detector call.
- * - foundMarkerInLastFrames: internal variable. It is used to cache if markers were found in the last frame.
+ *   The parameter tau_i has a direct influence on the processing speed.
  */
 struct CV_EXPORTS_W DetectorParameters {
 
@@ -222,13 +212,6 @@ struct CV_EXPORTS_W DetectorParameters {
     CV_PROP_RW bool useAruco3Detection;
     CV_PROP_RW int minSideLengthCanonicalImg;
     CV_PROP_RW float minMarkerLengthRatioOriginalImg;
-
-    // New Aruco functionality especially for video
-    CV_PROP_RW float cameraMotionSpeed;
-    CV_PROP_RW bool useGlobalThreshold;
-    CV_PROP_RW bool foundGlobalThreshold;
-    CV_PROP_RW float otsuGlobalThreshold;
-    CV_PROP_RW int foundMarkerInLastFrames;
 };
 
 
@@ -256,13 +239,12 @@ struct CV_EXPORTS_W DetectorParameters {
  * are searched. For each detected marker, it returns the 2D position of its corner in the image
  * and its corresponding identifier.
  * Note that this function does not perform pose estimation.
- * The function returns an estimate of the parameter minMarkerLengthRatioOriginalImg if useAruco3Detection=1. If not it returns 0.0.
- * @sa estimatePoseSingleMarkers, estimatePoseBoard
+ * @sa estimatePoseSingleMarkers,  estimatePoseBoard
  *
  */
-CV_EXPORTS_W float detectMarkers(InputArray image, const Ptr<Dictionary> &dictionary, OutputArrayOfArrays corners,
-                                 OutputArray ids, const Ptr<DetectorParameters> &parameters = DetectorParameters::create(),
-                                 OutputArrayOfArrays rejectedImgPoints = noArray(), InputArray cameraMatrix= noArray(), InputArray distCoeff= noArray());
+CV_EXPORTS_W void detectMarkers(InputArray image, const Ptr<Dictionary> &dictionary, OutputArrayOfArrays corners,
+                                OutputArray ids, const Ptr<DetectorParameters> &parameters = DetectorParameters::create(),
+                                OutputArrayOfArrays rejectedImgPoints = noArray(), InputArray cameraMatrix= noArray(), InputArray distCoeff= noArray());
 
 
 

--- a/modules/aruco/perf/perf_aruco.cpp
+++ b/modules/aruco/perf/perf_aruco.cpp
@@ -1,0 +1,291 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
+#include "perf_precomp.hpp"
+
+namespace opencv_test {
+using namespace perf;
+
+typedef tuple<bool, int> UseArucoParams;
+typedef TestBaseWithParam<UseArucoParams> EstimateAruco;
+#define ESTIMATE_PARAMS Combine(Values(false, true), Values(-1))
+
+static double deg2rad(double deg) { return deg * CV_PI / 180.; }
+
+class MarkerPainter
+{
+private:
+    int imgMarkerSize = 0;
+    Mat cameraMatrix;
+public:
+    MarkerPainter(const int size)
+    {
+        setImgMarkerSize(size);
+    }
+
+    void setImgMarkerSize(const int size)
+    {
+        imgMarkerSize = size;
+        cameraMatrix = Mat::eye(3, 3, CV_64FC1);
+        cameraMatrix.at<double>(0, 0) = cameraMatrix.at<double>(1, 1) = imgMarkerSize;
+        cameraMatrix.at<double>(0, 2) = imgMarkerSize / 2.0;
+        cameraMatrix.at<double>(1, 2) = imgMarkerSize / 2.0;
+    }
+
+    static std::pair<Mat, Mat> getSyntheticRT(double yaw, double pitch, double distance)
+    {
+        auto rvec_tvec = std::make_pair(Mat(3, 1, CV_64FC1), Mat(3, 1, CV_64FC1));
+        Mat& rvec = rvec_tvec.first;
+        Mat& tvec = rvec_tvec.second;
+
+        // Rvec
+        // first put the Z axis aiming to -X (like the camera axis system)
+        Mat rotZ(3, 1, CV_64FC1);
+        rotZ.ptr<double>(0)[0] = 0;
+        rotZ.ptr<double>(0)[1] = 0;
+        rotZ.ptr<double>(0)[2] = -0.5 * CV_PI;
+
+        Mat rotX(3, 1, CV_64FC1);
+        rotX.ptr<double>(0)[0] = 0.5 * CV_PI;
+        rotX.ptr<double>(0)[1] = 0;
+        rotX.ptr<double>(0)[2] = 0;
+
+        Mat camRvec, camTvec;
+        composeRT(rotZ, Mat(3, 1, CV_64FC1, Scalar::all(0)), rotX, Mat(3, 1, CV_64FC1, Scalar::all(0)),
+                  camRvec, camTvec);
+
+        // now pitch and yaw angles
+        Mat rotPitch(3, 1, CV_64FC1);
+        rotPitch.ptr<double>(0)[0] = 0;
+        rotPitch.ptr<double>(0)[1] = pitch;
+        rotPitch.ptr<double>(0)[2] = 0;
+
+        Mat rotYaw(3, 1, CV_64FC1);
+        rotYaw.ptr<double>(0)[0] = yaw;
+        rotYaw.ptr<double>(0)[1] = 0;
+        rotYaw.ptr<double>(0)[2] = 0;
+
+        composeRT(rotPitch, Mat(3, 1, CV_64FC1, Scalar::all(0)), rotYaw,
+                  Mat(3, 1, CV_64FC1, Scalar::all(0)), rvec, tvec);
+
+        // compose both rotations
+        composeRT(camRvec, Mat(3, 1, CV_64FC1, Scalar::all(0)), rvec,
+                  Mat(3, 1, CV_64FC1, Scalar::all(0)), rvec, tvec);
+
+        // Tvec, just move in z (camera) direction the specific distance
+        tvec.ptr<double>(0)[0] = 0.;
+        tvec.ptr<double>(0)[1] = 0.;
+        tvec.ptr<double>(0)[2] = distance;
+        return rvec_tvec;
+}
+
+    std::pair<Mat, vector<Point2f> > getProjectMarker(int id, double yaw, double pitch,
+                                                      const Ptr<aruco::DetectorParameters>& parameters,
+                                                      const Ptr<aruco::Dictionary>& dictionary)
+    {
+        auto marker_corners = std::make_pair(Mat(imgMarkerSize, imgMarkerSize, CV_8UC1, Scalar::all(255)), vector<Point2f>());
+        Mat& img = marker_corners.first;
+        vector<Point2f>& corners = marker_corners.second;
+
+        // canonical image
+        const int markerSizePixels = static_cast<int>(imgMarkerSize/sqrt(2.f));
+        aruco::drawMarker(dictionary, id, markerSizePixels, img, parameters->markerBorderBits);
+
+        // get rvec and tvec for the perspective
+        const double distance = 0.1;
+        auto rvec_tvec = MarkerPainter::getSyntheticRT(yaw, pitch, distance);
+        Mat& rvec = rvec_tvec.first;
+        Mat& tvec = rvec_tvec.second;
+
+        const float markerLength = 0.05f;
+        vector<Point3f> markerObjPoints;
+        markerObjPoints.emplace_back(Point3f(-markerLength / 2.f, +markerLength / 2.f, 0));
+        markerObjPoints.emplace_back(markerObjPoints[0] + Point3f(markerLength, 0, 0));
+        markerObjPoints.emplace_back(markerObjPoints[0] + Point3f(markerLength, -markerLength, 0));
+        markerObjPoints.emplace_back(markerObjPoints[0] + Point3f(0, -markerLength, 0));
+
+        // project markers and draw them
+        Mat distCoeffs(5, 1, CV_64FC1, Scalar::all(0));
+        projectPoints(markerObjPoints, rvec, tvec, cameraMatrix, distCoeffs, corners);
+
+        vector<Point2f> originalCorners;
+        originalCorners.emplace_back(Point2f(0.f, 0.f));
+        originalCorners.emplace_back(originalCorners[0]+Point2f((float)markerSizePixels, 0));
+        originalCorners.emplace_back(originalCorners[0]+Point2f((float)markerSizePixels, (float)markerSizePixels));
+        originalCorners.emplace_back(originalCorners[0]+Point2f(0, (float)markerSizePixels));
+
+        Mat transformation = getPerspectiveTransform(originalCorners, corners);
+
+        warpPerspective(img, img, transformation, Size(imgMarkerSize, imgMarkerSize), INTER_NEAREST, BORDER_CONSTANT,
+                        Scalar::all(255));
+        return marker_corners;
+    }
+
+    std::pair<Mat, map<int, vector<Point2f> > > getProjectMarkersTile(const int numMarkers,
+                                                                      const Ptr<aruco::DetectorParameters>& params,
+                                                                      const Ptr<aruco::Dictionary>& dictionary)
+    {
+        Mat tileImage(imgMarkerSize*numMarkers, imgMarkerSize*numMarkers, CV_8UC1, Scalar::all(255));
+        map<int, vector<Point2f> > idCorners;
+
+        int iter = 0, pitch = 0, yaw = 0;
+        for (int i = 0; i < numMarkers; i++)
+        {
+            for (int j = 0; j < numMarkers; j++)
+            {
+                int currentId = iter;
+                auto marker_corners = getProjectMarker(currentId, deg2rad(70+yaw), deg2rad(pitch), params, dictionary);
+                Point2i startPoint(j*imgMarkerSize, i*imgMarkerSize);
+                Mat tmp_roi = tileImage(Rect(startPoint.x, startPoint.y, imgMarkerSize, imgMarkerSize));
+                marker_corners.first.copyTo(tmp_roi);
+
+                for (Point2f& point: marker_corners.second)
+                    point += static_cast<Point2f>(startPoint);
+                idCorners[currentId] = marker_corners.second;
+                auto test = idCorners[currentId];
+                yaw = (yaw + 10) % 51; // 70+yaw >= 70 && 70+yaw <= 120
+                iter++;
+            }
+            pitch = (pitch + 60) % 360;
+        }
+        return std::make_pair(tileImage, idCorners);
+    }
+};
+
+static inline double getMaxDistance(map<int, vector<Point2f> > &golds, const vector<int>& ids,
+                                               const vector<vector<Point2f> >& corners)
+{
+    double distance = 0.;
+    for (size_t i = 0; i < ids.size(); i++)
+    {
+        int id = ids[i];
+        const auto gold_corners = golds.find(id);
+        if (gold_corners != golds.end())
+        for (int c = 0; c < 4; c++)
+            distance = std::max(distance, cv::norm(gold_corners->second[c] - corners[i][c]));
+    }
+    return distance;
+}
+
+PERF_TEST_P(EstimateAruco, ArucoFirst, ESTIMATE_PARAMS)
+{
+    UseArucoParams testParams = GetParam();
+    Ptr<aruco::Dictionary> dictionary = aruco::getPredefinedDictionary(aruco::DICT_6X6_250);
+    Ptr<aruco::DetectorParameters> detectorParams = aruco::DetectorParameters::create();
+    detectorParams->minDistanceToBorder = 1;
+    detectorParams->markerBorderBits = 1;
+    detectorParams->cornerRefinementMethod = cv::aruco::CORNER_REFINE_SUBPIX;
+
+    const int markerSize = 100;
+    const int numMarkersInRow = 9;
+    //USE_ARUCO3
+    detectorParams->useAruco3Detection = get<0>(testParams);
+    if (detectorParams->useAruco3Detection) {
+        detectorParams->minSideLengthCanonicalImg = 32;
+        detectorParams->minMarkerLengthRatioOriginalImg = 0.04f / numMarkersInRow;
+    }
+    MarkerPainter painter(markerSize);
+    auto image_map = painter.getProjectMarkersTile(numMarkersInRow, detectorParams, dictionary);
+
+    // detect markers
+    vector<vector<Point2f> > corners;
+    vector<int> ids;
+    TEST_CYCLE_N(10)
+    {
+        aruco::detectMarkers(image_map.first, dictionary, corners, ids, detectorParams);
+    }
+    ASSERT_EQ(numMarkersInRow*numMarkersInRow, static_cast<int>(ids.size()));
+    double maxDistance = getMaxDistance(image_map.second, ids, corners);
+    ASSERT_LT(maxDistance, 3.);
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P(EstimateAruco, ArucoSecond, ESTIMATE_PARAMS)
+{
+    UseArucoParams testParams = GetParam();
+    Ptr<aruco::Dictionary> dictionary = aruco::getPredefinedDictionary(aruco::DICT_6X6_250);
+    Ptr<aruco::DetectorParameters> detectorParams = aruco::DetectorParameters::create();
+    detectorParams->minDistanceToBorder = 1;
+    detectorParams->markerBorderBits = 1;
+    detectorParams->cornerRefinementMethod = cv::aruco::CORNER_REFINE_SUBPIX;
+
+    //USE_ARUCO3
+    detectorParams->useAruco3Detection = get<0>(testParams);
+    if (detectorParams->useAruco3Detection) {
+        detectorParams->minSideLengthCanonicalImg = 64;
+        detectorParams->minMarkerLengthRatioOriginalImg = 0.f;
+    }
+    const int markerSize = 200;
+    const int numMarkersInRow = 11;
+    MarkerPainter painter(markerSize);
+    auto image_map = painter.getProjectMarkersTile(numMarkersInRow, detectorParams, dictionary);
+
+    // detect markers
+    vector<vector<Point2f> > corners;
+    vector<int> ids;
+    TEST_CYCLE_N(10)
+    {
+        aruco::detectMarkers(image_map.first, dictionary, corners, ids, detectorParams);
+    }
+    ASSERT_EQ(numMarkersInRow*numMarkersInRow, static_cast<int>(ids.size()));
+    double maxDistance = getMaxDistance(image_map.second, ids, corners);
+    ASSERT_LT(maxDistance, 3.);
+    SANITY_CHECK_NOTHING();
+}
+
+struct Aruco3Params
+{
+    bool useAruco3Detection = false;
+    float minMarkerLengthRatioOriginalImg = 0.f;
+    int minSideLengthCanonicalImg = 0;
+
+    Aruco3Params(bool useAruco3, float minMarkerLen, int minSideLen): useAruco3Detection(useAruco3),
+                                                                      minMarkerLengthRatioOriginalImg(minMarkerLen),
+                                                                      minSideLengthCanonicalImg(minSideLen) {}
+    friend std::ostream& operator<<(std::ostream& os, const Aruco3Params& d)
+    {
+        os << d.useAruco3Detection << " " << d.minMarkerLengthRatioOriginalImg << " " << d.minSideLengthCanonicalImg;
+        return os;
+    }
+};
+typedef tuple<Aruco3Params, pair<int, int>> ArucoTestParams;
+
+typedef TestBaseWithParam<ArucoTestParams> EstimateLargeAruco;
+#define ESTIMATE_FHD_PARAMS Combine(Values(Aruco3Params(false, 0.f, 0), Aruco3Params(true, 0.f, 32), \
+Aruco3Params(true, 0.015f, 32), Aruco3Params(true, 0.f, 16), Aruco3Params(true, 0.0069f, 16)),       \
+Values(std::make_pair(1440, 1), std::make_pair(480, 3), std::make_pair(144, 10)))
+
+PERF_TEST_P(EstimateLargeAruco, ArucoFHD, ESTIMATE_FHD_PARAMS)
+{
+    ArucoTestParams testParams = GetParam();
+    Ptr<aruco::Dictionary> dictionary = aruco::getPredefinedDictionary(aruco::DICT_6X6_250);
+    Ptr<aruco::DetectorParameters> detectorParams = aruco::DetectorParameters::create();
+    detectorParams->minDistanceToBorder = 1;
+    detectorParams->markerBorderBits = 1;
+    detectorParams->cornerRefinementMethod = cv::aruco::CORNER_REFINE_SUBPIX;
+
+    //USE_ARUCO3
+    detectorParams->useAruco3Detection = get<0>(testParams).useAruco3Detection;
+    if (detectorParams->useAruco3Detection) {
+        detectorParams->minSideLengthCanonicalImg = get<0>(testParams).minSideLengthCanonicalImg;
+        detectorParams->minMarkerLengthRatioOriginalImg = get<0>(testParams).minMarkerLengthRatioOriginalImg;
+    }
+    const int markerSize = get<1>(testParams).first;       // 1440 or 480 or 144
+    const int numMarkersInRow = get<1>(testParams).second; // 1 or 3 or 144
+    MarkerPainter painter(markerSize);                     // num pixels is 1440x1440 as in FHD 1920x1080
+    auto image_map = painter.getProjectMarkersTile(numMarkersInRow, detectorParams, dictionary);
+
+    // detect markers
+    vector<vector<Point2f> > corners;
+    vector<int> ids;
+    TEST_CYCLE_N(10)
+    {
+        aruco::detectMarkers(image_map.first, dictionary, corners, ids, detectorParams);
+    }
+    ASSERT_EQ(numMarkersInRow*numMarkersInRow, static_cast<int>(ids.size()));
+    double maxDistance = getMaxDistance(image_map.second, ids, corners);
+    ASSERT_LT(maxDistance, 3.);
+    SANITY_CHECK_NOTHING();
+}
+
+}

--- a/modules/aruco/perf/perf_main.cpp
+++ b/modules/aruco/perf/perf_main.cpp
@@ -1,0 +1,3 @@
+#include "perf_precomp.hpp"
+
+CV_PERF_TEST_MAIN(aruco)

--- a/modules/aruco/perf/perf_precomp.hpp
+++ b/modules/aruco/perf/perf_precomp.hpp
@@ -1,0 +1,11 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
+#ifndef __OPENCV_PERF_PRECOMP_HPP__
+#define __OPENCV_PERF_PRECOMP_HPP__
+
+#include "opencv2/ts.hpp"
+#include "opencv2/aruco.hpp"
+#include "opencv2/calib3d.hpp"
+
+#endif

--- a/modules/aruco/samples/detect_markers.cpp
+++ b/modules/aruco/samples/detect_markers.cpp
@@ -68,58 +68,6 @@ const char* keys  =
 }
 //! [aruco_detect_markers_keys]
 
-/**
- */
-static bool readCameraParameters(string filename, Mat &camMatrix, Mat &distCoeffs) {
-    FileStorage fs(filename, FileStorage::READ);
-    if(!fs.isOpened())
-        return false;
-    fs["camera_matrix"] >> camMatrix;
-    fs["distortion_coefficients"] >> distCoeffs;
-    return true;
-}
-
-
-
-/**
- */
-static bool readDetectorParameters(string filename, Ptr<aruco::DetectorParameters> &params) {
-    FileStorage fs(filename, FileStorage::READ);
-    if(!fs.isOpened())
-        return false;
-    fs["adaptiveThreshWinSizeMin"] >> params->adaptiveThreshWinSizeMin;
-    fs["adaptiveThreshWinSizeMax"] >> params->adaptiveThreshWinSizeMax;
-    fs["adaptiveThreshWinSizeStep"] >> params->adaptiveThreshWinSizeStep;
-    fs["adaptiveThreshConstant"] >> params->adaptiveThreshConstant;
-    fs["minMarkerPerimeterRate"] >> params->minMarkerPerimeterRate;
-    fs["maxMarkerPerimeterRate"] >> params->maxMarkerPerimeterRate;
-    fs["polygonalApproxAccuracyRate"] >> params->polygonalApproxAccuracyRate;
-    fs["minCornerDistanceRate"] >> params->minCornerDistanceRate;
-    fs["minDistanceToBorder"] >> params->minDistanceToBorder;
-    fs["minMarkerDistanceRate"] >> params->minMarkerDistanceRate;
-    fs["cornerRefinementMethod"] >> params->cornerRefinementMethod;
-    fs["cornerRefinementWinSize"] >> params->cornerRefinementWinSize;
-    fs["cornerRefinementMaxIterations"] >> params->cornerRefinementMaxIterations;
-    fs["cornerRefinementMinAccuracy"] >> params->cornerRefinementMinAccuracy;
-    fs["markerBorderBits"] >> params->markerBorderBits;
-    fs["perspectiveRemovePixelPerCell"] >> params->perspectiveRemovePixelPerCell;
-    fs["perspectiveRemoveIgnoredMarginPerCell"] >> params->perspectiveRemoveIgnoredMarginPerCell;
-    fs["maxErroneousBitsInBorderRate"] >> params->maxErroneousBitsInBorderRate;
-    fs["minOtsuStdDev"] >> params->minOtsuStdDev;
-    fs["errorCorrectionRate"] >> params->errorCorrectionRate;
-    // new aruco functionality
-    fs["useAruco3Detection"] >> params->useAruco3Detection;
-    fs["minSideLengthCanonicalImg"] >> params->minSideLengthCanonicalImg;
-    fs["minMarkerLengthRatioOriginalImg"] >> params->minMarkerLengthRatioOriginalImg;
-    fs["cameraMotionSpeed"] >> params->cameraMotionSpeed;
-    fs["useGlobalThreshold"] >> params->useGlobalThreshold;
-    return true;
-}
-
-
-
-/**
- */
 int main(int argc, char *argv[]) {
     CommandLineParser parser(argc, argv, keys);
     parser.about(about);

--- a/modules/aruco/samples/detector_params.yml
+++ b/modules/aruco/samples/detector_params.yml
@@ -28,5 +28,3 @@ minSideLengthCanonicalImg: 32 # 16, 32, 64 --> tau_c from the paper
 minMarkerLengthRatioOriginalImg: 0.02 # range [0,0.2] --> tau_i from the paper
 cameraMotionSpeed: 0.1 # range [0,1) --> tau_s from the paper
 useGlobalThreshold: 0
-
-

--- a/modules/aruco/samples/detector_params.yml
+++ b/modules/aruco/samples/detector_params.yml
@@ -22,7 +22,7 @@ maxErroneousBitsInBorderRate: 0.04
 minOtsuStdDev: 5.0
 errorCorrectionRate: 0.6
 
-# new aruco functionality
+# new aruco 3 functionality
 useAruco3Detection: 0
 minSideLengthCanonicalImg: 32 # 16, 32, 64 --> tau_c from the paper
 minMarkerLengthRatioOriginalImg: 0.02 # range [0,0.2] --> tau_i from the paper

--- a/modules/aruco/samples/detector_params.yml
+++ b/modules/aruco/samples/detector_params.yml
@@ -21,3 +21,12 @@ perspectiveRemoveIgnoredMarginPerCell: 0.13
 maxErroneousBitsInBorderRate: 0.04
 minOtsuStdDev: 5.0
 errorCorrectionRate: 0.6
+
+# new aruco functionality
+useAruco3Detection: 0
+minSideLengthCanonicalImg: 32 # 16, 32, 64 --> tau_c from the paper
+minMarkerLengthRatioOriginalImg: 0.02 # range [0,0.2] --> tau_i from the paper
+cameraMotionSpeed: 0.1 # range [0,1) --> tau_s from the paper
+useGlobalThreshold: 0
+
+

--- a/modules/aruco/src/aruco.cpp
+++ b/modules/aruco/src/aruco.cpp
@@ -704,7 +704,8 @@ static void _identifyCandidates(InputArray grey,
                                 vector< vector< Point2f > >& _accepted, vector< vector<Point> >& _contours, vector< int >& ids,
                                 const Ptr<DetectorParameters> &params,
                                 OutputArrayOfArrays _rejected = noArray()) {
-
+    CV_DbgAssert(grey.getMat().total() != 0);
+    CV_DbgAssert(grey.getMat().type() == CV_8UC1);
     int ncandidates = (int)_candidatesSet[0].size();
     vector< vector< Point2f > > accepted;
     vector< vector< Point2f > > rejected;

--- a/modules/aruco/src/aruco.cpp
+++ b/modules/aruco/src/aruco.cpp
@@ -87,7 +87,16 @@ DetectorParameters::DetectorParameters()
       aprilTagMaxLineFitMse(10.0),
       aprilTagMinWhiteBlackDiff(5),
       aprilTagDeglitch(0),
-      detectInvertedMarker(false){}
+      detectInvertedMarker(false),
+      useAruco3Detection(false),
+      minSideLengthCanonicalImg(32),
+      minMarkerLengthRatioOriginalImg(0.0),
+      cameraMotionSpeed(1.0),
+      useGlobalThreshold(true),
+      foundGlobalThreshold(false),
+      otsuGlobalThreshold(0.0),
+      foundMarkerInLastFrames(0)
+{}
 
 
 /**
@@ -173,7 +182,7 @@ static void _threshold(InputArray _in, OutputArray _out, int winSize, double con
 static void _findMarkerContours(InputArray _in, vector< vector< Point2f > > &candidates,
                                 vector< vector< Point > > &contoursOut, double minPerimeterRate,
                                 double maxPerimeterRate, double accuracyRate,
-                                double minCornerDistanceRate, int minDistanceToBorder) {
+                                double minCornerDistanceRate, int minDistanceToBorder, int minSize) {
 
     CV_Assert(minPerimeterRate > 0 && maxPerimeterRate > 0 && accuracyRate > 0 &&
               minCornerDistanceRate >= 0 && minDistanceToBorder >= 0);
@@ -183,6 +192,11 @@ static void _findMarkerContours(InputArray _in, vector< vector< Point2f > > &can
         (unsigned int)(minPerimeterRate * max(_in.getMat().cols, _in.getMat().rows));
     unsigned int maxPerimeterPixels =
         (unsigned int)(maxPerimeterRate * max(_in.getMat().cols, _in.getMat().rows));
+
+    // for aruco3 functionality
+    if (minSize != 0) {
+        minPerimeterPixels = 4*minSize;
+    }
 
     Mat contoursImg;
     _in.getMat().copyTo(contoursImg);
@@ -349,35 +363,33 @@ static void _filterTooCloseCandidates(const vector< vector< Point2f > > &candida
 
     // save possible candidates
     for(unsigned int i = 0; i < groupedCandidates.size(); i++) {
-        unsigned int smallerIdx = groupedCandidates[i][0];
-        unsigned int biggerIdx = smallerIdx;
-        double smallerArea = contourArea(candidatesIn[smallerIdx]);
-        double biggerArea = smallerArea;
+        int smallerIdx = groupedCandidates[i][0];
+        int biggerIdx = -1;
 
         // evaluate group elements
         for(unsigned int j = 1; j < groupedCandidates[i].size(); j++) {
-            unsigned int currIdx = groupedCandidates[i][j];
-            double currArea = contourArea(candidatesIn[currIdx]);
+            size_t currPerim = contoursIn[groupedCandidates[i][j]].size();
 
             // check if current contour is bigger
-            if(currArea >= biggerArea) {
-                biggerIdx = currIdx;
-                biggerArea = currArea;
-            }
+            if (biggerIdx < 0)
+                biggerIdx = groupedCandidates[i][j];
+            else if(currPerim >= contoursIn[biggerIdx].size())
+                biggerIdx = groupedCandidates[i][j];
 
             // check if current contour is smaller
-            if(currArea < smallerArea && detectInvertedMarker) {
-                smallerIdx = currIdx;
-                smallerArea = currArea;
-            }
+            if(currPerim < contoursIn[smallerIdx].size() && detectInvertedMarker)
+                smallerIdx = groupedCandidates[i][j];
         }
+        // add contours und candidates
+        if(biggerIdx > -1){
 
-        // add contours and candidates
-        biggerCandidates.push_back(candidatesIn[biggerIdx]);
-        biggerContours.push_back(contoursIn[biggerIdx]);
-        if(detectInvertedMarker) {
-            smallerCandidates.push_back(alignContourOrder(candidatesIn[biggerIdx][0], candidatesIn[smallerIdx]));
-            smallerContours.push_back(contoursIn[smallerIdx]);
+            biggerCandidates.push_back(candidatesIn[biggerIdx]);
+            biggerContours.push_back(contoursIn[biggerIdx]);
+
+            if( detectInvertedMarker ){
+                smallerCandidates.push_back(alignContourOrder(candidatesIn[biggerIdx][0], candidatesIn[smallerIdx]));
+                smallerContours.push_back(contoursIn[smallerIdx]);
+            }
         }
     }
     // to preserve the structure :: candidateSet< defaultCandidates, whiteCandidates >
@@ -392,7 +404,7 @@ static void _filterTooCloseCandidates(const vector< vector< Point2f > > &candida
 /**
  * @brief Initial steps on finding square candidates
  */
-static void _detectInitialCandidates(const Mat &grey, vector< vector< Point2f > > &candidates,
+static float _detectInitialCandidates(const Mat &grey, vector< vector< Point2f > > &candidates,
                                      vector< vector< Point > > &contours,
                                      const Ptr<DetectorParameters> &params) {
 
@@ -406,26 +418,51 @@ static void _detectInitialCandidates(const Mat &grey, vector< vector< Point2f > 
 
     vector< vector< vector< Point2f > > > candidatesArrays((size_t) nScales);
     vector< vector< vector< Point > > > contoursArrays((size_t) nScales);
-
-    ////for each value in the interval of thresholding window sizes
-    parallel_for_(Range(0, nScales), [&](const Range& range) {
-        const int begin = range.start;
-        const int end = range.end;
-
-        for (int i = begin; i < end; i++) {
-            int currScale = params->adaptiveThreshWinSizeMin + i * params->adaptiveThreshWinSizeStep;
-            // threshold
-            Mat thresh;
-            _threshold(grey, thresh, currScale, params->adaptiveThreshConstant);
-
-            // detect rectangles
-            _findMarkerContours(thresh, candidatesArrays[i], contoursArrays[i],
-                                params->minMarkerPerimeterRate, params->maxMarkerPerimeterRate,
-                                params->polygonalApproxAccuracyRate, params->minCornerDistanceRate,
-                                params->minDistanceToBorder);
+    double otsu_treshold = 0.0;
+    // extract with global theshold)
+    if (params->useGlobalThreshold && params->foundMarkerInLastFrames > 2 && params->useAruco3Detection) {
+        Mat thresh;
+        if (params->foundGlobalThreshold) {
+            cv::threshold(grey, thresh, (double)params->otsuGlobalThreshold, 255, cv::THRESH_BINARY_INV);
+            otsu_treshold = (double)params->otsuGlobalThreshold;
         }
-    });
+        else { // first time get threshold with otsu
+            otsu_treshold = cv::threshold(grey, thresh, 0, 255, cv::THRESH_BINARY_INV | cv::THRESH_OTSU);
+            params->foundGlobalThreshold = true;
 
+        }
+        // get lines
+        const int el_size = 3;
+        const int el_size_half = static_cast<int>(el_size / 2.0);
+        cv::Mat struc_el = cv::getStructuringElement(cv::MORPH_CROSS, cv::Size(el_size,el_size), cv::Point(el_size_half,el_size_half));
+        cv::Mat eroded_imaged;
+        cv::erode(thresh, eroded_imaged, struc_el);
+        cv::bitwise_xor(eroded_imaged, thresh, thresh);
+        _findMarkerContours(thresh, candidatesArrays[0], contoursArrays[0],
+                            params->minMarkerPerimeterRate, params->maxMarkerPerimeterRate,
+                            params->polygonalApproxAccuracyRate, params->minCornerDistanceRate,
+                            params->minDistanceToBorder, params->minSideLengthCanonicalImg);
+    }
+    else {
+        ////for each value in the interval of thresholding window sizes
+        parallel_for_(Range(0, nScales), [&](const Range& range) {
+            const int begin = range.start;
+            const int end = range.end;
+
+            for (int i = begin; i < end; i++) {
+                int currScale = params->adaptiveThreshWinSizeMin + i * params->adaptiveThreshWinSizeStep;
+                // threshold
+                Mat thresh;
+                _threshold(grey, thresh, currScale, params->adaptiveThreshConstant);
+
+                // detect rectangles
+                _findMarkerContours(thresh, candidatesArrays[i], contoursArrays[i],
+                                    params->minMarkerPerimeterRate, params->maxMarkerPerimeterRate,
+                                    params->polygonalApproxAccuracyRate, params->minCornerDistanceRate,
+                                    params->minDistanceToBorder, params->minSideLengthCanonicalImg);
+            }
+        });
+    }
     // join candidates
     for(int i = 0; i < nScales; i++) {
         for(unsigned int j = 0; j < candidatesArrays[i].size(); j++) {
@@ -433,27 +470,27 @@ static void _detectInitialCandidates(const Mat &grey, vector< vector< Point2f > 
             contours.push_back(contoursArrays[i][j]);
         }
     }
+    return static_cast<float>(otsu_treshold);
 }
 
 
 /**
  * @brief Detect square candidates in the input image
  */
-static void _detectCandidates(InputArray _image, vector< vector< vector< Point2f > > >& candidatesSetOut,
+static float _detectCandidates(InputArray _image, vector< vector< vector< Point2f > > >& candidatesSetOut,
                               vector< vector< vector< Point > > >& contoursSetOut, const Ptr<DetectorParameters> &_params) {
 
-    Mat image = _image.getMat();
-    CV_Assert(image.total() != 0);
+    Mat grey = _image.getMat();
+    CV_Assert(grey.total() != 0);
 
     /// 1. CONVERT TO GRAY
-    Mat grey;
-    _convertToGrey(image, grey);
+    //Mat grey;
+    //_convertToGrey(image, grey);
 
     vector< vector< Point2f > > candidates;
     vector< vector< Point > > contours;
     /// 2. DETECT FIRST SET OF CANDIDATES
-    _detectInitialCandidates(grey, candidates, contours, _params);
-
+    float new_otsu_global_thresh = _detectInitialCandidates(grey, candidates, contours, _params);
     /// 3. SORT CORNERS
     _reorderCandidatesCorners(candidates);
 
@@ -461,6 +498,7 @@ static void _detectCandidates(InputArray _image, vector< vector< vector< Point2f
     // save the outter/inner border (i.e. potential candidates)
     _filterTooCloseCandidates(candidates, candidatesSetOut, contours, contoursSetOut,
                               _params->minMarkerDistanceRate, _params->detectInvertedMarker);
+    return new_otsu_global_thresh;
 }
 
 
@@ -568,8 +606,9 @@ static int _getBorderErrors(const Mat &bits, int markerSize, int borderSize) {
  *                           2 if the candidate is a white candidate
  */
 static uint8_t _identifyOneCandidate(const Ptr<Dictionary>& dictionary, InputArray _image,
-                                  vector<Point2f>& _corners, int& idx,
-                                  const Ptr<DetectorParameters>& params, int& rotation)
+                                  const vector<Point2f>& _corners, int& idx,
+                                  const Ptr<DetectorParameters>& params, int& rotation,
+                                  const float& scale = 1.f)
 {
     CV_Assert(_corners.size() == 4);
     CV_Assert(_image.getMat().total() != 0);
@@ -577,8 +616,15 @@ static uint8_t _identifyOneCandidate(const Ptr<Dictionary>& dictionary, InputArr
 
     uint8_t typ=1;
     // get bits
+    // scale corners to the correct size to search on the corresponding image pyramid
+    vector<Point2f> scaled_corners(4);
+    for (int i = 0; i < 4; ++i) {
+        scaled_corners[i].x = _corners[i].x * scale;
+        scaled_corners[i].y = _corners[i].y * scale;
+    }
+
     Mat candidateBits =
-        _extractBits(_image, _corners, dictionary->markerSize, params->markerBorderBits,
+        _extractBits(_image, scaled_corners, dictionary->markerSize, params->markerBorderBits,
                      params->perspectiveRemovePixelPerCell,
                      params->perspectiveRemoveIgnoredMarginPerCell, params->minOtsuStdDev);
 
@@ -606,7 +652,7 @@ static uint8_t _identifyOneCandidate(const Ptr<Dictionary>& dictionary, InputArr
     Mat onlyBits =
         candidateBits.rowRange(params->markerBorderBits,
                                candidateBits.rows - params->markerBorderBits)
-            .colRange(params->markerBorderBits, candidateBits.cols - params->markerBorderBits);
+            .colRange(params->markerBorderBits, candidateBits.rows - params->markerBorderBits);
 
     // try to indentify the marker
     if(!dictionary->identify(onlyBits, idx, rotation, params->errorCorrectionRate))
@@ -618,28 +664,38 @@ static uint8_t _identifyOneCandidate(const Ptr<Dictionary>& dictionary, InputArr
 /**
  * @brief Copy the contents of a corners vector to an OutputArray, settings its size.
  */
-static void _copyVector2Output(vector< vector< Point2f > > &vec, OutputArrayOfArrays out) {
+static void _copyVector2Output(vector< vector< Point2f > > &vec, OutputArrayOfArrays out, const double& scale = 1.0) {
     out.create((int)vec.size(), 1, CV_32FC2);
 
+    vector<Point2f> vec_scaled(4);
     if(out.isMatVector()) {
         for (unsigned int i = 0; i < vec.size(); i++) {
             out.create(4, 1, CV_32FC2, i);
             Mat &m = out.getMatRef(i);
-            Mat(Mat(vec[i]).t()).copyTo(m);
+            for (int p = 0; p < 4; ++p) {
+                vec_scaled[p] = vec[i][p]*scale;
+            }
+            Mat(Mat(vec_scaled).t()).copyTo(m);
         }
     }
     else if(out.isUMatVector()) {
         for (unsigned int i = 0; i < vec.size(); i++) {
             out.create(4, 1, CV_32FC2, i);
             UMat &m = out.getUMatRef(i);
-            Mat(Mat(vec[i]).t()).copyTo(m);
+            for (int p = 0; p < 4; ++p) {
+                vec_scaled[p] = vec[i][p]*scale;
+            }
+            Mat(Mat(vec_scaled).t()).copyTo(m);
         }
     }
     else if(out.kind() == _OutputArray::STD_VECTOR_VECTOR){
         for (unsigned int i = 0; i < vec.size(); i++) {
             out.create(4, 1, CV_32FC2, i);
             Mat m = out.getMat(i);
-            Mat(Mat(vec[i]).t()).copyTo(m);
+            for (int p = 0; p < 4; ++p) {
+                vec_scaled[p] = vec[i][p]*scale;
+            }
+            Mat(Mat(vec_scaled).t()).copyTo(m);
         }
     }
     else {
@@ -655,10 +711,35 @@ static void correctCornerPosition( vector< Point2f >& _candidate, int rotate){
     std::rotate(_candidate.begin(), _candidate.begin() + 4 - rotate, _candidate.end());
 }
 
+static size_t _findOptPyrImageForCanonicalImg(
+        const std::vector<cv::Size>& img_pyr_sizes,
+        const cv::Size& resized_seg_image,
+        const int& cur_perimeter,
+        const int& min_perimeter) {
+
+    size_t h = 0;
+    double dist = std::numeric_limits<double>::max();
+    for (size_t i = 0; i < img_pyr_sizes.size(); ++i) {
+        const double factor = (double)resized_seg_image.width / img_pyr_sizes[i].width;
+        const double perimeter_scaled = cur_perimeter * factor;
+        // instead of std::abs() favor the larger pyramid level by checking if the distance is postive
+        // will slow down the algorithm but find more corners in the end
+        const double new_dist = perimeter_scaled - min_perimeter;
+        if (new_dist < dist && new_dist > 0.0) {
+            dist = new_dist;
+            h = i;
+        }
+    }
+    return h;
+}
+
 /**
  * @brief Identify square candidates according to a marker dictionary
  */
-static void _identifyCandidates(InputArray _image, vector< vector< vector< Point2f > > >& _candidatesSet,
+static void _identifyCandidates(InputArray _image,
+                                const std::vector<cv::Mat>& _image_pyr,
+                                const std::vector<cv::Size>& _image_pyr_sizes,
+                                vector< vector< vector< Point2f > > >& _candidatesSet,
                                 vector< vector< vector<Point> > >& _contoursSet, const Ptr<Dictionary> &_dictionary,
                                 vector< vector< Point2f > >& _accepted, vector< vector<Point> >& _contours, vector< int >& ids,
                                 const Ptr<DetectorParameters> &params,
@@ -679,16 +760,30 @@ static void _identifyCandidates(InputArray _image, vector< vector< vector< Point
     vector< int > rotated(ncandidates, 0);
     vector< uint8_t > validCandidates(ncandidates, 0);
 
+    const int min_perimeter = params->minSideLengthCanonicalImg * params->minSideLengthCanonicalImg;
+
     //// Analyze each of the candidates
     parallel_for_(Range(0, ncandidates), [&](const Range &range) {
         const int begin = range.start;
         const int end = range.end;
 
         vector< vector< Point2f > >& candidates = params->detectInvertedMarker ? _candidatesSet[1] : _candidatesSet[0];
+        vector< vector< Point > >& contourS = params->detectInvertedMarker ? _contoursSet[1] : _contoursSet[0];
 
         for(int i = begin; i < end; i++) {
             int currId;
-            validCandidates[i] = _identifyOneCandidate(_dictionary, grey, candidates[i], currId, params, rotated[i]);
+
+            // implements equation (4)
+            if (params->useAruco3Detection) {
+                const int perimeter_in_seg_img = (int)contourS[i].size();
+                const size_t n = _findOptPyrImageForCanonicalImg(_image_pyr_sizes, _image.size(), perimeter_in_seg_img, min_perimeter);
+                const Mat& pyr_img = _image_pyr[n];
+                const float scale = (float)_image_pyr_sizes[n].width / _image.cols();
+                validCandidates[i] = _identifyOneCandidate(_dictionary, pyr_img, candidates[i], currId, params, rotated[i], scale);
+            }
+            else {
+                validCandidates[i] = _identifyOneCandidate(_dictionary, _image, candidates[i], currId, params, rotated[i]);
+            }
 
             if(validCandidates[i] > 0)
                 idsTmp[i] = currId;
@@ -848,7 +943,6 @@ static void _refineCandidateLines(std::vector<Point>& nContours, std::vector<Poi
 
 	// saves extra group into corresponding
 	if( !cntPts[4].empty() ){
-            CV_CheckLT(group, 4, "FIXIT: avoiding infinite loop: implementation should be revised: https://github.com/opencv/opencv_contrib/issues/2738");
 		for( unsigned int i=0; i < cntPts[4].size() ; i++ )
 			cntPts[group].push_back(cntPts[4].at(i));
 		cntPts[4].clear();
@@ -1024,37 +1118,148 @@ static void _apriltag(Mat im_orig, const Ptr<DetectorParameters> & _params, std:
 
 /**
   */
-void detectMarkers(InputArray _image, const Ptr<Dictionary> &_dictionary, OutputArrayOfArrays _corners,
-                   OutputArray _ids, const Ptr<DetectorParameters> &_params,
-                   OutputArrayOfArrays _rejectedImgPoints, InputArrayOfArrays camMatrix, InputArrayOfArrays distCoeff) {
+float detectMarkers(InputArray _image, const Ptr<Dictionary> &_dictionary, OutputArrayOfArrays _corners,
+                     OutputArray _ids, const Ptr<DetectorParameters> &_params,
+                     OutputArrayOfArrays _rejectedImgPoints,
+                     InputArrayOfArrays camMatrix, InputArrayOfArrays distCoeff) {
 
     CV_Assert(!_image.empty());
+    // check that the parameters are set correctly if Aruco3 is used
+    CV_Assert(!(_params->useAruco3Detection == true &&
+                _params->minSideLengthCanonicalImg == 0 &&
+                _params->minMarkerLengthRatioOriginalImg == 0.0));
 
     Mat grey;
     _convertToGrey(_image.getMat(), grey);
 
-    /// STEP 1: Detect marker candidates
+    // Aruco3 functionality is the extension of Aruco.
+    // The description can be found in:
+    // [1] Speeded up detection of squared fiducial markers, 2018, FJ Romera-Ramirez et al.
+    // if Aruco3 functionality if not wanted
+    // change some parameters to be sure to turn it off
+    if (!_params->useAruco3Detection) {
+        _params->useGlobalThreshold = false;
+        _params->foundGlobalThreshold = false;
+        _params->minMarkerLengthRatioOriginalImg = 0.0;
+        _params->minSideLengthCanonicalImg = 0;
+    }
+    else {
+        // always turn on corner refinement in case of Aruco3, due to upsampling
+        _params->cornerRefinementMethod = CORNER_REFINE_SUBPIX;
+    }
+
+    /// Step 0: equation (2) from paper [1]
+    const int tau_i_dot = _params->minSideLengthCanonicalImg +
+            (int)((float)std::max(grey.cols, grey.rows) * _params->minMarkerLengthRatioOriginalImg);
+
+    //// Step 0.1: resize image with equation (1) from paper [1]
+    float fxfy = (float)_params->minSideLengthCanonicalImg / tau_i_dot;
+    if (!_params->useAruco3Detection) {
+        fxfy = 1.f;
+    }
+    const cv::Size seg_img_size = cv::Size(cvRound(fxfy * grey.cols), cvRound(fxfy * grey.rows));
+
+    const int image_area = seg_img_size.width * seg_img_size.height;
+
+    /// Step 1: create image pyramid. Section 3.4. in [1]
+    std::vector<cv::Mat> grey_pyramid;
+    int closest_pyr_image_idx = 0;
+    if (_params->useAruco3Detection) {
+        // find max level
+        int num_levels = 0;
+        int pyr_factor = 2;
+        const int min_size_2 = _params->minSideLengthCanonicalImg * _params->minSideLengthCanonicalImg;
+        // the closest pyramid image to the downsampled segmentation image
+        // will later be used as start index for corner upsampling
+        int min_dist = std::numeric_limits<int>::max();
+        while (true && min_size_2 < image_area) {
+            const int resized_img_area = (grey.cols / pyr_factor) * (grey.rows / pyr_factor);
+            if (resized_img_area - min_size_2 > 0) {
+                ++num_levels;
+                pyr_factor *= 2;
+                const int resized_diff = static_cast<int>(std::abs(resized_img_area - image_area));
+                if (resized_diff < min_dist) {
+                    closest_pyr_image_idx = num_levels;
+                    min_dist = resized_diff;
+                }
+            }
+            else
+                break;
+        }
+        if (num_levels > 0) {
+            --num_levels;
+        }
+        cv::buildPyramid(grey, grey_pyramid, num_levels);
+
+        // resize to segmentation image
+        // in this reduces size the contours will be detected
+        if (grey.size() != seg_img_size) {
+            cv::resize(grey, grey, seg_img_size);
+        }
+    }
+    else {
+        grey_pyramid.push_back(grey);
+    }
+
+    // save pyramid sizes
+    std::vector<cv::Size> img_pyr_sizes(grey_pyramid.size());
+    for (size_t i = 0; i < grey_pyramid.size(); ++i) {
+        img_pyr_sizes[i] = grey_pyramid[i].size();
+    }
+
+    /// STEP 2: Detect marker candidates
     vector< vector< Point2f > > candidates;
     vector< vector< Point > > contours;
     vector< int > ids;
 
     vector< vector< vector< Point2f > > > candidatesSet;
     vector< vector< vector< Point > > > contoursSet;
-    /// STEP 1.a Detect marker candidates :: using AprilTag
-    if(_params->cornerRefinementMethod == CORNER_REFINE_APRILTAG){
-        _apriltag(grey, _params, candidates, contours);
 
-        candidatesSet.push_back(candidates);
-        contoursSet.push_back(contours);
+	/// STEP 2.a Detect marker candidates :: using AprilTag
+    bool no_cand_found_in_first_iter = false;
+    for (int i=0; i < 2; ++i) {
+        // if a global threshold was found in the last iteration,
+        // but no candidates in this frame
+        if (i >= 1 && _params->foundGlobalThreshold && no_cand_found_in_first_iter) {
+            _params->foundGlobalThreshold = false;
+            _params->foundMarkerInLastFrames = 1;
+        }
+
+        // save otsu threshold when using video
+        // use it for subsequent frames for global thresholding. Paper [1] section 3.2.
+        float otsu_global_tresh_video = 0.0f;
+        if(_params->cornerRefinementMethod == CORNER_REFINE_APRILTAG){
+            _apriltag(grey, _params, candidates, contours);
+
+            candidatesSet.push_back(candidates);
+            contoursSet.push_back(contours);
+        }
+        /// STEP 1.b Detect marker candidates :: traditional way
+        else
+            otsu_global_tresh_video =  _detectCandidates(grey, candidatesSet, contoursSet, _params);
+
+
+        /// STEP 2: Check candidate codification (identify markers)
+        _identifyCandidates(grey, grey_pyramid, img_pyr_sizes, candidatesSet, contoursSet, _dictionary,
+                            candidates, contours, ids, _params, _rejectedImgPoints);
+
+        // if we found corners set the otsu threshold for the next iteration (for video processing)
+        if (candidates.size() > 0) {
+            if (_params->foundGlobalThreshold) {
+                _params->otsuGlobalThreshold = otsu_global_tresh_video;
+            }
+            _params->foundMarkerInLastFrames++;
+            // if we found candidates we can break the for loop
+            // if not we are going into a second loop and use adaptive thresholding to try to find candidates
+            // see section 3.2 in [1]
+            break;
+        }
+        else {
+            no_cand_found_in_first_iter = true;
+            _params->foundGlobalThreshold = false;
+            _params->foundMarkerInLastFrames = 0;
+        }
     }
-
-    /// STEP 1.b Detect marker candidates :: traditional way
-    else
-        _detectCandidates(grey, candidatesSet, contoursSet, _params);
-
-    /// STEP 2: Check candidate codification (identify markers)
-    _identifyCandidates(grey, candidatesSet, contoursSet, _dictionary, candidates, contours, ids, _params,
-                        _rejectedImgPoints);
 
     // copy to output arrays
     _copyVector2Output(candidates, _corners);
@@ -1062,23 +1267,59 @@ void detectMarkers(InputArray _image, const Ptr<Dictionary> &_dictionary, Output
 
     /// STEP 3: Corner refinement :: use corner subpix
     if( _params->cornerRefinementMethod == CORNER_REFINE_SUBPIX ) {
-        CV_Assert(_params->cornerRefinementWinSize > 0 && _params->cornerRefinementMaxIterations > 0 &&
+        CV_Assert(_params->cornerRefinementWinSize > 0 &&
+                  _params->cornerRefinementMaxIterations > 0 &&
                   _params->cornerRefinementMinAccuracy > 0);
+        if (_params->useAruco3Detection) {
+            // if Aruco3 feature is selected we use
+            const float scale_init = (float)grey_pyramid[closest_pyr_image_idx].cols / grey.cols;
+            const float scale_pyr  = (float)grey_pyramid[0].cols / grey_pyramid[1].cols;
 
-        //// do corner refinement for each of the detected markers
-        parallel_for_(Range(0, _corners.cols()), [&](const Range& range) {
+            // Do subpixel estimation. In Aruco3 start on the lowest pyramid level and
+            // upsample the corners
+            parallel_for_(Range(0, _corners.cols()), [&](const Range& range) {
             const int begin = range.start;
             const int end = range.end;
 
-            for (int i = begin; i < end; i++) {
-                cornerSubPix(grey, _corners.getMat(i),
-                             Size(_params->cornerRefinementWinSize, _params->cornerRefinementWinSize),
-                             Size(-1, -1),
-                             TermCriteria(TermCriteria::MAX_ITER | TermCriteria::EPS,
-                                          _params->cornerRefinementMaxIterations,
-                                          _params->cornerRefinementMinAccuracy));
-            }
-        });
+                for (int i = begin; i < end; i++) {
+                    // scale it up to the closest pyramid level
+                    for (int p = 0; p < 4; ++p) {
+                         _corners.getMat(i).ptr<Point2f>(0)[p] *= scale_init;
+                    }
+
+                    for (int n = closest_pyr_image_idx-1; n >= 0; --n) {
+                        // scale them to new pyramid level
+                        for (int p = 0; p < 4; ++p) {
+                            _corners.getMat(i).ptr<Point2f>(0)[p] *= scale_pyr;
+                        }
+                        // use larger win size for larger images
+                        const int subpix_win_size = std::max(grey_pyramid[n].cols, grey_pyramid[n].rows) > 1080 ? 5 : 3;
+                        cornerSubPix(grey_pyramid[n], _corners.getMat(i),
+                                     Size(subpix_win_size, subpix_win_size),
+                                     Size(-1, -1),
+                                     TermCriteria(TermCriteria::MAX_ITER | TermCriteria::EPS,
+                                                  _params->cornerRefinementMaxIterations,
+                                                  _params->cornerRefinementMinAccuracy));
+                    }
+                }
+            });
+        }
+        else { // no pyramid search
+            //// do corner refinement for each of the detected markers
+            parallel_for_(Range(0, _corners.cols()), [&](const Range& range) {
+                const int begin = range.start;
+                const int end = range.end;
+
+                for (int i = begin; i < end; i++) {
+                    cornerSubPix(grey, _corners.getMat(i),
+                                 Size(_params->cornerRefinementWinSize, _params->cornerRefinementWinSize),
+                                 Size(-1, -1),
+                                 TermCriteria(TermCriteria::MAX_ITER | TermCriteria::EPS,
+                                              _params->cornerRefinementMaxIterations,
+                                              _params->cornerRefinementMinAccuracy));
+                }
+            });
+        }
     }
 
     /// STEP 3, Optional : Corner refinement :: use contour container
@@ -1097,6 +1338,24 @@ void detectMarkers(InputArray _image, const Ptr<Dictionary> &_dictionary, Output
             // copy the corners to the output array
             _copyVector2Output(candidates, _corners);
         }
+    }
+
+    if (_params->cornerRefinementMethod != CORNER_REFINE_APRILTAG &&
+        _params->cornerRefinementMethod != CORNER_REFINE_SUBPIX) {
+        // scale to orignal size, this however will lead to inaccurate detections!
+        _copyVector2Output(candidates, _corners, 1./fxfy);
+    }
+
+    // if the detection is used on a video the parameter tau_i (eq. 2) can be dynamically updated
+    // according to section 3.2.7. in the paper
+    // sort contours according to perimeter
+    if (contours.size() > 0 && _params->cameraMotionSpeed > 0 && _params->useAruco3Detection) {
+        std::sort(contours.begin(), contours.end(), [](vector<Point> a, vector<Point> b) {return a.size() < b.size();});
+        const float next_frame_tau_i = (1.f - _params->cameraMotionSpeed) * contours[0].size() / 4.f;
+        return next_frame_tau_i / std::max(img_pyr_sizes[0].width, img_pyr_sizes[0].height); // normalize new tau_i
+    }
+    else {
+        return 0.f;
     }
 }
 

--- a/modules/aruco/test/test_arucodetection.cpp
+++ b/modules/aruco/test/test_arucodetection.cpp
@@ -258,6 +258,7 @@ class CV_ArucoDetectionPerspective : public cvtest::BaseTest {
     enum checkWithParameter{
         USE_APRILTAG=1,             /// Detect marker candidates :: using AprilTag
         DETECT_INVERTED_MARKER,     /// Check if there is a white marker
+        USE_ARUCO3                  /// Check if aruco3 should be used
     };
 
     protected:
@@ -306,6 +307,11 @@ void CV_ArucoDetectionPerspective::run(int tryWith) {
                     params->cornerRefinementMethod = cv::aruco::CORNER_REFINE_APRILTAG;
                 }
 
+                if (CV_ArucoDetectionPerspective::USE_ARUCO3 == tryWith) {
+                    params->useAruco3Detection = true;
+                    params->cornerRefinementMethod = cv::aruco::CORNER_REFINE_SUBPIX;
+                }
+
                 // detect markers
                 vector< vector< Point2f > > corners;
                 vector< int > ids;
@@ -313,6 +319,9 @@ void CV_ArucoDetectionPerspective::run(int tryWith) {
 
                 // check results
                 if(ids.size() != 1 || (ids.size() == 1 && ids[0] != currentId)) {
+                    aruco::detectMarkers(img, dictionary, corners, ids, params);
+                    cv::imshow("img",img);
+                    cv::waitKey(0);
                     if(ids.size() != 1)
                         ts->printf(cvtest::TS::LOG, "Incorrect number of detected markers");
                     else
@@ -523,6 +532,7 @@ void CV_ArucoBitCorrection::run(int) {
 
 typedef CV_ArucoDetectionPerspective CV_AprilTagDetectionPerspective;
 typedef CV_ArucoDetectionPerspective CV_InvertedArucoDetectionPerspective;
+typedef CV_ArucoDetectionPerspective CV_Aruco3DetectionPerspective;
 
 TEST(CV_InvertedArucoDetectionPerspective, algorithmic) {
     CV_InvertedArucoDetectionPerspective test;
@@ -532,6 +542,11 @@ TEST(CV_InvertedArucoDetectionPerspective, algorithmic) {
 TEST(CV_AprilTagDetectionPerspective, algorithmic) {
     CV_AprilTagDetectionPerspective test;
     test.safe_run(CV_ArucoDetectionPerspective::USE_APRILTAG);
+}
+
+TEST(CV_Aruco3DetectionPerspective, algorithmic) {
+    CV_Aruco3DetectionPerspective test;
+    test.safe_run(CV_ArucoDetectionPerspective::USE_ARUCO3);
 }
 
 TEST(CV_ArucoDetectionSimple, algorithmic) {

--- a/modules/aruco/test/test_arucodetection.cpp
+++ b/modules/aruco/test/test_arucodetection.cpp
@@ -320,8 +320,6 @@ void CV_ArucoDetectionPerspective::run(int tryWith) {
                 // check results
                 if(ids.size() != 1 || (ids.size() == 1 && ids[0] != currentId)) {
                     aruco::detectMarkers(img, dictionary, corners, ids, params);
-                    cv::imshow("img",img);
-                    cv::waitKey(0);
                     if(ids.size() != 1)
                         ts->printf(cvtest::TS::LOG, "Incorrect number of detected markers");
                     else

--- a/modules/aruco/test/test_arucodetection.cpp
+++ b/modules/aruco/test/test_arucodetection.cpp
@@ -319,7 +319,6 @@ void CV_ArucoDetectionPerspective::run(int tryWith) {
 
                 // check results
                 if(ids.size() != 1 || (ids.size() == 1 && ids[0] != currentId)) {
-                    aruco::detectMarkers(img, dictionary, corners, ids, params);
                     if(ids.size() != 1)
                         ts->printf(cvtest::TS::LOG, "Incorrect number of detected markers");
                     else

--- a/modules/aruco/test/test_boarddetection.cpp
+++ b/modules/aruco/test/test_boarddetection.cpp
@@ -185,13 +185,8 @@ void CV_ArucoBoardPose::run(int run_with) {
     cameraMatrix.at< double >(1, 2) = imgSize.height / 2;
     Mat distCoeffs(5, 1, CV_64FC1, Scalar::all(0));
 
-    double max_dist = 0.4;
-    // aruco3 detection is a bit worse from large distances it seems
-    if (run_with == checkWithParameter::USE_ARUCO3) {
-        max_dist = 0.2;
-    }
     // for different perspectives
-    for(double distance = 0.2; distance <= max_dist; distance += 0.2) {
+    for(double distance = 0.2; distance <= 0.4; distance += 0.2) {
         for(int yaw = 0; yaw < 360; yaw += 100) {
             for(int pitch = 30; pitch <= 90; pitch += 50) {
                 for(unsigned int i = 0; i < gridboard->ids.size(); i++)
@@ -210,6 +205,8 @@ void CV_ArucoBoardPose::run(int run_with) {
                 params->minDistanceToBorder = 3;
                 if (run_with == checkWithParameter::USE_ARUCO3) {
                     params->useAruco3Detection = true;
+                    params->cornerRefinementMethod = aruco::CORNER_REFINE_SUBPIX;
+                    params->minSideLengthCanonicalImg = 16;
                 }
                 params->markerBorderBits = markerBorder;
                 aruco::detectMarkers(img, dictionary, corners, ids, params);


### PR DESCRIPTION
Added improvements to the ArUco module made by the author @urbste. New PR was created to fix issues and rebase with 4.x (and to avoid regression in original PR).

- Original PR: opencv#2790
- [Original article](https://www.researchgate.net/publication/325787310_Speeded_Up_Detection_of_Squared_Fiducial_Markers)

This PR:
- adds new 3 performance tests (19 configurations)
- enables old tests with distance parameter 0.4 for ArUco3 (CV_ArucoBoardPose test)
- fix several "index" bugs
- removes global threshold parameters - to add this parameters need to add PImpl pattern and create `ArucoDetector` class (like QRCodeDetector class). I suggest return global threshold parameters in next PR after create `ArucoDetector` class and API changes (this changes could significantly increase "git diff").

Configuration - Ryzen 7 2700x, 32GB 2933 mhz DDR4
Performance tests result (image size is 1440x1440 - the number of pixels is the same as in FHD image with size 1920x1080):

- with global threshold parameters:

| Algorithm | Parameters | Number of markers | Result, ms |
|--|--|--|--|
| base alg | default | 1   | mean=6.93   median=6.97   min=4.61   stddev=1.20 (17.3%)|
| arcuo3 | tau_c=32, tau_i=0.15 | 1   | mean=1.52   median=1.48   min=1.41   stddev=0.10 (6.5%) |
| arcuo3 | tau_c=16, tau_i=0.008 |  1  | mean=1.46   median=1.46   min=1.37   stddev=0.04 (3.0%) |
| base alg | default | 9   | mean=8.49   median=8.55   min=5.96   stddev=1.35 (15.9%)|
| arcuo3 | tau_c=32, tau_i=0.15 | 9   | mean=2.03   median=2.03   min=1.67   stddev=0.10 (4.7%) |
| arcuo3 | tau_c=16, tau_i=0.008 |  9  | mean=2.03   median=2.02   min=1.91   stddev=0.07 (3.4%) |
| base alg | default | 100 | mean=17.91  median=18.05  min=13   stddev=1.78 (10.0%)|
| arcuo3 | tau_c=32, tau_i=0.15 | 100 | mean=5.09   median=5.22   min=4.53   stddev=0.32 (6.3%) |
| arcuo3 | tau_c=16, tau_i=0.008 |  100| mean=5.11   median=5.13   min=4.67   stddev=0.29 (5.7%) |

- without global threshold parameters (these parameters will be returned in the next PR):

| Algorithm | Parameters | Number of markers | Result, ms |
|--|--|--|--|
| base alg | default | 1   | mean=6.84   median=6.69   min=4.7   stddev=0.96 (14.0%)|
| arcuo3 | tau_c=32, tau_i=0.15 | 1   | mean=3.03   median=3.08   min=2.51   stddev=0.20 (6.5%) |
| arcuo3 | tau_c=16, tau_i=0.008 |  1  | mean=2.94   median=3.03   min=2.31   stddev=0.29 (9.9%) |
| base alg | default | 9   | mean=8.39   median=8.02   min=6.08   stddev=1.44 (17.1%)|
| arcuo3 | tau_c=32, tau_i=0.15 | 9   | mean=3.80   median=3.80   min=2.98   stddev=0.32 (8.4%) |
| arcuo3 | tau_c=16, tau_i=0.008 |  9  | mean=3.65   median=3.73   min=3.09   stddev=0.28 (7.8%) |
| base alg | default | 100 | mean=18.40  median=19.29  min=14.09   stddev=1.95 (10.6%)|
| arcuo3 | tau_c=32, tau_i=0.15 | 100 | mean=8.23   median=8.14   min=8.04   stddev=0.22 (2.6%) |
| arcuo3 | tau_c=16, tau_i=0.008 |  100| mean=8.46   median=8.20   min=8.08   stddev=0.45 (5.4%) |


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
