### PR TITLE
freetype: Add function to load font from buffer(additional patch)

### DIFF
--- a/modules/freetype/include/opencv2/freetype.hpp
+++ b/modules/freetype/include/opencv2/freetype.hpp
@@ -84,6 +84,19 @@ The function loadFontData loads font data.
 
     CV_WRAP virtual void loadFontData(String fontFileName, int idx) = 0;
 
+/** @brief Load font data.
+
+The function loadFontData loads font data.
+The data is not copied, the user needs to make sure the data lives at least as long as FreeType2.
+After the FreeType2 object is destroyed, the buffer can be safely deallocated.
+
+@param pBuf pointer to buffer containing font data
+@param bufSize size of buffer
+@param idx face_index to select a font faces in a single file.
+*/
+
+    CV_WRAP virtual void loadFontData(uchar* pBuf, size_t bufSize, int idx) = 0;
+
 /** @brief Set Split Number from Bezier-curve to line
 
 The function setSplitNumber set the number of split points from bezier-curve to line.

--- a/modules/freetype/include/opencv2/freetype.hpp
+++ b/modules/freetype/include/opencv2/freetype.hpp
@@ -76,7 +76,7 @@ class CV_EXPORTS_W FreeType2 : public Algorithm
 public:
 /** @brief Load font data.
 
-The function loadFontData loads font data.
+The function loadFontData loads font data from file.
 
 @param fontFileName FontFile Name
 @param idx face_index to select a font faces in a single file.
@@ -86,7 +86,7 @@ The function loadFontData loads font data.
 
 /** @brief Load font data.
 
-The function loadFontData loads font data.
+The function loadFontData loads font data from memory.
 The data is not copied, the user needs to make sure the data lives at least as long as FreeType2.
 After the FreeType2 object is destroyed, the buffer can be safely deallocated.
 
@@ -95,7 +95,7 @@ After the FreeType2 object is destroyed, the buffer can be safely deallocated.
 @param idx face_index to select a font faces in a single file.
 */
 
-    CV_WRAP virtual void loadFontData(uchar* pBuf, size_t bufSize, int idx) = 0;
+    CV_WRAP virtual void loadFontData(char* pBuf, size_t bufSize, int idx) = 0;
 
 /** @brief Set Split Number from Bezier-curve to line
 

--- a/modules/freetype/test/test_basic.cpp
+++ b/modules/freetype/test/test_basic.cpp
@@ -55,6 +55,39 @@ TEST(Freetype_Basic, success )
     EXPECT_NO_THROW( ft2->putText(dst, "Basic,success", Point( 0,  50), 50, col, -1, LINE_AA, true ) );
 }
 
+TEST(Freetype_Basic, in_memory_font )
+{
+    const string root = cvtest::TS::ptr()->get_data_path();
+    const string font_path = root + "freetype/mplus/Mplus1-Regular.ttf";
+
+    cv::Ptr<cv::freetype::FreeType2> ft2;
+    EXPECT_NO_THROW( ft2 = cv::freetype::createFreeType2() );
+    EXPECT_NO_THROW( ft2->loadFontData( font_path, 0 ) );
+
+    Mat dst(600,600, CV_8UC3, Scalar::all(255) );
+    Scalar col(128,64,255,192);
+    EXPECT_NO_THROW( ft2->putText(dst, "Basic,success", Point( 0,  50), 50, col, -1, LINE_AA, true ) );
+
+    FILE* fp = fopen(font_path.c_str(), "rb");
+    ASSERT_TRUE(fp != NULL);
+    fseek(fp, 0, SEEK_END);
+    const size_t file_size = ftell(fp);
+    fseek(fp, 0, SEEK_SET);
+
+    std::vector<uchar> font_buffer(file_size);
+    const size_t actual_read = fread(&font_buffer[0], 1, file_size, fp);
+    fclose(fp);
+    ASSERT_EQ(file_size, actual_read);
+
+    cv::Ptr<cv::freetype::FreeType2> ft2_in_memory;
+    EXPECT_NO_THROW( ft2_in_memory = cv::freetype::createFreeType2() );
+    EXPECT_NO_THROW( ft2_in_memory->loadFontData( &font_buffer[0], file_size, 0 ) );
+    Mat dst_in_memory(600,600, CV_8UC3, Scalar::all(255) );
+    EXPECT_NO_THROW( ft2_in_memory->putText(dst_in_memory, "Basic,success", Point( 0,  50), 50, col, -1, LINE_AA, true ) );
+
+    EXPECT_PRED_FORMAT2(cvtest::MatComparator(0, 0), dst, dst_in_memory);
+}
+
 /******************
  * loadFontData()
  *****************/


### PR DESCRIPTION
Original pull request is https://github.com/opencv/opencv_contrib/pull/3586 .
Current pull request contains additional patches for review.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
