### PR TITLE
Fix CUDA texture bugs and replace all instances of CUDA texture references with texture objects

### DIFF
--- a/modules/cudaarithm/src/lut.hpp
+++ b/modules/cudaarithm/src/lut.hpp
@@ -15,14 +15,10 @@ class LookUpTableImpl : public LookUpTable
 {
 public:
     LookUpTableImpl(InputArray lut);
-    ~LookUpTableImpl();
-
     void transform(InputArray src, OutputArray dst, Stream& stream = Stream::Null()) CV_OVERRIDE;
-
 private:
     GpuMat d_lut;
-    cudaTextureObject_t texLutTableObj;
-    bool cc30;
+    size_t szInBytes = 0;
 };
 
 } }

--- a/modules/cudaimgproc/test/test_color.cpp
+++ b/modules/cudaimgproc/test/test_color.cpp
@@ -2294,14 +2294,15 @@ INSTANTIATE_TEST_CASE_P(CUDA_ImgProc, CvtColor, testing::Combine(
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 // Demosaicing
 
-struct Demosaicing : testing::TestWithParam<cv::cuda::DeviceInfo>
+struct Demosaicing : testing::TestWithParam<testing::tuple<cv::cuda::DeviceInfo, bool>>
 {
     cv::cuda::DeviceInfo devInfo;
+    bool useRoi;
 
     virtual void SetUp()
     {
-        devInfo = GetParam();
-
+        devInfo = GET_PARAM(0);
+        useRoi = GET_PARAM(1);
         cv::cuda::setDevice(devInfo.deviceID());
     }
 
@@ -2419,7 +2420,7 @@ CUDA_TEST_P(Demosaicing, BayerBG2BGR_MHT)
     mosaic(img, src, cv::Point(1, 1));
 
     cv::cuda::GpuMat dst;
-    cv::cuda::demosaicing(loadMat(src), dst, cv::cuda::COLOR_BayerBG2BGR_MHT);
+    cv::cuda::demosaicing(loadMat(src, useRoi), dst, cv::cuda::COLOR_BayerBG2BGR_MHT);
 
     EXPECT_MAT_SIMILAR(img, dst, 5e-3);
 }
@@ -2433,7 +2434,7 @@ CUDA_TEST_P(Demosaicing, BayerGB2BGR_MHT)
     mosaic(img, src, cv::Point(0, 1));
 
     cv::cuda::GpuMat dst;
-    cv::cuda::demosaicing(loadMat(src), dst, cv::cuda::COLOR_BayerGB2BGR_MHT);
+    cv::cuda::demosaicing(loadMat(src, useRoi), dst, cv::cuda::COLOR_BayerGB2BGR_MHT);
 
     EXPECT_MAT_SIMILAR(img, dst, 5e-3);
 }
@@ -2447,7 +2448,7 @@ CUDA_TEST_P(Demosaicing, BayerRG2BGR_MHT)
     mosaic(img, src, cv::Point(0, 0));
 
     cv::cuda::GpuMat dst;
-    cv::cuda::demosaicing(loadMat(src), dst, cv::cuda::COLOR_BayerRG2BGR_MHT);
+    cv::cuda::demosaicing(loadMat(src, useRoi), dst, cv::cuda::COLOR_BayerRG2BGR_MHT);
 
     EXPECT_MAT_SIMILAR(img, dst, 5e-3);
 }
@@ -2461,12 +2462,11 @@ CUDA_TEST_P(Demosaicing, BayerGR2BGR_MHT)
     mosaic(img, src, cv::Point(1, 0));
 
     cv::cuda::GpuMat dst;
-    cv::cuda::demosaicing(loadMat(src), dst, cv::cuda::COLOR_BayerGR2BGR_MHT);
-
+    cv::cuda::demosaicing(loadMat(src, useRoi), dst, cv::cuda::COLOR_BayerGR2BGR_MHT);
     EXPECT_MAT_SIMILAR(img, dst, 5e-3);
 }
 
-INSTANTIATE_TEST_CASE_P(CUDA_ImgProc, Demosaicing, ALL_DEVICES);
+INSTANTIATE_TEST_CASE_P(CUDA_ImgProc, Demosaicing, testing::Combine(ALL_DEVICES, WHOLE_SUBMAT));
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 // swapChannels

