### PR TITLE
Fixed memory leak in EllipseDetector and Mat addressing

### DIFF
--- a/modules/ximgproc/src/find_ellipses.cpp
+++ b/modules/ximgproc/src/find_ellipses.cpp
@@ -1272,9 +1272,9 @@ void EllipseDetectorImpl::preProcessing(Mat1b &image, Mat1b &dp, Mat1b &dn) {
 
     // buffer
     int *magBuffer[3];
-    void *buffer = malloc((imgSize.width + 2) * (imgSize.height + 2) +
-                          (imgSize.width + 2) * 3 * sizeof(int));
-    magBuffer[0] = (int *) buffer;
+    AutoBuffer<int> buffer((imgSize.width + 2) * (imgSize.height + 2) +
+                          (imgSize.width + 2) * 3);
+    magBuffer[0] = buffer.data();
     magBuffer[1] = magBuffer[0] + imgSize.width + 2;
     magBuffer[2] = magBuffer[1] + imgSize.width + 2;
     uchar *map = (uchar *) (magBuffer[2] + imgSize.width + 2);
@@ -1300,8 +1300,8 @@ void EllipseDetectorImpl::preProcessing(Mat1b &image, Mat1b &dp, Mat1b &dn) {
     // 2 - the pixel does belong to an edge
     for (int i = 0; i <= imgSize.height; i++) {
         int *tmpMag = magBuffer[(i > 0) + 1] + 1;
-        const short *tmpDx = (short *) (dx[i]);
-        const short *tmpDy = (short *) (dy[i]);
+        const short *tmpDx = dx.ptr<short>(i);
+        const short *tmpDy = dy.ptr<short>(i);
         uchar *tmpMap;
         int prevFlag = 0;
 


### PR DESCRIPTION
Relates to https://github.com/opencv/opencv_contrib/pull/3322
More accurate replacement for https://github.com/opencv/opencv_contrib/pull/3393

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
