### PR TITLE
Added 32FC1 type support and mask to cuda::meanStdDev implementation

### DIFF
--- a/modules/cudaarithm/include/opencv2/cudaarithm.hpp
+++ b/modules/cudaarithm/include/opencv2/cudaarithm.hpp
@@ -685,21 +685,39 @@ CV_EXPORTS_W void reduce(InputArray mtx, OutputArray vec, int dim, int reduceOp,
 
 /** @brief Computes a mean value and a standard deviation of matrix elements.
 
-@param mtx Source matrix. CV_8UC1 matrices are supported for now.
-@param mean Mean value.
-@param stddev Standard deviation value.
+@param src Source matrix. CV_8UC1 and CV_32FC1 matrices are supported for now.
+@param dst Target GpuMat with size 1x2 and type CV_64FC1. The first value is mean, the second - stddev.
+@param mask Operation mask.
+@param stream Stream for the asynchronous version.
 
 @sa meanStdDev
  */
-CV_EXPORTS_W void meanStdDev(InputArray mtx, Scalar& mean, Scalar& stddev);
-/** @overload */
+CV_EXPORTS_W void meanStdDev(InputArray src, OutputArray dst, InputArray mask, Stream& stream = Stream::Null());
+/** @overload
+@param mtx Source matrix. CV_8UC1 and CV_32FC1 matrices are supported for now.
+@param dst Target GpuMat with size 1x2 and type CV_64FC1. The first value is mean, the second - stddev.
+@param stream Stream for the asynchronous version.
+ */
 CV_EXPORTS_W void meanStdDev(InputArray mtx, OutputArray dst, Stream& stream = Stream::Null());
+/** @overload
+@param src Source matrix. CV_8UC1 and CV_32FC1 matrices are supported for now.
+@param mean Mean value.
+@param stddev Standard deviation value.
+@param mask Operation mask.
+ */
+CV_EXPORTS_W void meanStdDev(InputArray src, CV_OUT Scalar& mean, CV_OUT Scalar& stddev, InputArray mask);
+/** @overload
+@param mtx Source matrix. CV_8UC1 and CV_32FC1 matrices are supported for now.
+@param mean Mean value.
+@param stddev Standard deviation value.
+ */
+CV_EXPORTS_W void meanStdDev(InputArray mtx, CV_OUT Scalar& mean, CV_OUT Scalar& stddev);
 
 /** @brief Computes a standard deviation of integral images.
 
 @param src Source image. Only the CV_32SC1 type is supported.
 @param sqr Squared source image. Only the CV_32FC1 type is supported.
-@param dst Destination image with the same type and size as src .
+@param dst Destination image with the same type and size as src.
 @param rect Rectangular window.
 @param stream Stream for the asynchronous version.
  */


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
buildworker:Custom=linux-4,linux-6
build_image:Custom=ubuntu-cuda:18.04
```