### PR TITLE
text: change default char_whitelist parameter.

### DIFF
--- a/modules/text/include/opencv2/text/ocr.hpp
+++ b/modules/text/include/opencv2/text/ocr.hpp
@@ -153,14 +153,16 @@ public:
     @param datapath the name of the parent directory of tessdata ended with "/", or NULL to use the
     system's default directory.
     @param language an ISO 639-3 code or NULL will default to "eng".
-    @param char_whitelist specifies the list of characters used for recognition. NULL defaults to
-    "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".
+    @param char_whitelist specifies the list of characters used for recognition. NULL defaults to ""
+    (All characters will be used for recognition).
     @param oem tesseract-ocr offers different OCR Engine Modes (OEM), by default
     tesseract::OEM_DEFAULT is used. See the tesseract-ocr API documentation for other possible
     values.
     @param psmode tesseract-ocr offers different Page Segmentation Modes (PSM) tesseract::PSM_AUTO
     (fully automatic layout analysis) is used. See the tesseract-ocr API documentation for other
     possible values.
+
+    @note The char_whitelist default is changed after OpenCV 4.7.0/3.19.0 from "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ" to "".
      */
     CV_WRAP static Ptr<OCRTesseract> create(const char* datapath=NULL, const char* language=NULL,
                                     const char* char_whitelist=NULL, int oem=OEM_DEFAULT, int psmode=PSM_AUTO);

--- a/modules/text/src/ocr_tesseract.cpp
+++ b/modules/text/src/ocr_tesseract.cpp
@@ -163,10 +163,12 @@ public:
         tesseract::PageSegMode pagesegmode = (tesseract::PageSegMode)psmode;
         tess.SetPageSegMode(pagesegmode);
 
+        // tessedit_whitelist default changes from [0-9a-zA-Z] to "".
+        // See https://github.com/opencv/opencv_contrib/issues/3457
         if(char_whitelist != NULL)
             tess.SetVariable("tessedit_char_whitelist", char_whitelist);
         else
-            tess.SetVariable("tessedit_char_whitelist", "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ");
+            tess.SetVariable("tessedit_char_whitelist", "");
 
         tess.SetVariable("save_best_choices", "T");
 #else


### PR DESCRIPTION
Fix https://github.com/opencv/opencv_contrib/issues/3457

This patch changes char_whitelist default from [0-9a-zA-Z] to all characters.

Current setting text module missrecognizes in CJK and other languages in default because it accepts only [0-9a-zA-Z]. 

And in "eng" language, wordlist contains some characters outside of [0-9a-zA-Z].
Those words are not recognized with default parameters.

So to disable whitelist is better than using "0-9a-zA-Z". 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
