### PR TITLE
Use T as temp var type in polyanticlockwise()

### DIFF
--- a/modules/mcc/src/common.cpp
+++ b/modules/mcc/src/common.cpp
@@ -86,5 +86,30 @@ mace_center(const std::vector<cv::Point2f> &ps)
     return center;
 }
 
+void polyanticlockwise(std::vector<cv::Point2f> &points)
+{
+    // Sort the points in anti-clockwise order
+    // Trace a line between the first and second point.
+    // If the third point is at the right side, then the points are anti-clockwise
+    cv::Point2f v1 = points[1] - points[0];
+    cv::Point2f v2 = points[2] - points[0];
+
+    //if the third point is in the left side, then sort in anti-clockwise order
+    if ((v1.x * v2.y) - (v1.y * v2.x) < 0.0)
+        std::swap(points[1], points[3]);
+}
+void polyclockwise(std::vector<cv::Point2f> &points)
+{
+    // Sort the points in clockwise order
+    // Trace a line between the first and second point.
+    // If the third point is at the right side, then the points are clockwise
+    cv::Point2f v1 = points[1] - points[0];
+    cv::Point2f v2 = points[2] - points[0];
+
+    //if the third point is in the left side, then sort in clockwise order
+    if ((v1.x * v2.y) - (v1.y * v2.x) > 0.0)
+        std::swap(points[1], points[3]);
+}
+
 } // namespace mcc
 } // namespace cv

--- a/modules/mcc/src/common.hpp
+++ b/modules/mcc/src/common.hpp
@@ -79,10 +79,10 @@ void polyanticlockwise(std::vector<T> &points)
     // Sort the points in anti-clockwise order
     // Trace a line between the first and second point.
     // If the third point is at the right side, then the points are anti-clockwise
-    cv::Point v1 = points[1] - points[0];
-    cv::Point v2 = points[2] - points[0];
+    T v1 = points[1] - points[0];
+    T v2 = points[2] - points[0];
 
-    double o = (v1.x * v2.y) - (v1.y * v2.x);
+    double o = ((double)v1.x * v2.y) - ((double)v1.y * v2.x);
 
     if (o < 0.0) //if the third point is in the left side, then sort in anti-clockwise order
         std::swap(points[1], points[3]);
@@ -93,10 +93,10 @@ void polyclockwise(std::vector<T> &points)
     // Sort the points in clockwise order
     // Trace a line between the first and second point.
     // If the third point is at the right side, then the points are clockwise
-    cv::Point v1 = points[1] - points[0];
-    cv::Point v2 = points[2] - points[0];
+    T v1 = points[1] - points[0];
+    T v2 = points[2] - points[0];
 
-    double o = (v1.x * v2.y) - (v1.y * v2.x);
+    double o = ((double)v1.x * v2.y) - ((double)v1.y * v2.x);
 
     if (o > 0.0) //if the third point is in the left side, then sort in clockwise order
         std::swap(points[1], points[3]);

--- a/modules/mcc/src/common.hpp
+++ b/modules/mcc/src/common.hpp
@@ -73,32 +73,28 @@ void unique(const std::vector<T> &A, std::vector<T> &U)
             U.push_back(Tm[i]);
 }
 
-template <typename T>
-void polyanticlockwise(std::vector<T> &points)
+void polyanticlockwise(std::vector<cv::Point2f> &points)
 {
     // Sort the points in anti-clockwise order
     // Trace a line between the first and second point.
     // If the third point is at the right side, then the points are anti-clockwise
-    T v1 = points[1] - points[0];
-    T v2 = points[2] - points[0];
+    cv::Point2f v1 = points[1] - points[0];
+    cv::Point2f v2 = points[2] - points[0];
 
-    double o = ((double)v1.x * v2.y) - ((double)v1.y * v2.x);
-
-    if (o < 0.0) //if the third point is in the left side, then sort in anti-clockwise order
+    //if the third point is in the left side, then sort in anti-clockwise order
+    if ((v1.x * v2.y) - (v1.y * v2.x) < 0.0)
         std::swap(points[1], points[3]);
 }
-template <typename T>
-void polyclockwise(std::vector<T> &points)
+void polyclockwise(std::vector<cv::Point2f> &points)
 {
     // Sort the points in clockwise order
     // Trace a line between the first and second point.
     // If the third point is at the right side, then the points are clockwise
-    T v1 = points[1] - points[0];
-    T v2 = points[2] - points[0];
+    cv::Point2f v1 = points[1] - points[0];
+    cv::Point2f v2 = points[2] - points[0];
 
-    double o = ((double)v1.x * v2.y) - ((double)v1.y * v2.x);
-
-    if (o > 0.0) //if the third point is in the left side, then sort in clockwise order
+    //if the third point is in the left side, then sort in clockwise order
+    if ((v1.x * v2.y) - (v1.y * v2.x) > 0.0)
         std::swap(points[1], points[3]);
 }
 // Does lexical cast of the input argument to string

--- a/modules/mcc/src/common.hpp
+++ b/modules/mcc/src/common.hpp
@@ -73,30 +73,9 @@ void unique(const std::vector<T> &A, std::vector<T> &U)
             U.push_back(Tm[i]);
 }
 
-void polyanticlockwise(std::vector<cv::Point2f> &points)
-{
-    // Sort the points in anti-clockwise order
-    // Trace a line between the first and second point.
-    // If the third point is at the right side, then the points are anti-clockwise
-    cv::Point2f v1 = points[1] - points[0];
-    cv::Point2f v2 = points[2] - points[0];
+void polyanticlockwise(std::vector<cv::Point2f> &points);
+void polyclockwise(std::vector<cv::Point2f> &points);
 
-    //if the third point is in the left side, then sort in anti-clockwise order
-    if ((v1.x * v2.y) - (v1.y * v2.x) < 0.0)
-        std::swap(points[1], points[3]);
-}
-void polyclockwise(std::vector<cv::Point2f> &points)
-{
-    // Sort the points in clockwise order
-    // Trace a line between the first and second point.
-    // If the third point is at the right side, then the points are clockwise
-    cv::Point2f v1 = points[1] - points[0];
-    cv::Point2f v2 = points[2] - points[0];
-
-    //if the third point is in the left side, then sort in clockwise order
-    if ((v1.x * v2.y) - (v1.y * v2.x) > 0.0)
-        std::swap(points[1], points[3]);
-}
 // Does lexical cast of the input argument to string
 template <typename T>
 std::string ToString(const T &value)


### PR DESCRIPTION
To match the input data type.
Cast inner computation to double to prevent int overflows for any input type.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work (the input image triggering the overflow is not publicly available)
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
