### PR TITLE
Fix cuda::minMax and cuda::minMaxLoc python bindings

### DIFF
--- a/modules/cudaarithm/include/opencv2/cudaarithm.hpp
+++ b/modules/cudaarithm/include/opencv2/cudaarithm.hpp
@@ -620,7 +620,7 @@ The function does not work with CV_64F images on GPUs with the compute capabilit
 
 @sa minMaxLoc
  */
-CV_EXPORTS_W void minMax(InputArray src, double* minVal, double* maxVal, InputArray mask = noArray());
+CV_EXPORTS_W void minMax(InputArray src, CV_OUT double* minVal, CV_OUT double* maxVal, InputArray mask = noArray());
 /** @overload */
 CV_EXPORTS_W void findMinMax(InputArray src, OutputArray dst, InputArray mask = noArray(), Stream& stream = Stream::Null());
 
@@ -637,7 +637,7 @@ The function does not work with CV_64F images on GPU with the compute capability
 
 @sa minMaxLoc
  */
-CV_EXPORTS_W void minMaxLoc(InputArray src, double* minVal, double* maxVal, Point* minLoc, Point* maxLoc,
+CV_EXPORTS_W void minMaxLoc(InputArray src, CV_OUT double* minVal, CV_OUT double* maxVal, CV_OUT Point* minLoc, CV_OUT Point* maxLoc,
                           InputArray mask = noArray());
 /** @overload */
 CV_EXPORTS_W void findMinMaxLoc(InputArray src, OutputArray minMaxVals, OutputArray loc,

--- a/modules/cudaarithm/misc/python/test/test_cudaarithm.py
+++ b/modules/cudaarithm/misc/python/test/test_cudaarithm.py
@@ -154,6 +154,9 @@ class cudaarithm_test(NewOpenCVTests):
         cv.cuda.max(cuMat1, cuMat2, cuMatDst)
         self.assertTrue(np.allclose(cuMatDst.download(),cv.max(npMat1, npMat2)))
 
+        self.assertTrue(cv.cuda.minMax(cuMat1),cv.minMaxLoc(npMat1)[:2])
+        self.assertTrue(cv.cuda.minMaxLoc(cuMat1),cv.minMaxLoc(npMat1))
+
     def test_convolution(self):
         npMat = (np.random.random((128, 128)) * 255).astype(np.float32)
         npDims = np.array(npMat.shape)


### PR DESCRIPTION
As reported [here](https://forum.opencv.org/t/how-to-use-the-cv-minmaxloc-function-in-python/8056) the python bindings do not output the results from both cuda::minMax and cuda::minMaxLoc.  This PR adds this functionality and includes a python test for verification.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake


```
force_builders=Custom
buildworker:Custom=linux-4,linux-6
build_image:Custom=ubuntu-cuda:18.04
```