### PR TITLE
build: fix warnings

### DIFF
--- a/modules/cudev/include/opencv2/cudev/ptr2d/texture.hpp
+++ b/modules/cudev/include/opencv2/cudev/ptr2d/texture.hpp
@@ -250,9 +250,9 @@ namespace cv {  namespace cudev {
         {
         }
 
-        __host__ TextureOff(PtrStepSz<T> src, const int yoff = 0, const int xoff = 0, const bool normalizedCoords = false, const cudaTextureFilterMode filterMode = cudaFilterModePoint,
+        __host__ TextureOff(PtrStepSz<T> src, const int yoff_ = 0, const int xoff_ = 0, const bool normalizedCoords = false, const cudaTextureFilterMode filterMode = cudaFilterModePoint,
             const cudaTextureAddressMode addressMode = cudaAddressModeClamp, const cudaTextureReadMode readMode = cudaReadModeElementType) :
-            TextureOff(src.rows, src.cols, src.data, src.step, yoff, xoff, normalizedCoords, filterMode, addressMode, readMode)
+            TextureOff(src.rows, src.cols, src.data, src.step, yoff_, xoff_, normalizedCoords, filterMode, addressMode, readMode)
         {
         }
 

--- a/modules/xfeatures2d/src/cuda/surf.cu
+++ b/modules/xfeatures2d/src/cuda/surf.cu
@@ -233,17 +233,21 @@ namespace cv { namespace cuda { namespace device
             __host__ Mask(cudev::TexturePtr<unsigned int> tex_): tex(tex_) {};
             __device__ bool check(int sum_i, int sum_j, int size)
             {
-                if (!useMask) return true;
-                float ratio = (float)size / 9.0f;
-
+                int dx1 = 0;
+                int dy1 = 0;
+                int dx2 = 0;
+                int dy2 = 0;
+                float ratio = 0;
                 float d = 0;
-
-                int dx1 = __float2int_rn(ratio * c_DM[0]);
-                int dy1 = __float2int_rn(ratio * c_DM[1]);
-                int dx2 = __float2int_rn(ratio * c_DM[2]);
-                int dy2 = __float2int_rn(ratio * c_DM[3]);
-
                 float t = 0;
+
+                if (!useMask) return true;
+                ratio = (float)size / 9.0f;
+                dx1 = __float2int_rn(ratio * c_DM[0]);
+                dy1 = __float2int_rn(ratio * c_DM[1]);
+                dx2 = __float2int_rn(ratio * c_DM[2]);
+                dy2 = __float2int_rn(ratio * c_DM[3]);
+
                 t += tex(sum_i + dy1, sum_j + dx1);
                 t -= tex(sum_i + dy2, sum_j + dx1);
                 t -= tex(sum_i + dy1, sum_j + dx2);


### PR DESCRIPTION
### Pull Request Readiness Checklist

similar to #3417, but this one starts from 4.x

```
FilterMode, cudaTextureAddressMode, cudaTextureReadMode)’:
/opencv_contrib/modules/cudev/include/opencv2/cudev/ptr2d/texture.hpp:254:99: warning: declaration of ‘xoff’ shadows a member of ‘cv::cudev::TextureOff<T, R>’ [-Wshadow]
  254 |             const cudaTextureAddressMode addressMode = cudaAddressModeClamp, const cudaTextureReadMode readMode = cudaReadModeElementType) :
      |                                                                                                   ^
/opencv_contrib/modules/cudev/include/opencv2/cudev/ptr2d/texture.hpp:267:14: note: shadowed declaration is here
  267 |         int xoff = 0;
      |             ^~~~
/opencv_contrib/modules/cudev/include/opencv2/cudev/ptr2d/texture.hpp:254:99: warning: declaration of ‘yoff’ shadows a member of ‘cv::cudev::TextureOff<T, R>’ [-Wshadow]
  254 |             const cudaTextureAddressMode addressMode = cudaAddressModeClamp, const cudaTextureReadMode readMode = cudaReadModeElementType) :
      |                                                                                                   ^
/opencv_contrib/modules/cudev/include/opencv2/cudev/ptr2d/texture.hpp:268:5: note: shadowed declaration is here
  268 |         int yoff = 0;
      |             ^~~~
```

For the warning message below, I'm not that sure if it makes impact on performance

```
/opencv_contrib/modules/xfeatures2d/src/cuda/surf.cu(237): warning: dynamic initialization in unreachable code
          detected during:
            instantiation of "__nv_bool cv::cuda::device::surf::Mask<useMask>::check(int, int, int) [with useMask=false]" 
(302): here
            instantiation of "void cv::cuda::device::surf::icvFindMaximaInLayer(T, cv::cuda::PtrStepf, cv::cuda::PtrStepf, int4 *, unsigned int *) [with T=cv::cuda::device::surf::Mask<false>]" 
(376): here
```

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
buildworker:Custom=linux-1
docker_image:Custom=ubuntu-cuda:16.04
```