### PR TITLE
https://github.com/opencv/opencv_contrib/issues/1578

### DIFF
--- a/modules/xphoto/src/inpainting.cpp
+++ b/modules/xphoto/src/inpainting.cpp
@@ -281,6 +281,9 @@ namespace xphoto
         /** Writing result **/
         for (size_t i = 0; i < labelSeq.size(); ++i)
         {
+            if (pPath[i].x >= img.cols || pPath[i].y >= img.rows)
+                continue;
+
             cv::Vec <float, cn> val = pointSeq[i][labelSeq[i]];
             img.template at<cv::Vec <float, cn> >(pPath[i]) = val;
         }

--- a/modules/xphoto/src/photomontage.hpp
+++ b/modules/xphoto/src/photomontage.hpp
@@ -132,6 +132,12 @@ template <typename Tp> void Photomontage <Tp>::
 setWeights(GCGraph <TWeight> &graph, const int idx1, const int idx2,
     const int l1, const int l2, const int lx)
 {
+    if ((size_t)idx1 >= pointSeq.size() || (size_t)idx2 >= pointSeq.size() 
+        || (size_t)l1 >= pointSeq[idx1].size() || (size_t)l1 >= pointSeq[idx2].size()
+        || (size_t)l2 >= pointSeq[idx1].size() || (size_t)l2 >= pointSeq[idx2].size()
+        || (size_t)lx >= pointSeq[idx1].size() || (size_t)lx >= pointSeq[idx2].size()) 
+        return;
+
     if (l1 == l2)
     {
         /** Link from A to B **/

--- a/modules/xphoto/src/photomontage.hpp
+++ b/modules/xphoto/src/photomontage.hpp
@@ -132,10 +132,10 @@ template <typename Tp> void Photomontage <Tp>::
 setWeights(GCGraph <TWeight> &graph, const int idx1, const int idx2,
     const int l1, const int l2, const int lx)
 {
-    if ((size_t)idx1 >= pointSeq.size() || (size_t)idx2 >= pointSeq.size() 
+    if ((size_t)idx1 >= pointSeq.size() || (size_t)idx2 >= pointSeq.size()
         || (size_t)l1 >= pointSeq[idx1].size() || (size_t)l1 >= pointSeq[idx2].size()
         || (size_t)l2 >= pointSeq[idx1].size() || (size_t)l2 >= pointSeq[idx2].size()
-        || (size_t)lx >= pointSeq[idx1].size() || (size_t)lx >= pointSeq[idx2].size()) 
+        || (size_t)lx >= pointSeq[idx1].size() || (size_t)lx >= pointSeq[idx2].size())
         return;
 
     if (l1 == l2)


### PR DESCRIPTION
resolves #1578

It's not THE SOLUTION because it does not fix the root cause (I don't know the algorithm) but it's a WORKAROUND to fix indexes out of bounds.
Using this changed I was able to do the inpaint (SHIFTMAP) on the example files.

![output_shiftmap](https://user-images.githubusercontent.com/7062741/150750525-cbf40907-f6d3-47a9-bef4-20874637e92d.jpg)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ x ] I agree to contribute to the project under Apache 2 License.
- [ x ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ x ] The PR is proposed to proper branch
- [ x ] There is reference to original bug report and related work
- [ x ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ x ] The feature is well documented and sample code can be built with the project CMake

