### PR TITLE
Remove unused nrot variable.

### DIFF
--- a/modules/ximgproc/src/edge_drawing.cpp
+++ b/modules/ximgproc/src/edge_drawing.cpp
@@ -229,7 +229,7 @@ private:
     static void DeallocateMatrix(double** m, int noRows);
     static void AperB_T(double** A_, double** B_, double** _res, int _righA, int _colA, int _righB, int _colB);
     static void AperB(double** A_, double** B_, double** _res, int _righA, int _colA, int _righB, int _colB);
-    static void jacobi(double** a, int n, double d[], double** v, int nrot);
+    static void jacobi(double** a, int n, double d[], double** v);
     static void ROTATE(double** a, int i, int j, int k, int l, double tau, double s);
     static double computeEllipsePerimeter(EllipseEquation* eq);
     static double ComputeEllipseError(EllipseEquation* eq, double* px, double* py, int noPoints);
@@ -5340,7 +5340,6 @@ bool EdgeDrawingImpl::EllipseFit(double* x, double* y, int noPoints, EllipseEqua
     double** V = AllocateMatrix(7, 7);
     double** sol = AllocateMatrix(7, 7);
     double tx, ty;
-    int nrot = 0;
 
     memset(d, 0, sizeof(double) * 7);
 
@@ -5384,7 +5383,7 @@ bool EdgeDrawingImpl::EllipseFit(double* x, double* y, int noPoints, EllipseEqua
     AperB_T(Const, invL, temp, 6, 6, 6, 6);
     AperB(invL, temp, C, 6, 6, 6, 6);
 
-    jacobi(C, 6, d, V, nrot);
+    jacobi(C, 6, d, V);
 
     A_TperB(invL, V, sol, 6, 6, 6, 6);
 
@@ -5634,7 +5633,7 @@ void EdgeDrawingImpl::AperB(double** A_, double** B_, double** _res, int _righA,
         }
 }
 
-void EdgeDrawingImpl::jacobi(double** a, int n, double d[], double** v, int nrot)
+void EdgeDrawingImpl::jacobi(double** a, int n, double d[], double** v)
 {
     int j, iq, ip, i;
     double tresh, theta, tau, t, sm, s, h, g, c;
@@ -5655,7 +5654,6 @@ void EdgeDrawingImpl::jacobi(double** a, int n, double d[], double** v, int nrot
         b[ip] = d[ip] = a[ip][ip];
         z[ip] = 0.0;
     }
-    nrot = 0;
     for (i = 1; i <= 50; i++)
     {
         sm = 0.0;
@@ -5719,7 +5717,6 @@ void EdgeDrawingImpl::jacobi(double** a, int n, double d[], double** v, int nrot
                     {
                         ROTATE(v, j, ip, j, iq, tau, s);
                     }
-                    ++nrot;
                 }
             }
         }


### PR DESCRIPTION
This is to quiet the -Wunused-but-set-parameter clang diagnostic warning.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
