### PR TITLE
Fix array out of range when no edges found

### DIFF
--- a/modules/line_descriptor/src/binary_descriptor.cpp
+++ b/modules/line_descriptor/src/binary_descriptor.cpp
@@ -2250,7 +2250,7 @@ int BinaryDescriptor::EDLineDetector::EDline( cv::Mat &image, LineChains &lines 
   unsigned int linePixelID = edges.sId[edges.numOfEdges];
   lines.xCors.resize( linePixelID );
   lines.yCors.resize( linePixelID );
-  lines.sId.resize( 5 * edges.numOfEdges );
+  lines.sId.resize( 5 * edges.numOfEdges + 1);
   unsigned int *pEdgeXCors = &edges.xCors.front();
   unsigned int *pEdgeYCors = &edges.yCors.front();
   unsigned int *pEdgeSID = &edges.sId.front();


### PR DESCRIPTION
When input image is almost black edges.numOfEdges could be zero. In this case lines.sId size is zero and "detect lines" loop is never executed, so this array doesn't get chances to increase (see commit https://github.com/opencv/opencv_contrib/commit/7e14b4bba1766641975c88ca8a0bbf51511461f4).

Just before return the pointer to the beginning of lines.sId (pLineSID) is dereferenced at index 0, causing the AV because size of array is zero and pLineSID is invalid.

This fix simply make sure lines.sId contains at least one item.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
