### PR TITLE
Fix memory leak in cudacodec

### DIFF
--- a/modules/cudacodec/src/frame_queue.cpp
+++ b/modules/cudacodec/src/frame_queue.cpp
@@ -46,9 +46,31 @@
 #ifdef HAVE_NVCUVID
 
 RawPacket::RawPacket(const unsigned char* _data, const size_t _size, const bool _containsKeyFrame) : size(_size), containsKeyFrame(_containsKeyFrame) {
-    data = cv::makePtr<unsigned char*>(new unsigned char[size]);
-    memcpy(*data, _data, size);
+    data = new unsigned char[size];
+    memcpy(data, _data, size);
 };
+
+RawPacket::~RawPacket() {
+    if (data) delete[] data;
+}
+
+RawPacket::RawPacket(const RawPacket& other) : RawPacket(other.data, other.size, other.containsKeyFrame) {
+}
+
+RawPacket::RawPacket(RawPacket&& other) noexcept : data(std::exchange(other.data, nullptr)), size(std::exchange(other.size, 0)),
+    containsKeyFrame(std::exchange(other.containsKeyFrame, false))  {
+}
+
+RawPacket& RawPacket::operator=(const RawPacket& other) {
+    return *this = RawPacket(other);
+}
+
+RawPacket& RawPacket::operator=(RawPacket&& other) noexcept {
+    std::swap(data, other.data);
+    size = other.size;
+    containsKeyFrame = other.containsKeyFrame;
+    return *this;
+}
 
 cv::cudacodec::detail::FrameQueue::~FrameQueue() {
     if (isFrameInUse_)

--- a/modules/cudacodec/src/frame_queue.cpp
+++ b/modules/cudacodec/src/frame_queue.cpp
@@ -45,32 +45,8 @@
 
 #ifdef HAVE_NVCUVID
 
-RawPacket::RawPacket(const unsigned char* _data, const size_t _size, const bool _containsKeyFrame) : size(_size), containsKeyFrame(_containsKeyFrame) {
-    data = new unsigned char[size];
-    memcpy(data, _data, size);
-};
-
-RawPacket::~RawPacket() {
-    if (data) delete[] data;
-}
-
-RawPacket::RawPacket(const RawPacket& other) : RawPacket(other.data, other.size, other.containsKeyFrame) {
-}
-
-RawPacket::RawPacket(RawPacket&& other) noexcept : data(std::exchange(other.data, nullptr)), size(std::exchange(other.size, 0)),
-    containsKeyFrame(std::exchange(other.containsKeyFrame, false))  {
-}
-
-RawPacket& RawPacket::operator=(const RawPacket& other) {
-    return *this = RawPacket(other);
-}
-
-RawPacket& RawPacket::operator=(RawPacket&& other) noexcept {
-    std::swap(data, other.data);
-    size = other.size;
-    containsKeyFrame = other.containsKeyFrame;
-    return *this;
-}
+RawPacket::RawPacket(const unsigned char* data_, const size_t size, const bool containsKeyFrame_) :
+    data(data_,data_ + size), containsKeyFrame(containsKeyFrame_) {};
 
 cv::cudacodec::detail::FrameQueue::~FrameQueue() {
     if (isFrameInUse_)

--- a/modules/cudacodec/src/frame_queue.hpp
+++ b/modules/cudacodec/src/frame_queue.hpp
@@ -50,11 +50,16 @@
 class RawPacket {
 public:
     RawPacket(const unsigned char* _data, const size_t _size = 0, const bool _containsKeyFrame = false);
-    unsigned char* Data() const { return *data; }
-    size_t size;
-    bool containsKeyFrame;
+    ~RawPacket();
+    RawPacket(const RawPacket& other);
+    RawPacket(RawPacket&& other) noexcept;
+    RawPacket& operator=(const RawPacket& other);
+    RawPacket& operator=(RawPacket&& other) noexcept;
+    unsigned char* Data() const { return data; }
+    size_t size = 0;
+    bool containsKeyFrame = false;
 private:
-    cv::Ptr<unsigned char*> data = 0;
+    unsigned char* data = 0;
 };
 
 namespace cv { namespace cudacodec { namespace detail {

--- a/modules/cudacodec/src/frame_queue.hpp
+++ b/modules/cudacodec/src/frame_queue.hpp
@@ -50,16 +50,12 @@
 class RawPacket {
 public:
     RawPacket(const unsigned char* _data, const size_t _size = 0, const bool _containsKeyFrame = false);
-    ~RawPacket();
-    RawPacket(const RawPacket& other);
-    RawPacket(RawPacket&& other) noexcept;
-    RawPacket& operator=(const RawPacket& other);
-    RawPacket& operator=(RawPacket&& other) noexcept;
-    unsigned char* Data() const { return data; }
-    size_t size = 0;
-    bool containsKeyFrame = false;
+    const unsigned char* Data() const noexcept { return data.data(); }
+    size_t Size() const noexcept  { return data.size(); }
+    bool ContainsKeyFrame() const noexcept  { return containsKeyFrame; }
 private:
-    unsigned char* data = 0;
+    std::vector<unsigned char> data;
+    bool containsKeyFrame = false;
 };
 
 namespace cv { namespace cudacodec { namespace detail {

--- a/modules/cudacodec/src/video_reader.cpp
+++ b/modules/cudacodec/src/video_reader.cpp
@@ -254,7 +254,8 @@ namespace
             if (idx >= rawPacketsBaseIdx && idx < rawPacketsBaseIdx + rawPackets.size()) {
                 if (!frame.isMat())
                     CV_Error(Error::StsUnsupportedFormat, "Raw data is stored on the host and must be retrieved using a cv::Mat");
-                Mat tmp(1, rawPackets.at(idx - rawPacketsBaseIdx).size, CV_8UC1, rawPackets.at(idx - rawPacketsBaseIdx).Data(), rawPackets.at(idx - rawPacketsBaseIdx).size);
+                const size_t i = idx - rawPacketsBaseIdx;
+                Mat tmp(1, rawPackets.at(i).Size(), CV_8UC1, const_cast<unsigned char*>(rawPackets.at(i).Data()), rawPackets.at(i).Size());
                 frame.getMatRef() = tmp;
             }
         }
@@ -299,7 +300,7 @@ namespace
         case VideoReaderProps::PROP_LRF_HAS_KEY_FRAME: {
             const int iPacket = propertyVal - rawPacketsBaseIdx;
             if (videoSource_->RawModeEnabled() && iPacket >= 0 && iPacket < rawPackets.size()) {
-                propertyVal = rawPackets.at(iPacket).containsKeyFrame;
+                propertyVal = rawPackets.at(iPacket).ContainsKeyFrame();
                 return true;
             }
             else


### PR DESCRIPTION
In https://github.com/opencv/opencv_contrib/pull/3098 I carelessly introduced a memory leak, this fix should address that issue.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
