### PR TITLE
OdometryFrame: arg order changed

### DIFF
--- a/modules/rgbd/src/colored_kinfu.cpp
+++ b/modules/rgbd/src/colored_kinfu.cpp
@@ -290,7 +290,7 @@ bool ColoredKinFuImpl<MatType>::updateT(const MatType& _depth, const MatType& _r
     else
         rgb = _rgb;
 
-    OdometryFrame newFrame(rgb, depth);
+    OdometryFrame newFrame(depth, rgb);
 
     if(frameCounter == 0)
     {
@@ -325,7 +325,7 @@ bool ColoredKinFuImpl<MatType>::updateT(const MatType& _depth, const MatType& _r
         volume.raycast(pose, points, normals, colors);
         std::vector<MatType> pch(3);
         split(points, pch);
-        newFrame = OdometryFrame(colors, pch[2], noArray(), normals);
+        newFrame = OdometryFrame(pch[2], colors, noArray(), normals);
     }
 
     renderFrame = newFrame;

--- a/modules/rgbd/src/colored_kinfu.cpp
+++ b/modules/rgbd/src/colored_kinfu.cpp
@@ -284,6 +284,8 @@ bool ColoredKinFuImpl<MatType>::updateT(const MatType& _depth, const MatType& _r
         std::vector<MatType> channels;
         _rgb.convertTo(rgb_tmp, COLOR_TYPE);
         cv::split(rgb_tmp, channels);
+        // we use 4-channel RGB0 image
+        // for vectorization simplicity
         channels.push_back(MatType::zeros(channels[0].size(), CV_32F));
         merge(channels, rgb);
     }

--- a/modules/rgbd/src/dynafu.cpp
+++ b/modules/rgbd/src/dynafu.cpp
@@ -315,7 +315,7 @@ bool DynaFuImpl<T>::updateT(const T& _depth)
     else
         depth = _depth;
 
-    OdometryFrame newFrame(noArray(), depth);
+    OdometryFrame newFrame(depth);
 
     //icp->prepareFrameCache(newFrame, OdometryFrame::CACHE_SRC);
 
@@ -337,7 +337,7 @@ bool DynaFuImpl<T>::updateT(const T& _depth)
         renderSurface(_depthRender, _vertRender, _normRender, false);
         _depthRender.convertTo(estdDepth, DEPTH_TYPE);
 
-        OdometryFrame estdFrame(noArray(), estdDepth);
+        OdometryFrame estdFrame(estdDepth);
         //icp->setDepthFactor(1.f);
         //icp->prepareFrameCache(estdFrame, OdometryFrame::CACHE_SRC);
         //icp->setDepthFactor(params.depthFactor);
@@ -360,9 +360,9 @@ bool DynaFuImpl<T>::updateT(const T& _depth)
             renderSurface(_depthRender, _vertRender, _normRender);
             _depthRender.convertTo(estdDepth, DEPTH_TYPE);
 
-            estdFrame = OdometryFrame(noArray(), estdDepth);
+            estdFrame = OdometryFrame(estdDepth);
             icp.prepareFrame(estdFrame);
-            //estdFrame = OdometryFrame::create(noArray(), estdDepth, noArray(), noArray(), -1);
+            //estdFrame = OdometryFrame::create(estdDepth, noArray(), noArray(), noArray(), -1);
             //icp->setDepthFactor(1.f);
             //icp->prepareFrameCache(estdFrame, OdometryFrame::CACHE_SRC);
             //icp->setDepthFactor(params.depthFactor);

--- a/modules/rgbd/src/kinfu.cpp
+++ b/modules/rgbd/src/kinfu.cpp
@@ -258,7 +258,7 @@ bool KinFuImpl<MatType>::updateT(const MatType& _depth)
     else
         depth = _depth;
 
-    OdometryFrame newFrame(noArray(), depth);
+    OdometryFrame newFrame(depth);
 
     if(frameCounter == 0)
     {
@@ -292,7 +292,7 @@ bool KinFuImpl<MatType>::updateT(const MatType& _depth)
 
         std::vector<MatType> pch(3);
         split(points, pch);
-        newFrame = OdometryFrame(noArray(), pch[2], noArray(), normals);
+        newFrame = OdometryFrame(pch[2], noArray(), noArray(), normals);
     }
 
     renderFrame = newFrame;

--- a/modules/rgbd/src/large_kinfu.cpp
+++ b/modules/rgbd/src/large_kinfu.cpp
@@ -321,7 +321,7 @@ bool LargeKinfuImpl<MatType>::updateT(const MatType& _depth)
     else
         depth = _depth;
 
-    OdometryFrame newFrame(noArray(), depth);
+    OdometryFrame newFrame(depth);
 
     CV_LOG_INFO(NULL, "Current frameID: " << frameCounter);
     for (const auto& it : submapMgr->activeSubmaps)


### PR DESCRIPTION
Connected PR in main repo: [#22925@main](https://github.com/opencv/opencv/pull/22925)

### Changes

`OdometryFrame` constructor signature changed to more convenient where depth goes at 1st place, RGB image at 2nd.
This works better for depth-only `Odometry` algorithms.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
