### PR TITLE
sfm: Fix unknown uint type error in mingw

### DIFF
--- a/modules/sfm/src/libmv_light/libmv/multiview/robust_estimation.h
+++ b/modules/sfm/src/libmv_light/libmv/multiview/robust_estimation.h
@@ -54,10 +54,10 @@ class MLEScorer {
   double threshold_;
 };
 
-static uint IterationsRequired(int min_samples,
+static unsigned int IterationsRequired(int min_samples,
                         double outliers_probability,
                         double inlier_ratio) {
-  return static_cast<uint>(
+  return static_cast<unsigned int>(
       log(outliers_probability) / log(1.0 - pow(inlier_ratio, min_samples)));
 }
 


### PR DESCRIPTION
```
uint is defined in sys/types.h in Linux for compatibility.
But it is not defined in Win32 platform. This fixes the following error:

opencv_contrib/modules/sfm/src/libmv_light/libmv/multiview/robust_estimation.h:59:8: error: 'uint' does not name a type; did you mean 'int'?
   59 | static uint IterationsRequired(int min_samples,
      |        ^~~~
      |        int
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
