### PR TITLE
replaced recursion DFS to stack DFS

### DIFF
--- a/modules/text/src/text_detector_swt.cpp
+++ b/modules/text/src/text_detector_swt.cpp
@@ -7,6 +7,7 @@
 
 #include <unordered_map>
 #include <limits>
+#include <stack>
 
 using namespace std;
 
@@ -91,18 +92,30 @@ void addEdge(std::vector< std::vector<int> >& adj, int u, int v)
 static
 void DFSUtil(int v, std::vector<bool> & visited, std::vector< std::vector<int> >& adj, int label, std::vector<int> &component_id)
 {
-    // Mark the current node as visited and label it as belonging to the current component
-    visited[v] = true;
-    component_id[v] = label;
+    // Mark the current node as visited and label it as belonging to the current component    
     // Recur for all the vertices
     // adjacent to this vertex
-    for (size_t i = 0; i < adj[v].size(); i++) {
-        int neighbour = adj[v][i];
-        if (!visited[neighbour]) {
-            DFSUtil(neighbour, visited, adj, label, component_id);
+    
+    stack<int> s;
+    s.push(v);
+    while(!s.empty()){
+        v = s.top();
+        s.pop();
+        if(!visited[v])
+        {
+            visited[v] = true;
+            component_id[v] = label;
+            for (size_t i = 0; i < adj[v].size(); i++) {
+                int neighbour = adj[v][i];
+                if(!visited[neighbour])
+                {
+                    s.push(neighbour);
+                }
+            }
         }
     }
 }
+
 
 static
 int connected_components(std::vector< std::vector<int> >& adj, std::vector<int> &component_id, int num_vertices)


### PR DESCRIPTION
See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

    [ Y] I agree to contribute to the project under Apache 2 License.
    [ Y] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
    [ Y] The PR is proposed to the proper branch
    [ N] There is a reference to the original bug report and related work
    [ N] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
    Patch to opencv_extra has the same branch name.
    [ N] The feature is well documented and sample code can be built with the project CMake

The function `DFSUtil` in `opencv/opencv_contrib/modules/text/sample/text_detection_swt.cpp` implements Depth First Search (DFS) using recursion. This implementation uses the call stack of the program for recursion which makes it prone to stack overflow due to very deep recursion. This error was encountered for some images from my testset. The error was found through Valgrind.

Fix:
Implemented the `DFSUtil` function using external stack. This implementation was tested using the same images and the program is now working as intended.