### PR TITLE
Remove unused size of get_subbox_chart_physical()

### DIFF
--- a/modules/mcc/src/checker_detector.cpp
+++ b/modules/mcc/src/checker_detector.cpp
@@ -802,8 +802,7 @@ void CCheckerDetectorImpl::
 
         // get physical char box model
         std::vector<cv::Point2f> chartPhy;
-        cv::Size size_box_phy;
-        get_subbox_chart_physical(points, chartPhy, size_box_phy);
+        get_subbox_chart_physical(points, chartPhy);
 
         // Find the perspective transformation that brings current chart to rectangular form
         Matx33f ccT = cv::getPerspectiveTransform(points, chartPhy);
@@ -1101,7 +1100,7 @@ void CCheckerDetectorImpl::
 }
 
 void CCheckerDetectorImpl::
-    get_subbox_chart_physical(const std::vector<cv::Point2f> &points, std::vector<cv::Point2f> &chartPhy, cv::Size &size)
+    get_subbox_chart_physical(const std::vector<cv::Point2f> &points, std::vector<cv::Point2f> &chartPhy)
 {
     float w, h;
     cv::Point2f v1 = points[1] - points[0];
@@ -1117,8 +1116,6 @@ void CCheckerDetectorImpl::
     chartPhy[1] = cv::Point2f(w, 0);
     chartPhy[2] = cv::Point2f(w, h);
     chartPhy[3] = cv::Point2f(0, h);
-
-    size = cv::Size((int)w, (int)h);
 }
 
 void CCheckerDetectorImpl::

--- a/modules/mcc/src/checker_detector.hpp
+++ b/modules/mcc/src/checker_detector.hpp
@@ -164,8 +164,7 @@ protected:
 private: // methods aux
     void get_subbox_chart_physical(
         const std::vector<cv::Point2f> &points,
-        std::vector<cv::Point2f> &chartPhy,
-        cv::Size &size);
+        std::vector<cv::Point2f> &chartPhy);
 
     void reduce_array(
         const std::vector<float> &x,


### PR DESCRIPTION
The argument size of get_subbox_chart_physical() is unused.
get_subbox_chart_physical() is called only in one place.
The local variable h could overflow the cast to int and lead to a SIGILL in some environments, see https://github.com/opencv/opencv_contrib/issues/3320.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
