### PR TITLE
Fix compile error (with GCC 12.2.0 & Clang 14.0.6 at least) - tinyxml2

### DIFF
--- a/modules/datasets/src/tinyxml2/tinyxml2.h
+++ b/modules/datasets/src/tinyxml2/tinyxml2.h
@@ -212,7 +212,7 @@ template <class T, int INIT>
 class DynArray
 {
 public:
-    DynArray< T, INIT >() {
+    explicit DynArray< T, INIT >() {
         _mem = _pool;
         _allocated = INIT;
         _size = 0;


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x ] I agree to contribute to the project under Apache 2 License.
- [x ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


Fixed build error with GCC 12+ and Clang 14+:
      "DynArray< T, INIT >()" error: expected unqualified-id before ‘)’
