### PR TITLE
Remove references to deprecated NumPy type aliases.

### DIFF
--- a/modules/aruco/misc/pattern_generator/MarkerPrinter.py
+++ b/modules/aruco/misc/pattern_generator/MarkerPrinter.py
@@ -409,8 +409,8 @@ class MarkerPrinter:
             subChessboardBlockX = np.clip ( np.arange(0, subSize[0] * subDivide[0] + 1, subSize[0]), 0, chessboardSize[0])
             subChessboardBlockY = np.clip ( np.arange(0, subSize[1] * subDivide[1] + 1, subSize[1]), 0, chessboardSize[1])
 
-            subChessboardSliceX = subChessboardBlockX.astype(np.float) * squareLength
-            subChessboardSliceY = subChessboardBlockY.astype(np.float) * squareLength
+            subChessboardSliceX = subChessboardBlockX.astype(float) * squareLength
+            subChessboardSliceY = subChessboardBlockY.astype(float) * squareLength
 
             for subXID in range(subDivide[0]):
                 for subYID in range(subDivide[1]):
@@ -722,8 +722,8 @@ class MarkerPrinter:
             subChessboardBlockX = np.clip ( np.arange(0, subSize[0] * subDivide[0] + 1, subSize[0]), 0, chessboardSize[0])
             subChessboardBlockY = np.clip ( np.arange(0, subSize[1] * subDivide[1] + 1, subSize[1]), 0, chessboardSize[1])
 
-            subChessboardSliceX = subChessboardBlockX.astype(np.float) * squareLength
-            subChessboardSliceY = subChessboardBlockY.astype(np.float) * squareLength
+            subChessboardSliceX = subChessboardBlockX.astype(float) * squareLength
+            subChessboardSliceY = subChessboardBlockY.astype(float) * squareLength
 
             for subXID in range(subDivide[0]):
                 for subYID in range(subDivide[1]):
@@ -922,8 +922,8 @@ class MarkerPrinter:
             subChessboardBlockX = np.clip ( np.arange(0, subSize[0] * subDivide[0] + 1, subSize[0]), 0, chessboardSize[0])
             subChessboardBlockY = np.clip ( np.arange(0, subSize[1] * subDivide[1] + 1, subSize[1]), 0, chessboardSize[1])
 
-            subChessboardSliceX = subChessboardBlockX.astype(np.float) * (markerLength + markerSeparation)
-            subChessboardSliceY = subChessboardBlockY.astype(np.float) * (markerLength + markerSeparation)
+            subChessboardSliceX = subChessboardBlockX.astype(float) * (markerLength + markerSeparation)
+            subChessboardSliceY = subChessboardBlockY.astype(float) * (markerLength + markerSeparation)
 
             subChessboardSliceX[-1] -= markerSeparation
             subChessboardSliceY[-1] -= markerSeparation


### PR DESCRIPTION
This change replaces references to a number of deprecated NumPy type aliases (np.bool, np.int, np.float, np.complex, np.object, np.str) with their recommended replacement (bool, int, float, complex, object, str).

Those types were deprecated in 1.20 and are removed in 1.24, cf numpy/numpy#22607.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
