### PR TITLE
fix: remove using namespace cuda from public header

### DIFF
--- a/modules/cudacodec/include/opencv2/cudacodec.hpp
+++ b/modules/cudacodec/include/opencv2/cudacodec.hpp
@@ -59,8 +59,6 @@
 
 namespace cv { namespace cudacodec {
 
-using namespace cuda;  // Stream
-
 //! @addtogroup cudacodec
 //! @{
 
@@ -264,7 +262,7 @@ public:
 @param stream Stream for frame pre-processing.
 */
 CV_EXPORTS_W Ptr<cudacodec::VideoWriter> createVideoWriter(const String& fileName, const Size frameSize, const Codec codec = Codec::H264, const double fps = 25.0,
-    const ColorFormat colorFormat = ColorFormat::BGR, Ptr<EncoderCallback> encoderCallback = 0, const Stream& stream = Stream::Null());
+    const ColorFormat colorFormat = ColorFormat::BGR, Ptr<EncoderCallback> encoderCallback = 0, const cuda::Stream& stream = cuda::Stream::Null());
 
 /** @brief Creates video writer.
 
@@ -278,7 +276,7 @@ CV_EXPORTS_W Ptr<cudacodec::VideoWriter> createVideoWriter(const String& fileNam
 @param stream Stream for frame pre-processing.
 */
 CV_EXPORTS_W Ptr<cudacodec::VideoWriter> createVideoWriter(const String& fileName, const Size frameSize, const Codec codec, const double fps,  const ColorFormat colorFormat,
-    const EncoderParams& params, Ptr<EncoderCallback> encoderCallback = 0, const Stream& stream = Stream::Null());
+    const EncoderParams& params, Ptr<EncoderCallback> encoderCallback = 0, const cuda::Stream& stream = cuda::Stream::Null());
 
 ////////////////////////////////// Video Decoding //////////////////////////////////////////
 
@@ -313,7 +311,7 @@ enum DeinterlaceMode
     -   This function demonstrates how to map the luma histogram back so that it is equivalent to the result obtained from cuda::calcHist()
     if the returned frame was colorFormat::GRAY.
  */
-CV_EXPORTS_W void MapHist(const GpuMat& hist, CV_OUT Mat& histFull);
+CV_EXPORTS_W void MapHist(const cuda::GpuMat& hist, CV_OUT Mat& histFull);
 
 /** @brief Struct providing information about video file format. :
  */
@@ -387,7 +385,7 @@ public:
     If no frames have been grabbed (there are no more frames in video file), the methods return false.
     The method throws an Exception if error occurs.
      */
-    CV_WRAP virtual bool nextFrame(CV_OUT GpuMat& frame, Stream &stream = Stream::Null()) = 0;
+    CV_WRAP virtual bool nextFrame(CV_OUT cuda::GpuMat& frame, cuda::Stream &stream = cuda::Stream::Null()) = 0;
 
     /** @brief Grabs, decodes and returns the next video frame and frame luma histogram.
 
@@ -401,7 +399,7 @@ public:
 
     @note Histogram data is collected by NVDEC during the decoding process resulting in zero performance penalty. NVDEC computes the histogram data for only the luma component of decoded output, not on post-processed frame(i.e. when scaling, cropping, etc. applied).  If the source is encoded using a limited range of luma values (FormatInfo::videoFullRangeFlag == false) then the histogram bin values will correspond to to this limited range of values and will need to be mapped to contain the same output as cuda::calcHist().  The MapHist() utility function can be used to perform this mapping on the host if required.
      */
-    CV_WRAP_AS(nextFrameWithHist) virtual bool nextFrame(CV_OUT GpuMat& frame, CV_OUT GpuMat& histogram, Stream& stream = Stream::Null()) = 0;
+    CV_WRAP_AS(nextFrameWithHist) virtual bool nextFrame(CV_OUT cuda::GpuMat& frame, CV_OUT cuda::GpuMat& histogram, cuda::Stream& stream = cuda::Stream::Null()) = 0;
 
     /** @brief Returns information about video file format.
     */
@@ -418,7 +416,7 @@ public:
     The primary use of the function is for reading both the encoded and decoded video data when rawMode is enabled.  With rawMode enabled
     retrieve() can be called following grab() to retrieve all the data associated with the current video source since the last call to grab() or the creation of the VideoReader.
      */
-    CV_WRAP virtual bool grab(Stream& stream = Stream::Null()) = 0;
+    CV_WRAP virtual bool grab(cuda::Stream& stream = cuda::Stream::Null()) = 0;
 
     /** @brief Returns previously grabbed video data.
 
@@ -457,7 +455,7 @@ public:
     The method returns data associated with the current video source since the last call to grab(). If no data is present
     the method returns false and the function returns an empty image.
      */
-    CV_WRAP inline bool retrieve(CV_OUT GpuMat& frame) const {
+    CV_WRAP inline bool retrieve(CV_OUT cuda::GpuMat& frame) const {
         return retrieve(OutputArray(frame));
     }
 

--- a/modules/cudacodec/src/video_decoder.hpp
+++ b/modules/cudacodec/src/video_decoder.hpp
@@ -96,7 +96,7 @@ public:
         return cuvidDecodePicture(decoder_, picParams) == CUDA_SUCCESS;
     }
 
-    GpuMat mapFrame(int picIdx, CUVIDPROCPARAMS& videoProcParams)
+    cuda::GpuMat mapFrame(int picIdx, CUVIDPROCPARAMS& videoProcParams)
     {
         CUdeviceptr ptr;
         unsigned int pitch;


### PR DESCRIPTION
Avoid `using namespace` statements in public header without any reason.

merge after opencv/opencv#24029 and opencv/opencv#24046

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
