### PR TITLE
Expose cudacodec::VideoReader::format() to python bindings

### DIFF
--- a/modules/cudacodec/include/opencv2/cudacodec.hpp
+++ b/modules/cudacodec/include/opencv2/cudacodec.hpp
@@ -290,22 +290,25 @@ enum DeinterlaceMode
 
 /** @brief Struct providing information about video file format. :
  */
-struct FormatInfo
+struct CV_EXPORTS_W_SIMPLE FormatInfo
 {
-    Codec codec;
-    ChromaFormat chromaFormat;
-    int nBitDepthMinus8 = -1;
-    int ulWidth = 0;//!< Coded sequence width in pixels.
-    int ulHeight = 0;//!< Coded sequence height in pixels.
-    int width = 0;//!< Width of the decoded frame returned by nextFrame(frame).
-    int height = 0;//!< Height of the decoded frame returned by nextFrame(frame).
-    int ulMaxWidth = 0;
-    int ulMaxHeight = 0;
-    Rect displayArea;//!< ROI inside the decoded frame returned by nextFrame(frame), containing the useable video frame.
-    bool valid = false;
-    double fps = 0;
-    int ulNumDecodeSurfaces = 0;//!< Maximum number of internal decode surfaces.
-    DeinterlaceMode deinterlaceMode;
+    CV_WRAP FormatInfo() : nBitDepthMinus8(-1), ulWidth(0), ulHeight(0), width(0), height(0), ulMaxWidth(0), ulMaxHeight(0), valid(false),
+        fps(0), ulNumDecodeSurfaces(0) {};
+
+    CV_PROP_RW Codec codec;
+    CV_PROP_RW ChromaFormat chromaFormat;
+    CV_PROP_RW int nBitDepthMinus8;
+    CV_PROP_RW int ulWidth;//!< Coded sequence width in pixels.
+    CV_PROP_RW int ulHeight;//!< Coded sequence height in pixels.
+    CV_PROP_RW int width;//!< Width of the decoded frame returned by nextFrame(frame).
+    CV_PROP_RW int height;//!< Height of the decoded frame returned by nextFrame(frame).
+    int ulMaxWidth;
+    int ulMaxHeight;
+    CV_PROP_RW Rect displayArea;//!< ROI inside the decoded frame returned by nextFrame(frame), containing the useable video frame.
+    CV_PROP_RW bool valid;
+    CV_PROP_RW double fps;
+    CV_PROP_RW int ulNumDecodeSurfaces;//!< Maximum number of internal decode surfaces.
+    CV_PROP_RW DeinterlaceMode deinterlaceMode;
 };
 
 /** @brief cv::cudacodec::VideoReader generic properties identifier.
@@ -342,7 +345,7 @@ public:
 
     /** @brief Returns information about video file format.
     */
-    virtual FormatInfo format() const = 0;
+    CV_WRAP virtual FormatInfo format() const = 0;
 
     /** @brief Grabs the next frame from the video source.
 

--- a/modules/cudacodec/misc/python/test/test_cudacodec.py
+++ b/modules/cudacodec/misc/python/test/test_cudacodec.py
@@ -19,10 +19,16 @@ class cudacodec_test(NewOpenCVTests):
         vid_path = os.environ['OPENCV_TEST_DATA_PATH'] + '/cv/video/1920x1080.avi'
         try:
             reader = cv.cudacodec.createVideoReader(vid_path)
+            format_info = reader.format()
             ret, gpu_mat = reader.nextFrame()
             self.assertTrue(ret)
             self.assertTrue('GpuMat' in str(type(gpu_mat)), msg=type(gpu_mat))
             #TODO: print(cv.utils.dumpInputArray(gpu_mat)) # - no support for GpuMat
+
+            if(not format_info.valid):
+              format_info = reader.format()
+            sz = gpu_mat.size()
+            self.assertTrue(sz[0] == format_info.width and sz[1] == format_info.height)
 
             # not checking output, therefore sepearate tests for different signatures is unecessary
             ret, _gpu_mat2 = reader.nextFrame(gpu_mat)


### PR DESCRIPTION
Fix issue identified in https://github.com/opencv/opencv_contrib/issues/3195 by exposing cudacodec::VideoReader::format() to python bindings and updating the python test to check verify this.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
buildworker:Custom=linux-4,linux-6
build_image:Custom=ubuntu-cuda:18.04
```