### PR TITLE
ChArUco pre460 pattern support via switch

### DIFF
--- a/modules/aruco/include/opencv2/aruco/board.hpp
+++ b/modules/aruco/include/opencv2/aruco/board.hpp
@@ -203,17 +203,19 @@ public:
      * @param markerLength marker side length (same unit than squareLength)
      * @param dictionary dictionary of markers indicating the type of markers.
      * The first markers in the dictionary are used to fill the white chessboard squares.
+     * @param legacy legacy chessboard pattern (pre 4.6.0). Pattern generation was changed to be consistent across OpenCV, leading to incompatible even row patterns. Legacy switch enables old behavior to support pre-existing targets, see https://github.com/opencv/opencv_contrib/issues/3291).
      * @return the output CharucoBoard object
      *
      * This functions creates a CharucoBoard object given the number of squares in each direction
      * and the size of the markers and chessboard squares.
      */
     CV_WRAP static Ptr<CharucoBoard> create(int squaresX, int squaresY, float squareLength,
-                                            float markerLength, const Ptr<Dictionary> &dictionary);
+                                            float markerLength, const Ptr<Dictionary> &dictionary, bool legacy = true);
 
     CV_WRAP Size getChessboardSize() const;
     CV_WRAP float getSquareLength() const;
     CV_WRAP float getMarkerLength() const;
+    CV_WRAP bool getLegacyFlag() const;
 
 protected:
     struct CharucoImpl;

--- a/modules/aruco/test/test_aruco_utils.hpp
+++ b/modules/aruco/test/test_aruco_utils.hpp
@@ -6,13 +6,13 @@ namespace opencv_test {
 namespace {
 
 static inline vector<Point2f> getAxis(InputArray _cameraMatrix, InputArray _distCoeffs, InputArray _rvec,
-                                      InputArray _tvec, float length, const float offset = 0.f)
+                                      InputArray _tvec, float length, const Point2f offset = Point2f(0, 0))
 {
     vector<Point3f> axis;
-    axis.push_back(Point3f(offset, offset, 0.f));
-    axis.push_back(Point3f(length+offset, offset, 0.f));
-    axis.push_back(Point3f(offset, length+offset, 0.f));
-    axis.push_back(Point3f(offset, offset, length));
+    axis.push_back(Point3f(offset.x, offset.y, 0.f));
+    axis.push_back(Point3f(length+offset.x, offset.y, 0.f));
+    axis.push_back(Point3f(offset.x, length+offset.y, 0.f));
+    axis.push_back(Point3f(offset.x, offset.y, length));
     vector<Point2f> axis_to_img;
     projectPoints(axis, _rvec, _tvec, _cameraMatrix, _distCoeffs, axis_to_img);
     return axis_to_img;


### PR DESCRIPTION
Support pre- and post-4.6.0 ChaRuCo patterns (even rows) via a "legacy" flag. Default is set to "true" for best backwards compatibility as discussed in https://github.com/opencv/opencv_contrib/issues/3291.

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [X] There is a reference to the original bug report and related work
- [X] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X] The feature is well documented and sample code can be built with the project CMake
