### PR TITLE
Wstringop-overflow warning fix in bio inspired module

### DIFF
--- a/modules/bioinspired/src/transientareassegmentationmodule.cpp
+++ b/modules/bioinspired/src/transientareassegmentationmodule.cpp
@@ -136,7 +136,7 @@ public:
     /**
      * @return the current parameters setup
      */
-    struct SegmentationParameters getParameters();
+    SegmentationParameters getParameters();
 
     /**
      * parameters setup display method
@@ -202,7 +202,7 @@ protected:
      */
     inline const std::valarray<float> &getMotionContextPicture() const {return _contextMotionEnergy;}
 
-    struct cv::bioinspired::SegmentationParameters _segmentationParameters;
+    cv::bioinspired::SegmentationParameters _segmentationParameters;
     // template buffers and related acess pointers
     std::valarray<float> _inputToSegment;
     std::valarray<float> _contextMotionEnergy;
@@ -233,7 +233,7 @@ public:
     inline virtual void setup(cv::FileStorage &fs, const bool applyDefaultSetupOnFailure) CV_OVERRIDE { _segmTool.setup(fs, applyDefaultSetupOnFailure); }
     inline virtual void setup(SegmentationParameters newParameters) CV_OVERRIDE { _segmTool.setup(newParameters); }
     inline virtual String printSetup() CV_OVERRIDE { return _segmTool.printSetup(); }
-    inline virtual struct SegmentationParameters getParameters() CV_OVERRIDE { return _segmTool.getParameters(); }
+    inline virtual SegmentationParameters getParameters() CV_OVERRIDE { return _segmTool.getParameters(); }
     inline virtual void write( String fs ) const CV_OVERRIDE { _segmTool.write(fs); }
     inline virtual void run(InputArray inputToSegment, const int channelIndex) CV_OVERRIDE { _segmTool.run(inputToSegment, channelIndex); }
     inline virtual void getSegmentationPicture(OutputArray transientAreas) CV_OVERRIDE { return _segmTool.getSegmentationPicture(transientAreas); }
@@ -285,7 +285,7 @@ void TransientAreasSegmentationModuleImpl::clearAllBuffers()
     _segmentedAreas=0;
 }
 
-struct SegmentationParameters TransientAreasSegmentationModuleImpl::getParameters()
+SegmentationParameters TransientAreasSegmentationModuleImpl::getParameters()
 {
     return _segmentationParameters;
 }
@@ -343,7 +343,7 @@ void TransientAreasSegmentationModuleImpl::setup(cv::FileStorage &fs, const bool
         std::cout<<"Retina::setup: resetting retina with default parameters"<<std::endl;
         if (applyDefaultSetupOnFailure)
         {
-            struct cv::bioinspired::SegmentationParameters defaults;
+            cv::bioinspired::SegmentationParameters defaults;
             setup(defaults);
         }
         std::cout<<"SegmentationModule::setup: wrong/unappropriate xml parameter file : error report :`n=>"<<e.what()<<std::endl;
@@ -356,7 +356,7 @@ void TransientAreasSegmentationModuleImpl::setup(cv::bioinspired::SegmentationPa
 {
 
     // copy structure contents
-    memcpy(&_segmentationParameters, &newParameters, sizeof(cv::bioinspired::SegmentationParameters));
+    _segmentationParameters = newParameters;
     // apply setup
     // init local motion energy extraction low pass filter
     BasicRetinaFilter::setLPfilterParameters(0, newParameters.localEnergy_temporalConstant, newParameters.localEnergy_spatialConstant);


### PR DESCRIPTION
Fixes GCC 11 warning (ubuntu 22.04):
```
2102/3265] Building CXX object modules/bioinspired/CMakeFiles/opencv_bioinspired.dir/src/transientareassegmentationmodule.cpp.o
In file included from /usr/include/string.h:535,
                 from /usr/include/c++/11/cstring:42,
                 from /home/ci/opencv/modules/core/include/opencv2/core/cvstd.hpp:53,
                 from /home/ci/opencv/modules/core/include/opencv2/core/base.hpp:58,
                 from /home/ci/opencv/modules/core/include/opencv2/core.hpp:53,
                 from /home/ci/opencv_contrib/modules/bioinspired/include/opencv2/bioinspired.hpp:46,
                 from /home/ci/opencv_contrib/modules/bioinspired/src/precomp.hpp:47,
                 from /home/ci/opencv_contrib/modules/bioinspired/src/transientareassegmentationmodule.cpp:77:
In function 'void* memcpy(void*, const void*, size_t)',
    inlined from 'void cv::bioinspired::TransientAreasSegmentationModuleImpl::setup(cv::bioinspired::SegmentationParameters)' at /home/ci/opencv_contrib/modules/bioinspired/src/transientareassegmentationmodule.cpp:359:11,
    inlined from 'cv::bioinspired::TransientAreasSegmentationModuleImpl::TransientAreasSegmentationModuleImpl(cv::Size)' at /home/ci/opencv_contrib/modules/bioinspired/src/transientareassegmentationmodule.cpp:269:10:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:29:33: warning: writing 32 bytes into a region of size 4 [-Wstringop-overflow=]
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
