### PR TITLE
`cudaoptflow`: fix `FarnebackOpticalFlow` internal stream synchronization when used with an external CUDA stream

### DIFF
--- a/modules/cudaoptflow/src/farneback.cpp
+++ b/modules/cudaoptflow/src/farneback.cpp
@@ -140,6 +140,7 @@ namespace
         int polyN_;
         double polySigma_;
         int flags_;
+        Event sourceStreamComplete;
 
     private:
         void prepareGaussian(
@@ -317,7 +318,10 @@ namespace
 
         Stream streams[5];
         if (stream)
+        {
             streams[0] = stream;
+            sourceStreamComplete.record();
+        }
 
         Size size = frame0.size();
         GpuMat prevFlowX, prevFlowY, curFlowX, curFlowY;
@@ -336,6 +340,8 @@ namespace
         }
 
         frame0.convertTo(frames_[0], CV_32F, streams[0]);
+        if (stream)
+            streams[1].waitEvent(sourceStreamComplete);
         frame1.convertTo(frames_[1], CV_32F, streams[1]);
 
         if (fastPyramids_)


### PR DESCRIPTION
Fix https://github.com/opencv/opencv/issues/24540 and add test to confirm.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
