### PR TITLE
Fix cudacodec and cudastereo python bindings

### DIFF
--- a/modules/cudacodec/include/opencv2/cudacodec.hpp
+++ b/modules/cudacodec/include/opencv2/cudacodec.hpp
@@ -353,8 +353,12 @@ public:
 
     /** @brief Grabs, decodes and returns the next video frame.
 
-    If no frames has been grabbed (there are no more frames in video file), the methods return false .
-    The method throws Exception if error occurs.
+    @param [out] frame The video frame.
+    @param stream Stream for the asynchronous version.
+    @return `false` if no frames have been grabbed.
+
+    If no frames have been grabbed (there are no more frames in video file), the methods return false.
+    The method throws an Exception if error occurs.
      */
     CV_WRAP virtual bool nextFrame(CV_OUT GpuMat& frame, Stream &stream = Stream::Null()) = 0;
 
@@ -364,6 +368,7 @@ public:
 
     /** @brief Grabs the next frame from the video source.
 
+    @param stream Stream for the asynchronous version.
     @return `true` (non-zero) in the case of success.
 
     The method/function grabs the next frame from video file or camera and returns true (non-zero) in
@@ -376,17 +381,44 @@ public:
 
     /** @brief Returns previously grabbed video data.
 
-    @param [out] frame The returned data which depends on the provided idx.  If there is no new data since the last call to grab() the image will be empty.
-    @param idx Determins the returned data inside image. The returned data can be the:
-    Decoded frame, idx = get(PROP_DECODED_FRAME_IDX).
-    Extra data if available, idx = get(PROP_EXTRA_DATA_INDEX).
-    Raw encoded data package.  To retrieve package i,  idx = get(PROP_RAW_PACKAGES_BASE_INDEX) + i with i < get(PROP_NUMBER_OF_RAW_PACKAGES_SINCE_LAST_GRAB)
-    @return `false` if no frames has been grabbed
+    @param [out] frame The returned data which depends on the provided idx.
+    @param idx Determines the returned data inside image. The returned data can be the:
+     - Decoded frame, idx = get(PROP_DECODED_FRAME_IDX).
+     - Extra data if available, idx = get(PROP_EXTRA_DATA_INDEX).
+     - Raw encoded data package.  To retrieve package i,  idx = get(PROP_RAW_PACKAGES_BASE_INDEX) + i with i < get(PROP_NUMBER_OF_RAW_PACKAGES_SINCE_LAST_GRAB)
+    @return `false` if no frames have been grabbed
 
     The method returns data associated with the current video source since the last call to grab() or the creation of the VideoReader. If no data is present
     the method returns false and the function returns an empty image.
      */
-    CV_WRAP virtual bool retrieve(CV_OUT OutputArray frame, const size_t idx = static_cast<size_t>(VideoReaderProps::PROP_DECODED_FRAME_IDX)) const = 0;
+    virtual bool retrieve(OutputArray frame, const size_t idx = static_cast<size_t>(VideoReaderProps::PROP_DECODED_FRAME_IDX)) const = 0;
+
+    /** @brief Returns previously grabbed encoded video data.
+
+    @param [out] frame The encoded video data.
+    @param idx Determines the returned data inside image. The returned data can be the:
+     - Extra data if available, idx = get(PROP_EXTRA_DATA_INDEX).
+     - Raw encoded data package.  To retrieve package i,  idx = get(PROP_RAW_PACKAGES_BASE_INDEX) + i with i < get(PROP_NUMBER_OF_RAW_PACKAGES_SINCE_LAST_GRAB)
+    @return `false` if no frames have been grabbed
+
+    The method returns data associated with the current video source since the last call to grab() or the creation of the VideoReader. If no data is present
+    the method returns false and the function returns an empty image.
+     */
+    CV_WRAP inline bool retrieve(CV_OUT Mat& frame, const size_t idx) const {
+        return retrieve(OutputArray(frame), idx);
+    }
+
+    /** @brief Returns the next video frame.
+
+    @param [out] frame The video frame.  If grab() has not been called then this will be empty().
+    @return `false` if no frames have been grabbed
+
+    The method returns data associated with the current video source since the last call to grab(). If no data is present
+    the method returns false and the function returns an empty image.
+     */
+    CV_WRAP inline bool retrieve(CV_OUT GpuMat& frame) const {
+        return retrieve(OutputArray(frame));
+    }
 
     /** @brief Sets a property in the VideoReader.
 
@@ -395,7 +427,10 @@ public:
     @param propertyVal Value of the property.
     @return `true` if the property has been set.
      */
