### PR TITLE
Add dictionary bindings

### DIFF
--- a/modules/aruco/include/opencv2/aruco/dictionary.hpp
+++ b/modules/aruco/include/opencv2/aruco/dictionary.hpp
@@ -117,13 +117,13 @@ class CV_EXPORTS_W Dictionary {
      * @brief Given a matrix of bits. Returns whether if marker is identified or not.
      * It returns by reference the correct id (if any) and the correct rotation
      */
-    bool identify(const Mat &onlyBits, int &idx, int &rotation, double maxCorrectionRate) const;
+    CV_WRAP bool identify(const Mat &onlyBits, CV_OUT int &idx, CV_OUT int &rotation, double maxCorrectionRate) const;
 
     /**
       * @brief Returns the distance of the input bits to the specific id. If allRotations is true,
       * the four posible bits rotation are considered
       */
-    int getDistanceToId(InputArray bits, int id, bool allRotations = true) const;
+    CV_WRAP int getDistanceToId(InputArray bits, int id, bool allRotations = true) const;
 
 
     /**

--- a/modules/aruco/misc/python/test/test_aruco.py
+++ b/modules/aruco/misc/python/test/test_aruco.py
@@ -64,6 +64,26 @@ class aruco_test(NewOpenCVTests):
             if os.path.exists(filename):
                 os.remove(filename)
 
+    def test_identify(self):
+        aruco_dict = cv.aruco.Dictionary_get(cv.aruco.DICT_4X4_50)
+        expected_idx = 9
+        expected_rotation = 2
+        bit_marker = np.array([[0, 1, 1, 0], [1, 0, 1, 0], [1, 1, 1, 1], [0, 0, 1, 1]], dtype=np.uint8)
+
+        check, idx, rotation = aruco_dict.identify(bit_marker, 0)
+
+        self.assertTrue(check, True)
+        self.assertEqual(idx, expected_idx)
+        self.assertEqual(rotation, expected_rotation)
+
+    def test_getDistanceToId(self):
+        aruco_dict = cv.aruco.Dictionary_get(cv.aruco.DICT_4X4_50)
+        idx = 7
+        rotation = 3
+        bit_marker = np.array([[0, 1, 0, 1], [0, 1, 1, 1], [1, 1, 0, 0], [0, 1, 0, 0]], dtype=np.uint8)
+        dist = aruco_dict.getDistanceToId(bit_marker, idx)
+
+        self.assertEqual(dist, 0)
 
 if __name__ == '__main__':
     NewOpenCVTests.bootstrap()


### PR DESCRIPTION
Added python bindings for `identify()/getDistanceToId()`

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
