### PR TITLE
Allow new glog in SFM CMake Project

### DIFF
--- a/modules/sfm/CMakeLists.txt
+++ b/modules/sfm/CMakeLists.txt
@@ -6,20 +6,20 @@ set(the_description "SFM algorithms")
 
 find_package(Ceres QUIET)
 
-if(NOT Gflags_FOUND)  # Ceres find gflags on the own, so separate search isn't necessary
+if(NOT (Gflags_FOUND)  # Ceres find gflags on the own, so separate search isn't necessary
   find_package(Gflags QUIET)
 endif()
-if(NOT Glog_FOUND)  # Ceres find glog on the own, so separate search isn't necessary
+if(NOT (Glog_FOUND OR glog_FOUND)  # Ceres find glog on the own, so separate search isn't necessary
   find_package(Glog QUIET)
 endif()
 
-if(NOT Gflags_FOUND OR NOT Glog_FOUND)
+if(NOT Gflags_FOUND OR NOT (Glog_FOUND OR glog_FOUND))
   # try local search scripts
   list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
   if(NOT Gflags_FOUND)
     find_package(Gflags QUIET)
   endif()
-  if(NOT Glog_FOUND)
+  if(NOT (Glog_FOUND OR glog_FOUND))
     find_package(Glog QUIET)
   endif()
 endif()

--- a/modules/sfm/CMakeLists.txt
+++ b/modules/sfm/CMakeLists.txt
@@ -6,7 +6,7 @@ set(the_description "SFM algorithms")
 
 find_package(Ceres QUIET)
 
-if(NOT (Gflags_FOUND)  # Ceres find gflags on the own, so separate search isn't necessary
+if(NOT Gflags_FOUND)  # Ceres find gflags on the own, so separate search isn't necessary
   find_package(Gflags QUIET)
 endif()
 if(NOT (Glog_FOUND OR glog_FOUND)  # Ceres find glog on the own, so separate search isn't necessary

--- a/modules/sfm/CMakeLists.txt
+++ b/modules/sfm/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(Ceres QUIET)
 if(NOT Gflags_FOUND)  # Ceres find gflags on the own, so separate search isn't necessary
   find_package(Gflags QUIET)
 endif()
-if(NOT (Glog_FOUND OR glog_FOUND)  # Ceres find glog on the own, so separate search isn't necessary
+if(NOT (Glog_FOUND OR glog_FOUND))  # Ceres find glog on the own, so separate search isn't necessary
   find_package(Glog QUIET)
 endif()
 


### PR DESCRIPTION
The latest version of glog provides native CMake support, meaning that find_package(glog) can be used without hassle. The Ceres project supports this. However, if Ceres finds the new glog, it sets variables glog_FOUND and not Glog_FOUND, which the CMakeLists.txt of the SFM module checks for. The assumption that glog has not been found then leads to errors later on, as valid variables are replaced with NOT-FOUND in the following search scripts.

This PR adds support for the new glog by simply checking for both Glog_FOUND AND glog_FOUND. While there may be more sophisticated ways to solve this (e.g. I would recommend updating FindGlog.cmake to the newest version included in Ceres) this seemed to be the minimal effort solution which worked for me, at least as a temporary fix before newer CMake find scripts are added.


```
force_builders=linux,docs
```