### PR TITLE
add maxconers and mindistance setter to gftt

### DIFF
--- a/modules/cudaimgproc/include/opencv2/cudaimgproc.hpp
+++ b/modules/cudaimgproc/include/opencv2/cudaimgproc.hpp
@@ -579,8 +579,8 @@ public:
      */
     CV_WRAP virtual void detect(InputArray image, OutputArray corners, InputArray mask = noArray(), Stream& stream = Stream::Null()) = 0;
 
-    virtual void setMaxCorners(int maxCorners) = 0;
-    virtual void setMinDistance(double minDistance) = 0;
+    CV_WRAP virtual void setMaxCorners(int maxCorners) = 0;
+    CV_WRAP virtual void setMinDistance(double minDistance) = 0;
 };
 
 /** @brief Creates implementation for cuda::CornersDetector .

--- a/modules/cudaimgproc/include/opencv2/cudaimgproc.hpp
+++ b/modules/cudaimgproc/include/opencv2/cudaimgproc.hpp
@@ -578,6 +578,9 @@ public:
     @param stream Stream for the asynchronous version.
      */
     CV_WRAP virtual void detect(InputArray image, OutputArray corners, InputArray mask = noArray(), Stream& stream = Stream::Null()) = 0;
+
+    virtual void setMaxCorners(int maxCorners) = 0;
+    virtual void setMinDistance(double minDistance) = 0;
 };
 
 /** @brief Creates implementation for cuda::CornersDetector .

--- a/modules/cudaimgproc/src/gftt.cpp
+++ b/modules/cudaimgproc/src/gftt.cpp
@@ -69,7 +69,8 @@ namespace
                                     int blockSize, bool useHarrisDetector, double harrisK);
         ~GoodFeaturesToTrackDetector();
         void detect(InputArray image, OutputArray corners, InputArray mask, Stream& stream);
-
+        void setMaxCorners(int maxCorners) CV_OVERRIDE { maxCorners_ = maxCorners; }
+        void setMinDistance(double minDistance) CV_OVERRIDE { minDistance_ = minDistance; }
     private:
         int maxCorners_;
         double qualityLevel_;


### PR DESCRIPTION
Currently, there is no way to change max corners & min distance once GoodFeaturesToTrackDetector is created.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
