### PR TITLE
Use ceres::Manifolds instead of ceres::LocalParameterization.

### DIFF
--- a/modules/sfm/src/libmv_light/libmv/simple_pipeline/bundle.cc
+++ b/modules/sfm/src/libmv_light/libmv/simple_pipeline/bundle.cc
@@ -24,6 +24,7 @@
 
 #include "ceres/ceres.h"
 #include "ceres/rotation.h"
+#include "ceres/version.h"
 #include "libmv/base/vector.h"
 #include "libmv/logging/logging.h"
 #include "libmv/multiview/fundamental.h"
@@ -485,7 +486,11 @@ void EuclideanBundleCommonIntrinsics(
     PackCamerasRotationAndTranslation(tracks, *reconstruction);
 
   // Parameterization used to restrict camera motion for modal solvers.
+#if CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 1
+  ceres::SubsetManifold *constant_translation_manifold = NULL;
+#else
   ceres::SubsetParameterization *constant_translation_parameterization = NULL;
+#endif
   if (bundle_constraints & BUNDLE_NO_TRANSLATION) {
       std::vector<int> constant_translation;
 
@@ -494,8 +499,13 @@ void EuclideanBundleCommonIntrinsics(
       constant_translation.push_back(4);
       constant_translation.push_back(5);
 
+#if CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 1
+      constant_translation_parameterization =
+        new ceres::SubsetManifold(6, constant_translation);
+#else
       constant_translation_parameterization =
         new ceres::SubsetParameterization(6, constant_translation);
+#endif
   }
 
   // Add residual blocks to the problem.
@@ -538,8 +548,13 @@ void EuclideanBundleCommonIntrinsics(
       }
 
       if (bundle_constraints & BUNDLE_NO_TRANSLATION) {
+#if CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 1
+        problem.SetParameterization(current_camera_R_t,
+                                    constant_translation_manifold);
+#else
         problem.SetParameterization(current_camera_R_t,
                                     constant_translation_parameterization);
+#endif
       }
 
       zero_weight_tracks_flags[marker.track] = false;
@@ -586,10 +601,17 @@ void EuclideanBundleCommonIntrinsics(
     // Always set K3 constant, it's not used at the moment.
     constant_intrinsics.push_back(OFFSET_K3);
 
+#if CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 1
+    ceres::SubsetManifold *subset_manifold =
+      new ceres::SubsetManifold(OFFSET_MAX, constant_intrinsics);
+
+    problem.SetManifold(ceres_intrinsics, subset_manifold);
+#else
     ceres::SubsetParameterization *subset_parameterization =
       new ceres::SubsetParameterization(OFFSET_MAX, constant_intrinsics);
 
     problem.SetParameterization(ceres_intrinsics, subset_parameterization);
+#endif
   }
 
   // Configure the solver.

--- a/modules/sfm/src/libmv_light/libmv/simple_pipeline/bundle.cc
+++ b/modules/sfm/src/libmv_light/libmv/simple_pipeline/bundle.cc
@@ -548,7 +548,7 @@ void EuclideanBundleCommonIntrinsics(
       }
 
       if (bundle_constraints & BUNDLE_NO_TRANSLATION) {
-#if CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 1
+#if CERES_VERSION_MAJOR >= 3 || (CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 1)
         problem.SetParameterization(current_camera_R_t,
                                     constant_translation_manifold);
 #else
@@ -601,7 +601,7 @@ void EuclideanBundleCommonIntrinsics(
     // Always set K3 constant, it's not used at the moment.
     constant_intrinsics.push_back(OFFSET_K3);
 
-#if CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 1
+#if CERES_VERSION_MAJOR >= 3 || (CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 1)
     ceres::SubsetManifold *subset_manifold =
       new ceres::SubsetManifold(OFFSET_MAX, constant_intrinsics);
 

--- a/modules/sfm/src/libmv_light/libmv/simple_pipeline/bundle.cc
+++ b/modules/sfm/src/libmv_light/libmv/simple_pipeline/bundle.cc
@@ -486,7 +486,7 @@ void EuclideanBundleCommonIntrinsics(
     PackCamerasRotationAndTranslation(tracks, *reconstruction);
 
   // Parameterization used to restrict camera motion for modal solvers.
-#if CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 1
+#if CERES_VERSION_MAJOR >= 3 || (CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 1)
   ceres::SubsetManifold *constant_translation_manifold = NULL;
 #else
   ceres::SubsetParameterization *constant_translation_parameterization = NULL;
@@ -499,7 +499,7 @@ void EuclideanBundleCommonIntrinsics(
       constant_translation.push_back(4);
       constant_translation.push_back(5);
 
-#if CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 1
+#if CERES_VERSION_MAJOR >= 3 || (CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 1)
       constant_translation_manifold =
         new ceres::SubsetManifold(6, constant_translation);
 #else

--- a/modules/sfm/src/libmv_light/libmv/simple_pipeline/bundle.cc
+++ b/modules/sfm/src/libmv_light/libmv/simple_pipeline/bundle.cc
@@ -500,7 +500,7 @@ void EuclideanBundleCommonIntrinsics(
       constant_translation.push_back(5);
 
 #if CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 1
-      constant_translation_parameterization =
+      constant_translation_manifold =
         new ceres::SubsetManifold(6, constant_translation);
 #else
       constant_translation_parameterization =


### PR DESCRIPTION
Use ceres::Manifolds instead of ceres::LocalParameterization.
The latter is deprecated.

This fixes https://github.com/opencv/opencv_contrib/issues/3218

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
