### PR TITLE
`cudacodec::VideoReader` - ensure `FormatInfo.valid == true` on return from constructor

### DIFF
--- a/modules/cudacodec/src/video_decoder.cpp
+++ b/modules/cudacodec/src/video_decoder.cpp
@@ -160,9 +160,11 @@ void cv::cudacodec::detail::VideoDecoder::create(const FormatInfo& videoFormat)
     createInfo_.ulCreationFlags     = videoCreateFlags;
     createInfo_.vidLock = lock_;
     cuSafeCall(cuCtxPushCurrent(ctx_));
-    cuSafeCall(cuvidCreateDecoder(&decoder_, &createInfo_));
+    {
+        AutoLock autoLock(mtx_);
+        cuSafeCall(cuvidCreateDecoder(&decoder_, &createInfo_));
+    }
     cuSafeCall(cuCtxPopCurrent(NULL));
-    inited_ = true;
 }
 
 int cv::cudacodec::detail::VideoDecoder::reconfigure(const FormatInfo& videoFormat) {

--- a/modules/cudacodec/src/video_decoder.hpp
+++ b/modules/cudacodec/src/video_decoder.hpp
@@ -70,6 +70,7 @@ public:
     void create(const FormatInfo& videoFormat);
     int reconfigure(const FormatInfo& videoFormat);
     void release();
+    bool inited() { AutoLock autoLock(mtx_); return decoder_; }
 
     // Get the codec-type currently used.
     cudaVideoCodec codec() const { return static_cast<cudaVideoCodec>(videoFormat_.codec); }
@@ -84,8 +85,6 @@ public:
 
     unsigned long targetWidth() { return videoFormat_.width; }
     unsigned long targetHeight() { return videoFormat_.height; }
-
-    bool inited() { return inited_; }
 
     cudaVideoChromaFormat chromaFormat() const { return static_cast<cudaVideoChromaFormat>(videoFormat_.chromaFormat); }
     int nBitDepthMinus8() const { return videoFormat_.nBitDepthMinus8; }
@@ -114,10 +113,9 @@ public:
 private:
     CUcontext ctx_ = 0;
     CUvideoctxlock lock_;
-    CUvideodecoder        decoder_ = 0;
+    CUvideodecoder decoder_ = 0;
     FormatInfo videoFormat_ = {};
     Mutex mtx_;
-    bool inited_ = false;
 };
 
 }}}

--- a/modules/cudacodec/test/test_video.cpp
+++ b/modules/cudacodec/test/test_video.cpp
@@ -230,14 +230,15 @@ CUDA_TEST_P(Scaling, Reader)
         static_cast<int>(params.targetSz.width * targetRoiIn.width), static_cast<int>(params.targetSz.height * targetRoiIn.height));
 
     cv::Ptr<cv::cudacodec::VideoReader> reader = cv::cudacodec::createVideoReader(inputFile, {}, params);
+    const cudacodec::FormatInfo format = reader->format();
+    ASSERT_TRUE(format.valid);
     ASSERT_TRUE(reader->set(cudacodec::ColorFormat::GRAY));
     GpuMat frame;
     ASSERT_TRUE(reader->nextFrame(frame));
-    const cudacodec::FormatInfo format = reader->format();
     Size targetSzOut = params.targetSz;
     Rect srcRoiOut = params.srcRoi, targetRoiOut = params.targetRoi;
     ForceAlignment(srcRoiOut, targetRoiOut, targetSzOut);
-    ASSERT_TRUE(format.valid && format.targetSz == targetSzOut && format.srcRoi == srcRoiOut && format.targetRoi == targetRoiOut);
+    ASSERT_TRUE(format.targetSz == targetSzOut && format.srcRoi == srcRoiOut && format.targetRoi == targetRoiOut);
     ASSERT_TRUE(frame.size() == targetSzOut);
     GpuMat frameGs;
     cv::cuda::resize(frameOr(srcRoiOut), frameGs, targetRoiOut.size(), 0, 0, INTER_AREA);
@@ -310,8 +311,6 @@ CUDA_TEST_P(Video, Reader)
         double colorFormat;
         ASSERT_TRUE(reader->get(cudacodec::VideoReaderProps::PROP_COLOR_FORMAT, colorFormat) && static_cast<cudacodec::ColorFormat>(colorFormat) == formatToChannels.first);
         ASSERT_TRUE(reader->nextFrame(frame));
-        if(!fmt.valid)
-            fmt = reader->format();
         const int height = formatToChannels.first == cudacodec::ColorFormat::NV_NV12 ? static_cast<int>(1.5 * fmt.height) : fmt.height;
         ASSERT_TRUE(frame.cols == fmt.width && frame.rows == height);
         ASSERT_FALSE(frame.empty());
@@ -326,6 +325,7 @@ CUDA_TEST_P(ColorConversion, Reader)
     const std::string inputFile = std::string(cvtest::TS::ptr()->get_data_path()) + "../" + get<0>(GET_PARAM(2));
     const bool videoFullRangeFlag = get<1>(GET_PARAM(2));
     cv::Ptr<cv::cudacodec::VideoReader> reader = cv::cudacodec::createVideoReader(inputFile);
