### PR TITLE
Add support for missing codecs to cudacodec

### DIFF
--- a/modules/cudacodec/src/ffmpeg_video_source.cpp
+++ b/modules/cudacodec/src/ffmpeg_video_source.cpp
@@ -72,7 +72,9 @@ Codec FourccToCodec(int codec)
     switch (codec)
     {
     case CV_FOURCC_MACRO('m', 'p', 'e', 'g'): // fallthru
+    case CV_FOURCC_MACRO('m', 'p', 'g', '1'): // fallthru
     case CV_FOURCC_MACRO('M', 'P', 'G', '1'): return MPEG1;
+    case CV_FOURCC_MACRO('m', 'p', 'g', '2'): // fallthru
     case CV_FOURCC_MACRO('M', 'P', 'G', '2'): return MPEG2;
     case CV_FOURCC_MACRO('X', 'V', 'I', 'D'): // fallthru
     case CV_FOURCC_MACRO('m', 'p', '4', 'v'): // fallthru
@@ -85,8 +87,18 @@ Codec FourccToCodec(int codec)
     case CV_FOURCC_MACRO('h', '2', '6', '5'): // fallthru
     case CV_FOURCC_MACRO('h', 'e', 'v', 'c'): return HEVC;
     case CV_FOURCC_MACRO('M', 'J', 'P', 'G'): return JPEG;
-    case CV_FOURCC_MACRO('V', 'P', '8', '0'): return VP8;
-    case CV_FOURCC_MACRO('V', 'P', '9', '0'): return VP9;
+    case CV_FOURCC_MACRO('v', 'p', '8', '0'): // fallthru
+    case CV_FOURCC_MACRO('V', 'P', '8', '0'): // fallthru
+    case CV_FOURCC_MACRO('v', 'p', '0', '8'): // fallthru
+    case CV_FOURCC_MACRO('V', 'P', '0', '8'): return VP8;
+    case CV_FOURCC_MACRO('v', 'p', '9', '0'): // fallthru
+    case CV_FOURCC_MACRO('V', 'P', '9', '0'): // fallthru
+    case CV_FOURCC_MACRO('V', 'P', '0', '9'): // fallthru
+    case CV_FOURCC_MACRO('v', 'p', '0', '9'): return VP9;
+    case CV_FOURCC_MACRO('a', 'v', '1', '0'): // fallthru
+    case CV_FOURCC_MACRO('A', 'V', '1', '0'): // fallthru
+    case CV_FOURCC_MACRO('a', 'v', '0', '1'): // fallthru
+    case CV_FOURCC_MACRO('A', 'V', '0', '1'): return AV1;
     default:
         break;
     }

--- a/modules/cudacodec/test/test_video.cpp
+++ b/modules/cudacodec/test/test_video.cpp
@@ -185,6 +185,11 @@ CUDA_TEST_P(Video, Reader)
     if (GET_PARAM(1) == "cv/video/768x576.avi" && !videoio_registry::hasBackend(CAP_FFMPEG))
         throw SkipTestException("FFmpeg backend not found");
 
+#ifdef _WIN32  // handle old FFmpeg backend
+    if (GET_PARAM(1) == "/cv/tracking/faceocc2/data/faceocc2.webm")
+        throw SkipTestException("Feature not yet supported by Windows FFmpeg shared library!");
+#endif
+
     const std::vector<std::pair< cudacodec::ColorFormat, int>> formatsToChannels = {
         {cudacodec::ColorFormat::GRAY,1},
         {cudacodec::ColorFormat::BGR,3},
@@ -196,7 +201,7 @@ CUDA_TEST_P(Video, Reader)
     cv::Ptr<cv::cudacodec::VideoReader> reader = cv::cudacodec::createVideoReader(inputFile);
     cv::cudacodec::FormatInfo fmt = reader->format();
     cv::cuda::GpuMat frame;
-    for (int i = 0; i < 100; i++)
+    for (int i = 0; i < 10; i++)
     {
         // request a different colour format for each frame
         const std::pair< cudacodec::ColorFormat, int>& formatToChannels = formatsToChannels[i % formatsToChannels.size()];
@@ -426,8 +431,10 @@ INSTANTIATE_TEST_CASE_P(CUDA_Codec, CheckSet, testing::Combine(
     ALL_DEVICES,
     testing::Values("highgui/video/big_buck_bunny.mp4")));
 
-#define VIDEO_SRC_R "highgui/video/big_buck_bunny.mp4", "cv/video/768x576.avi", "cv/video/1920x1080.avi", "highgui/video/big_buck_bunny.avi", \
-    "highgui/video/big_buck_bunny.h264", "highgui/video/big_buck_bunny.h265", "highgui/video/big_buck_bunny.mpg"
+#define VIDEO_SRC_R  "highgui/video/big_buck_bunny.mp4", "cv/video/768x576.avi", "cv/video/1920x1080.avi", "highgui/video/big_buck_bunny.avi", \
+    "highgui/video/big_buck_bunny.h264", "highgui/video/big_buck_bunny.h265", "highgui/video/big_buck_bunny.mpg", \
+    "highgui/video/sample_322x242_15frames.yuv420p.libvpx-vp9.mp4", "highgui/video/sample_322x242_15frames.yuv420p.libaom-av1.mp4", \
+    "cv/tracking/faceocc2/data/faceocc2.webm"
 INSTANTIATE_TEST_CASE_P(CUDA_Codec, Video, testing::Combine(
     ALL_DEVICES,
     testing::Values(VIDEO_SRC_R)));


### PR DESCRIPTION
Currently cudacodec does not support all the codecs supported by nvdec or all possible fourcc codes returned by FFmpeg.  This PR should address this by adding the av1 codec and dealing with all combinations of upper/lower case and 3 character fourcc combinations.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
