### PR TITLE
changed CAP_OPENNI flag to CAP_OPENNI2 in linemod sample

### DIFF
--- a/modules/rgbd/samples/linemod.cpp
+++ b/modules/rgbd/samples/linemod.cpp
@@ -191,7 +191,7 @@ int main(int argc, char * argv[])
   int num_modalities = (int)detector->getModalities().size();
 
   // Open Kinect sensor
-  cv::VideoCapture capture( cv::CAP_OPENNI );
+  cv::VideoCapture capture( cv::CAP_OPENNI2 );
   if (!capture.isOpened())
   {
     printf("Could not open OpenNI-capable sensor\n");


### PR DESCRIPTION
Flag CAP_OPENNI is obsolete. It Changed to CAP_OPENNI2 flag.
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
