### PR TITLE
RLOF OptFlow Bug Fix

### DIFF
--- a/modules/optflow/src/rlofflow.cpp
+++ b/modules/optflow/src/rlofflow.cpp
@@ -409,7 +409,7 @@ class SparseRLOFOpticalFlowImpl : public SparseRLOFOpticalFlow
         if (forwardBackwardThreshold > 0)
         {
             // use temp variable to properly initialize refPoints 
-            // inside 'calcLocalOpticalFlow' when 'use_initial_flow' and 'forward_backward_threshold' parameters are used
+            // inside 'calcLocalOpticalFlow' when 'use_init_flow' and 'fwd_bwd_thresh' parameters are used
             bool temp_param = param->getUseInitialFlow();
             param->setUseInitialFlow(false);
             // reuse image pyramids

--- a/modules/optflow/src/rlofflow.cpp
+++ b/modules/optflow/src/rlofflow.cpp
@@ -408,7 +408,7 @@ class SparseRLOFOpticalFlowImpl : public SparseRLOFOpticalFlow
         cv::Mat(1,npoints , CV_32FC2, &nextPoints[0]).copyTo(nextPtsMat);
         if (forwardBackwardThreshold > 0)
         {
-            // use temp variable to properly initialize refPoints 
+            // use temp variable to properly initialize refPoints
             // inside 'calcLocalOpticalFlow' when 'use_init_flow' and 'fwd_bwd_thresh' parameters are used
             bool temp_param = param->getUseInitialFlow();
             param->setUseInitialFlow(false);

--- a/modules/optflow/src/rlofflow.cpp
+++ b/modules/optflow/src/rlofflow.cpp
@@ -408,8 +408,13 @@ class SparseRLOFOpticalFlowImpl : public SparseRLOFOpticalFlow
         cv::Mat(1,npoints , CV_32FC2, &nextPoints[0]).copyTo(nextPtsMat);
         if (forwardBackwardThreshold > 0)
         {
+            // use temp variable to properly initialize refPoints 
+            // inside 'calcLocalOpticalFlow' when 'use_initial_flow' and 'forward_backward_threshold' parameters are used
+            bool temp_param = param->getUseInitialFlow();
+            param->setUseInitialFlow(false);
             // reuse image pyramids
             calcLocalOpticalFlow(nextImage, prevImage, currPyramid, prevPyramid, nextPoints, refPoints, *(param.get()));
+            param->setUseInitialFlow(temp_param);
         }
         for (unsigned int r = 0; r < refPoints.size(); r++)
         {


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


The bug has already been reported and explained on the OpenCV forum:

- [optflow-calcopticalflowsparserlof-giving-assertion-error](https://forum.opencv.org/t/cv2-optflow-calcopticalflowsparserlof-giving-assertion-error/4835)
- [calcopticalflowsparserlof-assertion-error-in-initialflow](https://forum.opencv.org/t/calcopticalflowsparserlof-assertion-error-in-initialflow/8669)

The bug is manifested only if 'UseInitialFlow' is set to true and 'ForwardBackwardThreshold' > 0 (enabled).

