### PR TITLE
Fix ovis module building error with OGRE 1.12.9

### DIFF
--- a/modules/ovis/src/ovis.cpp
+++ b/modules/ovis/src/ovis.cpp
@@ -453,7 +453,8 @@ public:
         if(tus->getTextureName() != name)
         {
             RTShader::ShaderGenerator::getSingleton().invalidateMaterial(
-                RTShader::ShaderGenerator::DEFAULT_SCHEME_NAME, *bgplane->getMaterial());
+                RTShader::ShaderGenerator::DEFAULT_SCHEME_NAME, bgplane->getMaterial()->getName(),
+                RESOURCEGROUP_NAME);
 
             tus->setTextureName(name);
             tus->setTextureAddressingMode(TAM_CLAMP);


### PR DESCRIPTION
Hi, this fixes the build error that I started to get while building the ovis module with OGRE 1.12.9 since OpenCV 4.6.0.
The error was:
```
/home/pro/projects/opencv-lib/opencv-4.6/opencv_contrib-4.6.0/modules/ovis/src/ovis.cpp: In member function ‘virtual void cv::ovis::WindowSceneImpl::setBackground(cv::InputArray)’:
/home/pro/projects/opencv-lib/opencv-4.6/opencv_contrib-4.6.0/modules/ovis/src/ovis.cpp:456:65: error: cannot convert ‘std::__shared_ptr_access<Ogre::Material, __gnu_cxx::_S_atomic, false, false>::element_type’ {aka ‘Ogre::Material’} to ‘const String&’
  456 |                 RTShader::ShaderGenerator::DEFAULT_SCHEME_NAME, *bgplane->getMaterial());
      |                                                                 ^~~~~~~~~~~~~~~~~~~~~~~
      |                                                                 |
      |                                                                 std::__shared_ptr_access<Ogre::Material, __gnu_cxx::_S_atomic, false, false>::element_type {aka Ogre::Material}
In file included from /usr/include/OGRE/RTShaderSystem/OgreRTShaderSystem.h:32,
                 from /usr/include/OGRE/Bites/OgreSGTechniqueResolverListener.h:32,
                 from /usr/include/OGRE/Bites/OgreApplicationContextBase.h:41,
                 from /usr/include/OGRE/Bites/OgreApplicationContext.h:33,
                 from /home/pro/projects/opencv-lib/opencv-4.6/opencv_contrib-4.6.0/modules/ovis/src/ovis.cpp:7:
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
