### PR TITLE
Use texture Object to make cv::cuda::HoughSegmentDetectorImpl::detect() thread-safe

### DIFF
--- a/modules/cudaimgproc/src/cuda/hough_segments.cu
+++ b/modules/cudaimgproc/src/cuda/hough_segments.cu
@@ -44,14 +44,13 @@
 
 #include "opencv2/core/cuda/common.hpp"
 #include "opencv2/core/cuda/vec_math.hpp"
+#include "opencv2/cudev.hpp"
 
 namespace cv { namespace cuda { namespace device
 {
     namespace hough_segments
     {
-        texture<uchar, cudaTextureType2D, cudaReadModeElementType> tex_mask(false, cudaFilterModePoint, cudaAddressModeClamp);
-
-        __global__ void houghLinesProbabilistic(const PtrStepSzi accum,
+        __global__ void houghLinesProbabilistic(cv::cudev::Texture<uchar> src, const PtrStepSzi accum,
                                                 int4* out, const int maxSize,
                                                 const float rho, const float theta,
                                                 const int lineGap, const int lineLength,
@@ -157,7 +156,7 @@ namespace cv { namespace cuda { namespace device
 
                 for (;;)
                 {
-                    if (tex2D(tex_mask, p1.x, p1.y))
+                    if (src(p1.y, p1.x))
                     {
                         gap = 0;
 
@@ -213,16 +212,17 @@ namespace cv { namespace cuda { namespace device
             }
         }
 
-        int houghLinesProbabilistic_gpu(PtrStepSzb mask, PtrStepSzi accum, int4* out, int maxSize, float rho, float theta, int lineGap, int lineLength, int* counterPtr, cudaStream_t stream)
+        int houghLinesProbabilistic_gpu(GpuMat &mask, PtrStepSzi accum, int4* out, int maxSize, float rho, float theta, int lineGap, int lineLength, int* counterPtr, cudaStream_t stream)
         {
             cudaSafeCall( cudaMemsetAsync(counterPtr, 0, sizeof(int), stream) );
 
             const dim3 block(32, 8);
             const dim3 grid(divUp(accum.cols - 2, block.x), divUp(accum.rows - 2, block.y));
+            
+            cv::cudev::GpuMat_<uchar> src_(mask);
+            cv::cudev::Texture<uchar> tex(src_, false, cudaFilterModePoint, cudaAddressModeClamp);
 
-            bindTexture(&tex_mask, mask);
-
-            houghLinesProbabilistic<<<grid, block, 0, stream>>>(accum,
+            houghLinesProbabilistic<<<grid, block, 0, stream>>>(tex, accum,
                                                      out, maxSize,
                                                      rho, theta,
                                                      lineGap, lineLength,

--- a/modules/cudaimgproc/src/hough_segments.cpp
+++ b/modules/cudaimgproc/src/hough_segments.cpp
@@ -65,7 +65,7 @@ namespace cv { namespace cuda { namespace device
 
     namespace hough_segments
     {
-        int houghLinesProbabilistic_gpu(PtrStepSzb mask, PtrStepSzi accum, int4* out, int maxSize, float rho, float theta, int lineGap, int lineLength, int* counterPtr, cudaStream_t stream);
+        int houghLinesProbabilistic_gpu(GpuMat &mask, PtrStepSzi accum, int4* out, int maxSize, float rho, float theta, int lineGap, int lineLength, int* counterPtr, cudaStream_t stream);
     }
 }}}
 

--- a/modules/cudaimgproc/test/test_hough.cpp
+++ b/modules/cudaimgproc/test/test_hough.cpp
@@ -156,7 +156,7 @@ CUDA_TEST_P(HoughLinesProbabilistic, Accuracy)
     Ptr<cv::cuda::HoughSegmentDetector> hough = cv::cuda::createHoughSegmentDetector(rho, theta, minLineLength, maxLineGap);
 
     cv::cuda::GpuMat d_lines;
-    hough->detect(loadMat(src, false), d_lines);
+    hough->detect(loadMat(src, useRoi), d_lines);
 
     std::vector<cv::Vec4i> linesSegment;
     std::vector<cv::Vec2f> lines;

--- a/modules/cudaimgproc/test/test_hough.cpp
+++ b/modules/cudaimgproc/test/test_hough.cpp
@@ -114,6 +114,68 @@ INSTANTIATE_TEST_CASE_P(CUDA_ImgProc, HoughLines, testing::Combine(
     WHOLE_SUBMAT));
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
+// HoughLines Probabilistic
+PARAM_TEST_CASE(HoughLinesProbabilistic, cv::cuda::DeviceInfo, cv::Size, UseRoi)
+{
+    static void generateLines(cv::Mat& img)
+    {
+        img.setTo(cv::Scalar::all(0));
+
+        cv::line(img, cv::Point(10, 0), cv::Point(10, 20), cv::Scalar::all(255));
+        cv::line(img, cv::Point(20, 50), cv::Point(40, 50), cv::Scalar::all(255));
+    }
+
+    static void drawLines(cv::Mat& dst, const std::vector<cv::Vec4i>& linesSegment)
+    {
+        dst.setTo(cv::Scalar::all(0));
+
+        for (size_t i = 0; i < linesSegment.size(); ++i)
+        {
+            Vec4i l = linesSegment[i];
+            cv::line(dst, cv::Point(l[0], l[1]), cv::Point(l[2], l[3]), cv::Scalar::all(255));
+        }
+
+    }
+};
+
+CUDA_TEST_P(HoughLinesProbabilistic, Accuracy)
+{
+    const cv::cuda::DeviceInfo devInfo = GET_PARAM(0);
+    cv::cuda::setDevice(devInfo.deviceID());
+    const cv::Size size = GET_PARAM(1);
+    const bool useRoi = GET_PARAM(2);
+
+    const float rho = 1.0f;
+    const float theta = (float) (1.0 * CV_PI / 180.0);
+    const int minLineLength = 15;
+    const int maxLineGap = 8;
+
+    cv::Mat src(size, CV_8UC1);
+    generateLines(src);
+
+    Ptr<cv::cuda::HoughSegmentDetector> hough = cv::cuda::createHoughSegmentDetector(rho, theta, minLineLength, maxLineGap);
+
+    cv::cuda::GpuMat d_lines;
+    hough->detect(loadMat(src, false), d_lines);
+
+    std::vector<cv::Vec4i> linesSegment;
+    std::vector<cv::Vec2f> lines;
+    d_lines.download(linesSegment);
+
+    cv::Mat dst(size, CV_8UC1);
+    drawLines(dst, linesSegment);
+
+    ASSERT_MAT_NEAR(src, dst, 0.0);
+
+}
+
+INSTANTIATE_TEST_CASE_P(CUDA_ImgProc, HoughLinesProbabilistic, testing::Combine(
+    ALL_DEVICES,
+    DIFFERENT_SIZES,
+    WHOLE_SUBMAT));
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////
 // HoughCircles
 
 PARAM_TEST_CASE(HoughCircles, cv::cuda::DeviceInfo, cv::Size, UseRoi)


### PR DESCRIPTION
This PR fixes #3184 by using texture Object to make `cv::cuda::HoughSegmentDetectorImpl::detect()` thread-safe.

This PR also includes unit test for probabilistic hough segment detector. Previously, there was no unit test for this function.

Also note that, this solution is only thread-safe for `CV_CUDEV_ARCH>=300`. This is the same solution as existing code for canny algorithm that is already part of `opencv_contrib`. See here : https://github.com/opencv/opencv_contrib/commit/6ca24c818f8266c3a7e554e7a583dcdf5dc2010f

<cut/>

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
buildworker:Custom=linux-4,linux-6
build_image:Custom=ubuntu-cuda:18.04
```