### PR TITLE
Add RTSP features to cudacodec::VideoReader

### DIFF
--- a/modules/cudacodec/include/opencv2/cudacodec.hpp
+++ b/modules/cudacodec/include/opencv2/cudacodec.hpp
@@ -484,7 +484,7 @@ struct CV_EXPORTS_W_SIMPLE VideoReaderInitParams {
     CV_WRAP VideoReaderInitParams() : udpSource(false), liveSource(false), minNumDecodeSurfaces(0), rawMode(0) {};
     CV_PROP_RW bool udpSource;
     CV_PROP_RW bool liveSource;
-    CV_PROP_RW bool minNumDecodeSurfaces;
+    CV_PROP_RW int minNumDecodeSurfaces;
     CV_PROP_RW bool rawMode;
 };
 

--- a/modules/cudacodec/include/opencv2/cudacodec.hpp
+++ b/modules/cudacodec/include/opencv2/cudacodec.hpp
@@ -322,7 +322,7 @@ enum class VideoReaderProps {
     PROP_LRF_HAS_KEY_FRAME = 5, //!< FFmpeg source only - Indicates whether the Last Raw Frame (LRF), output from VideoReader::retrieve() when VideoReader is initialized in raw mode, contains encoded data for a key frame.
     PROP_COLOR_FORMAT = 6, //!< Set the ColorFormat of the decoded frame.  This can be changed before every call to nextFrame() and retrieve().
     PROP_UDP_SOURCE = 7, //!< Status of VideoReaderInitParams::udpSource initialization.
-    PROP_LIVE_SOURCE = 8, //!< Status of VideoReaderInitParams::liveSource initialization.
+    PROP_ALLOW_FRAME_DROP = 8, //!< Status of VideoReaderInitParams::allowFrameDrop initialization.
 #ifndef CV_DOXYGEN
     PROP_NOT_SUPPORTED
 #endif
@@ -472,8 +472,9 @@ public:
 
 /** @brief VideoReader initialization parameters
 @param udpSource Remove validation which can cause VideoReader() to throw exceptions when reading from a UDP source.
-@param liveCapture Prevent delay and eventual disconnection from a live capture source when the rate frames are consumed is less than the rate they are captured.
-Use with caution, frames will be dropped when nextFrame()/grab() are called at a slower rate than the source fps.
+@param allowFrameDrop Allow frames to be dropped when ingesting from a live capture source to prevent delay and eventual disconnection
+when calls to nextFrame()/grab() cannot keep up with the source's fps.  Only use if delay and disconnection are a problem, i.e. not when decoding from
+video files where setting this flag will cause frames to be unnecessarily discarded.
 @param minNumDecodeSurfaces Minimum number of internal decode surfaces used by the hardware decoder.  NVDEC will automatically determine the minimum number of
 surfaces it requires for correct functionality and optimal video memory usage but not necessarily for best performance, which depends on the design of the
 overall application. The optimal number of decode surfaces (in terms of performance and memory utilization) should be decided by experimentation for each application,
@@ -481,9 +482,9 @@ but it cannot go below the number determined by NVDEC.
 @param rawMode Allow the raw encoded data which has been read up until the last call to grab() to be retrieved by calling retrieve(rawData,RAW_DATA_IDX).
 */
 struct CV_EXPORTS_W_SIMPLE VideoReaderInitParams {
-    CV_WRAP VideoReaderInitParams() : udpSource(false), liveSource(false), minNumDecodeSurfaces(0), rawMode(0) {};
+    CV_WRAP VideoReaderInitParams() : udpSource(false), allowFrameDrop(false), minNumDecodeSurfaces(0), rawMode(0) {};
     CV_PROP_RW bool udpSource;
-    CV_PROP_RW bool liveSource;
+    CV_PROP_RW bool allowFrameDrop;
     CV_PROP_RW int minNumDecodeSurfaces;
     CV_PROP_RW bool rawMode;
 };

--- a/modules/cudacodec/src/frame_queue.cpp
+++ b/modules/cudacodec/src/frame_queue.cpp
@@ -55,14 +55,10 @@ cv::cudacodec::detail::FrameQueue::~FrameQueue() {
         delete[] isFrameInUse_;
 }
 
-void cv::cudacodec::detail::FrameQueue::init(const int _maxSz, const bool force) {
+void cv::cudacodec::detail::FrameQueue::init(const int _maxSz) {
     AutoLock autoLock(mtx_);
-    if (isFrameInUse_) {
-        if (force)
-            delete[] isFrameInUse_;
-        else
-            return;
-    }
+    if (isFrameInUse_)
+        return;
     maxSz = _maxSz;
     displayQueue_ = std::vector<CUVIDPARSERDISPINFO>(maxSz, CUVIDPARSERDISPINFO());
     isFrameInUse_ = new volatile int[maxSz];

--- a/modules/cudacodec/src/frame_queue.cpp
+++ b/modules/cudacodec/src/frame_queue.cpp
@@ -69,11 +69,11 @@ void cv::cudacodec::detail::FrameQueue::init(const int _maxSz, const bool force)
     std::memset((void*)isFrameInUse_, 0, sizeof(*isFrameInUse_) * maxSz);
 }
 
-bool cv::cudacodec::detail::FrameQueue::waitUntilFrameAvailable(int pictureIndex, const bool force)
+bool cv::cudacodec::detail::FrameQueue::waitUntilFrameAvailable(int pictureIndex, const bool allowFrameDrop)
 {
     while (isInUse(pictureIndex))
     {
-        if (force && dequeueUntil(pictureIndex))
+        if (allowFrameDrop && dequeueUntil(pictureIndex))
             break;
         // Decoder is getting too far ahead from display
         Thread::sleep(1);

--- a/modules/cudacodec/src/frame_queue.hpp
+++ b/modules/cudacodec/src/frame_queue.hpp
@@ -72,9 +72,9 @@ public:
     // If the requested frame is available the method returns true.
     // If decoding was interrupted before the requested frame becomes
     // available, the method returns false.
-    // If force == true, spin is disabled and n > 0 frames are discarded
+    // If allowFrameDrop == true, spin is disabled and n > 0 frames are discarded
     // to ensure a frame is available.
-    bool waitUntilFrameAvailable(int pictureIndex, const bool force = false);
+    bool waitUntilFrameAvailable(int pictureIndex, const bool allowFrameDrop = false);
 
     void enqueue(const CUVIDPARSERDISPINFO* picParams, const std::vector<RawPacket> rawPackets);
 

--- a/modules/cudacodec/src/frame_queue.hpp
+++ b/modules/cudacodec/src/frame_queue.hpp
@@ -63,7 +63,7 @@ class FrameQueue
 {
 public:
     ~FrameQueue();
-    void init(const int _maxSz, const bool force = false);
+    void init(const int _maxSz);
 
     void endDecode() { endOfDecode_ = true; }
     bool isEndOfDecode() const { return endOfDecode_ != 0;}

--- a/modules/cudacodec/src/frame_queue.hpp
+++ b/modules/cudacodec/src/frame_queue.hpp
@@ -63,7 +63,7 @@ class FrameQueue
 {
 public:
     ~FrameQueue();
-    void init(const int _maxSz);
+    void init(const int _maxSz, const bool force = false);
 
     void endDecode() { endOfDecode_ = true; }
     bool isEndOfDecode() const { return endOfDecode_ != 0;}
@@ -72,7 +72,9 @@ public:
     // If the requested frame is available the method returns true.
     // If decoding was interrupted before the requested frame becomes
     // available, the method returns false.
-    bool waitUntilFrameAvailable(int pictureIndex);
+    // If force == true, spin is disabled and n > 0 frames are discarded
+    // to ensure a frame is available.
+    bool waitUntilFrameAvailable(int pictureIndex, const bool force = false);
 
     void enqueue(const CUVIDPARSERDISPINFO* picParams, const std::vector<RawPacket> rawPackets);
 
@@ -84,8 +86,16 @@ public:
     //      false, if the queue was empty and no new frame could be returned.
     bool dequeue(CUVIDPARSERDISPINFO& displayInfo, std::vector<RawPacket>& rawPackets);
 
-    void releaseFrame(const CUVIDPARSERDISPINFO& picParams) { isFrameInUse_[picParams.picture_index] = false; }
+    // Deque all frames up to and including the frame with index pictureIndex - must only
+    // be called in the same thread as enqueue.
+    // Parameters:
+    //      pictureIndex - Display index of the frame.
+    // Returns:
+    //      true, if successful,
+    //      false, if no frames are dequed.
+    bool dequeueUntil(const int pictureIndex);
 
+    void releaseFrame(const CUVIDPARSERDISPINFO& picParams) { isFrameInUse_[picParams.picture_index] = 0; }
 private:
     bool isInUse(int pictureIndex) const { return isFrameInUse_[pictureIndex] != 0; }
 

--- a/modules/cudacodec/src/video_parser.hpp
+++ b/modules/cudacodec/src/video_parser.hpp
@@ -52,7 +52,7 @@ namespace cv { namespace cudacodec { namespace detail {
 class VideoParser
 {
 public:
-    VideoParser(VideoDecoder* videoDecoder, FrameQueue* frameQueue);
+    VideoParser(VideoDecoder* videoDecoder, FrameQueue* frameQueue, const bool liveSource = false, const bool udpSource = false);
 
     ~VideoParser()
     {
@@ -63,13 +63,19 @@ public:
 
     bool hasError() const { return hasError_; }
 
+    bool udpSource() const { return  maxUnparsedPackets_ == 0; }
+
+    bool liveStream() const { return liveSource_; }
+
 private:
-    VideoDecoder* videoDecoder_;
-    FrameQueue* frameQueue_;
+    VideoDecoder* videoDecoder_ = 0;
+    FrameQueue* frameQueue_ = 0;
     CUvideoparser parser_;
-    int unparsedPackets_;
+    int unparsedPackets_ = 0;
+    int maxUnparsedPackets_ = 20;
     std::vector<RawPacket> currentFramePackets;
-    volatile bool hasError_;
+    volatile bool hasError_ = false;
+    bool liveSource_ = false;
 
     // Called when the decoder encounters a video format change (or initial sequence header)
     // This particular implementation of the callback returns 0 in case the video format changes

--- a/modules/cudacodec/src/video_parser.hpp
+++ b/modules/cudacodec/src/video_parser.hpp
@@ -52,7 +52,7 @@ namespace cv { namespace cudacodec { namespace detail {
 class VideoParser
 {
 public:
-    VideoParser(VideoDecoder* videoDecoder, FrameQueue* frameQueue, const bool liveSource = false, const bool udpSource = false);
+    VideoParser(VideoDecoder* videoDecoder, FrameQueue* frameQueue, const bool allowFrameDrop = false, const bool udpSource = false);
 
     ~VideoParser()
     {
@@ -65,7 +65,7 @@ public:
 
     bool udpSource() const { return  maxUnparsedPackets_ == 0; }
 
-    bool liveStream() const { return liveSource_; }
+    bool allowFrameDrops() const { return allowFrameDrop_; }
 
 private:
     VideoDecoder* videoDecoder_ = 0;
@@ -75,7 +75,7 @@ private:
     int maxUnparsedPackets_ = 20;
     std::vector<RawPacket> currentFramePackets;
     volatile bool hasError_ = false;
-    bool liveSource_ = false;
+    bool allowFrameDrop_ = false;
 
     // Called when the decoder encounters a video format change (or initial sequence header)
     // This particular implementation of the callback returns 0 in case the video format changes

--- a/modules/cudacodec/test/test_video.cpp
+++ b/modules/cudacodec/test/test_video.cpp
@@ -70,6 +70,10 @@ PARAM_TEST_CASE(CheckDecodeSurfaces, cv::cuda::DeviceInfo, std::string)
 {
 };
 
+PARAM_TEST_CASE(CheckInitParams, cv::cuda::DeviceInfo, std::string, bool, bool, bool)
+{
+};
+
 struct CheckParams : testing::TestWithParam<cv::cuda::DeviceInfo>
 {
     cv::cuda::DeviceInfo devInfo;
@@ -127,10 +131,9 @@ CUDA_TEST_P(CheckExtraData, Reader)
     const string path = get<0>(GET_PARAM(1));
     const int sz = get<1>(GET_PARAM(1));
     std::string inputFile = std::string(cvtest::TS::ptr()->get_data_path()) + "../" + path;
-    cv::Ptr<cv::cudacodec::VideoReader> reader = cv::cudacodec::createVideoReader(inputFile, {}, true);
-    double rawModeVal = -1;
-    ASSERT_TRUE(reader->get(cv::cudacodec::VideoReaderProps::PROP_RAW_MODE, rawModeVal));
-    ASSERT_TRUE(rawModeVal);
+    cv::cudacodec::VideoReaderInitParams params;
+    params.rawMode = true;
+    cv::Ptr<cv::cudacodec::VideoReader> reader = cv::cudacodec::createVideoReader(inputFile, {}, params);
     double extraDataIdx = -1;
     ASSERT_TRUE(reader->get(cv::cudacodec::VideoReaderProps::PROP_EXTRA_DATA_INDEX, extraDataIdx));
     ASSERT_EQ(extraDataIdx, 1 );
@@ -151,10 +154,9 @@ CUDA_TEST_P(CheckKeyFrame, Reader)
 
     const string path = GET_PARAM(1);
     std::string inputFile = std::string(cvtest::TS::ptr()->get_data_path()) + "../" + path;
-    cv::Ptr<cv::cudacodec::VideoReader> reader = cv::cudacodec::createVideoReader(inputFile, {}, true);
-    double rawModeVal = -1;
-    ASSERT_TRUE(reader->get(cv::cudacodec::VideoReaderProps::PROP_RAW_MODE, rawModeVal));
-    ASSERT_TRUE(rawModeVal);
+    cv::cudacodec::VideoReaderInitParams params;
+    params.rawMode = true;
+    cv::Ptr<cv::cudacodec::VideoReader> reader = cv::cudacodec::createVideoReader(inputFile, {}, params);
     double rawIdxBase = -1;
     ASSERT_TRUE(reader->get(cv::cudacodec::VideoReaderProps::PROP_RAW_PACKAGES_BASE_INDEX, rawIdxBase));
     ASSERT_EQ(rawIdxBase, 2);
@@ -222,10 +224,9 @@ CUDA_TEST_P(VideoReadRaw, Reader)
     {
         std::ofstream file(fileNameOut, std::ios::binary);
         ASSERT_TRUE(file.is_open());
-        cv::Ptr<cv::cudacodec::VideoReader> reader = cv::cudacodec::createVideoReader(inputFile, {}, true);
-        double rawModeVal = -1;
-        ASSERT_TRUE(reader->get(cv::cudacodec::VideoReaderProps::PROP_RAW_MODE, rawModeVal));
-        ASSERT_TRUE(rawModeVal);
+        cv::cudacodec::VideoReaderInitParams params;
+        params.rawMode = true;
+        cv::Ptr<cv::cudacodec::VideoReader> reader = cv::cudacodec::createVideoReader(inputFile, {}, params);
         double rawIdxBase = -1;
         ASSERT_TRUE(reader->get(cv::cudacodec::VideoReaderProps::PROP_RAW_PACKAGES_BASE_INDEX, rawIdxBase));
         ASSERT_EQ(rawIdxBase, 2);
@@ -250,7 +251,9 @@ CUDA_TEST_P(VideoReadRaw, Reader)
 
     {
         cv::Ptr<cv::cudacodec::VideoReader> readerReference = cv::cudacodec::createVideoReader(inputFile);
-        cv::Ptr<cv::cudacodec::VideoReader> readerActual = cv::cudacodec::createVideoReader(fileNameOut, {}, true);
+        cv::cudacodec::VideoReaderInitParams params;
+        params.rawMode = true;
+        cv::Ptr<cv::cudacodec::VideoReader> readerActual = cv::cudacodec::createVideoReader(fileNameOut, {}, params);
         double decodedFrameIdx = -1;
         ASSERT_TRUE(readerActual->get(cv::cudacodec::VideoReaderProps::PROP_DECODED_FRAME_IDX, decodedFrameIdx));
         ASSERT_EQ(decodedFrameIdx, 0);
@@ -323,7 +326,9 @@ CUDA_TEST_P(CheckDecodeSurfaces, Reader)
     }
 
     {
-        cv::Ptr<cv::cudacodec::VideoReader> reader = cv::cudacodec::createVideoReader(inputFile, {}, false, ulNumDecodeSurfaces - 1);
+        cv::cudacodec::VideoReaderInitParams params;
+        params.minNumDecodeSurfaces = ulNumDecodeSurfaces - 1;
+        cv::Ptr<cv::cudacodec::VideoReader> reader = cv::cudacodec::createVideoReader(inputFile, {}, params);
         cv::cudacodec::FormatInfo fmt = reader->format();
         if (!fmt.valid) {
             reader->grab();
@@ -335,7 +340,9 @@ CUDA_TEST_P(CheckDecodeSurfaces, Reader)
     }
 
     {
-        cv::Ptr<cv::cudacodec::VideoReader> reader = cv::cudacodec::createVideoReader(inputFile, {}, false, ulNumDecodeSurfaces + 1);
+        cv::cudacodec::VideoReaderInitParams params;
+        params.minNumDecodeSurfaces = ulNumDecodeSurfaces + 1;
+        cv::Ptr<cv::cudacodec::VideoReader> reader = cv::cudacodec::createVideoReader(inputFile, {}, params);
         cv::cudacodec::FormatInfo fmt = reader->format();
         if (!fmt.valid) {
             reader->grab();
@@ -346,6 +353,22 @@ CUDA_TEST_P(CheckDecodeSurfaces, Reader)
         for (int i = 0; i < 100; i++) ASSERT_TRUE(reader->grab());
     }
 }
+
+CUDA_TEST_P(CheckInitParams, Reader)
+{
+    cv::cuda::setDevice(GET_PARAM(0).deviceID());
+    const std::string inputFile = std::string(cvtest::TS::ptr()->get_data_path()) + "../" + GET_PARAM(1);
+    cv::cudacodec::VideoReaderInitParams params;
+    params.udpSource = GET_PARAM(2);
+    params.liveSource = GET_PARAM(3);
+    params.rawMode = GET_PARAM(4);
+    double udpSource = 0, liveSource = 0, rawMode = 0;
+    cv::Ptr<cv::cudacodec::VideoReader> reader = cv::cudacodec::createVideoReader(inputFile, {}, params);
+    ASSERT_TRUE(reader->get(cv::cudacodec::VideoReaderProps::PROP_UDP_SOURCE, udpSource) && static_cast<bool>(udpSource) == params.udpSource);
+    ASSERT_TRUE(reader->get(cv::cudacodec::VideoReaderProps::PROP_LIVE_SOURCE, liveSource) && static_cast<bool>(liveSource) == params.liveSource);
+    ASSERT_TRUE(reader->get(cv::cudacodec::VideoReaderProps::PROP_RAW_MODE, rawMode) && static_cast<bool>(rawMode) == params.rawMode);
+}
+
 #endif // HAVE_NVCUVID
 
 #if defined(_WIN32) && defined(HAVE_NVCUVENC)
@@ -432,6 +455,11 @@ INSTANTIATE_TEST_CASE_P(CUDA_Codec, CheckParams, ALL_DEVICES);
 INSTANTIATE_TEST_CASE_P(CUDA_Codec, CheckDecodeSurfaces, testing::Combine(
     ALL_DEVICES,
     testing::Values("highgui/video/big_buck_bunny.mp4")));
+
+INSTANTIATE_TEST_CASE_P(CUDA_Codec, CheckInitParams, testing::Combine(
+    ALL_DEVICES,
+    testing::Values("highgui/video/big_buck_bunny.mp4"),
+    testing::Values(true,false), testing::Values(true,false), testing::Values(true,false)));
 
 #endif // HAVE_NVCUVID || HAVE_NVCUVENC
 }} // namespace

--- a/modules/cudacodec/test/test_video.cpp
+++ b/modules/cudacodec/test/test_video.cpp
@@ -360,12 +360,12 @@ CUDA_TEST_P(CheckInitParams, Reader)
     const std::string inputFile = std::string(cvtest::TS::ptr()->get_data_path()) + "../" + GET_PARAM(1);
     cv::cudacodec::VideoReaderInitParams params;
     params.udpSource = GET_PARAM(2);
-    params.liveSource = GET_PARAM(3);
+    params.allowFrameDrop = GET_PARAM(3);
     params.rawMode = GET_PARAM(4);
-    double udpSource = 0, liveSource = 0, rawMode = 0;
+    double udpSource = 0, allowFrameDrop = 0, rawMode = 0;
     cv::Ptr<cv::cudacodec::VideoReader> reader = cv::cudacodec::createVideoReader(inputFile, {}, params);
     ASSERT_TRUE(reader->get(cv::cudacodec::VideoReaderProps::PROP_UDP_SOURCE, udpSource) && static_cast<bool>(udpSource) == params.udpSource);
-    ASSERT_TRUE(reader->get(cv::cudacodec::VideoReaderProps::PROP_LIVE_SOURCE, liveSource) && static_cast<bool>(liveSource) == params.liveSource);
+    ASSERT_TRUE(reader->get(cv::cudacodec::VideoReaderProps::PROP_ALLOW_FRAME_DROP, allowFrameDrop) && static_cast<bool>(allowFrameDrop) == params.allowFrameDrop);
     ASSERT_TRUE(reader->get(cv::cudacodec::VideoReaderProps::PROP_RAW_MODE, rawMode) && static_cast<bool>(rawMode) == params.rawMode);
 }
 


### PR DESCRIPTION
Add the below two features to `cudacodec::VideoReader` to help when streaming from live sources.
1) Lift the limit on the maximum number of unparsed packets if streaming from a source over UDP, see https://github.com/opencv/opencv_contrib/issues/3225#issuecomment-1100206377
2) Internally drop frames if the rate which frames are requested by `nextFrame()/grab()` is less than the source FPS.  Although this is something which a user would eventually accomodate for themselves (by reading at the appropriate rate and choosing which packets to discard) it would be a useful for this to be "automatic" until they have implemented that functionality.

Testing - currently the additional tests only check that the new parameters have been set inside `VideoReader` and do not verify the functionality of (1) and (2).  This is because testing (1) requires a new test video file (I am not sure if that is overkill for this small feature) and testing (2) require a live RTSP source.  I can easily include an extra test file if required but I am not sure how I can simulate an live RTSP source?

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake