### PR TITLE
freetype: support 8UC1/8UC4 image

### DIFF
--- a/modules/freetype/include/opencv2/freetype.hpp
+++ b/modules/freetype/include/opencv2/freetype.hpp
@@ -99,7 +99,7 @@ If you want to draw small glyph, small is better.
 
 The function putText renders the specified text string in the image. Symbols that cannot be rendered using the specified font are replaced by "Tofu" or non-drawn.
 
-@param img Image. (Only 8UC3 image is supported.)
+@param img Image. (Only 8UC1/8UC3/8UC4 2D mat is supported.)
 @param text Text string to be drawn.
 @param org Bottom-left/Top-left corner of the text string in the image.
 @param fontHeight Drawing font size by pixel unit.
@@ -123,7 +123,7 @@ That is, the following code renders some text, the tight box surrounding it, and
     String text = "Funny text inside the box";
     int fontHeight = 60;
     int thickness = -1;
-    int linestyle = 8;
+    int linestyle = LINE_8;
 
     Mat img(600, 800, CV_8UC3, Scalar::all(0));
 

--- a/modules/freetype/include/opencv2/freetype.hpp
+++ b/modules/freetype/include/opencv2/freetype.hpp
@@ -82,7 +82,7 @@ The function loadFontData loads font data.
 @param idx face_index to select a font faces in a single file.
 */
 
-    CV_WRAP virtual void loadFontData(String fontFileName, int32_t idx) = 0;
+    CV_WRAP virtual void loadFontData(String fontFileName, int idx) = 0;
 
 /** @brief Set Split Number from Bezier-curve to line
 

--- a/modules/freetype/include/opencv2/freetype.hpp
+++ b/modules/freetype/include/opencv2/freetype.hpp
@@ -79,10 +79,10 @@ public:
 The function loadFontData loads font data.
 
 @param fontFileName FontFile Name
-@param id face_index to select a font faces in a single file.
+@param idx face_index to select a font faces in a single file.
 */
 
-    CV_WRAP virtual void loadFontData(String fontFileName, int id) = 0;
+    CV_WRAP virtual void loadFontData(String fontFileName, long idx) = 0;
 
 /** @brief Set Split Number from Bezier-curve to line
 

--- a/modules/freetype/include/opencv2/freetype.hpp
+++ b/modules/freetype/include/opencv2/freetype.hpp
@@ -82,7 +82,7 @@ The function loadFontData loads font data.
 @param idx face_index to select a font faces in a single file.
 */
 
