### PR TITLE
freetype: fix for huge CtoL param.

### DIFF
--- a/modules/freetype/test/test_basic.cpp
+++ b/modules/freetype/test/test_basic.cpp
@@ -12,15 +12,59 @@ struct MattypeParams
     bool expect_success;
 };
 
-::std::ostream& operator<<(::std::ostream& os, const MattypeParams& prm) {
-      return os << prm.title;
+::std::ostream& operator<<(::std::ostream& os, const MattypeParams& prm)
+{
+    os << "title = " << prm.title << " ";
+    os << "mattype = ";
+
+    switch( CV_MAT_DEPTH( prm.mattype ) )
+    {
+        case CV_8U:    os << "CV_8U" ; break;
+        case CV_8S:    os << "CV_8S" ; break;
+        case CV_16U:   os << "CV_16U"; break;
+        case CV_16S:   os << "CV_16S"; break;
+        case CV_32S:   os << "CV_32S"; break;
+        case CV_32F:   os << "CV_32F"; break;
+        case CV_64F:   os << "CV_64F"; break;
+        case CV_16F:   os << "CV_16F"; break;
+
+// OpenCV5
+#ifdef CV_16BF
+        case CV_16BF:  os << "CV_16BF"; break;
+#endif
+#ifdef CV_Bool
+        case CV_Bool:  os << "CV_Bool"; break;
+#endif
+#ifdef CV_64U
+        case CV_64U:  os << "CV_64U"; break;
+#endif
+#ifdef CV_64S
+        case CV_64S:  os << "CV_64S"; break;
+#endif
+#ifdef CV_32U
+        case CV_32U:  os << "CV_32U"; break;
+#endif
+        default:       os << "CV UNKNOWN_DEPTH(" << CV_MAT_DEPTH( prm.mattype ) << ")" ; break;
+    }
+
+    switch( CV_MAT_CN( prm.mattype ) )
+    {
+        case 1:        os << "C1" ; break;
+        case 2:        os << "C2" ; break;
+        case 3:        os << "C3" ; break;
+        case 4:        os << "C4" ; break;
+        default:       os << "UNKNOWN_CN" << CV_MAT_CN( prm.mattype ) << ")" ; break;
+    }
+
+    os << " expected = " << (prm.expect_success? "true": "false") ;
+
+    return os;
 }
 
 const MattypeParams mattype_list[] =
 {
     { "CV_8UC1",  CV_8UC1,  true},  { "CV_8UC2",  CV_8UC2,  false},
     { "CV_8UC3",  CV_8UC3,  true},  { "CV_8UC4",  CV_8UC4,  true},
-
     { "CV_8SC1",  CV_8SC1,  false}, { "CV_8SC2",  CV_8SC2,  false},
     { "CV_8SC3",  CV_8SC3,  false}, { "CV_8SC4",  CV_8SC4,  false},
     { "CV_16UC1", CV_16UC1, false}, { "CV_16UC2", CV_16UC2, false},
@@ -34,7 +78,35 @@ const MattypeParams mattype_list[] =
     { "CV_64FC1", CV_64FC1, false}, { "CV_64FC2", CV_64FC2, false},
     { "CV_64FC3", CV_64FC3, false}, { "CV_64FC4", CV_64FC4, false},
     { "CV_16FC1", CV_16FC1, false}, { "CV_16FC2", CV_16FC2, false},
-    { "CV_16FC3", CV_16FC3, false}, { "CV_16FC4", CV_16FC4, false},
+    { "CV_16FC3", CV_16FC3, false}, { "CV_16FC4", CV_16FC4, false}
+
+// OpenCV5
+#ifdef CV_16BF
+    ,
+    { "CV_16BFC1", CV_16BFC1, false}, { "CV_16FC2", CV_16BFC2, false},
+    { "CV_16BFC3", CV_16BFC3, false}, { "CV_16FC4", CV_16BFC4, false}
+#endif
+#ifdef CV_Bool
+    ,
+    { "CV_BoolC1", CV_BoolC1, false}, { "CV_BoolC2", CV_BoolC2, false},
+    { "CV_BoolC3", CV_BoolC3, false}, { "CV_BoolC4", CV_BoolC4, false}
+#endif
+#ifdef CV_64U
+    ,
+    { "CV_64UC1", CV_64UC1, false},   { "CV_64UC2", CV_64UC2, false},
+    { "CV_64UC3", CV_64UC3, false},   { "CV_64UC4", CV_64UC4, false}
+#endif
+#ifdef CV_64S
+    ,
+    { "CV_64SC1", CV_64SC1, false},   { "CV_64SC2", CV_64SC2, false},
+    { "CV_64SC3", CV_64SC3, false},   { "CV_64SC4", CV_64SC4, false}
+#endif
+#ifdef CV_32U
+    ,
+    { "CV_32UC1", CV_32UC1, false},   { "CV_32UC2", CV_32UC2, false},
+    { "CV_32UC3", CV_32UC3, false},   { "CV_32UC4", CV_32UC4, false}
+#endif
+
 };
 
 /******************
@@ -152,19 +224,32 @@ TEST_P(ctol_range, success)
     EXPECT_NO_THROW( ft2->putText(dst, "CtoL", Point( 0,  50), 50, col, 1, LINE_4, true ) );
     EXPECT_NO_THROW( ft2->putText(dst, "LINE_4: oOpPqQ", Point( 40, 100), 50, col, 1, LINE_4, true ) );
     EXPECT_NO_THROW( ft2->putText(dst, "LINE_8: oOpPqQ", Point( 40, 150), 50, col, 1, LINE_8, true ) );
-    EXPECT_NO_THROW( ft2->putText(dst, "LINE_AA:oOpPqQ", Point( 40, 150), 50, col, 1, LINE_AA, true ) );
+    EXPECT_NO_THROW( ft2->putText(dst, "LINE_AA:oOpPqQ", Point( 40, 200), 50, col, 1, LINE_AA, true ) );
+
+    if (cvtest::debugLevel > 0 )
+    {
+        imwrite( cv::format("CtoL%d-MatType.png", GetParam()) , dst );
+    }
 }
 
 const int ctol_list[] =
 {
     1,
+    2,
+    4,
     8,
     16,
     32,
     64,
     128,
-    // INT_MAX -1,  // Hang-up
-    // INT_MAX      // Hang-up
+    256,
+    512,
+    1024,
+    2048,
+    4096,
+    8192,
+    INT_MAX -1,
+    INT_MAX
 };
 
 INSTANTIATE_TEST_CASE_P(Freetype_setSplitNumber, ctol_range,


### PR DESCRIPTION
The freetype module uses CtoL param to split bezier curve segment to polylines.
This patch makes local upper limitation for each segments. It is determined with total length of polylines at anchors.
And skip to push_back() same points, likes imgproc::ellipse2Poly().

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
