### PR TITLE
3.4: -Wunused-but-set-variable warnings fix after XCode update

### DIFF
--- a/modules/ccalib/src/ccalib.cpp
+++ b/modules/ccalib/src/ccalib.cpp
@@ -247,22 +247,15 @@ void CustomPattern::check_matches(vector<Point2f>& matched, const vector<Point2f
     perspectiveTransform(pattern, proj, H);
 
     int deleted = 0;
-    double error_sum = 0;
-    double error_sum_filtered = 0;
     for (uint i = 0; i < proj.size(); ++i)
     {
         double error = norm(matched[i] - proj[i]);
-        error_sum += error;
         if (error >= MAX_PROJ_ERROR_PX)
         {
             deleteStdVecElem(good, i);
             deleteStdVecElem(matched, i);
             deleteStdVecElem(pattern_3d, i);
             ++deleted;
-        }
-        else
-        {
-            error_sum_filtered += error;
         }
     }
 }

--- a/modules/line_descriptor/src/binary_descriptor_matcher.cpp
+++ b/modules/line_descriptor/src/binary_descriptor_matcher.cpp
@@ -644,9 +644,6 @@ void BinaryDescriptorMatcher::Mihasher::query( UINT32* results, UINT32* numres, 
 
   /* counting everything retrieved (duplicates are counted multiple times)
    number of lookups (and xors) */
-  UINT32 nl = 0;
-
-  UINT32 nd = 0;
   UINT32 *arr;
   int size = 0;
   UINT32 index;
@@ -672,8 +669,6 @@ void BinaryDescriptorMatcher::Mihasher::query( UINT32* results, UINT32* numres, 
       else
         curb = b - 1;
       UINT64 chunksk = chunks[k];
-      /* number of bit-strings with s number of 1s */
-      nl += xornum[s + 1] - xornum[s];
 
       /* the bit-string with s number of 1s */
       UINT64 bitstr = 0;
@@ -706,7 +701,6 @@ void BinaryDescriptorMatcher::Mihasher::query( UINT32* results, UINT32* numres, 
           arr = H[k].query( chunksk ^ bitstr, &size );  // lookup
           if( size )
           { /* the corresponding bucket is not empty */
-            nd += size;
             for ( int c = 0; c < size; c++ )
             {
               index = arr[c];

--- a/modules/stereo/src/stereo_binary_bm.cpp
+++ b/modules/stereo/src/stereo_binary_bm.cpp
@@ -342,14 +342,6 @@ namespace cv
 
                 Mat left = preFilteredImg0, right = preFilteredImg1;
 
-                int ndisp = params.numDisparities;
-
-                int wsz = params.kernelSize;
-                int bufSize0 = (int)((ndisp + 2)*sizeof(int));
-                bufSize0 += (int)((height + wsz + 2)*ndisp*sizeof(int));
-                bufSize0 += (int)((height + wsz + 2)*sizeof(int));
-                bufSize0 += (int)((height + wsz + 2)*ndisp*(wsz + 2)*sizeof(uchar) + 256);
-
                 int bufSize1 = (int)((width + params.preFilterSize + 2) * sizeof(int) + 256);
                 if(params.usePrefilter == true)
                 {

--- a/modules/structured_light/src/graycodepattern.cpp
+++ b/modules/structured_light/src/graycodepattern.cpp
@@ -259,9 +259,6 @@ bool GrayCodePattern_Impl::decode( const std::vector< std::vector<Mat> >& patter
     Mat& disparityMap_ = *( Mat* ) disparityMap.getObj();
     disparityMap_ = Mat( cam_height, cam_width, CV_64F, double( 0 ) );
 
-    double number_of_pixels_cam1 = 0;
-    double number_of_pixels_cam2 = 0;
-
     for( int i = 0; i < params.width; i++ )
     {
       for( int j = 0; j < params.height; j++ )
@@ -278,8 +275,6 @@ bool GrayCodePattern_Impl::decode( const std::vector< std::vector<Mat> >& patter
         double sump1x = 0;
         double sump2x = 0;
 
-        number_of_pixels_cam1 += cam1Pixs.size();
-        number_of_pixels_cam2 += cam2Pixs.size();
         for( int c1 = 0; c1 < (int) cam1Pixs.size(); c1++ )
         {
           p1 = cam1Pixs[c1];

--- a/modules/tracking/src/multiTracker.cpp
+++ b/modules/tracking/src/multiTracker.cpp
@@ -266,7 +266,6 @@ namespace cv
 		Mat tmp;
 		int dx = initSize.width / 10, dy = initSize.height / 10;
 		Size2d size = img.size();
-		double scale = 1.0;
 		int npos = 0, nneg = 0;
 		double maxSc = -5.0;
 		Rect2d maxScRect;
@@ -335,7 +334,6 @@ namespace cv
 			scaleID++;
 			size.width /= tld::SCALE_STEP;
 			size.height /= tld::SCALE_STEP;
-			scale *= tld::SCALE_STEP;
 			resize(img, tmp, size, 0, 0, tld::DOWNSCALE_MODE);
 			resized_imgs.push_back(tmp);
 			GaussianBlur(resized_imgs[scaleID], tmp, tld::GaussBlurKernelSize, 0.0f);

--- a/modules/tracking/src/tldDetector.cpp
+++ b/modules/tracking/src/tldDetector.cpp
@@ -363,7 +363,6 @@ namespace cv
 			Mat tmp;
 			int dx = initSize.width / 10, dy = initSize.height / 10;
 			Size2d size = img.size();
-			double scale = 1.0;
 			int npos = 0, nneg = 0;
 			double maxSc = -5.0;
 			Rect2d maxScRect;
@@ -398,7 +397,6 @@ namespace cv
 				scaleID++;
 				size.width /= SCALE_STEP;
 				size.height /= SCALE_STEP;
-				scale *= SCALE_STEP;
 				resize(img, tmp, size, 0, 0, DOWNSCALE_MODE);
 				resized_imgs.push_back(tmp);
 				GaussianBlur(resized_imgs[scaleID], tmp, GaussBlurKernelSize, 0.0f);

--- a/modules/ximgproc/src/brightedges.cpp
+++ b/modules/ximgproc/src/brightedges.cpp
@@ -150,7 +150,7 @@ namespace cv
                 iedge.ptr(row + 1)[col + 2] +
                 iedge.ptr(row - 1)[col + 2];
             if (line < weight) lines += 1;
-            if (line == 1) return 0;
+            if (lines == 1) return 0;
             // Compute surrounding pixels for dark zone
             int surround = iedge.ptr(row - 1)[col - 1] +
                 iedge.ptr(row - 1)[col] +


### PR DESCRIPTION
Patch for 4.x: https://github.com/opencv/opencv_contrib/pull/3434
Merge with https://github.com/opencv/opencv/pull/23214

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
