### PR TITLE
[WeChat QR] Fixing issue that Hybrid Binarizer not working due to integral calculation.

### DIFF
--- a/modules/wechat_qrcode/src/zxing/common/binarizer/hybrid_binarizer.cpp
+++ b/modules/wechat_qrcode/src/zxing/common/binarizer/hybrid_binarizer.cpp
@@ -55,7 +55,9 @@ Ref<Binarizer> HybridBinarizer::createBinarizer(Ref<LuminanceSource> source) {
 }
 
 int HybridBinarizer::initBlockIntegral() {
-    blockIntegral_ = new Array<int>(width * height);
+    blockIntegralWidth = subWidth_ + 1;
+    blockIntegralHeight = subHeight_ + 1;
+    blockIntegral_ = new Array<int>(blockIntegralWidth * blockIntegralHeight);
 
     int* integral = blockIntegral_->data();
 
@@ -64,34 +66,27 @@ int HybridBinarizer::initBlockIntegral() {
     // first row only
     int rs = 0;
 
-    for (int j = 0; j < width; j++) {
+    for (int j = 0; j < blockIntegralWidth; j++) {
         integral[j] = 0;
     }
 
-    for (int i = 0; i < height; i++) {
-        integral[i * width] = 0;
-    }
-
-    for (int j = 0; j < subWidth_; j++) {
-        rs += blocks_[j].threshold;
-        integral[width + j + 1] = rs;
+    for (int i = 0; i < blockIntegralHeight; i++) {
+        integral[i * blockIntegralWidth] = 0;
     }
 
     // remaining cells are sum above and to the left
-    int offset = width;
     int offsetBlock = 0;
+    int offsetIntegral = 0;
 
-    for (int i = 1; i < subHeight_; ++i) {
+    for (int i = 0; i < subHeight_; ++i) {
         // therow = grayByte_->getByteRow(i);
         offsetBlock = i * subWidth_;
-
+        offsetIntegral = (i + 1) * blockIntegralWidth;
         rs = 0;
-
-        offset += width;
 
         for (int j = 0; j < subWidth_; ++j) {
             rs += blocks_[offsetBlock + j].threshold;
-            integral[offset + j + 1] = rs + integral[offset - width + j + 1];
+            integral[offsetIntegral + j + 1] = rs + integral[offsetIntegral - blockIntegralWidth + j + 1];
         }
     }
 
@@ -201,8 +196,8 @@ void HybridBinarizer::calculateThresholdForBlock(Ref<ByteMatrix>& _luminances, i
             int sum = 0;
             // int sum2 = 0;
 
-            int offset1 = (top - THRES_BLOCKSIZE) * (subWidth + 1) + left - THRES_BLOCKSIZE;
-            int offset2 = (top + THRES_BLOCKSIZE + 1) * (subWidth + 1) + left - THRES_BLOCKSIZE;
+            int offset1 = (top - THRES_BLOCKSIZE) * blockIntegralWidth + left - THRES_BLOCKSIZE;
+            int offset2 = (top + THRES_BLOCKSIZE + 1) * blockIntegralWidth + left - THRES_BLOCKSIZE;
 
             int blocksize = THRES_BLOCKSIZE * 2 + 1;
 

--- a/modules/wechat_qrcode/src/zxing/common/binarizer/hybrid_binarizer.hpp
+++ b/modules/wechat_qrcode/src/zxing/common/binarizer/hybrid_binarizer.hpp
@@ -35,6 +35,8 @@ private:
 
     int subWidth_;
     int subHeight_;
+    int blockIntegralWidth;
+    int blockIntegralHeight;
 
 public:
     explicit HybridBinarizer(Ref<LuminanceSource> source);


### PR DESCRIPTION
This should fixes #3156 #3008 

The size of block array `blocks_` is `subWidth * subHeight` but the block integral size is `width * height`. I believe something wrong when calculating the `blockIntegral` with that size.

https://github.com/opencv/opencv_contrib/blob/508c8db05e438635c84825629c069252bb53771a/modules/wechat_qrcode/src/zxing/common/binarizer/hybrid_binarizer.cpp#L41

https://github.com/opencv/opencv_contrib/blob/508c8db05e438635c84825629c069252bb53771a/modules/wechat_qrcode/src/zxing/common/binarizer/hybrid_binarizer.cpp#L58

I suggest change it size to `(subWidth + 1) * (subHeight + 1)` (These extra row and column is just for padding 0 arroud). Also update the precalculation of the `blockIntegral`, calculate sum base on that `blockIntegral`


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

`
force_builders=linux,docs
`