### PR TITLE
`cudacodec::VideoReader`: force output frame resolution to be display not coded size

### DIFF
--- a/modules/cudacodec/src/video_parser.cpp
+++ b/modules/cudacodec/src/video_parser.cpp
@@ -122,16 +122,16 @@ int CUDAAPI cv::cudacodec::detail::VideoParser::HandleVideoSequence(void* userDa
         newFormat.ulHeight = format->coded_height;
         newFormat.fps = format->frame_rate.numerator / static_cast<float>(format->frame_rate.denominator);
         newFormat.targetSz = thiz->videoDecoder_->getTargetSz();
-        newFormat.width = newFormat.targetSz.width ? newFormat.targetSz.width : format->coded_width;
-        newFormat.height = newFormat.targetSz.height ? newFormat.targetSz.height : format->coded_height;
         newFormat.srcRoi = thiz->videoDecoder_->getSrcRoi();
         if (newFormat.srcRoi.empty()) {
-            format->display_area.right = format->coded_width;
-            format->display_area.bottom = format->coded_height;
             newFormat.displayArea = Rect(Point(format->display_area.left, format->display_area.top), Point(format->display_area.right, format->display_area.bottom));
+            if (newFormat.targetSz.empty())
+                newFormat.targetSz = Size((format->display_area.right - format->display_area.left), (format->display_area.bottom - format->display_area.top));
         }
         else
             newFormat.displayArea = newFormat.srcRoi;
+        newFormat.width = newFormat.targetSz.width ? newFormat.targetSz.width : format->coded_width;
+        newFormat.height = newFormat.targetSz.height ? newFormat.targetSz.height : format->coded_height;
         newFormat.targetRoi = thiz->videoDecoder_->getTargetRoi();
         newFormat.ulNumDecodeSurfaces = min(!thiz->allowFrameDrop_ ? max(thiz->videoDecoder_->nDecodeSurfaces(), static_cast<int>(format->min_num_decode_surfaces)) :
             format->min_num_decode_surfaces * 2, 32);

--- a/modules/cudacodec/test/test_video.cpp
+++ b/modules/cudacodec/test/test_video.cpp
@@ -58,6 +58,10 @@ PARAM_TEST_CASE(Scaling, cv::cuda::DeviceInfo, std::string, Size2f, Rect2f, Rect
 {
 };
 
+struct DisplayResolution : testing::TestWithParam<cv::cuda::DeviceInfo>
+{
+};
+
 PARAM_TEST_CASE(Video, cv::cuda::DeviceInfo, std::string)
 {
 };
@@ -221,6 +225,37 @@ CUDA_TEST_P(Scaling, Reader)
     // assert on mean absolute error due to different resize algorithms
     const double mae = cv::cuda::norm(frameGs, frame(targetRoiOut), NORM_L1)/frameGs.size().area();
     ASSERT_LT(mae, 2.35);
+}
+
+CUDA_TEST_P(DisplayResolution, Reader)
+{
+    cv::cuda::setDevice(GetParam().deviceID());
+    std::string inputFile = std::string(cvtest::TS::ptr()->get_data_path()) + "../cv/video/1920x1080.avi";
+    const Rect displayArea(0, 0, 1920, 1080);
+    GpuMat frame;
+
+    {
+        // verify the output frame is the diplay size (1920x1080) and not the coded size (1920x1088)
+        cv::Ptr<cv::cudacodec::VideoReader> reader = cv::cudacodec::createVideoReader(inputFile);
+        reader->set(cudacodec::ColorFormat::GRAY);
+        ASSERT_TRUE(reader->nextFrame(frame));
+        const cudacodec::FormatInfo format = reader->format();
+        ASSERT_TRUE(format.displayArea == displayArea);
+        ASSERT_TRUE(frame.size() == displayArea.size() && frame.size() == format.targetSz);
+    }
+
+    {
+        // extra check to verify display frame has not been post-processed and is just a cropped version of the coded sized frame
+        cudacodec::VideoReaderInitParams params;
+        params.srcRoi = Rect(0, 0, 1920, 1088);
+        cv::Ptr<cv::cudacodec::VideoReader> readerCodedSz = cv::cudacodec::createVideoReader(inputFile, {}, params);
+        readerCodedSz->set(cudacodec::ColorFormat::GRAY);
+        GpuMat frameCodedSz;
+        ASSERT_TRUE(readerCodedSz->nextFrame(frameCodedSz));
+        const cudacodec::FormatInfo formatCodedSz = readerCodedSz->format();
+        const double err = cv::cuda::norm(frame, frameCodedSz(displayArea), NORM_INF);
+        ASSERT_TRUE(err == 0);
+    }
 }
 
 CUDA_TEST_P(Video, Reader)
@@ -663,6 +698,8 @@ INSTANTIATE_TEST_CASE_P(CUDA_Codec, CheckSet, testing::Combine(
 #define TARGET_ROI Rect2f(0,0,1,1), Rect2f(0.2f,0.3f,0.6f,0.7f)
 INSTANTIATE_TEST_CASE_P(CUDA_Codec, Scaling, testing::Combine(
     ALL_DEVICES, testing::Values(VIDEO_SRC_SCALING), testing::Values(TARGET_SZ), testing::Values(SRC_ROI), testing::Values(TARGET_ROI)));
+
+INSTANTIATE_TEST_CASE_P(CUDA_Codec, DisplayResolution, ALL_DEVICES);
 
 #define VIDEO_SRC_R "highgui/video/big_buck_bunny.mp4", "cv/video/768x576.avi", "cv/video/1920x1080.avi", "highgui/video/big_buck_bunny.avi", \
     "highgui/video/big_buck_bunny.h264", "highgui/video/big_buck_bunny.h265", "highgui/video/big_buck_bunny.mpg", \


### PR DESCRIPTION
Now that cropping can automatically be applied inside `cudacodec::VideoReader` (https://github.com/opencv/opencv_contrib/pull/3355) in addition to the fixes in https://github.com/opencv/opencv_contrib/pull/3001 this PR automatically removes any redundant rows in decoded video's.  E.g 1080p is internally decoded to 1920x1088, currently this results in a 1920x1088 frame being returned from `VideoReader->nextFrame()` which the user has to manually crop using the information contained in `VideoReader::FormatInfo`, with this PR it will result in a 1920x1080 frame being returned.

This resolves issues such as https://github.com/opencv/opencv_contrib/issues/3195 and https://github.com/opencv/opencv/issues/21207#issuecomment-1473930858

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
