### PR TITLE
Make alphamat public header auto sufficient

### DIFF
--- a/modules/alphamat/include/opencv2/alphamat.hpp
+++ b/modules/alphamat/include/opencv2/alphamat.hpp
@@ -7,6 +7,8 @@
 #ifndef _OPENCV_ALPHAMAT_HPP_
 #define _OPENCV_ALPHAMAT_HPP_
 
+#include <opencv2/core.hpp>
+
 /**
  * @defgroup alphamat Alpha Matting
  * Alpha matting is used to extract a foreground object with soft boundaries from a background image.


### PR DESCRIPTION
alphamat header depends on `InputArray`, `OutputArray` and `CV_EXPORTS_W` but doesn't include related opencv2/core.hpp, so this header can break depending on include order.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
