### PR TITLE
sfm: Fix redefinition error in 32 bit mingw-w64 environment

### DIFF
--- a/modules/sfm/src/libmv_light/libmv/numeric/numeric.h
+++ b/modules/sfm/src/libmv_light/libmv/numeric/numeric.h
@@ -33,7 +33,7 @@
 #include <Eigen/QR>
 #include <Eigen/SVD>
 
-#if !defined(__MINGW64__)
+#if !defined(__MINGW32__)
 #  if defined(_WIN32) || defined(__APPLE__) || \
       defined(__FreeBSD__) || defined(__NetBSD__)
 static void sincos(double x, double *sinx, double *cosx) {
@@ -41,7 +41,7 @@ static void sincos(double x, double *sinx, double *cosx) {
   *cosx = cos(x);
 }
 #  endif
-#endif  // !__MINGW64__
+#endif  // !__MINGW32__
 
 #if (defined(_WIN32)) && !defined(__MINGW32__)
 inline long lround(double d) {


### PR DESCRIPTION
```
sincos function is defined by mingw-w64 for both 32 bit and 64 bit environments.
Previously, sincos function was hidden for 64 bit mingw-w64 with __MINGW64__ macro.
This change also hides the sincos definition for 32 bit mingw-w64 with __MINGW32__ macro.
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
