### PR TITLE
[API Behavior Change] return four vertices of qrcode instead of axis aligned bounding box

### DIFF
--- a/modules/wechat_qrcode/src/decodermgr.cpp
+++ b/modules/wechat_qrcode/src/decodermgr.cpp
@@ -18,7 +18,7 @@ using zxing::Result;
 using zxing::UnicomBlock;
 namespace cv {
 namespace wechat_qrcode {
-int DecoderMgr::decodeImage(cv::Mat src, bool use_nn_detector, string& result) {
+int DecoderMgr::decodeImage(cv::Mat src, bool use_nn_detector, string& result, vector<Point2f>& points){
     int width = src.cols;
     int height = src.rows;
     if (width <= 20 || height <= 20)
@@ -46,6 +46,10 @@ int DecoderMgr::decodeImage(cv::Mat src, bool use_nn_detector, string& result) {
         int ret = TryDecode(source, zx_result);
         if (!ret) {
             result = zx_result->getText()->getText();
+            auto result_points = zx_result->getResultPoints();
+            for(int i=0; i < result_points->size(); i++){
+                points.emplace_back(result_points[i]->getX(), result_points[i]->getY());
+            }
             return ret;
         }
         // try different binarizers

--- a/modules/wechat_qrcode/src/decodermgr.hpp
+++ b/modules/wechat_qrcode/src/decodermgr.hpp
@@ -26,7 +26,7 @@ public:
     DecoderMgr() { reader_ = new zxing::qrcode::QRCodeReader(); };
     ~DecoderMgr(){};
 
-    int decodeImage(cv::Mat src, bool use_nn_detector, string& result);
+    int decodeImage(cv::Mat src, bool use_nn_detector, string& result, vector<Point2f>& points);
 
 private:
     zxing::Ref<zxing::UnicomBlock> qbarUicomBlock_;


### PR DESCRIPTION
API Behavior Change: return four vertices of qrcode instead of axis aligned bounding box.
The change can be tested by the original test files.
Related issue: https://github.com/opencv/opencv_contrib/issues/3037
Returning coordinate information of the qrcode detected.
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=linux,docs
```