### PR TITLE
make CVV module work with Qt6

### DIFF
--- a/modules/cvv/CMakeLists.txt
+++ b/modules/cvv/CMakeLists.txt
@@ -5,16 +5,20 @@ endif()
 
 set(the_description "Debug visualization framework")
 ocv_add_module(cvv opencv_core opencv_imgproc opencv_features2d WRAP python)
-
 ocv_warnings_disable(CMAKE_CXX_FLAGS -Wshadow -Wmissing-declarations)
 
-# Qt5
+# Qt
+set(CVV_QT_MODULES Core Gui Widgets)
+if(QT_VERSION_MAJOR EQUAL 6)
+  list(APPEND CVV_QT_MODULES Core5Compat)
+endif()
+
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS ${CVV_QT_MODULES})
+
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-foreach(dt5_dep Core Gui Widgets)
-  add_definitions(${Qt5${dt5_dep}_DEFINITIONS})
-  include_directories(${Qt5${dt5_dep}_INCLUDE_DIRS})
-  list(APPEND CVV_LIBRARIES ${Qt5${dt5_dep}_LIBRARIES})
+foreach(module ${CVV_QT_MODULES})
+  list(APPEND CVV_LIBRARIES ${Qt${QT_VERSION_MAJOR}${module}_LIBRARIES})
 endforeach()
 
 ocv_glob_module_sources()

--- a/modules/cvv/src/qtutil/matchview/matchscene.cpp
+++ b/modules/cvv/src/qtutil/matchview/matchscene.cpp
@@ -153,7 +153,7 @@ void MatchScene::rightClick(const QPoint &pos)
 				pmap = rightImage_->visibleImage();
 			}
 		}else{
-			pmap = QPixmap::grabWidget(graphicView_->viewport());
+			pmap = graphicView_->viewport()->grab();
 		}
 		pmap.save(fileName, 0, 100);
 	}

--- a/modules/cvv/src/qtutil/matchview/singlecolorkeypointpen.cpp
+++ b/modules/cvv/src/qtutil/matchview/singlecolorkeypointpen.cpp
@@ -15,7 +15,7 @@ SingleColorKeyPen::SingleColorKeyPen(std::vector<cv::KeyPoint>, QWidget *parent)
 	auto layout = util::make_unique<QVBoxLayout>();
 	auto button = util::make_unique<QPushButton>("Color Dialog");
 
-	layout->setMargin(0);
+	layout->setContentsMargins(QMargins());
 
 	connect(colordia_, SIGNAL(currentColorChanged(const QColor &)), this,
 		SLOT(updateColor(const QColor &)));

--- a/modules/cvv/src/qtutil/matchview/singlecolormatchpen.cpp
+++ b/modules/cvv/src/qtutil/matchview/singlecolormatchpen.cpp
@@ -23,7 +23,7 @@ SingleColorMatchPen::SingleColorMatchPen(std::vector<cv::DMatch>, QWidget *paren
 	connect(button.get(), SIGNAL(clicked(bool)), this,
 		SLOT(colorButtonClicked()));
 
-	layout->setMargin(0);
+	layout->setContentsMargins(QMargins());
 	layout->addWidget(button.release());
 
 	setLayout(layout.release());

--- a/modules/cvv/src/qtutil/matchview/zoomableproxyobject.cpp
+++ b/modules/cvv/src/qtutil/matchview/zoomableproxyobject.cpp
@@ -21,8 +21,8 @@ void ZoomableProxyObject::wheelEvent(QGraphicsSceneWheelEvent *event)
 	QPoint delta{ event->delta(), 0 };
 	QWheelEvent newEvent{ event->pos(),     event->screenPos(),
 			      delta,            delta,
-			      event->delta(),   event->orientation(),
-			      event->buttons(), event->modifiers() };
+			      event->buttons(), event->modifiers(),
+			      Qt::NoScrollPhase, true };
 	image_->wheelEvent(&newEvent);
 }
 

--- a/modules/cvv/src/qtutil/matchview/zoomableproxyobject.cpp
+++ b/modules/cvv/src/qtutil/matchview/zoomableproxyobject.cpp
@@ -19,10 +19,16 @@ ZoomableProxyObject::ZoomableProxyObject(ZoomableImage *zoom)
 void ZoomableProxyObject::wheelEvent(QGraphicsSceneWheelEvent *event)
 {
 	QPoint delta{ event->delta(), 0 };
+
 	QWheelEvent newEvent{ event->pos(),     event->screenPos(),
 			      delta,            delta,
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
 			      event->buttons(), event->modifiers(),
 			      Qt::NoScrollPhase, true };
+#else
+			      event->delta(),   event->orientation(),
+			      event->buttons(), event->modifiers() };
+#endif
 	image_->wheelEvent(&newEvent);
 }
 

