### PR TITLE
SURF: make test tolerate to rounding error

### DIFF
--- a/modules/xfeatures2d/test/test_surf.cuda.cpp
+++ b/modules/xfeatures2d/test/test_surf.cuda.cpp
@@ -99,7 +99,8 @@ CUDA_TEST_P(CUDA_SURF, Detector)
     std::vector<cv::KeyPoint> keypoints_gold;
     surf_gold->detect(image, keypoints_gold);
 
-    ASSERT_EQ(keypoints_gold.size(), keypoints.size());
+    int lengthDiff = abs((int)keypoints_gold.size()) - ((int)keypoints.size());
+    EXPECT_LE(lengthDiff, 1);
     int matchedCount = getMatchedPointsCount(keypoints_gold, keypoints);
     double matchedRatio = static_cast<double>(matchedCount) / keypoints_gold.size();
 
@@ -130,7 +131,8 @@ CUDA_TEST_P(CUDA_SURF, Detector_Masked)
     std::vector<cv::KeyPoint> keypoints_gold;
     surf_gold->detect(image, keypoints_gold, mask);
 
-    ASSERT_EQ(keypoints_gold.size(), keypoints.size());
+    int lengthDiff = abs((int)keypoints_gold.size()) - ((int)keypoints.size());
+    EXPECT_LE(lengthDiff, 1);
     int matchedCount = getMatchedPointsCount(keypoints_gold, keypoints);
     double matchedRatio = static_cast<double>(matchedCount) / keypoints_gold.size();
 
@@ -171,19 +173,11 @@ CUDA_TEST_P(CUDA_SURF, Descriptor)
     EXPECT_GT(matchedRatio, 0.6);
 }
 
-#if defined (__x86_64__) || defined (_M_X64)
 testing::internal::ValueArray3<SURF_HessianThreshold, SURF_HessianThreshold, SURF_HessianThreshold> thresholdValues =
     testing::Values(
             SURF_HessianThreshold(100.0),
             SURF_HessianThreshold(500.0),
             SURF_HessianThreshold(1000.0));
-#else
-// hessian computation is not bit-exact and lower threshold causes different count of detection
-testing::internal::ValueArray2<SURF_HessianThreshold, SURF_HessianThreshold> thresholdValues =
-    testing::Values(
-            SURF_HessianThreshold(830.0),
-            SURF_HessianThreshold(1000.0));
-#endif
 
 INSTANTIATE_TEST_CASE_P(CUDA_Features2D, CUDA_SURF, testing::Combine(
     thresholdValues,


### PR DESCRIPTION
### Pull Request Readiness Checklist
closes #3377
relates #2587

Stop using condition build and make the test itself tolerance to rounding error.
Sooner or later same issue might appear on OpenCL implementation, so make the UMat version also telerate

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
