### PR TITLE
Set window_size to 1 if round down results in 0 for barcodes

### DIFF
--- a/modules/barcode/src/detector/bardetect.cpp
+++ b/modules/barcode/src/detector/bardetect.cpp
@@ -86,6 +86,9 @@ void Detect::localization()
     for (const float scale:SCALE_LIST)
     {
         window_size = cvRound(min_side * scale);
+        if(window_size == 0) {
+            window_size = 1;
+        }
         calCoherence(window_size);
         barcodeErode();
         regionGrowing(window_size);


### PR DESCRIPTION
Without this fix, we will get a floating point error in `calCoherence` method due to divide by zero.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
