### PR TITLE
xphoto fix inpaint fsr

### DIFF
--- a/modules/xphoto/src/inpainting_fsr.impl.hpp
+++ b/modules/xphoto/src/inpainting_fsr.impl.hpp
@@ -748,7 +748,7 @@ icvDetermineProcessingOrder(
 
 
 static
-void inpaint_fsr(const Mat &src, const Mat &mask, Mat &dst, const int algorithmType)
+void inpaint_fsr(Mat src, const Mat &mask, Mat &dst, const int algorithmType)
 {
     CV_Assert(algorithmType == xphoto::INPAINT_FSR_BEST || algorithmType == xphoto::INPAINT_FSR_FAST);
     CV_Check(src.channels(), src.channels() == 1 || src.channels() == 3, "");
@@ -767,7 +767,7 @@ void inpaint_fsr(const Mat &src, const Mat &mask, Mat &dst, const int algorithmT
                 CV_Error(Error::StsUnsupportedFormat, "Unsupported source image format!");
                 break;
             }
-            src.convertTo(src, CV_8U, 1/257.0);
+            src.convertTo(src, CV_8U, 1/256.0);
             break;
         }
         case CV_32FC1:


### PR DESCRIPTION

resolves #2855

use a temporal Mat header for convertTo()

### Pull Request Readiness Checklist
- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch ? ? 
(this goes to the 4.x branch, there is no fsr inpainting in 3.4)
- [x] There is a reference to the original bug report and related work
