### PR TITLE
Fixed several test failures in Python tests for CUDA modules

### DIFF
--- a/modules/cudaoptflow/misc/python/test/test_nvidiaopticalflow.py
+++ b/modules/cudaoptflow/misc/python/test/test_nvidiaopticalflow.py
@@ -22,15 +22,15 @@ class nvidiaopticalflow_test(NewOpenCVTests):
         cuMat1 = cv.cuda_GpuMat(npMat1)
         cuMat2 = cv.cuda_GpuMat(npMat2)
         try:
-            nvof = cv.cuda_NvidiaOpticalFlow_1_0.create(cuMat1.shape[1], cuMat1.shape[0], 5, False, False, False, 0)
-            flow = nvof.calc(cuMat1, cuMat2, None)
-            self.assertTrue(flow.shape[1] > 0 and flow.shape[0] > 0)
-            flowUpSampled = nvof.upSampler(flow[0], cuMat1.shape[1], cuMat1.shape[0], nvof.getGridSize(), None)
+            nvof = cv.cuda_NvidiaOpticalFlow_1_0.create((npMat1.shape[1], npMat1.shape[0]), 5, False, False, False, 0)
+            flow, cost = nvof.calc(cuMat1, cuMat2, None)
+            self.assertTrue(flow.size()[1] > 0 and flow.size()[0] > 0)
+            flowUpSampled = nvof.upSampler(flow, (npMat1.shape[1], npMat1.shape[0]), nvof.getGridSize(), None)
             nvof.collectGarbage()
+            self.assertTrue(flowUpSampled.size()[1] > 0 and flowUpSampled.size()[0] > 0)
         except cv.error as e:
             if e.code == cv.Error.StsBadFunc or e.code == cv.Error.StsBadArg or e.code == cv.Error.StsNullPtr:
                 self.skipTest("Algorithm is not supported in the current environment")
-        self.assertTrue(flowUpSampled.shape[1] > 0 and flowUpSampled.shape[0] > 0)
 
 if __name__ == '__main__':
     NewOpenCVTests.bootstrap()


### PR DESCRIPTION
1. Not all GPUs support histogram generation by codec. Related to https://github.com/opencv/opencv_contrib/pull/3477.
2. Syntax fixes

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
