### PR TITLE
Add `threshold` parameter to cuda::HoughSegmentDetector

### DIFF
--- a/modules/cudaimgproc/include/opencv2/cudaimgproc.hpp
+++ b/modules/cudaimgproc/include/opencv2/cudaimgproc.hpp
@@ -425,6 +425,9 @@ public:
 
     CV_WRAP virtual void setMaxLines(int maxLines) = 0;
     CV_WRAP virtual int getMaxLines() const = 0;
+
+    CV_WRAP virtual void setThreshold(int threshold) = 0;
+    CV_WRAP virtual int getThreshold() const = 0;
 };
 
 /** @brief Creates implementation for cuda::HoughSegmentDetector .
@@ -434,8 +437,10 @@ public:
 @param minLineLength Minimum line length. Line segments shorter than that are rejected.
 @param maxLineGap Maximum allowed gap between points on the same line to link them.
 @param maxLines Maximum number of output lines.
+@param threshold %Accumulator threshold parameter. Only those lines are returned that get enough
+votes ( \f$>\texttt{threshold}\f$ ).
  */
-CV_EXPORTS_W Ptr<HoughSegmentDetector> createHoughSegmentDetector(float rho, float theta, int minLineLength, int maxLineGap, int maxLines = 4096);
+CV_EXPORTS_W Ptr<HoughSegmentDetector> createHoughSegmentDetector(float rho, float theta, int minLineLength, int maxLineGap, int maxLines = 4096, int threshold = -1);
 
 //////////////////////////////////////
 // HoughCircles


### PR DESCRIPTION
Tested locally that looks working roughly as much as non-CUDA counterpart relying on `threshold`.

Does not modify the behavior of existing call without the parameter. Doc comment simply copied from https://github.com/opencv/opencv/blob/4.x/modules/imgproc/include/opencv2/imgproc.hpp.

Closes #3444.
Closes #3023.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [X] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X] The feature is well documented and sample code can be built with the project CMake
