### PR TITLE
fix search for one contour in _filterTooCloseCandidates()

### DIFF
--- a/modules/aruco/src/aruco.cpp
+++ b/modules/aruco/src/aruco.cpp
@@ -280,11 +280,11 @@ static void _filterTooCloseCandidates(const vector< vector< Point2f > > &candida
                                       double minMarkerDistanceRate, bool detectInvertedMarker) {
 
     CV_Assert(minMarkerDistanceRate >= 0);
-
     vector<int> candGroup;
     candGroup.resize(candidatesIn.size(), -1);
     vector< vector<unsigned int> > groupedCandidates;
     for(unsigned int i = 0; i < candidatesIn.size(); i++) {
+        bool isSingleContour = true;
         for(unsigned int j = i + 1; j < candidatesIn.size(); j++) {
 
             int minimumPerimeter = min((int)contoursIn[i].size(), (int)contoursIn[j].size() );
@@ -305,7 +305,7 @@ static void _filterTooCloseCandidates(const vector< vector< Point2f > > &candida
                 // if mean square distance is too low, remove the smaller one of the two markers
                 double minMarkerDistancePixels = double(minimumPerimeter) * minMarkerDistanceRate;
                 if(distSq < minMarkerDistancePixels * minMarkerDistancePixels) {
-
+                    isSingleContour = false;
                     // i and j are not related to a group
                     if(candGroup[i]<0 && candGroup[j]<0){
                         // mark candidates with their corresponding group number
@@ -335,6 +335,14 @@ static void _filterTooCloseCandidates(const vector< vector< Point2f > > &candida
                     }
                 }
             }
+        }
+        if (isSingleContour && candGroup[i] < 0)
+        {
+            candGroup[i] = (int)groupedCandidates.size();
+            vector<unsigned int> grouped;
+            grouped.push_back(i);
+            grouped.push_back(i); // step "save possible candidates" require minimum 2 elements
+            groupedCandidates.push_back(grouped);
         }
     }
 

--- a/modules/aruco/test/test_arucodetection.cpp
+++ b/modules/aruco/test/test_arucodetection.cpp
@@ -644,4 +644,35 @@ TEST(CV_ArucoTutorial, can_find_gboriginal)
     }
 }
 
+TEST(CV_ArucoDetectMarkers, regression_3192)
+{
+    Ptr<aruco::Dictionary> dictionary = aruco::getPredefinedDictionary(aruco::DICT_4X4_50);
+    Ptr<aruco::DetectorParameters> detectorParams = aruco::DetectorParameters::create();
+    vector< int > markerIds;
+    vector<vector<Point2f> > markerCorners;
+    string imgPath = cvtest::findDataFile("aruco/regression_3192.png");
+    Mat image = imread(imgPath);
+    const size_t N = 2ull;
+    const int goldCorners[N][8] = { {345,120, 520,120, 520,295, 345,295}, {101,114, 270,112, 276,287, 101,287} };
+    const int goldCornersIds[N] = { 6, 4 };
+    map<int, const int*> mapGoldCorners;
+    for (size_t i = 0; i < N; i++)
+        mapGoldCorners[goldCornersIds[i]] = goldCorners[i];
+
+    aruco::detectMarkers(image, dictionary, markerCorners, markerIds, detectorParams);
+
+    ASSERT_EQ(N, markerIds.size());
+    for (size_t i = 0; i < N; i++)
+    {
+        int arucoId = markerIds[i];
+        ASSERT_EQ(4ull, markerCorners[i].size());
+        ASSERT_TRUE(mapGoldCorners.find(arucoId) != mapGoldCorners.end());
+        for (int j = 0; j < 4; j++)
+        {
+            EXPECT_NEAR(static_cast<float>(mapGoldCorners[arucoId][j * 2]), markerCorners[i][j].x, 1.f);
+            EXPECT_NEAR(static_cast<float>(mapGoldCorners[arucoId][j * 2 + 1]), markerCorners[i][j].y, 1.f);
+        }
+    }
+}
+
 }} // namespace

--- a/modules/aruco/test/test_charucodetection.cpp
+++ b/modules/aruco/test/test_charucodetection.cpp
@@ -745,7 +745,8 @@ TEST(Charuco, issue_14014)
     ASSERT_EQ(corners.size(), 19ull);
     EXPECT_EQ(Size(4, 1), corners[0].size()); // check dimension of detected corners
 
-    ASSERT_EQ(rejectedPoints.size(), 21ull);
+    size_t numRejPoints = rejectedPoints.size();
+    ASSERT_EQ(rejectedPoints.size(), 26ull); // optional check to track regressions
     EXPECT_EQ(Size(4, 1), rejectedPoints[0].size()); // check dimension of detected corners
 
     aruco::refineDetectedMarkers(img, board, corners, ids, rejectedPoints);
@@ -753,7 +754,7 @@ TEST(Charuco, issue_14014)
     ASSERT_EQ(corners.size(), 20ull);
     EXPECT_EQ(Size(4, 1), corners[0].size()); // check dimension of rejected corners after successfully refine
 
-    ASSERT_EQ(rejectedPoints.size(), 20ull);
+    ASSERT_EQ(rejectedPoints.size() + 1, numRejPoints);
     EXPECT_EQ(Size(4, 1), rejectedPoints[0].size()); // check dimension of rejected corners after successfully refine
 }
 


### PR DESCRIPTION
**Merge with extra**: https://github.com/opencv/opencv_extra/pull/965

This PR fixes:
- Unable to detect Aruco marker under some circumstances #3192 
- Aruco detection is worsened since OpenCV 4.1.2 #2492

The problem was in `_filterTooCloseCandidates()`. Fixed and added regression_3192, regression_2492 tests.

`opencv_extra=fix_filterTooCloseCandidates`

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