--- a/modules/cvv/src/qtutil/zoomableimage.cpp
+++ b/modules/cvv/src/qtutil/zoomableimage.cpp
@@ -398,7 +398,7 @@ QPointF ZoomableImage::mapImagePointToParent(QPointF point) const
 
 void ZoomableImage::mouseMoveEvent(QMouseEvent * event)
 {
-#if QT_VERSION >= 0x060000
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 	QPoint pos = event->globalPosition().toPoint();
 #else
 	QPoint pos = event->globalPos();

--- a/modules/cvv/src/qtutil/zoomableimage.cpp
+++ b/modules/cvv/src/qtutil/zoomableimage.cpp
@@ -398,7 +398,13 @@ QPointF ZoomableImage::mapImagePointToParent(QPointF point) const
 
 void ZoomableImage::mouseMoveEvent(QMouseEvent * event)
 {
-	QPointF imgPos=view_->mapToScene(view_->mapFromGlobal(event->globalPosition().toPoint()));
+#if QT_VERSION >= 0x060000
+	QPoint pos = event->globalPosition().toPoint();
+#else
+	QPoint pos = event->globalPos();
+#endif
+
+	QPointF imgPos=view_->mapToScene(view_->mapFromGlobal(pos));
 	bool inImage=(imgPos.x()>=0)
 			&&(imgPos.y()>=0)
 			&&(imgPos.x()<=imageWidth())

--- a/modules/cvv/src/qtutil/zoomableimage.cpp
+++ b/modules/cvv/src/qtutil/zoomableimage.cpp
@@ -205,7 +205,7 @@ ZoomableImage::ZoomableImage(const cv::Mat &mat, QWidget *parent)
 	view_->setFocusPolicy(Qt::NoFocus);
 	auto layout = util::make_unique<QHBoxLayout>();
 	layout->addWidget(view.release());
-	layout->setMargin(0);
+	layout->setContentsMargins(QMargins());
 	setLayout(layout.release());
 	setMat(mat_);
 	// rightklick
@@ -398,7 +398,7 @@ QPointF ZoomableImage::mapImagePointToParent(QPointF point) const
 
 void ZoomableImage::mouseMoveEvent(QMouseEvent * event)
 {
-	QPointF imgPos=view_->mapToScene(view_->mapFromGlobal(event->globalPos()));
+	QPointF imgPos=view_->mapToScene(view_->mapFromGlobal(event->globalPosition().toPoint()));
 	bool inImage=(imgPos.x()>=0)
 			&&(imgPos.y()>=0)
 			&&(imgPos.x()<=imageWidth())

--- a/modules/cvv/src/qtutil/zoomableimage.hpp
+++ b/modules/cvv/src/qtutil/zoomableimage.hpp
@@ -208,7 +208,7 @@ class ZoomableImage : public QWidget
 	 */
 	QPixmap visibleImage() const
 	{
-		return QPixmap::grabWidget(view_->viewport());
+		return view_->viewport()->grab();
 	}
 
 	/**

--- a/modules/cvv/src/stfl/stfl_engine.hpp
+++ b/modules/cvv/src/stfl/stfl_engine.hpp
@@ -773,7 +773,7 @@ private:
 		if (cmd == "group" || cmd == "sort")
 		{
 			int frontCut =
-			    std::min(qsizetype(hasByString ? 2 : 1), tokens.size());
+			    std::min(qsizetype(hasByString ? 2 : 1), qsizetype(tokens.size()));
 			tokens = cmdQuery.split(" ", Qt::SkipEmptyParts)
 			             .mid(frontCut, tokens.size());
 			QStringList args = tokens.join(" ").split(

--- a/modules/cvv/src/stfl/stfl_engine.hpp
+++ b/modules/cvv/src/stfl/stfl_engine.hpp
@@ -162,7 +162,7 @@ template <typename Element> class STFLEngine
 		}
 		QList<Element> elemList;
 		QStringList cmdStrings =
-		    query.split("#", QString::SkipEmptyParts);
+		    query.split("#", Qt::SkipEmptyParts);
 		elemList = executeFilters(elements, cmdStrings);
 		elemList = executeSortCmds(elemList, cmdStrings);
 		auto groups = executeGroupCmds(elemList, cmdStrings);
@@ -549,7 +549,7 @@ private:
 		{
 			using namespace std::placeholders;
 			QStringList arr =
-			    cmdString.split(" ", QString::SkipEmptyParts);
+			    cmdString.split(" ", Qt::SkipEmptyParts);
 			QString cmd;
 			if (arr.empty())
 			{
@@ -570,7 +570,7 @@ private:
 			else if (isFilterCSCmd(cmd))
 			{
 				QStringList arguments = arr.join("").split(
-				    ",", QString::SkipEmptyParts);
+				    ",", Qt::SkipEmptyParts);
 				std::for_each(arguments.begin(),
 				              arguments.end(), [](QString &str)
 				{ str.replace("\\,", ","); });
@@ -609,7 +609,7 @@ private:
 		for (QString cmdString : cmdStrings)
 		{
 			QStringList arr =
-			    cmdString.split(" ", QString::SkipEmptyParts);
+			    cmdString.split(" ", Qt::SkipEmptyParts);
 			if (arr.size() < 2)
 			{
 				continue;
@@ -619,7 +619,7 @@ private:
 			{
 				arr.removeFirst();
 			}
-			arr = arr.join(" ").split(",", QString::SkipEmptyParts);
+			arr = arr.join(" ").split(",", Qt::SkipEmptyParts);
 			for (QString cmdPart : arr)
 			{
 				cmdPart = cmdPart.trimmed();
@@ -647,7 +647,7 @@ private:
 			if (sortCmd.second)
 			{
 				auto sortFunc = sortFuncs[sortCmd.first];
-				qStableSort(resList.begin(), resList.end(),
+				std::stable_sort(resList.begin(), resList.end(),
 				            [&](const Element &elem1,
 				                const Element &elem2)
 				{ return sortFunc(elem1, elem2); });
@@ -655,7 +655,7 @@ private:
 			else
 			{
 				auto sortFunc = sortFuncs[sortCmd.first];
-				qStableSort(resList.begin(), resList.end(),
+				std::stable_sort(resList.begin(), resList.end(),
 				            [&](const Element &elem1,
 				                const Element &elem2)
 				{ return sortFunc(elem2, elem1); });
@@ -675,7 +675,7 @@ private:
 		for (QString cmdString : cmdStrings)
 		{
 			QStringList arr =
-			    cmdString.split(" ", QString::SkipEmptyParts);
+			    cmdString.split(" ", Qt::SkipEmptyParts);
 			if (arr.size() < 2)
 			{
 				continue;
@@ -689,7 +689,7 @@ private:
 			{
 				arr.removeFirst();
 			}
-			arr = arr.join("").split(",", QString::SkipEmptyParts);
+			arr = arr.join("").split(",", Qt::SkipEmptyParts);
 			for (QString cmdPart : arr)
 			{
 				QStringList cmdPartList = cmdPart.split(" ");
@@ -720,7 +720,7 @@ private:
 		for (auto it = groups.begin(); it != groups.end(); ++it)
 		{
 			ElementGroup<Element> elementGroup(
-			    it->first.split("\\|", QString::SkipEmptyParts),
+			    it->first.split("\\|", Qt::SkipEmptyParts),
 			    it->second);
 			groupList.push_back(elementGroup);
 		}
@@ -733,7 +733,7 @@ private:
 		for (QString cmdString : cmdStrings)
 		{
 			QStringList arr =
-			    cmdString.split(" ", QString::SkipEmptyParts);
+			    cmdString.split(" ", Qt::SkipEmptyParts);
 			if (arr.isEmpty())
 			{
 				continue;
@@ -743,7 +743,7 @@ private:
 			{
 				continue;
 			}
-			arr = arr.join("").split(",", QString::SkipEmptyParts);
+			arr = arr.join("").split(",", Qt::SkipEmptyParts);
 			additionalCommandFuncs[cmd](arr, groups);
 		}
 	}
@@ -762,11 +762,11 @@ private:
 		if (cmd == "group" || cmd == "sort")
 		{
 			int frontCut =
-			    std::min(1 + (hasByString ? 1 : 0), tokens.size());
-			tokens = cmdQuery.split(" ", QString::SkipEmptyParts)
+			    std::min(qsizetype(hasByString ? 2 : 1), tokens.size());
+			tokens = cmdQuery.split(" ", Qt::SkipEmptyParts)
 			             .mid(frontCut, tokens.size());
 			QStringList args = tokens.join(" ").split(
-			    ",", QString::SkipEmptyParts);
+			    ",", Qt::SkipEmptyParts);
 			args.removeDuplicates();
 			for (auto &arg : args)
 			{
@@ -806,7 +806,7 @@ private:
 			else
 			{
 				QStringList args = rejoined.split(
-				    ",", QString::SkipEmptyParts);
+				    ",", Qt::SkipEmptyParts);
 				if (isFilterCmd(cmd))
 				{
 					suggs = getSuggestionsForFilterCSCmd(cmd, args);
@@ -902,7 +902,7 @@ private:
 	QStringList getSuggestionsForFilterCmd(const QString &cmd,
 	                                       const QString &argument)
 	{
-		QStringList pool(filterPool[cmd].toList());
+		QStringList pool(filterPool[cmd].values());
 		return sortStringsByStringEquality(pool, argument);
 	}
 
@@ -918,7 +918,7 @@ private:
 		{
 			last = args[args.size() - 1];
 		}
-		QStringList pool(filterCSPool[cmd].toList());
+		QStringList pool(filterCSPool[cmd].values());
 		QStringList list = sortStringsByStringEquality(pool, last);
 		for (QString &item : list)
 		{
@@ -1022,7 +1022,7 @@ private:
 	void addQueryToStore(QString query)
 	{
 		QStringList storedCmds = getStoredCmds();
-		QStringList cmds = query.split("#", QString::SkipEmptyParts);
+		QStringList cmds = query.split("#", Qt::SkipEmptyParts);
 		cmds.removeDuplicates();
 		for (QString cmd : cmds)
 		{
@@ -1082,12 +1082,12 @@ private:
 	{
 		QMap<int, QStringList> weightedStrings;
 		auto compareWithWords =
-		    compareWith.split(" ", QString::SkipEmptyParts);
+		    compareWith.split(" ", Qt::SkipEmptyParts);
 		for (const QString &str : strings)
 		{
 			int strEqu = 0xFFFFFF; // infinity...
 			for (auto word :
-			     str.split(" ", QString::SkipEmptyParts))
+			     str.split(" ", Qt::SkipEmptyParts))
 			{
 				auto wordA = word.leftJustified(15, ' ');
 				for (const auto &word2 : compareWithWords)

--- a/modules/cvv/src/stfl/stfl_engine.hpp
+++ b/modules/cvv/src/stfl/stfl_engine.hpp
@@ -22,6 +22,17 @@
 #include "element_group.hpp"
 #include "../qtutil/util.hpp"
 
+
+// WORKAROUND:
+//   - Qt::SplitBehavior introduced in 5.14, QString::SplitBehavior was removed in Qt6
+//   - Support required part of Qt::SplitBehavior from 5.15 for older Qt versions
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
+namespace Qt {
+	static constexpr QString::SplitBehavior SkipEmptyParts = QString::SkipEmptyParts;
+}
+#endif
+
+
 namespace cvv
 {
 namespace stfl

--- a/modules/cvv/src/stfl/stfl_engine.hpp
+++ b/modules/cvv/src/stfl/stfl_engine.hpp
@@ -773,7 +773,7 @@ private:
 		if (cmd == "group" || cmd == "sort")
 		{
 			int frontCut =
-			    std::min(qsizetype(hasByString ? 2 : 1), qsizetype(tokens.size()));
+			    std::min(size_t(hasByString ? 2 : 1), size_t(tokens.size()));
 			tokens = cmdQuery.split(" ", Qt::SkipEmptyParts)
 			             .mid(frontCut, tokens.size());
 			QStringList args = tokens.join(" ").split(


### PR DESCRIPTION
OpenCV can be compiled against Qt5 and Qt6. The Contrib CVV module depends on Qt5 and has received an incomplete patch with #3072 that allows configuring but not compiling. CVV previously used some features that were deprecated in Qt5 and removed in Qt6.

This patch replaces the corresponding lines in the source code with functions that work in Qt5.15 LTS and Qt6.

This does fix the Issue #3146.

Note: CVV still uses `QRegExp` which can not directly replaced by `QRegularExpression`. Therefor Qt6 moved `QRegExp` to the module `Core5Compat`, which requires a `find_package` because it is not required by OpenCV main project.

<cut/>

## Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
Patch to opencv_extra has the same branch name.
    - This is a bug fix without additional tests.
    - It would be useful to add a CI pipeline which builds against Qt6 or even better to change the current pipelines to build against Qt6 by default, since Qt5 is out of support except for commercial users.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=linux,docs,custom
build_image:Custom=qt:16.04
buildworker:Custom=linux-1
```