### PR TITLE
Add missing stride in cuda::LinearFilter::apply - #3163

### DIFF
--- a/modules/cudafilters/src/filtering.cpp
+++ b/modules/cudafilters/src/filtering.cpp
@@ -281,7 +281,7 @@ namespace
         Size wholeSize;
         src.locateROI(wholeSize, ofs);
 
-        GpuMat srcWhole(wholeSize, src.type(), src.datastart);
+        GpuMat srcWhole(wholeSize, src.type(), src.datastart, src.step);
 
         func_(srcWhole, ofs.x, ofs.y, dst, kernel_.ptr<float>(),
               kernel_.cols, kernel_.rows, anchor_.x, anchor_.y,


### PR DESCRIPTION
This aplies the fix identified by @yl070360 in  https://github.com/opencv/opencv_contrib/issues/3163.

The stride information is currently missing inside `cuda::LinearFilter::apply()` producing incorrect results when `GpuMat`'s are constructed using pointers to pre-allocated device memory.

The current tests should to be sufficient to check this because they are wrongly passing at the moment due to another bug (see below) in the construction of `GpuMat`'s which can be fixed once this is merged.

**GpuMat Bug**
`GpuMat::dataend` wrongly points to the last element of an [alocated row ](https://github.com/opencv/opencv/blob/415a42f327104653604fc99314eb215cd938d6d7/modules/core/src/cuda/gpu_mat.cu#L191) instead of the last useable [element of the ROI](https://github.com/opencv/opencv/blob/415a42f327104653604fc99314eb215cd938d6d7/modules/core/src/cuda_gpu_mat.cpp#L100) unless the `GpuMat` is constructed from a pointer to pre-allocated device memory.
This means that `locateROI(wholeSize,ofs)` currently returns the stride in `wholeSize` instead of the width of the ROI.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
buildworker:Custom=linux-4,linux-6
build_image:Custom=ubuntu-cuda:18.04
```