### PR TITLE
Update xfeatures2d.hpp

### DIFF
--- a/modules/xfeatures2d/include/opencv2/xfeatures2d.hpp
+++ b/modules/xfeatures2d/include/opencv2/xfeatures2d.hpp
@@ -282,7 +282,7 @@ class CV_EXPORTS_W MSDDetector : public Feature2D {
 
 public:
 
-    static Ptr<MSDDetector> create(int m_patch_radius = 3, int m_search_area_radius = 5,
+   CV_WRAP static Ptr<MSDDetector> create(int m_patch_radius = 3, int m_search_area_radius = 5,
             int m_nms_radius = 5, int m_nms_scale_radius = 0, float m_th_saliency = 250.0f, int m_kNN = 4,
             float m_scale_factor = 1.25f, int m_n_scales = -1, bool m_compute_orientation = false);
 };

--- a/modules/xfeatures2d/misc/python/test/test_descriptors.py
+++ b/modules/xfeatures2d/misc/python/test/test_descriptors.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+# Python 2/3 compatibility
+from __future__ import print_function
+
+import os
+import numpy as np
+import cv2 as cv
+
+from tests_common import NewOpenCVTests
+
+class MSDDetector_test(NewOpenCVTests):
+
+    def test_create(self):
+
+        msd = cv.xfeatures2d.MSDDetector_create()
+        self.assertFalse(msd is None)
+
+        img1 = np.zeros((100, 100, 3), dtype=np.uint8)
+        kp1_, des1_ = msd.detectAndCompute(img1, None)
+
+
+if __name__ == '__main__':
+    NewOpenCVTests.bootstrap()

--- a/modules/xfeatures2d/misc/python/test/test_descriptors.py
+++ b/modules/xfeatures2d/misc/python/test/test_descriptors.py
@@ -17,7 +17,7 @@ class MSDDetector_test(NewOpenCVTests):
         self.assertFalse(msd is None)
 
         img1 = np.zeros((100, 100, 3), dtype=np.uint8)
-        kp1_, des1_ = msd.detectAndCompute(img1, None)
+        kp1_ = msd.detect(img1, None)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
add missing `CV_WRAP` to MSDDetector::create()

resolves: #3356

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
