### PR TITLE
fix(wechat_qrcode): Init nBytes after the count value is determined

### DIFF
--- a/modules/wechat_qrcode/src/zxing/qrcode/decoder/decoded_bit_stream_parser.cpp
+++ b/modules/wechat_qrcode/src/zxing/qrcode/decoder/decoded_bit_stream_parser.cpp
@@ -190,7 +190,6 @@ void DecodedBitStreamParser::decodeByteSegment(Ref<BitSource> bits_, string& res
                                                CharacterSetECI* currentCharacterSetECI,
                                                ArrayRef<ArrayRef<char> >& byteSegments,
                                                ErrorHandler& err_handler) {
-    int nBytes = count;
     BitSource& bits(*bits_);
     // Don't crash trying to read more bits than we have available.
     int available = bits.available();
@@ -198,8 +197,9 @@ void DecodedBitStreamParser::decodeByteSegment(Ref<BitSource> bits_, string& res
     if (count * 8 > available) {
         count = (available + 7 / 8);
     }
+    size_t nBytes = count;
 
-    ArrayRef<char> bytes_(count);
+    ArrayRef<char> bytes_(nBytes);
     char* readBytes = &(*bytes_)[0];
     for (int i = 0; i < count; i++) {
         //    readBytes[i] = (char) bits.readBits(8);


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