-    CV_WRAP virtual void loadFontData(String fontFileName, long idx) = 0;
+    CV_WRAP virtual void loadFontData(String fontFileName, int32_t idx) = 0;
 
 /** @brief Set Split Number from Bezier-curve to line
 

--- a/modules/freetype/src/freetype.cpp
+++ b/modules/freetype/src/freetype.cpp
@@ -66,7 +66,7 @@ class CV_EXPORTS_W FreeType2Impl CV_FINAL : public FreeType2
 public:
     FreeType2Impl();
     ~FreeType2Impl();
-    void loadFontData(String fontFileName, long idx) CV_OVERRIDE;
+    void loadFontData(String fontFileName, int32_t idx) CV_OVERRIDE;
     void setSplitNumber( int num ) CV_OVERRIDE;
     void putText(
         InputOutputArray img, const String& text, Point org,
@@ -178,7 +178,7 @@ FreeType2Impl::~FreeType2Impl()
     CV_Assert(!FT_Done_FreeType(mLibrary));
 }
 
-void FreeType2Impl::loadFontData(String fontFileName, long idx)
+void FreeType2Impl::loadFontData(String fontFileName, int32_t idx)
 {
     CV_Assert( idx >= 0 );
     if( mIsFaceAvailable  == true )

--- a/modules/freetype/src/freetype.cpp
+++ b/modules/freetype/src/freetype.cpp
@@ -66,7 +66,7 @@ class CV_EXPORTS_W FreeType2Impl CV_FINAL : public FreeType2
 public:
     FreeType2Impl();
     ~FreeType2Impl();
-    void loadFontData(String fontFileName, int32_t idx) CV_OVERRIDE;
+    void loadFontData(String fontFileName, int idx) CV_OVERRIDE;
     void setSplitNumber( int num ) CV_OVERRIDE;
     void putText(
         InputOutputArray img, const String& text, Point org,
@@ -178,7 +178,7 @@ FreeType2Impl::~FreeType2Impl()
     CV_Assert(!FT_Done_FreeType(mLibrary));
 }
 
-void FreeType2Impl::loadFontData(String fontFileName, int32_t idx)
+void FreeType2Impl::loadFontData(String fontFileName, int idx)
 {
     CV_Assert( idx >= 0 );
     if( mIsFaceAvailable  == true )
@@ -188,7 +188,7 @@ void FreeType2Impl::loadFontData(String fontFileName, int32_t idx)
     }
 
     mIsFaceAvailable = false;
-    CV_Assert( !FT_New_Face( mLibrary, fontFileName.c_str(), idx, &(mFace) ) );
+    CV_Assert( !FT_New_Face( mLibrary, fontFileName.c_str(), static_cast<FT_Long>(idx), &(mFace) ) );
 
     mHb_font = hb_ft_font_create (mFace, NULL);
     if ( mHb_font == NULL )

--- a/modules/freetype/test/test_basic.cpp
+++ b/modules/freetype/test/test_basic.cpp
@@ -1,0 +1,242 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+#include "test_precomp.hpp"
+
+#define OUTPUT_FILE
+// #undef OUTPUT_FILE
+
+namespace opencv_test { namespace {
+
+/******************
+ * Basically usage
+ *****************/
+
+TEST(Freetype_Basic, success )
+{
+    const string root = cvtest::TS::ptr()->get_data_path();
+    const string fontdata = root + "freetype/mplus/Mplus1-Regular.ttf";
+
+    cv::Ptr<cv::freetype::FreeType2> ft2;
+    EXPECT_NO_THROW( ft2 = cv::freetype::createFreeType2() );
+    EXPECT_NO_THROW( ft2->loadFontData( fontdata, 0 ) );
+
+    Mat dst(600,600, CV_8UC3, Scalar::all(255) );
+    Scalar col(128,64,255,192);
+    EXPECT_NO_THROW( ft2->putText(dst, "Basic,success", Point( 0,  50), 50, col, -1, LINE_AA, true ) );
+}
+
+/******************
+ * loadFontData()
+ *****************/
+
+TEST(Freetype_loadFontData, nonexist_file)
+{
+    const string root = cvtest::TS::ptr()->get_data_path();
+    const string fontdata = root + "UNEXITSTFONT"; /* NON EXISTS FONT DATA */
+
+    cv::Ptr<cv::freetype::FreeType2> ft2;
+    EXPECT_NO_THROW( ft2 = cv::freetype::createFreeType2() );
+    EXPECT_THROW( ft2->loadFontData( fontdata, 0 ), cv::Exception );
+    Mat dst(600,600, CV_8UC3, Scalar::all(255) );
+    Scalar col(128,64,255,192);
+    EXPECT_THROW( ft2->putText(dst, "nonexist_file", Point( 0,  50), 50, col, -1, LINE_AA, true ), cv::Exception );
+}
+
+TEST(Freetype_loadFontData, forget_calling)
+{
+    cv::Ptr<cv::freetype::FreeType2> ft2;
+    EXPECT_NO_THROW( ft2 = cv::freetype::createFreeType2() );
+
+    const string root = cvtest::TS::ptr()->get_data_path();
+    const string fontdata = root + "freetype/mplus/Mplus1-Regular.ttf";
+//    EXPECT_NO_THROW( ft2->loadFontData( fontdata, 0 ) );
+
+    Mat dst(600,600, CV_8UC3, Scalar::all(255) );
+
+    Scalar col(128,64,255,192);
+    EXPECT_THROW( ft2->putText(dst, "forget_calling", Point( 0,  50), 50, col, -1, LINE_AA, true ), cv::Exception );
+}
+
+TEST(Freetype_loadFontData, call_multiple)
+{
+    cv::Ptr<cv::freetype::FreeType2> ft2;
+    EXPECT_NO_THROW( ft2 = cv::freetype::createFreeType2() );
+
+    const string root = cvtest::TS::ptr()->get_data_path();
+    const string fontdata = root + "freetype/mplus/Mplus1-Regular.ttf";
+
+    for( int i = 0 ; i < 100 ; i ++ )
+    {
+        EXPECT_NO_THROW( ft2->loadFontData( fontdata, 0 ) );
+    }
+
+    Mat dst(600,600, CV_8UC3, Scalar::all(255) );
+    Scalar col(128,64,255,192);
+    EXPECT_NO_THROW( ft2->putText(dst, "call_mutilple", Point( 0,  50), 50, col, -1, LINE_AA, true ) );
+}
+
+typedef testing::TestWithParam<long> idx_range;
+
+TEST_P(idx_range, failed )
+{
+    cv::Ptr<cv::freetype::FreeType2> ft2;
+    EXPECT_NO_THROW( ft2 = cv::freetype::createFreeType2() );
+
+    const string root = cvtest::TS::ptr()->get_data_path();
+    const string fontdata = root + "freetype/mplus/Mplus1-Regular.ttf";
+    EXPECT_THROW( ft2->loadFontData( fontdata, GetParam() ), cv::Exception );
+}
+
+const long idx_failed_list[] =
+{
+    INT_MIN,
+    INT_MIN + 1,
+    -1,
+    1,
+    2,
+    INT_MAX - 1,
+    INT_MAX
+};
+
+INSTANTIATE_TEST_CASE_P(Freetype_loadFontData, idx_range,
+                        testing::ValuesIn(idx_failed_list));
+
+/******************
+ * setSplitNumber()
+ *****************/
+
+typedef testing::TestWithParam<long> ctol_range;
+
+TEST_P(ctol_range, success)
+{
+    cv::Ptr<cv::freetype::FreeType2> ft2;
+    EXPECT_NO_THROW( ft2 = cv::freetype::createFreeType2() );
+
+    const string root = cvtest::TS::ptr()->get_data_path();
+    const string fontdata = root + "freetype/mplus/Mplus1-Regular.ttf";
+    EXPECT_NO_THROW( ft2->loadFontData( fontdata, 0 ) );
+    EXPECT_NO_THROW( ft2->setSplitNumber(GetParam()) );
+
+    Mat dst(600,600, CV_8UC3, Scalar::all(255) );
+    Scalar col(128,64,255,192);
+    EXPECT_NO_THROW( ft2->putText(dst, "CtoL", Point( 0,  50), 50, col, 1, LINE_4, true ) );
+    EXPECT_NO_THROW( ft2->putText(dst, "LINE_4: oOpPqQ", Point( 40, 100), 50, col, 1, LINE_4, true ) );
+    EXPECT_NO_THROW( ft2->putText(dst, "LINE_8: oOpPqQ", Point( 40, 150), 50, col, 1, LINE_8, true ) );
+    EXPECT_NO_THROW( ft2->putText(dst, "LINE_AA:oOpPqQ", Point( 40, 150), 50, col, 1, LINE_AA, true ) );
+}
+
+const long ctol_list[] =
+{
+    1,
+    8,
+    16,
+    32,
+    64,
+    128,
+    // INT_MAX -1,  // Hang-up
+    // INT_MAX      // Hang-up
+};
+
+INSTANTIATE_TEST_CASE_P(Freetype_setSplitNumber, ctol_range,
+                        testing::ValuesIn(ctol_list));
+
+
+/********************
+ * putText()::common
+ *******************/
+
+TEST(Freetype_putText_common, invalid_img )
+{
+    const string root = cvtest::TS::ptr()->get_data_path();
+    const string fontdata = root + "freetype/mplus/Mplus1-Regular.ttf";
+
+    cv::Ptr<cv::freetype::FreeType2> ft2;
+    EXPECT_NO_THROW( ft2 = cv::freetype::createFreeType2() );
+    EXPECT_NO_THROW( ft2->loadFontData( fontdata, 0 ) );
+
+    Scalar col(128,64,255,192);
+    { /* empty mat */
+        Mat dst;
+        EXPECT_THROW( ft2->putText(dst, "Invalid_img(empty Mat)", Point( 0,  50), 50, col, -1, LINE_AA, true ), cv::Exception );
+    }
+    { /* not mat(scalar) */
+        Scalar dst;
+        EXPECT_THROW( ft2->putText(dst, "Invalid_img(Scalar)", Point( 0,  50), 50, col, -1, LINE_AA, true ), cv::Exception );
+    }
+}
+
+class mattype_params{
+public:
+    string title;
+    int type;
+    bool success;
+};
+::std::ostream& operator<<(::std::ostream& os, const mattype_params& prm) {
+      return os << "title=" << prm.title << " expect=" << (prm.success?"SUCCESS":"FAILED");
+}
+
+typedef testing::TestWithParam<mattype_params> MatType;
+
+TEST_P(MatType, dest_color_type)
+{
+    const string root = cvtest::TS::ptr()->get_data_path();
+    const string fontdata = root + "freetype/mplus/Mplus1-Regular.ttf";
+
+    const mattype_params testParam = static_cast<mattype_params>(GetParam());
+    const string title = testParam.title;
+    const int mattype = testParam.type;
+    const bool expect_success = testParam.success;
+
+    cv::Ptr<cv::freetype::FreeType2> ft2;
+    EXPECT_NO_THROW( ft2 = cv::freetype::createFreeType2() );
+    EXPECT_NO_THROW( ft2->loadFontData( fontdata, 0 ) );
+
+    Mat dst(600,600, mattype, Scalar::all(255) );
+
+    Scalar col(128,64,255,192);
+    if ( expect_success == true )
+    {
+        EXPECT_NO_THROW( ft2->putText(dst, title,                Point( 0,  50), 50, col, -1, LINE_AA, true ) );
+        EXPECT_NO_THROW( ft2->putText(dst, "LINE_4  FILL(mono)", Point(40, 100), 50, col, -1, LINE_4,  true ) );
+        EXPECT_NO_THROW( ft2->putText(dst, "LINE_8  FILL(mono)", Point(40, 150), 50, col, -1, LINE_8,  true ) );
+        EXPECT_NO_THROW( ft2->putText(dst, "LINE_AA FILL(blend)",Point(40, 200), 50, col, -1, LINE_AA, true ) );
+        EXPECT_NO_THROW( ft2->putText(dst, "LINE_4  OUTLINE(1)", Point(40, 250), 50, col,  1, LINE_4,  true ) );
+        EXPECT_NO_THROW( ft2->putText(dst, "LINE_8  OUTLINE(1)", Point(40, 300), 50, col,  1, LINE_8,  true ) );
+        EXPECT_NO_THROW( ft2->putText(dst, "LINE_AA OUTLINE(1)", Point(40, 350), 50, col,  1, LINE_AA, true ) );
+        EXPECT_NO_THROW( ft2->putText(dst, "LINE_4  OUTLINE(5)", Point(40, 400), 50, col,  5, LINE_4,  true ) );
+        EXPECT_NO_THROW( ft2->putText(dst, "LINE_8  OUTLINE(5)", Point(40, 450), 50, col,  5, LINE_8,  true ) );
+        EXPECT_NO_THROW( ft2->putText(dst, "LINE_AA OUTLINE(5)", Point(40, 500), 50, col,  5, LINE_AA, true ) );
+        putText(dst, "LINE_4 putText(th=1)" , Point( 40,550), FONT_HERSHEY_SIMPLEX, 0.5, col, 1, LINE_4);
+        putText(dst, "LINE_8 putText(th=1)" , Point( 40,565), FONT_HERSHEY_SIMPLEX, 0.5, col, 1, LINE_8);
+        putText(dst, "LINE_AA putText(th=1)", Point( 40,580), FONT_HERSHEY_SIMPLEX, 0.5, col, 1, LINE_AA);
+        putText(dst, "LINE_4 putText(th=2)" , Point( 240,550),FONT_HERSHEY_SIMPLEX, 0.5, col, 2, LINE_4);
+        putText(dst, "LINE_8 putText(th=2)" , Point( 240,565),FONT_HERSHEY_SIMPLEX, 0.5, col, 2, LINE_8);
+        putText(dst, "LINE_AA putText(th=2)", Point( 240,580),FONT_HERSHEY_SIMPLEX, 0.5, col, 2, LINE_AA);
+
+#ifdef OUTPUT_FILE
+        imwrite( cv::format("%s.png", title.c_str()), dst );
+#endif /* IMAGE_OUTPUT */
+
+    }else{
+        EXPECT_THROW( ft2->putText(dst, title, Point( 0,  50), 50, col, -1, LINE_AA, true ), cv::Exception );
+    }
+
+}
+
+const mattype_params mattype_list[] =
+{
+    { "CV_8UC1",  CV_8UC1,  false}, { "CV_8UC2",  CV_8UC2,  false}, { "CV_8UC3",  CV_8UC3,  true},  { "CV_8UC4",  CV_8UC4,  false},
+    { "CV_8SC1",  CV_8SC1,  false}, { "CV_8SC2",  CV_8SC2,  false}, { "CV_8SC3",  CV_8SC3,  false}, { "CV_8SC4",  CV_8SC4,  false},
+    { "CV_16UC1", CV_16UC1, false}, { "CV_16UC2", CV_16UC2, false}, { "CV_16UC3", CV_16UC3, false}, { "CV_16UC4", CV_16UC4, false},
+    { "CV_16SC1", CV_16SC1, false}, { "CV_16SC2", CV_16SC2, false}, { "CV_16SC3", CV_16SC3, false}, { "CV_16SC4", CV_16SC4, false},
+    { "CV_32SC1", CV_32SC1, false}, { "CV_32SC2", CV_32SC2, false}, { "CV_32SC3", CV_32SC3, false}, { "CV_32SC4", CV_32SC4, false},
+    { "CV_32FC1", CV_32FC1, false}, { "CV_32FC2", CV_32FC2, false}, { "CV_32FC3", CV_32FC3, false}, { "CV_32FC4", CV_32FC4, false},
+    { "CV_64FC1", CV_64FC1, false}, { "CV_64FC2", CV_64FC2, false}, { "CV_64FC3", CV_64FC3, false}, { "CV_64FC4", CV_64FC4, false},
+    { "CV_16FC1", CV_16FC1, false}, { "CV_16FC2", CV_16FC2, false}, { "CV_16FC3", CV_16FC3, false}, { "CV_16FC4", CV_16FC4, false},
+};
+
+INSTANTIATE_TEST_CASE_P(Freetype_putText_common, MatType,
+                        testing::ValuesIn(mattype_list));
+
+}} // namespace

