### PR TITLE
Reset cuda runtime error code to cudasuccess on runtime failure.

### DIFF
--- a/modules/cudev/include/opencv2/cudev/common.hpp
+++ b/modules/cudev/include/opencv2/cudev/common.hpp
@@ -69,8 +69,10 @@ using namespace cv::cuda;
 
 __host__ __forceinline__ void checkCudaError(cudaError_t err, const char* file, const int line, const char* func)
 {
-    if (cudaSuccess != err)
+    if (cudaSuccess != err) {
+        cudaGetLastError(); // reset the last stored error to cudaSuccess
         cv::error(cv::Error::GpuApiCallError, cudaGetErrorString(err), func, file, line);
+    }
 }
 
 #define CV_CUDEV_SAFE_CALL(expr) cv::cudev::checkCudaError((expr), __FILE__, __LINE__, CV_Func)


### PR DESCRIPTION
Make behaviour of `cudev::checkCudaError()` consistent with `cuda::checkCudaError()`.  See [Reset cuda runtime error code to cudasuccess on runtime failure.](https://github.com/opencv/opencv/pull/22633) for details.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
