### PR TITLE
ximgproc: GraphSegmentation: support CV_16U/CV_32F/CV_64F input

### DIFF
--- a/modules/ximgproc/include/opencv2/ximgproc/segmentation.hpp
+++ b/modules/ximgproc/include/opencv2/ximgproc/segmentation.hpp
@@ -46,7 +46,7 @@ namespace cv {
                     class CV_EXPORTS_W GraphSegmentation : public Algorithm {
                         public:
                             /** @brief Segment an image and store output in dst
-                                @param src The input image. Any number of channel (1 (Eg: Gray), 3 (Eg: RGB), 4 (Eg: RGB-D)) can be provided
+                                @param src The input image. Any number of channel (1 (Eg: Gray), 3 (Eg: RGB), 4 (Eg: RGB-D)) can be provided. Supported depth is CV_8U / CV_16U / CV_32F / CV_64F.
                                 @param dst The output segmentation. It's a CV_32SC1 Mat with the same number of cols and rows as input image, with an unique, sequential, id for each pixel.
                             */
                             CV_WRAP virtual void processImage(InputArray src, OutputArray dst) = 0;

--- a/modules/ximgproc/src/graphsegmentation.cpp
+++ b/modules/ximgproc/src/graphsegmentation.cpp
@@ -161,8 +161,18 @@ namespace cv {
 
                 Mat img_converted;
 
-                // Switch to float
-                img.convertTo(img_converted, CV_32F);
+                // Switch to [0,255] float
+                const int depth = CV_MAT_DEPTH( img.type() );
+                double alpha = 1.0;
+                switch( depth )
+                {
+                    case CV_8U:  alpha = 1.;             break;
+                    case CV_16U: alpha = 1. / 256.;      break;
+                    case CV_32F: alpha = 256. ;          break;
+                    case CV_64F: alpha = 256. ;          break;
+                    default: CV_Error(Error::StsBadArg,"Unsupported Mat type"); break;
+                }
+                img.convertTo(img_converted, CV_32F, alpha );
 
                 // Apply gaussian filter
                 GaussianBlur(img_converted, img_filtered, Size(0, 0), sigma, sigma);

--- a/modules/ximgproc/test/test_segmentation.cpp
+++ b/modules/ximgproc/test/test_segmentation.cpp
@@ -1,0 +1,86 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+#include "test_precomp.hpp"
+
+using namespace cv::ximgproc::segmentation;
+
+namespace opencv_test { namespace {
+
+// See https://github.com/opencv/opencv_contrib/issues/3544
+TEST(ximgproc_ImageSegmentation, createGraphSegmentation_issueC3544)
+{
+    cv::String testImagePath = cvtest::TS::ptr()->get_data_path() + "cv/ximgproc/" + "pascal_voc_bird.png";
+    Mat testImg = imread(testImagePath);
+    ASSERT_FALSE(testImg.empty()) << "Could not load input image " << testImagePath;
+    Ptr<GraphSegmentation> gs = createGraphSegmentation();
+    Mat segImg;
+    double min,max;
+
+    // Try CV_8UC3
+    Mat testImg_8UC3;
+    testImg_8UC3 = testImg.clone();
+    ASSERT_EQ(testImg_8UC3.type(), CV_8UC3 ) << "Input image is not CV_8UC3";
+    ASSERT_NO_THROW( gs->processImage(testImg_8UC3, segImg) );
+    ASSERT_NO_THROW( minMaxLoc(segImg, &min, &max) );
+    EXPECT_EQ( min, 0 );
+    EXPECT_EQ( max, 17 );
+
+    // Try CV_8UC1
+    Mat testImg_8UC1;
+    cvtColor(testImg, testImg_8UC1, COLOR_BGR2GRAY);
+    ASSERT_EQ(testImg_8UC1.type(), CV_8UC1 ) << "Input image is not CV_8UC1";
+    ASSERT_NO_THROW( gs->processImage(testImg_8UC1, segImg) );
+    ASSERT_NO_THROW( minMaxLoc(segImg, &min, &max) );
+    EXPECT_EQ( min, 0 );
+    EXPECT_EQ( max, 14 ); // Gray image
+
+    // Try CV_8UC4
+    Mat testImg_8UC4;
+    cvtColor(testImg, testImg_8UC4, COLOR_BGR2BGRA);
+    ASSERT_EQ(testImg_8UC4.type(), CV_8UC4 ) << "Input image is not CV_8UC4";
+    ASSERT_NO_THROW( gs->processImage(testImg_8UC4, segImg) );
+    ASSERT_NO_THROW( minMaxLoc(segImg, &min, &max) );
+    EXPECT_EQ( min, 0 );
+    EXPECT_EQ( max, 17 );
+
+    // Try CV_16UC3
+    Mat testImg_16UC3;
+    testImg.convertTo(testImg_16UC3, CV_16U, 256. , 0.0);
+    ASSERT_EQ(testImg_16UC3.type(), CV_16UC3 ) << "Input image is not CV_16UC3";
+    ASSERT_NO_THROW( gs->processImage(testImg_16UC3, segImg) );
+    ASSERT_NO_THROW( minMaxLoc(segImg, &min, &max) );
+    EXPECT_EQ( min, 0 );
+    EXPECT_EQ( max, 17 );
+
+    // Try CV_32FC3
+    Mat testImg_32FC3;
+    testImg.convertTo(testImg_32FC3, CV_32F, 1./256. , 0.0);
+    ASSERT_EQ(testImg_32FC3.type(), CV_32FC3 ) << "Input image is not CV_32FC3";
+    ASSERT_NO_THROW( gs->processImage(testImg_32FC3, segImg) );
+    ASSERT_NO_THROW( minMaxLoc(segImg, &min, &max) );
+    EXPECT_EQ( min, 0 );
+    EXPECT_EQ( max, 17 );
+
+    // Try CV_64FC3
+    Mat testImg_64FC3;
+    testImg.convertTo(testImg_64FC3, CV_64F, 1./256. , 0.0);
+    ASSERT_EQ(testImg_64FC3.type(), CV_64FC3 ) << "Input image is not CV_64FC3";
+    ASSERT_NO_THROW( gs->processImage(testImg_64FC3, segImg) );
+    ASSERT_NO_THROW( minMaxLoc(segImg, &min, &max) );
+    EXPECT_EQ( min, 0 );
+    EXPECT_EQ( max, 17 );
+
+    // Unsupported Images
+    ASSERT_ANY_THROW( gs->processImage( cv::Mat::zeros(320,240, CV_8SC1), segImg) );
+    ASSERT_ANY_THROW( gs->processImage( cv::Mat::zeros(320,240, CV_8SC3), segImg) );
+    ASSERT_ANY_THROW( gs->processImage( cv::Mat::zeros(320,240, CV_8SC4), segImg) );
+    ASSERT_ANY_THROW( gs->processImage( cv::Mat::zeros(320,240, CV_16SC1), segImg) );
+    ASSERT_ANY_THROW( gs->processImage( cv::Mat::zeros(320,240, CV_16SC3), segImg) );
+    ASSERT_ANY_THROW( gs->processImage( cv::Mat::zeros(320,240, CV_16SC4), segImg) );
+    ASSERT_ANY_THROW( gs->processImage( cv::Mat::zeros(320,240, CV_32SC1), segImg) );
+    ASSERT_ANY_THROW( gs->processImage( cv::Mat::zeros(320,240, CV_32SC3), segImg) );
+    ASSERT_ANY_THROW( gs->processImage( cv::Mat::zeros(320,240, CV_32SC4), segImg) );
+}
+
+}} // namespace


### PR DESCRIPTION
Fix https://github.com/opencv/opencv_contrib/issues/3544

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