+    cv::cudacodec::FormatInfo fmt = reader->format();
     reader->set(colorFormat);
     cv::VideoCapture cap(inputFile);
 
@@ -336,8 +336,8 @@ CUDA_TEST_P(ColorConversion, Reader)
         reader->nextFrame(frame);
         frame.download(frameFromDevice);
         cap.read(frameHost);
-        const cv::cudacodec::FormatInfo fmt = reader->format();
-        ASSERT_TRUE(fmt.valid && fmt.videoFullRangeFlag == videoFullRangeFlag);
+        fmt = reader->format();
+        ASSERT_TRUE(fmt.videoFullRangeFlag == videoFullRangeFlag);
         if (colorFormat == cv::cudacodec::ColorFormat::BGRA)
             cv::cvtColor(frameHost, frameHostGs, COLOR_BGR2BGRA);
         else
@@ -384,7 +384,7 @@ CUDA_TEST_P(ReconfigureDecoderWithScaling, Reader)
         if (nFrames++ == 0)
             initialSize = frame.size();
         fmt = reader->format();
-        ASSERT_TRUE(fmt.valid && (frame.size() == initialSize));
+        ASSERT_TRUE(frame.size() == initialSize);
         ASSERT_TRUE((frame.size() == targetSzOut) && (fmt.targetSz == targetSzOut) && (fmt.srcRoi == srcRoiOut) && (fmt.targetRoi == targetRoiOut));
         // simple check - zero borders, non zero contents
         ASSERT_TRUE(!cuda::absSum(frame, mask)[0] && cuda::sum(frame)[0]);
@@ -413,7 +413,7 @@ CUDA_TEST_P(ReconfigureDecoder, Reader)
             initialSize = frame.size();
             initialCodedSize = Size(fmt.ulWidth, fmt.ulHeight);
         }
-        ASSERT_TRUE(fmt.valid && (frame.size() == initialSize));
+        ASSERT_TRUE(frame.size() == initialSize);
         ASSERT_TRUE(fmt.srcRoi.empty());
         const bool resChanged = (initialCodedSize.width != fmt.ulWidth) || (initialCodedSize.height != fmt.ulHeight);
         if (resChanged)
@@ -541,11 +541,6 @@ CUDA_TEST_P(CheckDecodeSurfaces, Reader)
     {
         cv::Ptr<cv::cudacodec::VideoReader> reader = cv::cudacodec::createVideoReader(inputFile);
         cv::cudacodec::FormatInfo fmt = reader->format();
-        if (!fmt.valid) {
-            reader->grab();
-            fmt = reader->format();
-            ASSERT_TRUE(fmt.valid);
-        }
         ulNumDecodeSurfaces = fmt.ulNumDecodeSurfaces;
     }
 
@@ -554,11 +549,6 @@ CUDA_TEST_P(CheckDecodeSurfaces, Reader)
         params.minNumDecodeSurfaces = ulNumDecodeSurfaces - 1;
         cv::Ptr<cv::cudacodec::VideoReader> reader = cv::cudacodec::createVideoReader(inputFile, {}, params);
         cv::cudacodec::FormatInfo fmt = reader->format();
-        if (!fmt.valid) {
-            reader->grab();
-            fmt = reader->format();
-            ASSERT_TRUE(fmt.valid);
-        }
         ASSERT_TRUE(fmt.ulNumDecodeSurfaces == ulNumDecodeSurfaces);
         for (int i = 0; i < 100; i++) ASSERT_TRUE(reader->grab());
     }
@@ -568,11 +558,6 @@ CUDA_TEST_P(CheckDecodeSurfaces, Reader)
         params.minNumDecodeSurfaces = ulNumDecodeSurfaces + 1;
         cv::Ptr<cv::cudacodec::VideoReader> reader = cv::cudacodec::createVideoReader(inputFile, {}, params);
         cv::cudacodec::FormatInfo fmt = reader->format();
-        if (!fmt.valid) {
-            reader->grab();
-            fmt = reader->format();
-            ASSERT_TRUE(fmt.valid);
-        }
         ASSERT_TRUE(fmt.ulNumDecodeSurfaces == ulNumDecodeSurfaces + 1);
         for (int i = 0; i < 100; i++) ASSERT_TRUE(reader->grab());
     }
@@ -626,10 +611,6 @@ CUDA_TEST_P(TransCode, H264ToH265)
         cv::cuda::Stream stream;
         for (int i = 0; i < nFrames; ++i) {
             ASSERT_TRUE(reader->nextFrame(frame, stream));
-            if (!fmt.valid) {
-                fmt = reader->format();
-                ASSERT_TRUE(fmt.valid);
-            }
             ASSERT_FALSE(frame.empty());
             Mat tst; frame.download(tst);
             if (writer.empty()) {


### PR DESCRIPTION
As discussed in https://github.com/opencv/opencv_contrib/pull/3468#discussion_r1165613962 it would be useful if `VideoReader::FormatInfo` was valid in the constructor to make validation tasks simpler.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
