### PR TITLE
Fix compilation because of pointer/int comparison.

### DIFF
--- a/modules/cudastereo/src/cuda/stereobm.cu
+++ b/modules/cudastereo/src/cuda/stereobm.cu
@@ -281,7 +281,7 @@ namespace cv { namespace cuda { namespace device
 
                 InitColSSD<RADIUS>(x_tex, y_tex, img_step, left, right, d, col_ssd);
 
-                if (col_ssd_extra > 0)
+                if (col_ssd_extra != nullptr)
                     if (x_tex + BLOCK_W < cwidth)
                         InitColSSD<RADIUS>(x_tex + BLOCK_W, y_tex, img_step, left, right, d, col_ssd_extra);
 


### PR DESCRIPTION
Without this fix, the error is:

"ordered comparison between pointer and zero ('volatile unsigned int *' and 'int')"

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
