### PR TITLE
SetParameterization -> SetManifold to make SFM build with Ceres 2.1

### DIFF
--- a/modules/sfm/src/libmv_light/libmv/simple_pipeline/bundle.cc
+++ b/modules/sfm/src/libmv_light/libmv/simple_pipeline/bundle.cc
@@ -549,8 +549,8 @@ void EuclideanBundleCommonIntrinsics(
 
       if (bundle_constraints & BUNDLE_NO_TRANSLATION) {
 #if CERES_VERSION_MAJOR >= 3 || (CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 1)
-        problem.SetParameterization(current_camera_R_t,
-                                    constant_translation_manifold);
+        problem.SetManifold(current_camera_R_t,
+                            constant_translation_manifold);
 #else
         problem.SetParameterization(current_camera_R_t,
                                     constant_translation_parameterization);


### PR DESCRIPTION
`SetParameterization` doesn't work with Ceres 2.1, it fails with an error message
```LocalParameterizations are deprecated. Use SetManifold instead```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [+] I agree to contribute to the project under Apache 2 License.
- [+] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [+] The PR is proposed to the proper branch
- [-] There is a reference to the original bug report and related work
- [-] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [+] The feature is well documented and sample code can be built with the project CMake