--- a/modules/cudaimgproc/test/test_hough.cpp
+++ b/modules/cudaimgproc/test/test_hough.cpp
@@ -115,8 +115,20 @@ INSTANTIATE_TEST_CASE_P(CUDA_ImgProc, HoughLines, testing::Combine(
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 // HoughLines Probabilistic
-PARAM_TEST_CASE(HoughLinesProbabilistic, cv::cuda::DeviceInfo, cv::Size, UseRoi)
+PARAM_TEST_CASE(HoughLinesProbabilistic, DeviceInfo, Size, UseRoi)
 {
+    cv::cuda::DeviceInfo devInfo;
+    bool useRoi;
+    Size size;
+
+    virtual void SetUp()
+    {
+        devInfo = GET_PARAM(0);
+        size = GET_PARAM(1);
+        useRoi = GET_PARAM(2);
+        cv::cuda::setDevice(devInfo.deviceID());
+    }
+
     static void generateLines(cv::Mat& img)
     {
         img.setTo(cv::Scalar::all(0));
@@ -140,11 +152,6 @@ PARAM_TEST_CASE(HoughLinesProbabilistic, cv::cuda::DeviceInfo, cv::Size, UseRoi)
 
 CUDA_TEST_P(HoughLinesProbabilistic, Accuracy)
 {
-    const cv::cuda::DeviceInfo devInfo = GET_PARAM(0);
-    cv::cuda::setDevice(devInfo.deviceID());
-    const cv::Size size = GET_PARAM(1);
-    const bool useRoi = GET_PARAM(2);
-
     const float rho = 1.0f;
     const float theta = (float) (1.0 * CV_PI / 180.0);
     const int minLineLength = 15;
@@ -169,11 +176,54 @@ CUDA_TEST_P(HoughLinesProbabilistic, Accuracy)
 
 }
 
+void HoughLinesProbabilisticThread(const Ptr<HoughSegmentDetector> detector, const GpuMat& imgIn, const std::vector<GpuMat>& linesOut, Stream& stream) {
+    for (auto& lines : linesOut)
+        detector->detect(imgIn, lines, stream);
+    stream.waitForCompletion();
+}
+
+CUDA_TEST_P(HoughLinesProbabilistic, Async)
+{
+    constexpr int nThreads = 5;
+    constexpr int nIters = 5;
+    vector<Stream> streams(nThreads); // async test only
+    vector<GpuMat> imgsIn;
+    vector<Ptr<HoughSegmentDetector>> detectors;
+    vector<vector<GpuMat>> linesOut(nThreads);
+    const float rho = 1.0f;
+    const float theta = (float)(1.0 * CV_PI / 180.0);
+    const int minLineLength = 15;
+    const int maxLineGap = 8;
+
+    cv::Mat src(size, CV_8UC1);
+    generateLines(src);
+
+    for (int i = 0; i < nThreads; i++) {
+        imgsIn.push_back(loadMat(src, useRoi));
+        detectors.push_back(createHoughSegmentDetector(rho, theta, minLineLength, maxLineGap));
+        linesOut.push_back(vector<GpuMat>(nIters));
+    }
+
+    vector<std::thread> thread(nThreads);
+    for (int i = 0; i < nThreads; i++) thread.at(i) = std::thread(HoughLinesProbabilisticThread, detectors.at(i), std::ref(imgsIn.at(i)), std::ref(linesOut.at(i)), std::ref(streams.at(i)));
+    for (int i = 0; i < nThreads; i++) thread.at(i).join();
+
+    for (int i = 0; i < nThreads; i++) {
+        std::vector<cv::Vec4i> linesSegment;
+        std::vector<cv::Vec2f> lines;
+        for (const auto& line : linesOut.at(i)) {
+            line.download(linesSegment);
+            cv::Mat dst(size, CV_8UC1);
+            drawLines(dst, linesSegment);
+            ASSERT_MAT_NEAR(src, dst, 0.0);
+        }
+    }
+}
+
 INSTANTIATE_TEST_CASE_P(CUDA_ImgProc, HoughLinesProbabilistic, testing::Combine(
     ALL_DEVICES,
     DIFFERENT_SIZES,
     WHOLE_SUBMAT));
-
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 // HoughCircles

--- a/modules/cudaimgproc/test/test_precomp.hpp
+++ b/modules/cudaimgproc/test/test_precomp.hpp
@@ -49,4 +49,6 @@
 
 #include "cvconfig.h"
 
+#include <thread>
+
 #endif

--- a/modules/cudalegacy/include/opencv2/cudalegacy/NCV.hpp
+++ b/modules/cudalegacy/include/opencv2/cudalegacy/NCV.hpp
@@ -119,9 +119,9 @@ typedef               bool NcvBool;
 typedef          long long Ncv64s;
 
 #if defined(__APPLE__) && !defined(__CUDACC__)
-    typedef uint64_t Ncv64u;
+    typedef uint64 Ncv64u;
 #else
-    typedef unsigned long long Ncv64u;
+    typedef uint64 Ncv64u;
 #endif
 
 typedef                int Ncv32s;

--- a/modules/cudalegacy/include/opencv2/cudalegacy/NPP_staging.hpp
+++ b/modules/cudalegacy/include/opencv2/cudalegacy/NPP_staging.hpp
@@ -174,7 +174,7 @@ NCVStatus nppiStInterpolateFrames(const NppStInterpolationState *pState);
  * \return NCV status code
  */
 CV_EXPORTS
-NCVStatus nppiStFilterRowBorder_32f_C1R(const Ncv32f *pSrc,
+NCVStatus nppiStFilterRowBorder_32f_C1R(Ncv32f *pSrc,
                                         NcvSize32u srcSize,
                                         Ncv32u nSrcStep,
                                         Ncv32f *pDst,
@@ -182,7 +182,7 @@ NCVStatus nppiStFilterRowBorder_32f_C1R(const Ncv32f *pSrc,
                                         Ncv32u nDstStep,
                                         NcvRect32u oROI,
                                         NppStBorderType borderType,
-                                        const Ncv32f *pKernel,
+                                        Ncv32f *pKernel,
                                         Ncv32s nKernelSize,
                                         Ncv32s nAnchor,
                                         Ncv32f multiplier);
@@ -208,7 +208,7 @@ NCVStatus nppiStFilterRowBorder_32f_C1R(const Ncv32f *pSrc,
  * \return NCV status code
  */
 CV_EXPORTS
-NCVStatus nppiStFilterColumnBorder_32f_C1R(const Ncv32f *pSrc,
+NCVStatus nppiStFilterColumnBorder_32f_C1R(Ncv32f *pSrc,
                                            NcvSize32u srcSize,
                                            Ncv32u nSrcStep,
                                            Ncv32f *pDst,
@@ -216,7 +216,7 @@ NCVStatus nppiStFilterColumnBorder_32f_C1R(const Ncv32f *pSrc,
                                            Ncv32u nDstStep,
                                            NcvRect32u oROI,
                                            NppStBorderType borderType,
-                                           const Ncv32f *pKernel,
+                                           Ncv32f *pKernel,
                                            Ncv32s nKernelSize,
                                            Ncv32s nAnchor,
                                            Ncv32f multiplier);
@@ -319,7 +319,7 @@ NCVStatus nppiStVectorWarp_PSF2x2_32f_C1(const Ncv32f *pSrc,
  * \return NCV status code
  */
 CV_EXPORTS
-NCVStatus nppiStResize_32f_C1R(const Ncv32f *pSrc,
+NCVStatus nppiStResize_32f_C1R(Ncv32f *pSrc,
                                NcvSize32u srcSize,
                                Ncv32u nSrcStep,
                                NcvRect32u srcROI,

--- a/modules/cudalegacy/src/cuda/bm.cu
+++ b/modules/cudalegacy/src/cuda/bm.cu
@@ -46,29 +46,27 @@
 #include "opencv2/core/cuda/limits.hpp"
 #include "opencv2/core/cuda/functional.hpp"
 #include "opencv2/core/cuda/reduce.hpp"
+#include <opencv2/cudev/ptr2d/texture.hpp>
 
 using namespace cv::cuda;
 using namespace cv::cuda::device;
 
 namespace optflowbm
 {
-    texture<uchar, cudaTextureType2D, cudaReadModeElementType> tex_prev(false, cudaFilterModePoint, cudaAddressModeClamp);
-    texture<uchar, cudaTextureType2D, cudaReadModeElementType> tex_curr(false, cudaFilterModePoint, cudaAddressModeClamp);
-
-    __device__ int cmpBlocks(int X1, int Y1, int X2, int Y2, int2 blockSize)
+    __device__ int cmpBlocks(cv::cudev::TexturePtr<uchar> texCurr, cv::cudev::TexturePtr<uchar> texPrev, int X1, int Y1, int X2, int Y2, int2 blockSize)
     {
         int s = 0;
 
         for (int y = 0; y < blockSize.y; ++y)
         {
             for (int x = 0; x < blockSize.x; ++x)
-                s += ::abs(tex2D(tex_prev, X1 + x, Y1 + y) - tex2D(tex_curr, X2 + x, Y2 + y));
+                s += ::abs(texPrev(Y1 + y, X1 + x) -texCurr(Y2 + y, X2 + x));
         }
 
         return s;
     }
 
-    __global__ void calcOptFlowBM(PtrStepSzf velx, PtrStepf vely, const int2 blockSize, const int2 shiftSize, const bool usePrevious,
+    __global__ void calcOptFlowBM(cv::cudev::TexturePtr<uchar> texPrev, cv::cudev::TexturePtr<uchar> texCurr, PtrStepSzf velx, PtrStepf vely, const int2 blockSize, const int2 shiftSize, const bool usePrevious,
                                   const int maxX, const int maxY, const int acceptLevel, const int escapeLevel,
                                   const short2* ss, const int ssCount)
     {
@@ -90,7 +88,7 @@ namespace optflowbm
         int dist = numeric_limits<int>::max();
 
         if (0 <= X2 && X2 <= maxX && 0 <= Y2 && Y2 <= maxY)
-            dist = cmpBlocks(X1, Y1, X2, Y2, blockSize);
+            dist = cmpBlocks(texPrev, texCurr, X1, Y1, X2, Y2, blockSize);
 
         int countMin = 1;
         int sumx = offX;
@@ -111,7 +109,7 @@ namespace optflowbm
 
                 if (0 <= X2 && X2 <= maxX && 0 <= Y2 && Y2 <= maxY)
                 {
-                    const int tmpDist = cmpBlocks(X1, Y1, X2, Y2, blockSize);
+                    const int tmpDist = cmpBlocks(texPrev, texCurr, X1, Y1, X2, Y2, blockSize);
                     if (tmpDist < acceptLevel)
                     {
                         sumx = dx;
@@ -151,16 +149,12 @@ namespace optflowbm
     void calc(PtrStepSzb prev, PtrStepSzb curr, PtrStepSzf velx, PtrStepSzf vely, int2 blockSize, int2 shiftSize, bool usePrevious,
               int maxX, int maxY, int acceptLevel, int escapeLevel, const short2* ss, int ssCount, cudaStream_t stream)
     {
-        bindTexture(&tex_prev, prev);
-        bindTexture(&tex_curr, curr);
-
+        cv::cudev::Texture<uchar> texPrev(prev);
+        cv::cudev::Texture<uchar> texCurr(curr);
         const dim3 block(32, 8);
         const dim3 grid(divUp(velx.cols, block.x), divUp(vely.rows, block.y));
-
-        calcOptFlowBM<<<grid, block, 0, stream>>>(velx, vely, blockSize, shiftSize, usePrevious,
-                                                  maxX, maxY, acceptLevel,  escapeLevel, ss, ssCount);
+        calcOptFlowBM<<<grid, block, 0, stream>>>(texPrev, texCurr, velx, vely, blockSize, shiftSize, usePrevious, maxX, maxY, acceptLevel,  escapeLevel, ss, ssCount);
         cudaSafeCall( cudaGetLastError() );
-
         if (stream == 0)
             cudaSafeCall( cudaDeviceSynchronize() );
     }

--- a/modules/cudalegacy/test/TestHypothesesGrow.cpp
+++ b/modules/cudalegacy/test/TestHypothesesGrow.cpp
@@ -100,7 +100,8 @@ bool TestHypothesesGrow::process()
 
     NCV_SKIP_COND_BEGIN
     ncvAssertReturn(this->src.fill(h_vecSrc), false);
-    memset(h_vecDst.ptr(), 0, h_vecDst.length() * sizeof(NcvRect32u));
+
+    *h_vecDst.ptr() = {};
     NCVVectorReuse<Ncv32u> h_vecDst_as32u(h_vecDst.getSegment(), lenDst * sizeof(NcvRect32u) / sizeof(Ncv32u));
     ncvAssertReturn(h_vecDst_as32u.isMemReused(), false);
     ncvAssertReturn(this->src.fill(h_vecDst_as32u), false);

--- a/modules/cudaobjdetect/test/test_objdetect.cpp
+++ b/modules/cudaobjdetect/test/test_objdetect.cpp
@@ -222,7 +222,7 @@ INSTANTIATE_TEST_CASE_P(CUDA_ObjDetect, HOG, ALL_DEVICES);
 */
 //============== caltech hog tests =====================//
 
-struct CalTech : public ::testing::TestWithParam<tuple<cv::cuda::DeviceInfo, std::string> >
+struct CalTech : public ::testing::TestWithParam<tuple<cv::cuda::DeviceInfo, std::string, bool>>
 {
     cv::cuda::DeviceInfo devInfo;
     cv::Mat img;
@@ -232,7 +232,13 @@ struct CalTech : public ::testing::TestWithParam<tuple<cv::cuda::DeviceInfo, std
         devInfo = GET_PARAM(0);
         cv::cuda::setDevice(devInfo.deviceID());
 
-        img = readImage(GET_PARAM(1), cv::IMREAD_GRAYSCALE);
+        const bool grayScale = GET_PARAM(2);
+        if(grayScale)
+            img = readImage(GET_PARAM(1), IMREAD_GRAYSCALE);
+        else {
+            Mat imgBgr = readImage(GET_PARAM(1));
+            cv::cvtColor(imgBgr, img, COLOR_BGR2BGRA);
+        }
         ASSERT_FALSE(img.empty());
     }
 };
@@ -263,10 +269,11 @@ CUDA_TEST_P(CalTech, HOG)
 #endif
 }
 
+#define GREYSCALE true, false
 INSTANTIATE_TEST_CASE_P(detect, CalTech, testing::Combine(ALL_DEVICES,
     ::testing::Values<std::string>("caltech/image_00000009_0.png", "caltech/image_00000032_0.png",
         "caltech/image_00000165_0.png", "caltech/image_00000261_0.png", "caltech/image_00000469_0.png",
-        "caltech/image_00000527_0.png", "caltech/image_00000574_0.png")));
+        "caltech/image_00000527_0.png", "caltech/image_00000574_0.png"), testing::Values(GREYSCALE)));
 
 
 //------------------------variable GPU HOG Tests------------------------//

--- a/modules/cudaoptflow/src/cuda/pyrlk.cu
+++ b/modules/cudaoptflow/src/cuda/pyrlk.cu
@@ -50,8 +50,7 @@
 #include "opencv2/core/cuda/reduce.hpp"
 #include "opencv2/core/cuda/filters.hpp"
 #include "opencv2/core/cuda/border_interpolate.hpp"
-
-#include <iostream>
+#include  <opencv2/cudev/ptr2d/texture.hpp>
 
 using namespace cv::cuda;
 using namespace cv::cuda::device;
@@ -63,224 +62,6 @@ namespace pyrlk
     __constant__ int c_halfWin_x;
     __constant__ int c_halfWin_y;
     __constant__ int c_iters;
-
-    texture<uchar, cudaTextureType2D, cudaReadModeNormalizedFloat> tex_I8U(false, cudaFilterModeLinear, cudaAddressModeClamp);
-    texture<uchar4, cudaTextureType2D, cudaReadModeNormalizedFloat> tex_I8UC4(false, cudaFilterModeLinear, cudaAddressModeClamp);
-
-    texture<ushort4, cudaTextureType2D, cudaReadModeNormalizedFloat> tex_I16UC4(false, cudaFilterModeLinear, cudaAddressModeClamp);
-
-
-    texture<float, cudaTextureType2D, cudaReadModeElementType> tex_If(false, cudaFilterModeLinear, cudaAddressModeClamp);
-    texture<float4, cudaTextureType2D, cudaReadModeElementType> tex_If4(false, cudaFilterModeLinear, cudaAddressModeClamp);
-
-    texture<uchar, cudaTextureType2D, cudaReadModeElementType> tex_Ib(false, cudaFilterModePoint, cudaAddressModeClamp);
-
-    texture<uchar, cudaTextureType2D, cudaReadModeNormalizedFloat> tex_J8U(false, cudaFilterModeLinear, cudaAddressModeClamp);
-    texture<uchar4, cudaTextureType2D, cudaReadModeNormalizedFloat> tex_J8UC4(false, cudaFilterModeLinear, cudaAddressModeClamp);
-
-    texture<ushort4, cudaTextureType2D, cudaReadModeNormalizedFloat> tex_J16UC4(false, cudaFilterModeLinear, cudaAddressModeClamp);
-
-
-    texture<float, cudaTextureType2D, cudaReadModeElementType> tex_Jf(false, cudaFilterModeLinear, cudaAddressModeClamp);
-    texture<float4, cudaTextureType2D, cudaReadModeElementType> tex_Jf4(false, cudaFilterModeLinear, cudaAddressModeClamp);
-
-
-    template <int cn, typename T> struct Tex_I
-    {
-        static __host__ __forceinline__ void bindTexture_(PtrStepSz<typename TypeVec<T, cn>::vec_type> I)
-        {
-            CV_UNUSED(I);
-        }
-    };
-
-    template <> struct Tex_I<1, uchar>
-    {
-        static __device__ __forceinline__ float read(float x, float y)
-        {
-            return tex2D(tex_I8U, x, y);
-        }
-        static __host__ __forceinline__ void bindTexture_(PtrStepSz<uchar>& I)
-        {
-            bindTexture(&tex_I8U, I);
-        }
-    };
-    template <> struct Tex_I<1, ushort>
-    {
-        static __device__ __forceinline__ float read(float x, float y)
-        {
-            return 0.0;
-        }
-        static __host__ __forceinline__ void bindTexture_(PtrStepSz<ushort>& I)
-        {
-            CV_UNUSED(I);
-        }
-    };
-    template <> struct Tex_I<1, int>
-    {
-        static __device__ __forceinline__ float read(float x, float y)
-        {
-            return 0.0;
-        }
-        static __host__ __forceinline__ void bindTexture_(PtrStepSz<int>& I)
-        {
-            CV_UNUSED(I);
-        }
-    };
-    template <> struct Tex_I<1, float>
-    {
-        static __device__ __forceinline__ float read(float x, float y)
-        {
-            return tex2D(tex_If, x, y);
-        }
-        static __host__ __forceinline__ void bindTexture_(PtrStepSz<float>& I)
-        {
-            bindTexture(&tex_If, I);
-        }
-    };
-    // ****************** 3 channel specializations ************************
-    template <> struct Tex_I<3, uchar>
-    {
-        static __device__ __forceinline__ float3 read(float x, float y)
-        {
-            return make_float3(0,0,0);
-        }
-        static __host__ __forceinline__ void bindTexture_(PtrStepSz<uchar3> I)
-        {
-            CV_UNUSED(I);
-        }
-    };
-    template <> struct Tex_I<3, ushort>
-    {
-        static __device__ __forceinline__ float3 read(float x, float y)
-        {
-            return make_float3(0, 0, 0);
-        }
-        static __host__ __forceinline__ void bindTexture_(PtrStepSz<ushort3> I)
-        {
-            CV_UNUSED(I);
-        }
-    };
-    template <> struct Tex_I<3, int>
-    {
-        static __device__ __forceinline__ float3 read(float x, float y)
-        {
-            return make_float3(0, 0, 0);
-        }
-        static __host__ __forceinline__ void bindTexture_(PtrStepSz<int3> I)
-        {
-            CV_UNUSED(I);
-        }
-    };
-    template <> struct Tex_I<3, float>
-    {
-        static __device__ __forceinline__ float3 read(float x, float y)
-        {
-            return make_float3(0, 0, 0);
-        }
-        static __host__ __forceinline__ void bindTexture_(PtrStepSz<float3> I)
-        {
-            CV_UNUSED(I);
-        }
-    };
-    // ****************** 4 channel specializations ************************
-
-    template <> struct Tex_I<4, uchar>
-    {
-        static __device__ __forceinline__ float4 read(float x, float y)
-        {
-            return tex2D(tex_I8UC4, x, y);
-        }
-        static __host__ __forceinline__ void bindTexture_(PtrStepSz<uchar4>& I)
-        {
-            bindTexture(&tex_I8UC4, I);
-        }
-    };
-    template <> struct Tex_I<4, ushort>
-    {
-        static __device__ __forceinline__ float4 read(float x, float y)
-        {
-            return tex2D(tex_I16UC4, x, y);
-        }
-        static __host__ __forceinline__ void bindTexture_(PtrStepSz<ushort4>& I)
-        {
-            bindTexture(&tex_I16UC4, I);
-        }
-    };
-    template <> struct Tex_I<4, float>
-    {
-        static __device__ __forceinline__ float4 read(float x, float y)
-        {
-            return tex2D(tex_If4, x, y);
-        }
-        static __host__ __forceinline__ void bindTexture_(PtrStepSz<float4>& I)
-        {
-            bindTexture(&tex_If4, I);
-        }
-    };
-    // ************* J  ***************
-    template <int cn, typename T> struct Tex_J
-    {
-        static __host__ __forceinline__ void bindTexture_(PtrStepSz<typename TypeVec<T,cn>::vec_type>& J)
-        {
-            CV_UNUSED(J);
-        }
-    };
-    template <> struct Tex_J<1, uchar>
-    {
-        static __device__ __forceinline__ float read(float x, float y)
-        {
-            return tex2D(tex_J8U, x, y);
-        }
-        static __host__ __forceinline__ void bindTexture_(PtrStepSz<uchar>& J)
-        {
-            bindTexture(&tex_J8U, J);
-        }
-    };
-    template <> struct Tex_J<1, float>
-    {
-        static __device__ __forceinline__ float read(float x, float y)
-        {
-            return tex2D(tex_Jf, x, y);
-        }
-        static __host__ __forceinline__ void bindTexture_(PtrStepSz<float>& J)
-        {
-            bindTexture(&tex_Jf, J);
-        }
-    };
-    // ************* 4 channel specializations ***************
-    template <> struct Tex_J<4, uchar>
-    {
-        static __device__ __forceinline__ float4 read(float x, float y)
-        {
-            return tex2D(tex_J8UC4, x, y);
-        }
-        static __host__ __forceinline__ void bindTexture_(PtrStepSz<uchar4>& J)
-        {
-            bindTexture(&tex_J8UC4, J);
-        }
-    };
-    template <> struct Tex_J<4, ushort>
-    {
-        static __device__ __forceinline__ float4 read(float x, float y)
-        {
-            return tex2D(tex_J16UC4, x, y);
-        }
-        static __host__ __forceinline__ void bindTexture_(PtrStepSz<ushort4>& J)
-        {
-            bindTexture(&tex_J16UC4, J);
-        }
-    };
-    template <> struct Tex_J<4, float>
-    {
-        static __device__ __forceinline__ float4 read(float x, float y)
-        {
-            return tex2D(tex_Jf4, x, y);
-        }
-        static __host__ __forceinline__ void bindTexture_(PtrStepSz<float4>& J)
-        {
-            bindTexture(&tex_Jf4, J);
-        }
-    };
 
     __device__ __forceinline__ void accum(float& dst, const float& val)
     {
@@ -364,8 +145,8 @@ namespace pyrlk
         }
     };
 
-    template <int cn, int PATCH_X, int PATCH_Y, bool calcErr, typename T>
-    __global__ void sparseKernel(const float2* prevPts, float2* nextPts, uchar* status, float* err, const int level, const int rows, const int cols)
+    template <int cn, int PATCH_X, int PATCH_Y, bool calcErr, typename T, class Ptr2D>
+    __global__ void sparseKernel(const Ptr2D texI, const Ptr2D texJ, const float2* prevPts, float2* nextPts, uchar* status, float* err, const int level, const int rows, const int cols)
     {
     #if __CUDA_ARCH__ <= 110
         const int BLOCK_SIZE = 128;
@@ -413,15 +194,14 @@ namespace pyrlk
                 float x = prevPt.x + xBase + 0.5f;
                 float y = prevPt.y + yBase + 0.5f;
 
-                I_patch[i][j] = Tex_I<cn, T>::read(x, y);
+                I_patch[i][j] = texI(y, x);
 
                 // Scharr Deriv
+                work_type dIdx = 3.0f * texI(y - 1, x + 1) + 10.0f * texI(y, x + 1) + 3.0f * texI(y + 1, x + 1) -
+                    (3.0f * texI(y - 1, x - 1) + 10.0f * texI(y, x - 1) + 3.0f * texI(y + 1, x - 1));
 
-                work_type dIdx = 3.0f * Tex_I<cn,T>::read(x+1, y-1) + 10.0f * Tex_I<cn, T>::read(x+1, y) + 3.0f * Tex_I<cn,T>::read(x+1, y+1) -
-                                 (3.0f * Tex_I<cn,T>::read(x-1, y-1) + 10.0f * Tex_I<cn, T>::read(x-1, y) + 3.0f * Tex_I<cn,T>::read(x-1, y+1));
-
-                work_type dIdy = 3.0f * Tex_I<cn,T>::read(x-1, y+1) + 10.0f * Tex_I<cn, T>::read(x, y+1) + 3.0f * Tex_I<cn,T>::read(x+1, y+1) -
-                                (3.0f * Tex_I<cn,T>::read(x-1, y-1) + 10.0f * Tex_I<cn, T>::read(x, y-1) + 3.0f * Tex_I<cn,T>::read(x+1, y-1));
+                work_type dIdy = 3.0f * texI(y + 1, x - 1) + 10.0f * texI(y + 1, x) + 3.0f * texI(y + 1, x + 1) -
+                    (3.0f * texI(y - 1, x - 1) + 10.0f * texI(y - 1, x) + 3.0f * texI(y - 1, x + 1));
 
                 dIdx_patch[i][j] = dIdx;
                 dIdy_patch[i][j] = dIdy;
@@ -490,7 +270,8 @@ namespace pyrlk
                 for (int x = threadIdx.x, j = 0; x < c_winSize_x; x += blockDim.x, ++j)
                 {
                     work_type I_val = I_patch[i][j];
-                    work_type J_val = Tex_J<cn, T>::read(nextPt.x + x + 0.5f, nextPt.y + y + 0.5f);
+
+                    work_type J_val = texJ(nextPt.y + y + 0.5f, nextPt.x + x + 0.5f);
 
                     work_type diff = (J_val - I_val) * 32.0f;
 
@@ -533,7 +314,8 @@ namespace pyrlk
                 for (int x = threadIdx.x, j = 0; x < c_winSize_x; x += blockDim.x, ++j)
                 {
                     work_type I_val = I_patch[i][j];
-                    work_type J_val = Tex_J<cn, T>::read(nextPt.x + x + 0.5f, nextPt.y + y + 0.5f);
+
+                    work_type J_val = texJ(nextPt.y + y + 0.5f, nextPt.x + x + 0.5f);
 
                     work_type diff = J_val - I_val;
 
@@ -749,6 +531,27 @@ namespace pyrlk
         }
     } // __global__ void sparseKernel_
 
+    // Specialization for non float data, cudaFilterModeLinear only compatible with cudaReadModeNormalizedFloat.
+    template<int cn, class T> class TextureLinear : public cv::cudev::Texture<typename TypeVec<T, cn>::vec_type, typename TypeVec<float, cn>::vec_type> {
+    public:
+        typedef typename TypeVec<T, cn>::vec_type elem_type;
+        typedef typename TypeVec<float, cn>::vec_type ret_type;
+        __host__ TextureLinear(PtrStepSz<elem_type> src, const bool normalizedCoords = false, const cudaTextureAddressMode addressMode = cudaAddressModeClamp) :
+            cv::cudev::Texture<elem_type, ret_type>(src, normalizedCoords, cudaFilterModeLinear, addressMode, cudaReadModeNormalizedFloat)
+        {
+        }
+    };
+
+    // Specialization for float data, cudaReadModeNormalizedFloat only compatible with cudaReadModeElementType.
+    template<int cn> class TextureLinear<cn, float> : public cv::cudev::Texture<typename TypeVec<float, cn>::vec_type, typename TypeVec<float, cn>::vec_type>
+    {
+    public:
+        typedef typename TypeVec<float, cn>::vec_type float_type;
+        __host__ TextureLinear(PtrStepSz<float_type> src, const bool normalizedCoords = false, const cudaTextureAddressMode addressMode = cudaAddressModeClamp) :
+            cv::cudev::Texture <float_type, float_type>(src, normalizedCoords, cudaFilterModeLinear, addressMode, cudaReadModeElementType)
+        {
+        }
+    };
 
     template <int cn, int PATCH_X, int PATCH_Y, typename T> class sparse_caller
     {
@@ -756,16 +559,16 @@ namespace pyrlk
         static void call(PtrStepSz<typename TypeVec<T, cn>::vec_type> I, PtrStepSz<typename TypeVec<T, cn>::vec_type> J, int rows, int cols, const float2* prevPts, float2* nextPts, uchar* status, float* err, int ptcount,
             int level, dim3 block, cudaStream_t stream)
         {
+            typedef typename TypeVec<T, cn>::vec_type dType;
+            typedef typename TypeVec<float, cn>::vec_type rType;
+            TextureLinear<cn,T> texI(I);
+            TextureLinear<cn,T> texJ(J);
             dim3 grid(ptcount);
-            CV_UNUSED(I);
-            CV_UNUSED(J);
             if (level == 0 && err)
-                sparseKernel<cn, PATCH_X, PATCH_Y, true, T> <<<grid, block, 0, stream >>>(prevPts, nextPts, status, err, level, rows, cols);
+                sparseKernel<cn, PATCH_X, PATCH_Y, true, T, cv::cudev::TexturePtr<dType,rType>><<<grid, block, 0, stream>>>(texI, texJ, prevPts, nextPts, status, err, level, rows, cols);
             else
-                sparseKernel<cn, PATCH_X, PATCH_Y, false, T> <<<grid, block, 0, stream >>>(prevPts, nextPts, status, err, level, rows, cols);
-
+                sparseKernel<cn, PATCH_X, PATCH_Y, false, T, cv::cudev::TexturePtr<dType, rType>><<<grid, block, 0, stream>>>(texI, texJ, prevPts, nextPts, status, err, level, rows, cols);
             cudaSafeCall(cudaGetLastError());
-
             if (stream == 0)
                 cudaSafeCall(cudaDeviceSynchronize());
         }
@@ -903,8 +706,8 @@ namespace pyrlk
     };
 
 
-    template <bool calcErr>
-    __global__ void denseKernel(PtrStepf u, PtrStepf v, const PtrStepf prevU, const PtrStepf prevV, PtrStepf err, const int rows, const int cols)
+    template <bool calcErr, class Ptr2D>
+    __global__ void denseKernel(const Ptr2D texI, const Ptr2D texJ, PtrStepf u, PtrStepf v, const PtrStepf prevU, const PtrStepf prevV, PtrStepf err, const int rows, const int cols)
     {
         extern __shared__ int smem[];
 
@@ -925,15 +728,15 @@ namespace pyrlk
                 float x = xBase - c_halfWin_x + j + 0.5f;
                 float y = yBase - c_halfWin_y + i + 0.5f;
 
-                I_patch[i * patchWidth + j] = tex2D(tex_If, x, y);
+                I_patch[i * patchWidth + j] = texI(y, x);
 
                 // Scharr Deriv
 
-                dIdx_patch[i * patchWidth + j] = 3 * tex2D(tex_If, x+1, y-1) + 10 * tex2D(tex_If, x+1, y) + 3 * tex2D(tex_If, x+1, y+1) -
-                                                (3 * tex2D(tex_If, x-1, y-1) + 10 * tex2D(tex_If, x-1, y) + 3 * tex2D(tex_If, x-1, y+1));
+                dIdx_patch[i * patchWidth + j] = 3 * texI(y - 1, x + 1) + 10 * texI(y, x + 1) + 3 * texI(y + 1, x + 1) -
+                    (3 * texI(y - 1, x - 1) + 10 * texI(y, x - 1) + 3 * texI(y + 1, x - 1));
 
-                dIdy_patch[i * patchWidth + j] = 3 * tex2D(tex_If, x-1, y+1) + 10 * tex2D(tex_If, x, y+1) + 3 * tex2D(tex_If, x+1, y+1) -
-                                                (3 * tex2D(tex_If, x-1, y-1) + 10 * tex2D(tex_If, x, y-1) + 3 * tex2D(tex_If, x+1, y-1));
+                dIdy_patch[i * patchWidth + j] = 3 * texI(y + 1, x - 1) + 10 * texI(y + 1,x) + 3 * texI(y+ 1, x + 1) -
+                    (3 * texI(y - 1, x - 1) + 10 * texI(y - 1,x) + 3 * texI(y - 1, x + 1));
             }
         }
 
@@ -1004,7 +807,7 @@ namespace pyrlk
                 for (int j = 0; j < c_winSize_x; ++j)
                 {
                     int I = I_patch[(threadIdx.y + i) * patchWidth + threadIdx.x + j];
-                    int J = tex2D(tex_Jf, nextPt.x - c_halfWin_x + j + 0.5f, nextPt.y - c_halfWin_y + i + 0.5f);
+                    int J = texJ(nextPt.y - c_halfWin_y + i + 0.5f, nextPt.x - c_halfWin_x + j + 0.5f);
 
                     int diff = (J - I) * 32;
 
@@ -1040,7 +843,8 @@ namespace pyrlk
                 for (int j = 0; j < c_winSize_x; ++j)
                 {
                     int I = I_patch[(threadIdx.y + i) * patchWidth + threadIdx.x + j];
-                    int J = tex2D(tex_Jf, nextPt.x - c_halfWin_x + j + 0.5f, nextPt.y - c_halfWin_y + i + 0.5f);
+
+                    int J = texJ(nextPt.y - c_halfWin_y + i + 0.5f, nextPt.x - c_halfWin_x + j + 0.5f);
 
                     errval += ::abs(J - I);
                 }
@@ -1109,9 +913,6 @@ namespace pyrlk
                 { sparse_caller<cn, 1, 5,T>::call, sparse_caller<cn, 2, 5,T>::call, sparse_caller<cn, 3, 5,T>::call, sparse_caller<cn, 4, 5,T>::call, sparse_caller<cn, 5, 5,T>::call }
             };
 
-            Tex_I<cn, T>::bindTexture_(I);
-            Tex_J<cn, T>::bindTexture_(J);
-
             funcs[patch.y - 1][patch.x - 1](I, J, I.rows, I.cols, prevPts, nextPts, status, err, ptcount,
                 level, block, stream);
         }
@@ -1119,9 +920,8 @@ namespace pyrlk
         {
             dim3 block(16, 16);
             dim3 grid(divUp(I.cols, block.x), divUp(I.rows, block.y));
-            Tex_I<1, T>::bindTexture_(I);
-            Tex_J<1, T>::bindTexture_(J);
-
+            TextureLinear<1, T> texI(I);
+            TextureLinear<1, T> texJ(J);
             int2 halfWin = make_int2((winSize.x - 1) / 2, (winSize.y - 1) / 2);
             const int patchWidth = block.x + 2 * halfWin.x;
             const int patchHeight = block.y + 2 * halfWin.y;
@@ -1129,12 +929,12 @@ namespace pyrlk
 
             if (err.data)
             {
-                denseKernel<true> << <grid, block, smem_size, stream >> >(u, v, prevU, prevV, err, I.rows, I.cols);
+                denseKernel<true, cv::cudev::TexturePtr<T,float>><<<grid, block, smem_size, stream>>>(texI, texJ, u, v, prevU, prevV, err, I.rows, I.cols);
                 cudaSafeCall(cudaGetLastError());
             }
             else
             {
-                denseKernel<false> << <grid, block, smem_size, stream >> >(u, v, prevU, prevV, PtrStepf(), I.rows, I.cols);
+                denseKernel<false, cv::cudev::TexturePtr<T, float>><<<grid, block, smem_size, stream>>>(texI, texJ, u, v, prevU, prevV, PtrStepf(), I.rows, I.cols);
                 cudaSafeCall(cudaGetLastError());
             }
 

--- a/modules/cudastereo/src/cuda/stereobm.cu
+++ b/modules/cudastereo/src/cuda/stereobm.cu
@@ -43,7 +43,9 @@
 #if !defined CUDA_DISABLER
 
 #include "opencv2/core/cuda/common.hpp"
+#include <opencv2/cudev/ptr2d/texture.hpp>
 #include <limits.h>
+
 
 namespace cv { namespace cuda { namespace device
 {
@@ -601,13 +603,12 @@ namespace cv { namespace cuda { namespace device
         /////////////////////////////////// Textureness filtering ////////////////////////////////////////
         //////////////////////////////////////////////////////////////////////////////////////////////////
 
-        texture<unsigned char, 2, cudaReadModeNormalizedFloat> texForTF;
-
-        __device__ __forceinline__ float sobel(int x, int y)
+        __device__ __forceinline__ float sobel(cv::cudev::TexturePtr<uchar, float> texSrc, int x, int y)
         {
-            float conv = tex2D(texForTF, x - 1, y - 1) * (-1) + tex2D(texForTF, x + 1, y - 1) * (1) +
-                         tex2D(texForTF, x - 1, y    ) * (-2) + tex2D(texForTF, x + 1, y    ) * (2) +
-                         tex2D(texForTF, x - 1, y + 1) * (-1) + tex2D(texForTF, x + 1, y + 1) * (1);
+            float conv = texSrc(y - 1, x - 1) * (-1) + texSrc(y - 1, x + 1) * (1) +
+                texSrc(y, x - 1) * (-2) + texSrc(y, x + 1) * (2) +
+                texSrc(y + 1, x - 1) * (-1) + texSrc(y + 1, x + 1) * (1);
+
             return fabs(conv);
         }
 
@@ -635,7 +636,7 @@ namespace cv { namespace cuda { namespace device
 
         #define RpT (2 * ROWSperTHREAD)  // got experimentally
 
-        __global__ void textureness_kernel(PtrStepSzb disp, int winsz, float threshold)
+        __global__ void textureness_kernel(cv::cudev::TexturePtr<uchar,float> texSrc, PtrStepSzb disp, int winsz, float threshold)
         {
             int winsz2 = winsz/2;
             int n_dirty_pixels = (winsz2) * 2;
@@ -657,9 +658,9 @@ namespace cv { namespace cuda { namespace device
 
                 for(int i = y - winsz2; i <= y + winsz2; ++i)
                 {
-                    sum += sobel(x - winsz2, i);
+                    sum += sobel(texSrc, x - winsz2, i);
                     if (cols_extra)
-                        sum_extra += sobel(x + blockDim.x - winsz2, i);
+                        sum_extra += sobel(texSrc, x + blockDim.x - winsz2, i);
                 }
                 *cols = sum;
                 if (cols_extra)
@@ -675,12 +676,12 @@ namespace cv { namespace cuda { namespace device
 
                 for(int y = beg_row + 1; y < end_row; ++y)
                 {
-                    sum = sum - sobel(x - winsz2, y - winsz2 - 1) + sobel(x - winsz2, y + winsz2);
+                    sum = sum - sobel(texSrc, x - winsz2, y - winsz2 - 1) + sobel(texSrc, x - winsz2, y + winsz2);
                     *cols = sum;
 
                     if (cols_extra)
                     {
-                        sum_extra = sum_extra - sobel(x + blockDim.x - winsz2, y - winsz2 - 1) + sobel(x + blockDim.x - winsz2, y + winsz2);
+                        sum_extra = sum_extra - sobel(texSrc, x + blockDim.x - winsz2, y - winsz2 - 1) + sobel(texSrc, x + blockDim.x - winsz2, y + winsz2);
                         *cols_extra = sum_extra;
                     }
 
@@ -697,28 +698,16 @@ namespace cv { namespace cuda { namespace device
         void postfilter_textureness(const PtrStepSzb& input, int winsz, float avgTexturenessThreshold, const PtrStepSzb& disp, cudaStream_t & stream)
         {
             avgTexturenessThreshold *= winsz * winsz;
-
-            texForTF.filterMode     = cudaFilterModeLinear;
-            texForTF.addressMode[0] = cudaAddressModeWrap;
-            texForTF.addressMode[1] = cudaAddressModeWrap;
-
-            cudaChannelFormatDesc desc = cudaCreateChannelDesc<unsigned char>();
-            cudaSafeCall( cudaBindTexture2D( 0, texForTF, input.data, desc, input.cols, input.rows, input.step ) );
-
+            cv::cudev::Texture<unsigned char, float> tex(input, false, cudaFilterModeLinear, cudaAddressModeWrap, cudaReadModeNormalizedFloat);
             dim3 threads(128, 1, 1);
             dim3 grid(1, 1, 1);
-
             grid.x = divUp(input.cols, threads.x);
             grid.y = divUp(input.rows, RpT);
-
             size_t smem_size = (threads.x + threads.x + (winsz/2) * 2 ) * sizeof(float);
-            textureness_kernel<<<grid, threads, smem_size, stream>>>(disp, winsz, avgTexturenessThreshold);
+            textureness_kernel<<<grid, threads, smem_size, stream>>>(tex, disp, winsz, avgTexturenessThreshold);
             cudaSafeCall( cudaGetLastError() );
-
             if (stream == 0)
                 cudaSafeCall( cudaDeviceSynchronize() );
-
-            cudaSafeCall( cudaUnbindTexture (texForTF) );
         }
     } // namespace stereobm
 }}} // namespace cv { namespace cuda { namespace cudev

--- a/modules/cudawarping/src/cuda/warp.cu
+++ b/modules/cudawarping/src/cuda/warp.cu
@@ -48,6 +48,7 @@
 #include "opencv2/core/cuda/vec_math.hpp"
 #include "opencv2/core/cuda/saturate_cast.hpp"
 #include "opencv2/core/cuda/filters.hpp"
+#include <opencv2/cudev/ptr2d/texture.hpp>
 
 namespace cv { namespace cuda { namespace device
 {
@@ -164,8 +165,8 @@ namespace cv { namespace cuda { namespace device
                 dim3 grid(divUp(dst.cols, block.x), divUp(dst.rows, block.y));
 
                 B<work_type> brd(src.rows, src.cols, VecTraits<work_type>::make(borderValue));
-                BorderReader< PtrStep<T>, B<work_type> > brdSrc(src, brd);
-                Filter< BorderReader< PtrStep<T>, B<work_type> > > filter_src(brdSrc);
+                BorderReader<PtrStep<T>, B<work_type>> brdSrc(src, brd);
+                Filter<BorderReader<PtrStep<T>, B<work_type>>> filter_src(brdSrc);
 
                 warp<Transform><<<grid, block, 0, stream>>>(filter_src, dst, warpMat);
                 cudaSafeCall( cudaGetLastError() );
@@ -186,8 +187,8 @@ namespace cv { namespace cuda { namespace device
                 dim3 grid(divUp(dst.cols, block.x), divUp(dst.rows, block.y));
 
                 B<work_type> brd(src.rows, src.cols, VecTraits<work_type>::make(borderValue));
-                BorderReader< PtrStep<T>, B<work_type> > brdSrc(src, brd);
-                Filter< BorderReader< PtrStep<T>, B<work_type> > > filter_src(brdSrc);
+                BorderReader<PtrStep<T>, B<work_type>> brdSrc(src, brd);
+                Filter<BorderReader<PtrStep<T>, B<work_type>>> filter_src(brdSrc);
 
                 warp<Transform><<<grid, block>>>(filter_src, dst, warpMat);
                 cudaSafeCall( cudaGetLastError() );
@@ -196,86 +197,48 @@ namespace cv { namespace cuda { namespace device
             }
         };
 
-        #define OPENCV_CUDA_IMPLEMENT_WARP_TEX(type) \
-            texture< type , cudaTextureType2D > tex_warp_ ## type (0, cudaFilterModePoint, cudaAddressModeClamp); \
-            struct tex_warp_ ## type ## _reader \
-            { \
-                typedef type elem_type; \
-                typedef int index_type; \
-                int xoff, yoff; \
-                tex_warp_ ## type ## _reader (int xoff_, int yoff_) : xoff(xoff_), yoff(yoff_) {} \
-                __device__ __forceinline__ elem_type operator ()(index_type y, index_type x) const \
-                { \
-                    return tex2D(tex_warp_ ## type , x + xoff, y + yoff); \
-                } \
-            }; \
-            template <class Transform, template <typename> class Filter, template <typename> class B> struct WarpDispatcherNonStream<Transform, Filter, B, type> \
-            { \
-                static void call(PtrStepSz< type > src, PtrStepSz< type > srcWhole, int xoff, int yoff, PtrStepSz< type > dst, const float* borderValue, const float warpMat[Transform::rows*3], bool cc20) \
-                { \
-                    typedef typename TypeVec<float, VecTraits< type >::cn>::vec_type work_type; \
-                    dim3 block(32, cc20 ? 8 : 4); \
-                    dim3 grid(divUp(dst.cols, block.x), divUp(dst.rows, block.y)); \
-                    bindTexture(&tex_warp_ ## type , srcWhole); \
-                    tex_warp_ ## type ##_reader texSrc(xoff, yoff); \
-                    B<work_type> brd(src.rows, src.cols, VecTraits<work_type>::make(borderValue)); \
-                    BorderReader< tex_warp_ ## type ##_reader, B<work_type> > brdSrc(texSrc, brd); \
-                    Filter< BorderReader< tex_warp_ ## type ##_reader, B<work_type> > > filter_src(brdSrc); \
-                    warp<Transform><<<grid, block>>>(filter_src, dst, warpMat); \
-                    cudaSafeCall( cudaGetLastError() ); \
-                    cudaSafeCall( cudaDeviceSynchronize() ); \
-                } \
-            }; \
-            template <class Transform, template <typename> class Filter> struct WarpDispatcherNonStream<Transform, Filter, BrdReplicate, type> \
-            { \
-                static void call(PtrStepSz< type > src, PtrStepSz< type > srcWhole, int xoff, int yoff, PtrStepSz< type > dst, const float*, const float warpMat[Transform::rows*3], bool) \
-                { \
-                    dim3 block(32, 8); \
-                    dim3 grid(divUp(dst.cols, block.x), divUp(dst.rows, block.y)); \
-                    bindTexture(&tex_warp_ ## type , srcWhole); \
-                    tex_warp_ ## type ##_reader texSrc(xoff, yoff); \
-                    if (srcWhole.cols == src.cols && srcWhole.rows == src.rows) \
-                    { \
-                        Filter< tex_warp_ ## type ##_reader > filter_src(texSrc); \
-                        warp<Transform><<<grid, block>>>(filter_src, dst, warpMat); \
-                    } \
-                    else \
-                    { \
-                        BrdReplicate<type> brd(src.rows, src.cols); \
-                        BorderReader< tex_warp_ ## type ##_reader, BrdReplicate<type> > brdSrc(texSrc, brd); \
-                        Filter< BorderReader< tex_warp_ ## type ##_reader, BrdReplicate<type> > > filter_src(brdSrc); \
-                        warp<Transform><<<grid, block>>>(filter_src, dst, warpMat); \
-                    } \
-                    cudaSafeCall( cudaGetLastError() ); \
-                    cudaSafeCall( cudaDeviceSynchronize() ); \
-                } \
-            };
+        template <class Transform, template <typename> class Filter, template <typename> class B, typename T> struct WarpDispatcherNonStreamTex
+        {
+            static void call(PtrStepSz<T> src, PtrStepSz<T> srcWhole, int xoff, int yoff, PtrStepSz<T> dst, const float* borderValue, const float warpMat[Transform::rows*3], bool cc20)
+            {
+                typedef typename TypeVec<float, VecTraits<T>::cn>::vec_type work_type;
+                dim3 block(32, cc20 ? 8 : 4);
+                dim3 grid(divUp(dst.cols, block.x), divUp(dst.rows, block.y));
+                if (xoff || yoff) {
+                    cudev::TextureOff<T> texSrcWhole(srcWhole, yoff, xoff);
+                    B<work_type> brd(src.rows, src.cols, VecTraits<work_type>::make(borderValue));
+                    BorderReader<cudev::TextureOffPtr<T>, B<work_type>> brdSrc(texSrcWhole, brd);
+                    Filter<BorderReader<cudev::TextureOffPtr<T>, B<work_type>>> filter_src(brdSrc);
+                    warp<Transform><<<grid, block>>> (filter_src, dst, warpMat);
+                }
+                else {
+                    cudev::Texture<T> texSrcWhole(srcWhole);
+                    B<work_type> brd(src.rows, src.cols, VecTraits<work_type>::make(borderValue));
+                    BorderReader<cudev::TexturePtr<T>, B<work_type>>brdSrc(texSrcWhole, brd);
+                    Filter< BorderReader<cudev::TexturePtr<T>, B<work_type>>> filter_src(brdSrc);
+                    warp<Transform><<<grid, block>>> (filter_src, dst, warpMat);
+                }
+                cudaSafeCall( cudaGetLastError() );
+                cudaSafeCall( cudaDeviceSynchronize() );
+            }
+        };
 
-        OPENCV_CUDA_IMPLEMENT_WARP_TEX(uchar)
-        //OPENCV_CUDA_IMPLEMENT_WARP_TEX(uchar2)
-        OPENCV_CUDA_IMPLEMENT_WARP_TEX(uchar4)
-
-        //OPENCV_CUDA_IMPLEMENT_WARP_TEX(schar)
-        //OPENCV_CUDA_IMPLEMENT_WARP_TEX(char2)
-        //OPENCV_CUDA_IMPLEMENT_WARP_TEX(char4)
-
-        OPENCV_CUDA_IMPLEMENT_WARP_TEX(ushort)
-        //OPENCV_CUDA_IMPLEMENT_WARP_TEX(ushort2)
-        OPENCV_CUDA_IMPLEMENT_WARP_TEX(ushort4)
-
-        OPENCV_CUDA_IMPLEMENT_WARP_TEX(short)
-        //OPENCV_CUDA_IMPLEMENT_WARP_TEX(short2)
-        OPENCV_CUDA_IMPLEMENT_WARP_TEX(short4)
-
-        //OPENCV_CUDA_IMPLEMENT_WARP_TEX(int)
-        //OPENCV_CUDA_IMPLEMENT_WARP_TEX(int2)
-        //OPENCV_CUDA_IMPLEMENT_WARP_TEX(int4)
-
-        OPENCV_CUDA_IMPLEMENT_WARP_TEX(float)
-        //OPENCV_CUDA_IMPLEMENT_WARP_TEX(float2)
-        OPENCV_CUDA_IMPLEMENT_WARP_TEX(float4)
-
-        #undef OPENCV_CUDA_IMPLEMENT_WARP_TEX
+        template <class Transform, template <typename> class Filter, template <typename> class B> struct WarpDispatcherNonStream<Transform, Filter, B, uchar> :
+            WarpDispatcherNonStreamTex<Transform, Filter, B, uchar> {};
+        template <class Transform, template <typename> class Filter, template <typename> class B> struct WarpDispatcherNonStream<Transform, Filter, B, uchar4> :
+            WarpDispatcherNonStreamTex<Transform, Filter, B, uchar4> {};
+        template <class Transform, template <typename> class Filter, template <typename> class B> struct WarpDispatcherNonStream<Transform, Filter, B, ushort> :
+            WarpDispatcherNonStreamTex<Transform, Filter, B, ushort> {};
+        template <class Transform, template <typename> class Filter, template <typename> class B> struct WarpDispatcherNonStream<Transform, Filter, B, ushort4> :
+            WarpDispatcherNonStreamTex<Transform, Filter, B, ushort4> {};
+        template <class Transform, template <typename> class Filter, template <typename> class B> struct WarpDispatcherNonStream<Transform, Filter, B, short> :
+            WarpDispatcherNonStreamTex<Transform, Filter, B, short> {};
+        template <class Transform, template <typename> class Filter, template <typename> class B> struct WarpDispatcherNonStream<Transform, Filter, B, short4> :
+            WarpDispatcherNonStreamTex<Transform, Filter, B, short4> {};
+        template <class Transform, template <typename> class Filter, template <typename> class B> struct WarpDispatcherNonStream<Transform, Filter, B, float> :
+            WarpDispatcherNonStreamTex<Transform, Filter, B, float> {};
+        template <class Transform, template <typename> class Filter, template <typename> class B> struct WarpDispatcherNonStream<Transform, Filter, B, float4> :
+            WarpDispatcherNonStreamTex<Transform, Filter, B, float4> {};
 
         template <class Transform, template <typename> class Filter, template <typename> class B, typename T> struct WarpDispatcher
         {
@@ -319,8 +282,8 @@ namespace cv { namespace cuda { namespace device
                 }
             };
 
-            funcs[interpolation][borderMode](static_cast< PtrStepSz<T> >(src), static_cast< PtrStepSz<T> >(srcWhole), xoff, yoff,
-                                             static_cast< PtrStepSz<T> >(dst), borderValue, warpMat, stream, cc20);
+            funcs[interpolation][borderMode](static_cast<PtrStepSz<T>>(src), static_cast<PtrStepSz<T>>(srcWhole), xoff, yoff,
+                                             static_cast<PtrStepSz<T>>(dst), borderValue, warpMat, stream, cc20);
         }
 
         template <typename T> void warpAffine_gpu(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[2 * 3], PtrStepSzb dst, int interpolation,
@@ -330,32 +293,18 @@ namespace cv { namespace cuda { namespace device
         }
 
         template void warpAffine_gpu<uchar >(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[2 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
-        //template void warpAffine_gpu<uchar2>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[2 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
         template void warpAffine_gpu<uchar3>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[2 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
         template void warpAffine_gpu<uchar4>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[2 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
 
-        //template void warpAffine_gpu<schar>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[2 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
-        //template void warpAffine_gpu<char2>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[2 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
-        //template void warpAffine_gpu<char3>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[2 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
-        //template void warpAffine_gpu<char4>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[2 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
-
         template void warpAffine_gpu<ushort >(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[2 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
-        //template void warpAffine_gpu<ushort2>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[2 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
         template void warpAffine_gpu<ushort3>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[2 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
         template void warpAffine_gpu<ushort4>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[2 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
 
         template void warpAffine_gpu<short >(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[2 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
-        //template void warpAffine_gpu<short2>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[2 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
         template void warpAffine_gpu<short3>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[2 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
         template void warpAffine_gpu<short4>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[2 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
 
-        //template void warpAffine_gpu<int >(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[2 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
-        //template void warpAffine_gpu<int2>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[2 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
-        //template void warpAffine_gpu<int3>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[2 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
-        //template void warpAffine_gpu<int4>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[2 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
-
         template void warpAffine_gpu<float >(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[2 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
-        //template void warpAffine_gpu<float2>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[2 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
         template void warpAffine_gpu<float3>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[2 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
         template void warpAffine_gpu<float4>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[2 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
 
@@ -366,32 +315,18 @@ namespace cv { namespace cuda { namespace device
         }
 
         template void warpPerspective_gpu<uchar >(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[3 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
-        //template void warpPerspective_gpu<uchar2>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[3 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
         template void warpPerspective_gpu<uchar3>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[3 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
         template void warpPerspective_gpu<uchar4>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[3 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
 
-        //template void warpPerspective_gpu<schar>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[3 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
-        //template void warpPerspective_gpu<char2>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[3 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
-        //template void warpPerspective_gpu<char3>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[3 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
-        //template void warpPerspective_gpu<char4>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[3 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
-
         template void warpPerspective_gpu<ushort >(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[3 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
-        //template void warpPerspective_gpu<ushort2>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[3 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
         template void warpPerspective_gpu<ushort3>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[3 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
         template void warpPerspective_gpu<ushort4>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[3 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
 
         template void warpPerspective_gpu<short >(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[3 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
-        //template void warpPerspective_gpu<short2>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[3 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
         template void warpPerspective_gpu<short3>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[3 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
         template void warpPerspective_gpu<short4>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[3 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
 
-        //template void warpPerspective_gpu<int >(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[3 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
-        //template void warpPerspective_gpu<int2>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[3 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
-        //template void warpPerspective_gpu<int3>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[3 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
-        //template void warpPerspective_gpu<int4>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[3 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
-
         template void warpPerspective_gpu<float >(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[3 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
-        //template void warpPerspective_gpu<float2>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[3 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
         template void warpPerspective_gpu<float3>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[3 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
         template void warpPerspective_gpu<float4>(PtrStepSzb src, PtrStepSzb srcWhole, int xoff, int yoff, float coeffs[3 * 3], PtrStepSzb dst, int interpolation, int borderMode, const float* borderValue, cudaStream_t stream, bool cc20);
     } // namespace imgproc

--- a/modules/cudawarping/test/test_precomp.hpp
+++ b/modules/cudawarping/test/test_precomp.hpp
@@ -42,6 +42,8 @@
 #ifndef __OPENCV_TEST_PRECOMP_HPP__
 #define __OPENCV_TEST_PRECOMP_HPP__
 
+#include <thread>
+
 #include "opencv2/ts.hpp"
 #include "opencv2/ts/cuda_test.hpp"
 

--- a/modules/cudev/include/opencv2/cudev/warp/shuffle.hpp
+++ b/modules/cudev/include/opencv2/cudev/warp/shuffle.hpp
@@ -213,7 +213,7 @@ __device__ double shfl_up(double val, uint delta, int width = warpSize)
     return __hiloint2double(hi, lo);
 }
 
-__device__ __forceinline__ unsigned long long shfl_up(unsigned long long val, uint delta, int width = warpSize)
+__device__ __forceinline__ uint64 shfl_up(uint64 val, uint delta, int width = warpSize)
 {
     return __shfl_up(val, delta, width);
 }


### PR DESCRIPTION
CUDA texture objects replaced CUDA texture references in the [2012](https://developer.nvidia.com/blog/cuda-pro-tip-kepler-texture-objects-improve-performance-and-flexibility/) (CUDA SDK 5.0 toolkit) and could be removed at any time from future SDK releases by Nvidia as they were depreciated in April 2021 (CUDA SDK 11.3).

This PR replaces all instances of texture references with texture objects using the existing updated `cv::cudev::Texture class`.

Additionaly it addresses the three bugs below related to incorrect texture usage:
1) `cv::cuda::resize` - currently resize uses texture references if the default stream or no stream is passed.  Under these circumstances global texture references are used when multiple threads call `cv::cuda::resize` which is unsafe.
2) `cv::cuda::demosaicing` - returns incorrect results when passed image ROI's.
3) `cv::cuda::HoughSegmentDetector` - passes the existing `cv::cudev::Texture` object whose destructor calls `cudaDestroyTextureObject()` to the CUDA kernel.  This can cause the underlying `cudaTextureObject_t` to be destroyed on return from the copy to the stub function before the kernel is launched as described in the [Nvidia docs](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#global-function-argument-processing).

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake


```
force_builders=Custom
buildworker:Custom=linux-1
docker_image:Custom=ubuntu-cuda:16.04
```