### PR TITLE
`cudacodec`: Enable features available with updated ffmpeg dll

### DIFF
--- a/modules/cudacodec/src/ffmpeg_video_source.cpp
+++ b/modules/cudacodec/src/ffmpeg_video_source.cpp
@@ -66,55 +66,9 @@ static std::string fourccToString(int fourcc)
         (i32_c.c[3] >= ' ' && i32_c.c[3] < 128) ? i32_c.c[3] : '?');
 }
 
-// handle old FFmpeg backend - remove when windows shared library is updated
-#ifdef _WIN32
-static
-Codec FourccToCodecWin32Old(int codec)
-{
-    switch (codec)
-    {
-    case CV_FOURCC_MACRO('m', 'p', 'e', 'g'): // fallthru
-    case CV_FOURCC_MACRO('m', 'p', 'g', '1'): // fallthru
-    case CV_FOURCC_MACRO('M', 'P', 'G', '1'): return MPEG1;
-    case CV_FOURCC_MACRO('m', 'p', 'g', '2'): // fallthru
-    case CV_FOURCC_MACRO('M', 'P', 'G', '2'): return MPEG2;
-    case CV_FOURCC_MACRO('X', 'V', 'I', 'D'): // fallthru
-    case CV_FOURCC_MACRO('m', 'p', '4', 'v'): // fallthru
-    case CV_FOURCC_MACRO('D', 'I', 'V', 'X'): return MPEG4;
-    case CV_FOURCC_MACRO('W', 'V', 'C', '1'): return VC1;
-    case CV_FOURCC_MACRO('H', '2', '6', '4'): // fallthru
-    case CV_FOURCC_MACRO('h', '2', '6', '4'): // fallthru
-    case CV_FOURCC_MACRO('a', 'v', 'c', '1'): return H264;
-    case CV_FOURCC_MACRO('H', '2', '6', '5'): // fallthru
-    case CV_FOURCC_MACRO('h', '2', '6', '5'): // fallthru
-    case CV_FOURCC_MACRO('h', 'e', 'v', 'c'): return HEVC;
-    case CV_FOURCC_MACRO('M', 'J', 'P', 'G'): return JPEG;
-    case CV_FOURCC_MACRO('v', 'p', '8', '0'): // fallthru
-    case CV_FOURCC_MACRO('V', 'P', '8', '0'): // fallthru
-    case CV_FOURCC_MACRO('v', 'p', '0', '8'): // fallthru
-    case CV_FOURCC_MACRO('V', 'P', '0', '8'): return VP8;
-    case CV_FOURCC_MACRO('v', 'p', '9', '0'): // fallthru
-    case CV_FOURCC_MACRO('V', 'P', '9', '0'): // fallthru
-    case CV_FOURCC_MACRO('V', 'P', '0', '9'): // fallthru
-    case CV_FOURCC_MACRO('v', 'p', '0', '9'): return VP9;
-    case CV_FOURCC_MACRO('a', 'v', '1', '0'): // fallthru
-    case CV_FOURCC_MACRO('A', 'V', '1', '0'): // fallthru
-    case CV_FOURCC_MACRO('a', 'v', '0', '1'): // fallthru
-    case CV_FOURCC_MACRO('A', 'V', '0', '1'): return AV1;
-    default:
-        return NumCodecs;
-    }
-}
-#endif
-
 static
 Codec FourccToCodec(int codec)
 {
-#ifdef _WIN32 // handle old FFmpeg backend - remove when windows shared library is updated
-    Codec win32OldCodec = FourccToCodecWin32Old(codec);
-    if(win32OldCodec != NumCodecs)
-        return win32OldCodec;
-#endif
     switch (codec)
     {
     case CV_FOURCC_MACRO('m', 'p', 'g', '1'): return MPEG1;

--- a/modules/cudacodec/src/video_writer.cpp
+++ b/modules/cudacodec/src/video_writer.cpp
@@ -402,13 +402,10 @@ Ptr<VideoWriter> createVideoWriter(const String& fileName, const Size frameSize,
 {
     CV_Assert(params.idrPeriod >= params.gopLength);
     if (!encoderCallback) {
-        // required until PR for raw video encapsulation is merged and windows dll is updated
-#ifndef WIN32 // remove #define and keep code once merged
         try {
             encoderCallback = new FFmpegVideoWriter(fileName, codec, fps, frameSize, params.idrPeriod);
         }
         catch (...)
-#endif
         {
             encoderCallback = new RawVideoWriter(fileName);
         }

--- a/modules/cudacodec/test/test_video.cpp
+++ b/modules/cudacodec/test/test_video.cpp
@@ -611,9 +611,6 @@ CUDA_TEST_P(CheckInitParams, Reader)
 
 CUDA_TEST_P(Seek, Reader)
 {
-#if defined(WIN32)
-    throw SkipTestException("Test disabled on Windows until the FFMpeg wrapper is updated to include PR24012.");
-#endif
     std::string inputFile = std::string(cvtest::TS::ptr()->get_data_path()) + "../highgui/video/big_buck_bunny.mp4";
     // seek to a non key frame
     const int firstFrameIdx = 18;
@@ -660,13 +657,7 @@ CUDA_TEST_P(TransCode, H264ToH265)
     constexpr cv::cudacodec::ColorFormat colorFormat = cv::cudacodec::ColorFormat::NV_NV12;
     constexpr double fps = 25;
     const cudacodec::Codec codec = cudacodec::Codec::HEVC;
-    // required until PR for raw video encapsulation is merged and windows dll is updated
-#ifdef WIN32
-    const std::string ext = ".hevc";
-#else
-    // use this after update
     const std::string ext = ".mp4";
-#endif
     const std::string outputFile = cv::tempfile(ext.c_str());
     constexpr int nFrames = 5;
     Size frameSz;
@@ -743,13 +734,7 @@ CUDA_TEST_P(Write, Writer)
     const cudacodec::Codec codec = GET_PARAM(2);
     const double fps = GET_PARAM(3);
     const cv::cudacodec::ColorFormat colorFormat = GET_PARAM(4);
-    // required until PR for raw video encapsulation is merged and windows dll is updated
-#ifdef WIN32
-    const std::string ext = codec == cudacodec::Codec::H264 ? ".h264" : ".hevc";
-#else
-    // use this after update
     const std::string ext = ".mp4";
-#endif
     const std::string outputFile = cv::tempfile(ext.c_str());
     constexpr int nFrames = 5;
     Size frameSz;
@@ -827,13 +812,7 @@ CUDA_TEST_P(EncoderParams, Writer)
     const std::string inputFile = std::string(cvtest::TS::ptr()->get_data_path()) + "../highgui/video/big_buck_bunny.mp4";
     constexpr double fps = 25.0;
     constexpr cudacodec::Codec codec = cudacodec::Codec::H264;
-    // required until PR for raw video encapsulation is merged and windows dll is updated
-#ifdef WIN32
-    const std::string ext = ".h264";
-#else
-    // use this after update
     const std::string ext = ".mp4";
-#endif
     const std::string outputFile = cv::tempfile(ext.c_str());
     Size frameSz;
     const int nFrames = max(params.gopLength, params.idrPeriod) + 1;


### PR DESCRIPTION
Enable disabled windows features (https://github.com/opencv/opencv_contrib/pull/3569, https://github.com/opencv/opencv_contrib/pull/3488, https://github.com/opencv/opencv_contrib/pull/3542) which are now available in the ffmpeg shared libary.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
