### PR TITLE
fix wrong detector in detectCharucoDiamond

### DIFF
--- a/modules/aruco/src/charuco.cpp
+++ b/modules/aruco/src/charuco.cpp
@@ -39,7 +39,7 @@ void detectCharucoDiamond(InputArray _image, InputArrayOfArrays _markerCorners, 
     vector<Mat> markerCorners;
     _markerCorners.getMatVector(markerCorners);
 
-    detector.detectBoard(_image, _diamondCorners, _diamondIds, markerCorners, _markerIds.getMat());
+    detector.detectDiamonds(_image, _diamondCorners, _diamondIds, markerCorners, _markerIds.getMat());
 }
 
 


### PR DESCRIPTION
use diamond detector instead of board detector in detectCharucoDiamond()

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.

- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