-    CV_WRAP virtual bool set(const VideoReaderProps propertyId, const double propertyVal) = 0;
+    virtual bool set(const VideoReaderProps propertyId, const double propertyVal) = 0;
+    CV_WRAP inline bool setVideoReaderProps(const VideoReaderProps propertyId, double propertyVal) {
+        return set(propertyId, propertyVal);
+    }
 
     /** @brief Set the desired ColorFormat for the frame returned by nextFrame()/retrieve().
 
@@ -408,11 +443,12 @@ public:
     @param propertyId Property identifier from cv::cudacodec::VideoReaderProps (eg. cv::cudacodec::VideoReaderProps::PROP_DECODED_FRAME_IDX,
     cv::cudacodec::VideoReaderProps::PROP_EXTRA_DATA_INDEX, ...).
     @param propertyVal
-    In - Optional value required for querying specific propertyId's, e.g. the index of the raw package to be checked for a key frame (cv::cudacodec::VideoReaderProps::PROP_LRF_HAS_KEY_FRAME).
-    Out - Value of the property.
+     - In: Optional value required for querying specific propertyId's, e.g. the index of the raw package to be checked for a key frame (cv::cudacodec::VideoReaderProps::PROP_LRF_HAS_KEY_FRAME).
+     - Out: Value of the property.
     @return `true` unless the property is not supported.
     */
-    CV_WRAP virtual bool get(const VideoReaderProps propertyId, CV_IN_OUT double& propertyVal) const = 0;
+    virtual bool get(const VideoReaderProps propertyId, double& propertyVal) const = 0;
+    CV_WRAP virtual bool getVideoReaderProps(const VideoReaderProps propertyId,  CV_OUT double& propertyValOut, double propertyValIn = 0) const = 0;
 
     /** @brief Retrieves the specified property used by the VideoSource.
 

--- a/modules/cudacodec/test/test_video.cpp
+++ b/modules/cudacodec/test/test_video.cpp
@@ -201,6 +201,8 @@ CUDA_TEST_P(Video, Reader)
         // request a different colour format for each frame
         const std::pair< cudacodec::ColorFormat, int>& formatToChannels = formatsToChannels[i % formatsToChannels.size()];
         reader->set(formatToChannels.first);
+        double colorFormat;
+        ASSERT_TRUE(reader->get(cudacodec::VideoReaderProps::PROP_COLOR_FORMAT, colorFormat) && static_cast<cudacodec::ColorFormat>(colorFormat) == formatToChannels.first);
         ASSERT_TRUE(reader->nextFrame(frame));
         if(!fmt.valid)
             fmt = reader->format();

--- a/modules/cudastereo/include/opencv2/cudastereo.hpp
+++ b/modules/cudastereo/include/opencv2/cudastereo.hpp
@@ -355,7 +355,10 @@ disparity map.
 
 @sa reprojectImageTo3D
  */
-CV_EXPORTS_W void reprojectImageTo3D(InputArray disp, OutputArray xyzw, InputArray Q, int dst_cn = 4, Stream& stream = Stream::Null());
+CV_EXPORTS void reprojectImageTo3D(InputArray disp, OutputArray xyzw, InputArray Q, int dst_cn = 4, Stream& stream = Stream::Null());
+CV_EXPORTS_W inline void reprojectImageTo3D(GpuMat disp, CV_OUT GpuMat& xyzw, Mat Q, int dst_cn = 4, Stream& stream = Stream::Null()) {
+    reprojectImageTo3D((InputArray)disp, (OutputArray)xyzw, (InputArray)Q, dst_cn, stream);
+}
 
 /** @brief Colors a disparity image.
 

--- a/modules/cudastereo/misc/python/test/test_cudastereo.py
+++ b/modules/cudastereo/misc/python/test/test_cudastereo.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+import os
+import cv2 as cv
+import numpy as np
+
+from tests_common import NewOpenCVTests, unittest
+
+class cudastereo_test(NewOpenCVTests):
+    def setUp(self):
+        super(cudastereo_test, self).setUp()
+        if not cv.cuda.getCudaEnabledDeviceCount():
+            self.skipTest("No CUDA-capable device is detected")
+
+    def test_reprojectImageTo3D(self):
+        # Test's the functionality but not the results from reprojectImageTo3D
+        sz = (128,128)
+        np_disparity = np.random.randint(0, 64, sz, dtype=np.int16)
+        cu_disparity = cv.cuda_GpuMat(np_disparity)
+        np_q = np.random.randint(0, 100, (4, 4)).astype(np.float32)
+        stream = cv.cuda.Stream()
+        cu_xyz = cv.cuda.reprojectImageTo3D(cu_disparity, np_q, stream = stream)
+        self.assertTrue(cu_xyz.type() == cv.CV_32FC4 and cu_xyz.size() == sz)
+        cu_xyz1 = cv.cuda.GpuMat(sz, cv.CV_32FC3)
+        cv.cuda.reprojectImageTo3D(cu_disparity, np_q, cu_xyz1, 3, stream)
+        self.assertTrue(cu_xyz1.type() == cv.CV_32FC3 and cu_xyz1.size() == sz)
+
+if __name__ == '__main__':
+    NewOpenCVTests.bootstrap()


### PR DESCRIPTION
The python bindings for `cudastero::reprojectImageTo3D` (see https://forum.opencv.org/t/cv2-cuda-reprojectimageto3d-dispcu-q-error-5-bad-argument/5242) and some newere methods in `cudacodec::VideoReader` and  are not functioning correctly.

The PR fixes this issue and adds tests to check the input output functionality.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
