### PR TITLE
(4.x) Merge 3.4

### DIFF
--- a/modules/sfm/src/libmv_light/libmv/correspondence/CMakeLists.txt
+++ b/modules/sfm/src/libmv_light/libmv/correspondence/CMakeLists.txt
@@ -8,7 +8,7 @@ FILE(GLOB CORRESPONDENCE_HDRS *.h)
 
 ADD_LIBRARY(correspondence STATIC ${CORRESPONDENCE_SRC} ${CORRESPONDENCE_HDRS})
 
-TARGET_LINK_LIBRARIES(correspondence LINK_PRIVATE ${GLOG_LIBRARIES} multiview)
+ocv_target_link_libraries(correspondence LINK_PRIVATE ${GLOG_LIBRARIES} multiview opencv_imgcodecs)
 IF(TARGET Eigen3::Eigen)
   TARGET_LINK_LIBRARIES(correspondence LINK_PUBLIC Eigen3::Eigen)
 ENDIF()


### PR DESCRIPTION
#3169 from alalek:cmake_fix_sfm_build

Main PR: https://github.com/opencv/opencv/pull/21572
Previous "Merge 3.4": #3164

<cut/>


<details>

```
force_builders=Custom,Win64 OpenCL
buildworker:Custom=linux-4,linux-6
build_image:Custom=ubuntu-cuda:18.04
buildworker:Win64 OpenCL=windows-2
build_image:Win64 OpenCL=msvs2019
```

</details>
