### PR TITLE
Add GpuMat::locateROI test case

### DIFF
--- a/modules/cudaarithm/test/test_gpumat.cpp
+++ b/modules/cudaarithm/test/test_gpumat.cpp
@@ -387,6 +387,49 @@ INSTANTIATE_TEST_CASE_P(CUDA, GpuMat_ConvertTo, testing::Combine(
     WHOLE_SUBMAT));
 
 ////////////////////////////////////////////////////////////////////////////////
+// locateROI
+
+PARAM_TEST_CASE(GpuMat_LocateROI, cv::cuda::DeviceInfo, cv::Size, MatDepth, UseRoi)
+{
+    cv::cuda::DeviceInfo devInfo;
+    cv::Size size;
+    int depth;
+    bool useRoi;
+
+    virtual void SetUp()
+    {
+        devInfo = GET_PARAM(0);
+        size = GET_PARAM(1);
+        depth = GET_PARAM(2);
+        useRoi = GET_PARAM(3);
+
+        cv::cuda::setDevice(devInfo.deviceID());
+    }
+};
+
+CUDA_TEST_P(GpuMat_LocateROI, locateROI)
+{
+    Point ofsGold;
+    Size wholeSizeGold;
+    GpuMat src = createMat(size, depth, wholeSizeGold, ofsGold, useRoi);
+
+    Point ofs;
+    Size wholeSize;
+    src.locateROI(wholeSize, ofs);
+    ASSERT_TRUE(ofs == ofsGold && wholeSize == wholeSizeGold);
+
+    GpuMat srcPtr(src.size(), src.type(), src.data, src.step);
+    src.locateROI(wholeSize, ofs);
+    ASSERT_TRUE(ofs == ofsGold && wholeSize == wholeSizeGold);
+}
+
+INSTANTIATE_TEST_CASE_P(CUDA, GpuMat_LocateROI, testing::Combine(
+    ALL_DEVICES,
+    DIFFERENT_SIZES,
+    ALL_DEPTH,
+    WHOLE_SUBMAT));
+
+////////////////////////////////////////////////////////////////////////////////
 // ensureSizeIsEnough
 
 struct EnsureSizeIsEnough : testing::TestWithParam<cv::cuda::DeviceInfo>


### PR DESCRIPTION
**Main PR**: https://github.com/opencv/opencv/pull/21555

Test case for `GpuMat::locateROI()` added to check `GpuMat::dataend` calculation.

Dependant on https://github.com/opencv/opencv/pull/21555.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
buildworker:Custom=linux-4,linux-6
build_image:Custom=ubuntu-cuda:18.04
```