--- a/modules/freetype/test/test_basic.cpp
+++ b/modules/freetype/test/test_basic.cpp
@@ -7,7 +7,16 @@
 
 namespace opencv_test { namespace {
 
-typedef tuple<string, int, bool> MattypeParams;
+struct MattypeParams
+{
+    string title;
+    int mattype;
+    bool expect_success;
+};
+
+::std::ostream& operator<<(::std::ostream& os, const MattypeParams& prm) {
+      return os << prm.title;
+}
 
 const MattypeParams mattype_list[] =
 {
@@ -196,9 +205,9 @@ TEST_P(MatType_Test, default)
     const string fontdata = root + "freetype/mplus/Mplus1-Regular.ttf";
 
     const MattypeParams params = static_cast<MattypeParams>(GetParam());
-    const string title        = get<0>(params);
-    const int mattype         = get<1>(params);
-    const bool expect_success = get<2>(params);
+    const string title        = params.title;
+    const int mattype         = params.mattype;
+    const bool expect_success = params.expect_success;
 
     cv::Ptr<cv::freetype::FreeType2> ft2;
     EXPECT_NO_THROW( ft2 = cv::freetype::createFreeType2() );

--- a/modules/freetype/test/test_basic.cpp
+++ b/modules/freetype/test/test_basic.cpp
@@ -3,8 +3,6 @@
 // of this distribution and at http://opencv.org/license.html.
 #include "test_precomp.hpp"
 
-// #define OUTPUT_FILE
-
 namespace opencv_test { namespace {
 
 struct MattypeParams
@@ -107,7 +105,7 @@ TEST(Freetype_loadFontData, call_multiple)
     EXPECT_NO_THROW( ft2->putText(dst, "call_mutilple", Point( 0,  50), 50, col, -1, LINE_AA, true ) );
 }
 
-typedef testing::TestWithParam<long> idx_range;
+typedef testing::TestWithParam<int> idx_range;
 
 TEST_P(idx_range, failed )
 {
@@ -119,7 +117,7 @@ TEST_P(idx_range, failed )
     EXPECT_THROW( ft2->loadFontData( fontdata, GetParam() ), cv::Exception );
 }
 
-const long idx_failed_list[] =
+const int idx_failed_list[] =
 {
     INT_MIN,
     INT_MIN + 1,
@@ -137,7 +135,7 @@ INSTANTIATE_TEST_CASE_P(Freetype_loadFontData, idx_range,
  * setSplitNumber()
  *****************/
 
-typedef testing::TestWithParam<long> ctol_range;
+typedef testing::TestWithParam<int> ctol_range;
 
 TEST_P(ctol_range, success)
 {
@@ -157,7 +155,7 @@ TEST_P(ctol_range, success)
     EXPECT_NO_THROW( ft2->putText(dst, "LINE_AA:oOpPqQ", Point( 40, 150), 50, col, 1, LINE_AA, true ) );
 }
 
-const long ctol_list[] =
+const int ctol_list[] =
 {
     1,
     8,
@@ -240,9 +238,10 @@ TEST_P(MatType_Test, default)
     putText(dst, "LINE_8 putText(th=2)" , Point( 240,565),FONT_HERSHEY_SIMPLEX, 0.5, col, 2, LINE_8);
     putText(dst, "LINE_AA putText(th=2)", Point( 240,580),FONT_HERSHEY_SIMPLEX, 0.5, col, 2, LINE_AA);
 
-#ifdef OUTPUT_FILE
-    imwrite( cv::format("%s.png", title.c_str()), dst );
-#endif /* IMAGE_OUTPUT */
+    if (cvtest::debugLevel > 0 )
+    {
+        imwrite( cv::format("%s-MatType.png", title.c_str()), dst );
+    }
 }
 
 INSTANTIATE_TEST_CASE_P(Freetype_putText, MatType_Test,

--- a/modules/freetype/test/test_basic.cpp
+++ b/modules/freetype/test/test_basic.cpp
@@ -3,10 +3,32 @@
 // of this distribution and at http://opencv.org/license.html.
 #include "test_precomp.hpp"
 
-#define OUTPUT_FILE
-// #undef OUTPUT_FILE
+// #define OUTPUT_FILE
 
 namespace opencv_test { namespace {
+
+typedef tuple<string, int, bool> MattypeParams;
+
+const MattypeParams mattype_list[] =
+{
+    { "CV_8UC1",  CV_8UC1,  true},  { "CV_8UC2",  CV_8UC2,  false},
+    { "CV_8UC3",  CV_8UC3,  true},  { "CV_8UC4",  CV_8UC4,  true},
+
+    { "CV_8SC1",  CV_8SC1,  false}, { "CV_8SC2",  CV_8SC2,  false},
+    { "CV_8SC3",  CV_8SC3,  false}, { "CV_8SC4",  CV_8SC4,  false},
+    { "CV_16UC1", CV_16UC1, false}, { "CV_16UC2", CV_16UC2, false},
+    { "CV_16UC3", CV_16UC3, false}, { "CV_16UC4", CV_16UC4, false},
+    { "CV_16SC1", CV_16SC1, false}, { "CV_16SC2", CV_16SC2, false},
+    { "CV_16SC3", CV_16SC3, false}, { "CV_16SC4", CV_16SC4, false},
+    { "CV_32SC1", CV_32SC1, false}, { "CV_32SC2", CV_32SC2, false},
+    { "CV_32SC3", CV_32SC3, false}, { "CV_32SC4", CV_32SC4, false},
+    { "CV_32FC1", CV_32FC1, false}, { "CV_32FC2", CV_32FC2, false},
+    { "CV_32FC3", CV_32FC3, false}, { "CV_32FC4", CV_32FC4, false},
+    { "CV_64FC1", CV_64FC1, false}, { "CV_64FC2", CV_64FC2, false},
+    { "CV_64FC3", CV_64FC3, false}, { "CV_64FC4", CV_64FC4, false},
+    { "CV_16FC1", CV_16FC1, false}, { "CV_16FC2", CV_16FC2, false},
+    { "CV_16FC3", CV_16FC3, false}, { "CV_16FC4", CV_16FC4, false},
+};
 
 /******************
  * Basically usage
@@ -146,7 +168,7 @@ INSTANTIATE_TEST_CASE_P(Freetype_setSplitNumber, ctol_range,
  * putText()::common
  *******************/
 
-TEST(Freetype_putText_common, invalid_img )
+TEST(Freetype_putText, invalid_img )
 {
     const string root = cvtest::TS::ptr()->get_data_path();
     const string fontdata = root + "freetype/mplus/Mplus1-Regular.ttf";
@@ -166,27 +188,17 @@ TEST(Freetype_putText_common, invalid_img )
     }
 }
 
-class mattype_params{
-public:
-    string title;
-    int type;
-    bool success;
-};
-::std::ostream& operator<<(::std::ostream& os, const mattype_params& prm) {
-      return os << "title=" << prm.title << " expect=" << (prm.success?"SUCCESS":"FAILED");
-}
+typedef testing::TestWithParam<MattypeParams> MatType_Test;
 
-typedef testing::TestWithParam<mattype_params> MatType;
-
-TEST_P(MatType, dest_color_type)
+TEST_P(MatType_Test, default)
 {
     const string root = cvtest::TS::ptr()->get_data_path();
     const string fontdata = root + "freetype/mplus/Mplus1-Regular.ttf";
 
-    const mattype_params testParam = static_cast<mattype_params>(GetParam());
-    const string title = testParam.title;
-    const int mattype = testParam.type;
-    const bool expect_success = testParam.success;
+    const MattypeParams params = static_cast<MattypeParams>(GetParam());
+    const string title        = get<0>(params);
+    const int mattype         = get<1>(params);
+    const bool expect_success = get<2>(params);
 
     cv::Ptr<cv::freetype::FreeType2> ft2;
     EXPECT_NO_THROW( ft2 = cv::freetype::createFreeType2() );
@@ -195,48 +207,36 @@ TEST_P(MatType, dest_color_type)
     Mat dst(600,600, mattype, Scalar::all(255) );
 
     Scalar col(128,64,255,192);
-    if ( expect_success == true )
+
+    if ( expect_success == false )
     {
-        EXPECT_NO_THROW( ft2->putText(dst, title,                Point( 0,  50), 50, col, -1, LINE_AA, true ) );
-        EXPECT_NO_THROW( ft2->putText(dst, "LINE_4  FILL(mono)", Point(40, 100), 50, col, -1, LINE_4,  true ) );
-        EXPECT_NO_THROW( ft2->putText(dst, "LINE_8  FILL(mono)", Point(40, 150), 50, col, -1, LINE_8,  true ) );
-        EXPECT_NO_THROW( ft2->putText(dst, "LINE_AA FILL(blend)",Point(40, 200), 50, col, -1, LINE_AA, true ) );
-        EXPECT_NO_THROW( ft2->putText(dst, "LINE_4  OUTLINE(1)", Point(40, 250), 50, col,  1, LINE_4,  true ) );
-        EXPECT_NO_THROW( ft2->putText(dst, "LINE_8  OUTLINE(1)", Point(40, 300), 50, col,  1, LINE_8,  true ) );
-        EXPECT_NO_THROW( ft2->putText(dst, "LINE_AA OUTLINE(1)", Point(40, 350), 50, col,  1, LINE_AA, true ) );
-        EXPECT_NO_THROW( ft2->putText(dst, "LINE_4  OUTLINE(5)", Point(40, 400), 50, col,  5, LINE_4,  true ) );
-        EXPECT_NO_THROW( ft2->putText(dst, "LINE_8  OUTLINE(5)", Point(40, 450), 50, col,  5, LINE_8,  true ) );
-        EXPECT_NO_THROW( ft2->putText(dst, "LINE_AA OUTLINE(5)", Point(40, 500), 50, col,  5, LINE_AA, true ) );
-        putText(dst, "LINE_4 putText(th=1)" , Point( 40,550), FONT_HERSHEY_SIMPLEX, 0.5, col, 1, LINE_4);
-        putText(dst, "LINE_8 putText(th=1)" , Point( 40,565), FONT_HERSHEY_SIMPLEX, 0.5, col, 1, LINE_8);
-        putText(dst, "LINE_AA putText(th=1)", Point( 40,580), FONT_HERSHEY_SIMPLEX, 0.5, col, 1, LINE_AA);
-        putText(dst, "LINE_4 putText(th=2)" , Point( 240,550),FONT_HERSHEY_SIMPLEX, 0.5, col, 2, LINE_4);
-        putText(dst, "LINE_8 putText(th=2)" , Point( 240,565),FONT_HERSHEY_SIMPLEX, 0.5, col, 2, LINE_8);
-        putText(dst, "LINE_AA putText(th=2)", Point( 240,580),FONT_HERSHEY_SIMPLEX, 0.5, col, 2, LINE_AA);
-
-#ifdef OUTPUT_FILE
-        imwrite( cv::format("%s.png", title.c_str()), dst );
-#endif /* IMAGE_OUTPUT */
-
-    }else{
         EXPECT_THROW( ft2->putText(dst, title, Point( 0,  50), 50, col, -1, LINE_AA, true ), cv::Exception );
+        return;
     }
 
+    EXPECT_NO_THROW( ft2->putText(dst, title,                Point( 0,  50), 50, col, -1, LINE_AA, true ) );
+    EXPECT_NO_THROW( ft2->putText(dst, "LINE_4  FILL(mono)", Point(40, 100), 50, col, -1, LINE_4,  true ) );
+    EXPECT_NO_THROW( ft2->putText(dst, "LINE_8  FILL(mono)", Point(40, 150), 50, col, -1, LINE_8,  true ) );
+    EXPECT_NO_THROW( ft2->putText(dst, "LINE_AA FILL(blend)",Point(40, 200), 50, col, -1, LINE_AA, true ) );
+    EXPECT_NO_THROW( ft2->putText(dst, "LINE_4  OUTLINE(1)", Point(40, 250), 50, col,  1, LINE_4,  true ) );
+    EXPECT_NO_THROW( ft2->putText(dst, "LINE_8  OUTLINE(1)", Point(40, 300), 50, col,  1, LINE_8,  true ) );
+    EXPECT_NO_THROW( ft2->putText(dst, "LINE_AA OUTLINE(1)", Point(40, 350), 50, col,  1, LINE_AA, true ) );
+    EXPECT_NO_THROW( ft2->putText(dst, "LINE_4  OUTLINE(5)", Point(40, 400), 50, col,  5, LINE_4,  true ) );
+    EXPECT_NO_THROW( ft2->putText(dst, "LINE_8  OUTLINE(5)", Point(40, 450), 50, col,  5, LINE_8,  true ) );
+    EXPECT_NO_THROW( ft2->putText(dst, "LINE_AA OUTLINE(5)", Point(40, 500), 50, col,  5, LINE_AA, true ) );
+    putText(dst, "LINE_4 putText(th=1)" , Point( 40,550), FONT_HERSHEY_SIMPLEX, 0.5, col, 1, LINE_4);
+    putText(dst, "LINE_8 putText(th=1)" , Point( 40,565), FONT_HERSHEY_SIMPLEX, 0.5, col, 1, LINE_8);
+    putText(dst, "LINE_AA putText(th=1)", Point( 40,580), FONT_HERSHEY_SIMPLEX, 0.5, col, 1, LINE_AA);
+    putText(dst, "LINE_4 putText(th=2)" , Point( 240,550),FONT_HERSHEY_SIMPLEX, 0.5, col, 2, LINE_4);
+    putText(dst, "LINE_8 putText(th=2)" , Point( 240,565),FONT_HERSHEY_SIMPLEX, 0.5, col, 2, LINE_8);
+    putText(dst, "LINE_AA putText(th=2)", Point( 240,580),FONT_HERSHEY_SIMPLEX, 0.5, col, 2, LINE_AA);
+
+#ifdef OUTPUT_FILE
+    imwrite( cv::format("%s.png", title.c_str()), dst );
+#endif /* IMAGE_OUTPUT */
 }
 
-const mattype_params mattype_list[] =
-{
-    { "CV_8UC1",  CV_8UC1,  false}, { "CV_8UC2",  CV_8UC2,  false}, { "CV_8UC3",  CV_8UC3,  true},  { "CV_8UC4",  CV_8UC4,  false},
-    { "CV_8SC1",  CV_8SC1,  false}, { "CV_8SC2",  CV_8SC2,  false}, { "CV_8SC3",  CV_8SC3,  false}, { "CV_8SC4",  CV_8SC4,  false},
-    { "CV_16UC1", CV_16UC1, false}, { "CV_16UC2", CV_16UC2, false}, { "CV_16UC3", CV_16UC3, false}, { "CV_16UC4", CV_16UC4, false},
-    { "CV_16SC1", CV_16SC1, false}, { "CV_16SC2", CV_16SC2, false}, { "CV_16SC3", CV_16SC3, false}, { "CV_16SC4", CV_16SC4, false},
-    { "CV_32SC1", CV_32SC1, false}, { "CV_32SC2", CV_32SC2, false}, { "CV_32SC3", CV_32SC3, false}, { "CV_32SC4", CV_32SC4, false},
-    { "CV_32FC1", CV_32FC1, false}, { "CV_32FC2", CV_32FC2, false}, { "CV_32FC3", CV_32FC3, false}, { "CV_32FC4", CV_32FC4, false},
-    { "CV_64FC1", CV_64FC1, false}, { "CV_64FC2", CV_64FC2, false}, { "CV_64FC3", CV_64FC3, false}, { "CV_64FC4", CV_64FC4, false},
-    { "CV_16FC1", CV_16FC1, false}, { "CV_16FC2", CV_16FC2, false}, { "CV_16FC3", CV_16FC3, false}, { "CV_16FC4", CV_16FC4, false},
-};
-
-INSTANTIATE_TEST_CASE_P(Freetype_putText_common, MatType,
+INSTANTIATE_TEST_CASE_P(Freetype_putText, MatType_Test,
                         testing::ValuesIn(mattype_list));
 
 }} // namespace

--- a/modules/freetype/test/test_main.cpp
+++ b/modules/freetype/test/test_main.cpp
@@ -1,0 +1,6 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+#include "test_precomp.hpp"
+
+CV_TEST_MAIN("cv")

--- a/modules/freetype/test/test_main.cpp
+++ b/modules/freetype/test/test_main.cpp
@@ -4,3 +4,4 @@
 #include "test_precomp.hpp"
 
 CV_TEST_MAIN("cv")
+

--- a/modules/freetype/test/test_main.cpp
+++ b/modules/freetype/test/test_main.cpp
@@ -4,4 +4,3 @@
 #include "test_precomp.hpp"
 
 CV_TEST_MAIN("cv")
-

--- a/modules/freetype/test/test_precomp.hpp
+++ b/modules/freetype/test/test_precomp.hpp
@@ -1,0 +1,10 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+#ifndef __OPENCV_TEST_PRECOMP_HPP__
+#define __OPENCV_TEST_PRECOMP_HPP__
+
+#include "opencv2/freetype.hpp"
+#include "opencv2/ts.hpp"
+
+#endif

--- a/modules/freetype/test/test_putText.cpp
+++ b/modules/freetype/test/test_putText.cpp
@@ -7,7 +7,16 @@
 
 namespace opencv_test { namespace {
 
-typedef tuple < string, int, string > DrawingParams;
+struct DrawingParams
+{
+    string title;
+    int mattype;
+    string fontname;
+};
+
+::std::ostream& operator<<(::std::ostream& os, const DrawingParams& prm) {
+      return os << prm.title;
+}
 
 const DrawingParams drawing_list[] =
 {
@@ -24,9 +33,9 @@ typedef testing::TestWithParam<DrawingParams> BoundaryTest;
 TEST_P(BoundaryTest, default)
 {
     const DrawingParams params = GetParam();
-    const string title    = get<0>(params);
-    const int mattype     = get<1>(params);
-    const string fontname = get<2>(params);
+    const string title    = params.title;
+    const int mattype     = params.mattype;
+    const string fontname = params.fontname;
 
     const string root = cvtest::TS::ptr()->get_data_path();
     const string fontdata = root + fontname;
@@ -106,9 +115,9 @@ typedef testing::TestWithParam<DrawingParams> Ligaturetest;
 TEST_P(Ligaturetest, regression2827)
 {
     const DrawingParams params = GetParam();
-    const string title    = get<0>(params);
-    const int mattype     = get<1>(params);
-    const string fontname = get<2>(params);
+    const string title    = params.title;
+    const int mattype     = params.mattype;
+    const string fontname = params.fontname;
 
     const string root = cvtest::TS::ptr()->get_data_path();
     const string fontdata = root + fontname;

--- a/modules/freetype/test/test_putText.cpp
+++ b/modules/freetype/test/test_putText.cpp
@@ -3,8 +3,6 @@
 // of this distribution and at http://opencv.org/license.html.
 #include "test_precomp.hpp"
 
-// #define OUTPUT_FILE
-
 namespace opencv_test { namespace {
 
 struct DrawingParams
@@ -86,9 +84,10 @@ TEST_P(BoundaryTest, default)
         EXPECT_NO_THROW( ft2->putText(dst, text, textOrg, textHeight, col, -1, LINE_AA,  true ) );
     }
 
-#ifdef OUTPUT_FILE
-    imwrite( cv::format("%s-boundary.png", title.c_str()), dst );
-#endif /* IMAGE_OUTPUT */
+    if (cvtest::debugLevel > 0 )
+    {
+        imwrite( cv::format("%s-boundary.png", title.c_str()), dst );
+    }
 }
 
 INSTANTIATE_TEST_CASE_P(Freetype_putText, BoundaryTest,
@@ -111,8 +110,8 @@ static Mat clipRoiAs8UC1( Mat &dst, Rect roi_rect )
     return roi;
 }
 
-typedef testing::TestWithParam<DrawingParams> Ligaturetest;
-TEST_P(Ligaturetest, regression2827)
+typedef testing::TestWithParam<DrawingParams> LigatureTest;
+TEST_P(LigatureTest, regression2627)
 {
     const DrawingParams params = GetParam();
     const string title    = params.title;
@@ -190,12 +189,13 @@ TEST_P(Ligaturetest, regression2827)
         ty += skip_y;
     }
 
-#ifdef OUTPUT_FILE
-    imwrite( cv::format("%s-contrib2627.png", title.c_str()), dst );
-#endif /* IMAGE_OUTPUT */
+    if (cvtest::debugLevel > 0 )
+    {
+        imwrite( cv::format("%s-contrib2627.png", title.c_str()), dst );
+    }
 }
 
-INSTANTIATE_TEST_CASE_P(Freetype_putText, Ligaturetest,
+INSTANTIATE_TEST_CASE_P(Freetype_putText, LigatureTest,
                         testing::ValuesIn(drawing_list));
 
 }} // namespace

--- a/modules/freetype/test/test_putText.cpp
+++ b/modules/freetype/test/test_putText.cpp
@@ -1,0 +1,192 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+#include "test_precomp.hpp"
+
+// #define OUTPUT_FILE
+
+namespace opencv_test { namespace {
+
+typedef tuple < string, int, string > DrawingParams;
+
+const DrawingParams drawing_list[] =
+{
+    { "CV_8UC1-Mplus1-Regular", CV_8UC1, "freetype/mplus/Mplus1-Regular.ttf"},
+    { "CV_8UC3-Mplus1-Regular", CV_8UC3, "freetype/mplus/Mplus1-Regular.ttf"},
+    { "CV_8UC4-Mplus1-Regular", CV_8UC4, "freetype/mplus/Mplus1-Regular.ttf"},
+};
+
+/********************
+ * putText()::boundry
+ *******************/
+typedef testing::TestWithParam<DrawingParams> BoundaryTest;
+
+TEST_P(BoundaryTest, default)
+{
+    const DrawingParams params = GetParam();
+    const string title    = get<0>(params);
+    const int mattype     = get<1>(params);
+    const string fontname = get<2>(params);
+
+    const string root = cvtest::TS::ptr()->get_data_path();
+    const string fontdata = root + fontname;
+
+    cv::Ptr<cv::freetype::FreeType2> ft2;
+    EXPECT_NO_THROW( ft2 = cv::freetype::createFreeType2() );
+    EXPECT_NO_THROW( ft2->loadFontData( fontdata, 0 ) );
+
+    Mat dst(600,600, mattype, Scalar::all(255) );
+
+    Scalar col(128,64,255,192);
+    EXPECT_NO_THROW( ft2->putText(dst, title, Point( 100, 200), 20, col, -1, LINE_AA, true ) );
+
+    const int textHeight = 30;
+    for ( int iy = -50 ; iy <= +50 ; iy++ )
+    {
+        Point textOrg( 50, iy );
+        const string text = "top boundary";
+        EXPECT_NO_THROW( ft2->putText(dst, text, textOrg, textHeight, col, -1, LINE_4,  true ) );
+        EXPECT_NO_THROW( ft2->putText(dst, text, textOrg, textHeight, col, -1, LINE_8,  true ) );
+        EXPECT_NO_THROW( ft2->putText(dst, text, textOrg, textHeight, col, -1, LINE_AA,  true ) );
+    }
+
+    for ( int iy = -50 ; iy <= +50 ; iy++ )
+    {
+        Point textOrg( 400, dst.cols + iy );
+        const string text = "bottom boundary";
+        EXPECT_NO_THROW( ft2->putText(dst, text, textOrg, textHeight, col, -1, LINE_4,  true ) );
+        EXPECT_NO_THROW( ft2->putText(dst, text, textOrg, textHeight, col, -1, LINE_8,  true ) );
+        EXPECT_NO_THROW( ft2->putText(dst, text, textOrg, textHeight, col, -1, LINE_AA,  true ) );
+    }
+
+    for ( int ix = -50 ; ix <= +50 ; ix++ )
+    {
+        Point textOrg( ix, 100 );
+        const string text = "left boundary";
+        EXPECT_NO_THROW( ft2->putText(dst, text, textOrg, textHeight, col, -1, LINE_4,  true ) );
+        EXPECT_NO_THROW( ft2->putText(dst, text, textOrg, textHeight, col, -1, LINE_8,  true ) );
+        EXPECT_NO_THROW( ft2->putText(dst, text, textOrg, textHeight, col, -1, LINE_AA,  true ) );
+    }
+
+    for ( int ix = -50 ; ix <= +50 ; ix++ )
+    {
+        Point textOrg( dst.rows + ix, 500 );
+        const string text = "bottom boundary";
+        EXPECT_NO_THROW( ft2->putText(dst, text, textOrg, textHeight, col, -1, LINE_4,  true ) );
+        EXPECT_NO_THROW( ft2->putText(dst, text, textOrg, textHeight, col, -1, LINE_8,  true ) );
+        EXPECT_NO_THROW( ft2->putText(dst, text, textOrg, textHeight, col, -1, LINE_AA,  true ) );
+    }
+
+#ifdef OUTPUT_FILE
+    imwrite( cv::format("%s-boundary.png", title.c_str()), dst );
+#endif /* IMAGE_OUTPUT */
+}
+
+INSTANTIATE_TEST_CASE_P(Freetype_putText, BoundaryTest,
+                        testing::ValuesIn(drawing_list)) ;
+
+/*********************
+ * putText()::Ligature
+ *********************/
+
+// See https://github.com/opencv/opencv_contrib/issues/2627
+
+static Mat clipRoiAs8UC1( Mat &dst, Rect roi_rect )
+{
+    Mat roi = Mat(dst, roi_rect).clone();
+    switch( roi.type() ){
+    case CV_8UC4: cvtColor(roi,roi,COLOR_BGRA2GRAY); break;
+    case CV_8UC3: cvtColor(roi,roi,COLOR_BGR2GRAY); break;
+    case CV_8UC1: default: break; // Do nothing
+    }
+    return roi;
+}
+
+typedef testing::TestWithParam<DrawingParams> Ligaturetest;
+TEST_P(Ligaturetest, regression2827)
+{
+    const DrawingParams params = GetParam();
+    const string title    = get<0>(params);
+    const int mattype     = get<1>(params);
+    const string fontname = get<2>(params);
+
+    const string root = cvtest::TS::ptr()->get_data_path();
+    const string fontdata = root + fontname;
+
+    cv::Ptr<cv::freetype::FreeType2> ft2;
+    EXPECT_NO_THROW( ft2 = cv::freetype::createFreeType2() );
+    EXPECT_NO_THROW( ft2->loadFontData( fontdata, 0 ) );
+
+    Mat dst(600,600, mattype, Scalar(0,0,0,255) );
+    Scalar col(255,255,255,255);
+    EXPECT_NO_THROW( ft2->putText(dst, title, Point(  0, 50), 30, col, -1, LINE_AA, true ) );
+
+    vector<string> texts = {
+        "ffi", // ff will be combined to single glyph.
+        "fs",
+        "fi",
+        "ff",
+        "ae",
+        "tz",
+        "oe",
+        "\xE3\x81\xAF",             // HA ( HIRAGANA )
+        "\xE3\x81\xAF\xE3\x82\x99", // BA ( HA + VOICED SOUND MARK )
+        "\xE3\x81\xAF\xE3\x82\x9A", // PA ( HA + SEMI-VOICED SOUND MARK )
+        "\xE3\x83\x8F",             // HA ( KATAKANA )
+        "\xE3\x83\x8F\xE3\x82\x99", // BA ( HA + VOICED SOUND MARK )
+        "\xE3\x83\x8F\xE3\x82\x9A", // PA ( HA + SEMI-VOICED SOUND MARK )
+    };
+
+    const int fontHeight = 20;
+    const int margin = fontHeight / 2; // for current glyph right edgeto next glyph left edge
+
+    const int start_x    =  40;
+    const int start_y    = 100;
+    const int skip_x     = 100;
+    const int skip_y     =  25;
+
+    int tx = start_x;
+    int ty = start_y;
+
+    for (auto it = texts.begin(); it != texts.end(); it++ )
+    {
+        if ( ty + fontHeight * 3 > dst.rows ) {
+            ty = start_y;
+            tx = tx + skip_x;
+        }
+
+        EXPECT_NO_THROW( ft2->putText(dst, *it,  Point(tx,ty), fontHeight, col, -1, LINE_4,  true ) );
+
+        { // Check for next glyph area.
+            const Rect roi_rect = Rect( tx + fontHeight + margin, ty - fontHeight, fontHeight, fontHeight );
+            const Mat roi = clipRoiAs8UC1(dst, roi_rect);
+            EXPECT_EQ(0, countNonZero(roi) );
+        }
+        ty += skip_y;
+
+        EXPECT_NO_THROW( ft2->putText(dst, *it,  Point(tx,ty), fontHeight, col, -1, LINE_8,  true ) );
+        { // Check for next glyph area.
+            const Rect roi_rect = Rect( tx + fontHeight + margin, ty - fontHeight, fontHeight, fontHeight );
+            const Mat roi = clipRoiAs8UC1(dst, roi_rect);
+            EXPECT_EQ(0, countNonZero(roi) );
+        }
+        ty += skip_y;
+
+        EXPECT_NO_THROW( ft2->putText(dst, *it,  Point(tx,ty), fontHeight, col,  1, LINE_AA, true ) );
+        { // Check for next glyph area.
+            const Rect roi_rect = Rect( tx + fontHeight + margin, ty - fontHeight, fontHeight, fontHeight );
+            const Mat roi = clipRoiAs8UC1(dst, roi_rect);
+            EXPECT_EQ(0, countNonZero(roi) );
+        }
+        ty += skip_y;
+    }
+
+#ifdef OUTPUT_FILE
+    imwrite( cv::format("%s-contrib2627.png", title.c_str()), dst );
+#endif /* IMAGE_OUTPUT */
+}
+
+INSTANTIATE_TEST_CASE_P(Freetype_putText, Ligaturetest,
+                        testing::ValuesIn(drawing_list));
+
+}} // namespace


### PR DESCRIPTION
Fix https://github.com/opencv/opencv_contrib/issues/2009 (Request for 8UC4)
Fix https://github.com/opencv/opencv_contrib/issues/3276 (Request for 8UC1)

Related https://github.com/opencv/opencv_extra/pull/981

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [X] There is a reference to the original bug report and related work
- [ X There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X] The feature is well documented and sample code can be built with the project CMake
