### PR TITLE
Set higher minimum number of decode surfaces when creating cv::cudacodec::VideoReader

### DIFF
--- a/modules/cudacodec/include/opencv2/cudacodec.hpp
+++ b/modules/cudacodec/include/opencv2/cudacodec.hpp
@@ -457,16 +457,24 @@ The `params` parameter allows to specify extra parameters encoded as pairs `(par
     See cv::VideoCaptureProperties
 e.g. when streaming from an RTSP source CAP_PROP_OPEN_TIMEOUT_MSEC may need to be set.
 @param rawMode Allow the raw encoded data which has been read up until the last call to grab() to be retrieved by calling retrieve(rawData,RAW_DATA_IDX).
+@param minNumDecodeSurfaces Minimum number of internal decode surfaces used by the hardware decoder.  NVDEC will automatically determine the minimum number of
+surfaces it requires for correct functionality and optimal video memory usage but not necessarily for best performance, which depends on the design of the
+overall application. The optimal number of decode surfaces (in terms of performance and memory utilization) should be decided by experimentation for each application,
+but it cannot go below the number determined by NVDEC.
 
 FFMPEG is used to read videos. User can implement own demultiplexing with cudacodec::RawVideoSource
  */
-CV_EXPORTS_W Ptr<VideoReader> createVideoReader(const String& filename, const std::vector<int>& params = {}, const bool rawMode = false);
+CV_EXPORTS_W Ptr<VideoReader> createVideoReader(const String& filename, const std::vector<int>& params = {}, const bool rawMode = false, const int minNumDecodeSurfaces = 0);
 
 /** @overload
 @param source RAW video source implemented by user.
 @param rawMode Allow the raw encoded data which has been read up until the last call to grab() to be retrieved by calling retrieve(rawData,RAW_DATA_IDX).
+@param minNumDecodeSurfaces Minimum number of internal decode surfaces used by the hardware decoder.  NVDEC will automatically determine the minimum number of
+surfaces it requires for correct functionality and optimal video memory usage but not necessarily for best performance, which depends on the design of the
+overall application. The optimal number of decode surfaces (in terms of performance and memory utilization) should be decided by experimentation for each application,
+but it cannot go below the number determined by NVDEC.
 */
-CV_EXPORTS_W Ptr<VideoReader> createVideoReader(const Ptr<RawVideoSource>& source, const bool rawMode = false);
+CV_EXPORTS_W Ptr<VideoReader> createVideoReader(const Ptr<RawVideoSource>& source, const bool rawMode = false, const int minNumDecodeSurfaces = 0);
 
 //! @}
 

--- a/modules/cudacodec/src/video_decoder.hpp
+++ b/modules/cudacodec/src/video_decoder.hpp
@@ -49,9 +49,10 @@ namespace cv { namespace cudacodec { namespace detail {
 class VideoDecoder
 {
 public:
-    VideoDecoder(const Codec& codec, CUcontext ctx, CUvideoctxlock lock) : ctx_(ctx), lock_(lock), decoder_(0)
+    VideoDecoder(const Codec& codec, const int minNumDecodeSurfaces, CUcontext ctx, CUvideoctxlock lock) : ctx_(ctx), lock_(lock), decoder_(0)
     {
         videoFormat_.codec = codec;
+        videoFormat_.ulNumDecodeSurfaces = minNumDecodeSurfaces;
     }
 
     ~VideoDecoder()
@@ -64,7 +65,7 @@ public:
 
     // Get the code-type currently used.
     cudaVideoCodec codec() const { return static_cast<cudaVideoCodec>(videoFormat_.codec); }
-    unsigned long maxDecodeSurfaces() const { return videoFormat_.ulNumDecodeSurfaces; }
+    int nDecodeSurfaces() const { return videoFormat_.ulNumDecodeSurfaces; }
 
     unsigned long frameWidth() const { return videoFormat_.ulWidth; }
     unsigned long frameHeight() const { return videoFormat_.ulHeight; }

--- a/modules/cudacodec/src/video_parser.cpp
+++ b/modules/cudacodec/src/video_parser.cpp
@@ -110,7 +110,7 @@ int CUDAAPI cv::cudacodec::detail::VideoParser::HandleVideoSequence(void* userDa
         format->coded_height  != thiz->videoDecoder_->frameHeight() ||
         format->chroma_format != thiz->videoDecoder_->chromaFormat()||
         format->bit_depth_luma_minus8 != thiz->videoDecoder_->nBitDepthMinus8() ||
-        format->min_num_decode_surfaces != thiz->videoDecoder_->maxDecodeSurfaces())
+        format->min_num_decode_surfaces != thiz->videoDecoder_->nDecodeSurfaces())
     {
         FormatInfo newFormat;
         newFormat.codec = static_cast<Codec>(format->codec);
@@ -122,7 +122,7 @@ int CUDAAPI cv::cudacodec::detail::VideoParser::HandleVideoSequence(void* userDa
         newFormat.height = format->coded_height;
         newFormat.displayArea = Rect(Point(format->display_area.left, format->display_area.top), Point(format->display_area.right, format->display_area.bottom));
         newFormat.fps = format->frame_rate.numerator / static_cast<float>(format->frame_rate.denominator);
-        newFormat.ulNumDecodeSurfaces = format->min_num_decode_surfaces;
+        newFormat.ulNumDecodeSurfaces = max(thiz->videoDecoder_->nDecodeSurfaces(), static_cast<int>(format->min_num_decode_surfaces));
         if (format->progressive_sequence)
             newFormat.deinterlaceMode = Weave;
         else
@@ -154,7 +154,7 @@ int CUDAAPI cv::cudacodec::detail::VideoParser::HandleVideoSequence(void* userDa
         }
     }
 
-    return thiz->videoDecoder_->maxDecodeSurfaces();
+    return thiz->videoDecoder_->nDecodeSurfaces();
 }
 
 int CUDAAPI cv::cudacodec::detail::VideoParser::HandlePictureDecode(void* userData, CUVIDPICPARAMS* picParams)

--- a/modules/cudacodec/test/test_video.cpp
+++ b/modules/cudacodec/test/test_video.cpp
@@ -66,6 +66,10 @@ PARAM_TEST_CASE(CheckKeyFrame, cv::cuda::DeviceInfo, std::string)
 {
 };
 
+PARAM_TEST_CASE(CheckDecodeSurfaces, cv::cuda::DeviceInfo, std::string)
+{
+};
+
 struct CheckParams : testing::TestWithParam<cv::cuda::DeviceInfo>
 {
     cv::cuda::DeviceInfo devInfo;
@@ -281,12 +285,53 @@ CUDA_TEST_P(CheckParams, Reader)
                 cv::Ptr<cv::cudacodec::VideoReader> reader = cv::cudacodec::createVideoReader(inputFile, {
                     cv::VideoCaptureProperties::CAP_PROP_FORMAT, capPropFormats.at(i) });
             }
-            catch (cv::Exception ex) {
+            catch (cv::Exception &ex) {
                 if (ex.code == Error::StsUnsupportedFormat)
                     exceptionThrown = true;
             }
             ASSERT_EQ(exceptionThrown, exceptionsThrown.at(i));
         }
+    }
+}
+
+CUDA_TEST_P(CheckDecodeSurfaces, Reader)
+{
+    cv::cuda::setDevice(GET_PARAM(0).deviceID());
+    const std::string inputFile = std::string(cvtest::TS::ptr()->get_data_path()) + "../" + GET_PARAM(1);
+    int ulNumDecodeSurfaces = 0;
+    {
+        cv::Ptr<cv::cudacodec::VideoReader> reader = cv::cudacodec::createVideoReader(inputFile);
+        cv::cudacodec::FormatInfo fmt = reader->format();
+        if (!fmt.valid) {
+            reader->grab();
+            fmt = reader->format();
+            ASSERT_TRUE(fmt.valid);
+        }
+        ulNumDecodeSurfaces = fmt.ulNumDecodeSurfaces;
+    }
+
+    {
+        cv::Ptr<cv::cudacodec::VideoReader> reader = cv::cudacodec::createVideoReader(inputFile, {}, false, ulNumDecodeSurfaces - 1);
+        cv::cudacodec::FormatInfo fmt = reader->format();
+        if (!fmt.valid) {
+            reader->grab();
+            fmt = reader->format();
+            ASSERT_TRUE(fmt.valid);
+        }
+        ASSERT_TRUE(fmt.ulNumDecodeSurfaces == ulNumDecodeSurfaces);
+        for (int i = 0; i < 100; i++) ASSERT_TRUE(reader->grab());
+    }
+
+    {
+        cv::Ptr<cv::cudacodec::VideoReader> reader = cv::cudacodec::createVideoReader(inputFile, {}, false, ulNumDecodeSurfaces + 1);
+        cv::cudacodec::FormatInfo fmt = reader->format();
+        if (!fmt.valid) {
+            reader->grab();
+            fmt = reader->format();
+            ASSERT_TRUE(fmt.valid);
+        }
+        ASSERT_TRUE(fmt.ulNumDecodeSurfaces == ulNumDecodeSurfaces + 1);
+        for (int i = 0; i < 100; i++) ASSERT_TRUE(reader->grab());
     }
 }
 #endif // HAVE_NVCUVID
@@ -371,6 +416,10 @@ INSTANTIATE_TEST_CASE_P(CUDA_Codec, CheckKeyFrame, testing::Combine(
     testing::Values(VIDEO_SRC_R)));
 
 INSTANTIATE_TEST_CASE_P(CUDA_Codec, CheckParams, ALL_DEVICES);
+
+INSTANTIATE_TEST_CASE_P(CUDA_Codec, CheckDecodeSurfaces, testing::Combine(
+    ALL_DEVICES,
+    testing::Values("highgui/video/big_buck_bunny.mp4")));
 
 #endif // HAVE_NVCUVID || HAVE_NVCUVENC
 }} // namespace


### PR DESCRIPTION
`cv::cudacodec::VideoReader` uses the minimum number of decode surfaces for correct decoding.  From the NVIDIA documentation:

> This guarantees correct functionality and optimal video memory usage but not necessarily the best performance, which depends on the design of the overall application. The optimal number of decode surfaces (in terms of performance and memory utilization) should be decided by experimentation for each application, but it cannot go below ..

Therefore this pull request allows the user to specify a higher minimum number of decode surfaces when creating `cv::cudacodec::VideoReader` to increase the decoding performace at the cost of GPU memory, if required.

<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
buildworker:Custom=linux-4,linux-6
build_image:Custom=ubuntu-cuda:18.04
```