### PR TITLE
C-API cleanup for OpenCV 5.x (imgproc, highgui)

### DIFF
--- a/modules/cnn_3dobj/include/opencv2/cnn_3dobj.hpp
+++ b/modules/cnn_3dobj/include/opencv2/cnn_3dobj.hpp
@@ -66,7 +66,6 @@ the use of this software, even if advised of the possibility of such damage.
 
 #include "opencv2/viz/vizcore.hpp"
 #include "opencv2/highgui.hpp"
-#include "opencv2/highgui/highgui_c.h"
 #include "opencv2/imgproc.hpp"
 
 /** @defgroup cnn_3dobj 3D object recognition and pose estimation API

--- a/modules/freetype/src/precomp.hpp
+++ b/modules/freetype/src/precomp.hpp
@@ -50,7 +50,6 @@
 
 #include <opencv2/core.hpp>
 #include <opencv2/imgproc.hpp>
-#include <opencv2/imgproc/imgproc_c.h> // for CV_AA
 #include <opencv2/freetype.hpp>
 #include "opencv2/opencv_modules.hpp"
 


### PR DESCRIPTION
There were several places where obsolete API has been used. I could not fully test these changes (_cudalegacy_ and _rgbd_ example), but build process is fine.

This PR must be merged before opencv/opencv#22754 to preserve compatibility. Technically this PR can be backported to 4.x, I think.