### PR TITLE
Fix infinite loop on ArUco apriltag refinement

### DIFF
--- a/modules/aruco/src/apriltag_quad_thresh.cpp
+++ b/modules/aruco/src/apriltag_quad_thresh.cpp
@@ -1523,7 +1523,7 @@ out = Mat::zeros(h, w, CV_8UC3);
     zarray_t *quads = _zarray_create(sizeof(struct sQuad));
 
     //int chunksize = 1 + sz / (APRILTAG_TASKS_PER_THREAD_TARGET * numberOfThreads);
-    int chunksize = h / (10 * getNumThreads());
+    int chunksize = std::max(1, h / (10 * getNumThreads()));
     int sz = _zarray_size(clusters);
 
     // TODO PARALLELIZE

--- a/modules/aruco/test/test_arucodetection.cpp
+++ b/modules/aruco/test/test_arucodetection.cpp
@@ -759,7 +759,7 @@ TEST_P(ArucoThreading, number_of_threads_does_not_change_results)
 
     params->cornerRefinementMethod = GetParam();
 
-    std::vector<std::vector<cv::Point2f>> original_corners;
+    std::vector<std::vector<cv::Point2f> > original_corners;
     std::vector<int> original_ids;
     {
         NumThreadsSetter thread_num_setter(1);
@@ -774,7 +774,7 @@ TEST_P(ArucoThreading, number_of_threads_does_not_change_results)
     for (size_t i_num_threads = 0; i_num_threads < sizeof(num_threads_to_test)/sizeof(int); ++i_num_threads) {
         NumThreadsSetter thread_num_setter(num_threads_to_test[i_num_threads]);
 
-        std::vector<std::vector<cv::Point2f>> corners;
+        std::vector<std::vector<cv::Point2f> > corners;
         std::vector<int> ids;
         cv::aruco::detectMarkers(img, dictionary, corners, ids, params);
 

--- a/modules/aruco/test/test_arucodetection.cpp
+++ b/modules/aruco/test/test_arucodetection.cpp
@@ -717,4 +717,93 @@ TEST(CV_ArucoDetectMarkers, regression_2492)
     }
 }
 
+TEST(CV_ArucoDetectMarkers, number_of_threads_does_not_change_results)
+{
+    struct NumThreadsSetter {
+        NumThreadsSetter(const int num_threads)
+        : original_num_threads_(cv::getNumThreads()) {
+            cv::setNumThreads(num_threads);
+        }
+
+        ~NumThreadsSetter() {
+            cv::setNumThreads(original_num_threads_);
+        }
+     private:
+        int original_num_threads_;
+    };
+    cv::Ptr<cv::aruco::DetectorParameters> params = cv::aruco::DetectorParameters::create();
+    // We are not testing against different dictionaries
+    // As we are interested mostly in small images, smaller
+    // markers is better -> 4x4
+    cv::Ptr<cv::aruco::Dictionary> dictionary = cv::aruco::getPredefinedDictionary(cv::aruco::DICT_4X4_50);
+
+    // Height of the test image can be chosen quite freely
+    // We aim to test against small images as in those the
+    // number of threads has most effect
+    const int height_img = 20;
+    // Just to get nice white boarder
+    const int shift = height_img > 10 ? 5 : 1;
+    const int height_marker = height_img-2*shift;
+
+    // Create a test image
+    cv::Mat img_marker;
+    cv::aruco::drawMarker(dictionary, 23, height_marker, img_marker, 1);
+
+    // Copy to bigger image to get a white border
+    cv::Mat img(height_img, height_img, CV_8UC1);
+    img.setTo(255);
+    img_marker.copyTo(img(cv::Rect(shift, shift, height_marker, height_marker)));
+
+    // Number of threads to be tested. OpenCV uses C++03 so no list-initialization
+    std::vector<int> num_threads_to_test;
+    num_threads_to_test.push_back(1);
+    num_threads_to_test.push_back(2);
+    num_threads_to_test.push_back(8);
+    num_threads_to_test.push_back(16);
+    num_threads_to_test.push_back(32);
+    num_threads_to_test.push_back(height_img-1);
+    num_threads_to_test.push_back(height_img);
+    num_threads_to_test.push_back(height_img+1);
+
+    std::vector<cv::aruco::CornerRefineMethod> methods_to_test;
+    methods_to_test.push_back(cv::aruco::CORNER_REFINE_NONE);
+    methods_to_test.push_back(cv::aruco::CORNER_REFINE_SUBPIX);
+    methods_to_test.push_back(cv::aruco::CORNER_REFINE_CONTOUR);
+    methods_to_test.push_back(cv::aruco::CORNER_REFINE_APRILTAG);
+
+    for (size_t i_method = 0; i_method < methods_to_test.size(); ++i_method) {
+        params->cornerRefinementMethod = methods_to_test[i_method];
+
+        std::vector<std::vector<cv::Point2f>> original_corners;
+        std::vector<int> original_ids;
+        for (size_t i_num_threads = 0; i_num_threads < num_threads_to_test.size(); ++i_num_threads) {
+            NumThreadsSetter thread_num_setter(num_threads_to_test[i_num_threads]);
+
+            std::vector<std::vector<cv::Point2f>> corners;
+            std::vector<int> ids;
+            cv::aruco::detectMarkers(img, dictionary, corners, ids, params);
+
+            // If we don't find any markers, the test is broken
+            ASSERT_GE(ids.size(), 1);
+
+            if (original_corners.empty()) {
+                original_corners = corners;
+                original_ids = ids;
+            } else {
+                // Make sure we got the same result as the first time
+                ASSERT_EQ(corners.size(), original_corners.size());
+                ASSERT_EQ(ids.size(), original_ids.size());
+                ASSERT_EQ(ids.size(), corners.size());
+                for (size_t i = 0; i < corners.size(); ++i) {
+                    EXPECT_EQ(ids[i], original_ids[i]);
+                    for (size_t j = 0; j < corners[i].size(); ++j) {
+                        EXPECT_NEAR(corners[i][j].x, original_corners[i][j].x, 0.1f);
+                        EXPECT_NEAR(corners[i][j].y, original_corners[i][j].y, 0.1f);
+                    }
+                }
+            }
+        }
+    }
+}
+
 }} // namespace

