### PR TITLE
Fix warning for Aruco threading test

### DIFF
--- a/modules/aruco/test/test_arucodetection.cpp
+++ b/modules/aruco/test/test_arucodetection.cpp
@@ -766,8 +766,8 @@ TEST_P(ArucoThreading, number_of_threads_does_not_change_results)
         cv::aruco::detectMarkers(img, dictionary, original_corners, original_ids, params);
     }
 
-    ASSERT_EQ(original_ids.size(), 1);
-    ASSERT_EQ(original_corners.size(), 1);
+    ASSERT_EQ(original_ids.size(), 1ull);
+    ASSERT_EQ(original_corners.size(), 1ull);
 
     int num_threads_to_test[] = { 2, 8, 16, 32, height_img-1, height_img, height_img+1};
 
@@ -779,7 +779,7 @@ TEST_P(ArucoThreading, number_of_threads_does_not_change_results)
         cv::aruco::detectMarkers(img, dictionary, corners, ids, params);
 
         // If we don't find any markers, the test is broken
-        ASSERT_EQ(ids.size(), 1);
+        ASSERT_EQ(ids.size(), 1ull);
 
         // Make sure we got the same result as the first time
         ASSERT_EQ(corners.size(), original_corners.size());


### PR DESCRIPTION
Fix warning `comparison between signed and unsigned integer expressions` in `ArucoThreading` test from PR #3220.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