--- a/modules/aruco/test/test_arucodetection.cpp
+++ b/modules/aruco/test/test_arucodetection.cpp
@@ -717,7 +717,7 @@ TEST(CV_ArucoDetectMarkers, regression_2492)
     }
 }
 
-TEST(CV_ArucoDetectMarkers, number_of_threads_does_not_change_results)
+struct ArucoThreading: public testing::TestWithParam<cv::aruco::CornerRefineMethod>
 {
     struct NumThreadsSetter {
         NumThreadsSetter(const int num_threads)
@@ -731,6 +731,10 @@ TEST(CV_ArucoDetectMarkers, number_of_threads_does_not_change_results)
      private:
         int original_num_threads_;
     };
+};
+
+TEST_P(ArucoThreading, number_of_threads_does_not_change_results)
+{
     cv::Ptr<cv::aruco::DetectorParameters> params = cv::aruco::DetectorParameters::create();
     // We are not testing against different dictionaries
     // As we are interested mostly in small images, smaller
@@ -750,60 +754,54 @@ TEST(CV_ArucoDetectMarkers, number_of_threads_does_not_change_results)
     cv::aruco::drawMarker(dictionary, 23, height_marker, img_marker, 1);
 
     // Copy to bigger image to get a white border
-    cv::Mat img(height_img, height_img, CV_8UC1);
-    img.setTo(255);
+    cv::Mat img(height_img, height_img, CV_8UC1, cv::Scalar(255));
     img_marker.copyTo(img(cv::Rect(shift, shift, height_marker, height_marker)));
 
-    // Number of threads to be tested. OpenCV uses C++03 so no list-initialization
-    std::vector<int> num_threads_to_test;
-    num_threads_to_test.push_back(1);
-    num_threads_to_test.push_back(2);
-    num_threads_to_test.push_back(8);
-    num_threads_to_test.push_back(16);
-    num_threads_to_test.push_back(32);
-    num_threads_to_test.push_back(height_img-1);
-    num_threads_to_test.push_back(height_img);
-    num_threads_to_test.push_back(height_img+1);
+    params->cornerRefinementMethod = GetParam();
 
-    std::vector<cv::aruco::CornerRefineMethod> methods_to_test;
-    methods_to_test.push_back(cv::aruco::CORNER_REFINE_NONE);
-    methods_to_test.push_back(cv::aruco::CORNER_REFINE_SUBPIX);
-    methods_to_test.push_back(cv::aruco::CORNER_REFINE_CONTOUR);
-    methods_to_test.push_back(cv::aruco::CORNER_REFINE_APRILTAG);
+    std::vector<std::vector<cv::Point2f>> original_corners;
+    std::vector<int> original_ids;
+    {
+        NumThreadsSetter thread_num_setter(1);
+        cv::aruco::detectMarkers(img, dictionary, original_corners, original_ids, params);
+    }
 
-    for (size_t i_method = 0; i_method < methods_to_test.size(); ++i_method) {
-        params->cornerRefinementMethod = methods_to_test[i_method];
+    ASSERT_EQ(original_ids.size(), 1);
+    ASSERT_EQ(original_corners.size(), 1);
 
-        std::vector<std::vector<cv::Point2f>> original_corners;
-        std::vector<int> original_ids;
-        for (size_t i_num_threads = 0; i_num_threads < num_threads_to_test.size(); ++i_num_threads) {
-            NumThreadsSetter thread_num_setter(num_threads_to_test[i_num_threads]);
+    int num_threads_to_test[] = { 2, 8, 16, 32, height_img-1, height_img, height_img+1};
 
-            std::vector<std::vector<cv::Point2f>> corners;
-            std::vector<int> ids;
-            cv::aruco::detectMarkers(img, dictionary, corners, ids, params);
+    for (size_t i_num_threads = 0; i_num_threads < sizeof(num_threads_to_test)/sizeof(int); ++i_num_threads) {
+        NumThreadsSetter thread_num_setter(num_threads_to_test[i_num_threads]);
 
-            // If we don't find any markers, the test is broken
-            ASSERT_GE(ids.size(), 1);
+        std::vector<std::vector<cv::Point2f>> corners;
+        std::vector<int> ids;
+        cv::aruco::detectMarkers(img, dictionary, corners, ids, params);
 
-            if (original_corners.empty()) {
-                original_corners = corners;
-                original_ids = ids;
-            } else {
-                // Make sure we got the same result as the first time
-                ASSERT_EQ(corners.size(), original_corners.size());
-                ASSERT_EQ(ids.size(), original_ids.size());
-                ASSERT_EQ(ids.size(), corners.size());
-                for (size_t i = 0; i < corners.size(); ++i) {
-                    EXPECT_EQ(ids[i], original_ids[i]);
-                    for (size_t j = 0; j < corners[i].size(); ++j) {
-                        EXPECT_NEAR(corners[i][j].x, original_corners[i][j].x, 0.1f);
-                        EXPECT_NEAR(corners[i][j].y, original_corners[i][j].y, 0.1f);
-                    }
-                }
+        // If we don't find any markers, the test is broken
+        ASSERT_EQ(ids.size(), 1);
+
+        // Make sure we got the same result as the first time
+        ASSERT_EQ(corners.size(), original_corners.size());
+        ASSERT_EQ(ids.size(), original_ids.size());
+        ASSERT_EQ(ids.size(), corners.size());
+        for (size_t i = 0; i < corners.size(); ++i) {
+            EXPECT_EQ(ids[i], original_ids[i]);
+            for (size_t j = 0; j < corners[i].size(); ++j) {
+                EXPECT_NEAR(corners[i][j].x, original_corners[i][j].x, 0.1f);
+                EXPECT_NEAR(corners[i][j].y, original_corners[i][j].y, 0.1f);
             }
         }
     }
 }
+
+INSTANTIATE_TEST_CASE_P(
+        CV_ArucoDetectMarkers, ArucoThreading,
+        ::testing::Values(
+            cv::aruco::CORNER_REFINE_NONE,
+            cv::aruco::CORNER_REFINE_SUBPIX,
+            cv::aruco::CORNER_REFINE_CONTOUR,
+            cv::aruco::CORNER_REFINE_APRILTAG
+        ));
 
 }} // namespace


### PR DESCRIPTION
Software entered infinite loop when image height
was smaller than 10*cv::getNumThreads(). With high
core count machines this could happen with very
reasonable image sizes.

Fix is to ensure that chunksize is at least 1.

The bug can be triggered with following test program:

```
#include <opencv2/aruco.hpp>
#include <opencv2/core/utility.hpp>
#include <iostream>
#include <opencv2/imgcodecs.hpp>

int main(int argc, char *argv[]) {
    // Bug will happen even with 1 thread, but then the image
    // will be too small to detect corners.
    // cv::setNumThreads(1);
    const auto num_th = cv::getNumThreads();
    std::cout << "Number of threads: " << num_th << std::endl;

    // If 'freeze' is set to true, bug is triggered
    constexpr bool freeze = true;
    std::cout << "Should freeze: " << freeze << std::endl;

    // When triggering the bug, use image size that is
    // 1 pix smaller than 10*number of threads
    const auto height_img = freeze ? num_th*10-1 : num_th*10;
    std::cout << "Image height: " << height_img << std::endl;

    // Just to get nice white boarder
    const int shift = height_img > 10 ? 5 : 1;
    const auto height_marker = height_img-2*shift;

    // Create marker template
    cv::Mat img_marker;
    cv::Ptr<cv::aruco::Dictionary> dictionary = cv::aruco::getPredefinedDictionary(cv::aruco::DICT_4X4_50);
    cv::aruco::drawMarker(dictionary, 23, height_marker, img_marker, 1);

    // Copy to bigger image
    cv::Mat img(height_img, height_img, CV_8UC1);
    img.setTo(255);
    img_marker.copyTo(img(cv::Rect(shift, shift, height_marker, height_marker)));

    // Just for visualizing
    cv::imwrite("marker.png", img);

    // Bug only in apriltag refinement
    auto params = cv::aruco::DetectorParameters::create();
    params->cornerRefinementMethod = cv::aruco::CORNER_REFINE_APRILTAG;

    std::vector<std::vector<cv::Point2f>> corners;
    std::vector<int> ids;

    // If freeze=true, this will never return
    cv::aruco::detectMarkers(img, dictionary, corners, ids, params);

    // Ensure we get reasonable corners 
    // (not with this default test, white boarder needs to be bigger)
    for (const auto &marker : corners) {
        for (const auto &p : marker) {
            std::cout << p << std::endl;
        }
    }
}
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
