### PR TITLE
Implement fast guided filter

### DIFF
--- a/modules/ximgproc/doc/ximgproc.bib
+++ b/modules/ximgproc/doc/ximgproc.bib
@@ -54,6 +54,13 @@
   publisher={Springer}
 }
 
+@article{Kaiming15,
+  title={Fast guided filter},
+  author={He, Kaiming and Sun, Jian},
+  journal={arXiv preprint arXiv:1505.00996},
+  year={2015}
+}
+
 @inproceedings{Lee14,
   title={Outdoor place recognition in urban environments using straight lines},
   author={Lee, Jin Han and Lee, Sehyung and Zhang, Guoxuan and Lim, Jongwoo and Chung, Wan Kyun and Suh, Il Hong},

--- a/modules/ximgproc/include/opencv2/ximgproc/edge_filter.hpp
+++ b/modules/ximgproc/include/opencv2/ximgproc/edge_filter.hpp
@@ -123,15 +123,15 @@ void dtFilter(InputArray guide, InputArray src, OutputArray dst, double sigmaSpa
 //////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////
 
-/** @brief Interface for realizations of Guided Filter.
+/** @brief Interface for realizations of (Fast) Guided Filter.
 
-For more details about this filter see @cite Kaiming10 .
+For more details about this filter see @cite Kaiming10 @cite Kaiming15 .
  */
 class CV_EXPORTS_W GuidedFilter : public Algorithm
 {
 public:
 
-    /** @brief Apply Guided Filter to the filtering image.
+    /** @brief Apply (Fast) Guided Filter to the filtering image.
 
     @param src filtering image with any numbers of channels.
 
@@ -153,11 +153,14 @@ channels then only first 3 channels will be used.
 @param eps regularization term of Guided Filter. \f${eps}^2\f$ is similar to the sigma in the color
 space into bilateralFilter.
 
-For more details about Guided Filter parameters, see the original article @cite Kaiming10 .
- */
-CV_EXPORTS_W Ptr<GuidedFilter> createGuidedFilter(InputArray guide, int radius, double eps);
+@param scale subsample factor of Fast Guided Filter, use a scale less than 1 to speeds up computation
+with almost no visible degradation. (e.g. scale==0.5 shrinks the image by 2x inside the filter)
 
-/** @brief Simple one-line Guided Filter call.
+For more details about (Fast) Guided Filter parameters, see the original articles @cite Kaiming10 @cite Kaiming15 .
+ */
+CV_EXPORTS_W Ptr<GuidedFilter> createGuidedFilter(InputArray guide, int radius, double eps, double scale = 1.0);
+
+/** @brief Simple one-line (Fast) Guided Filter call.
 
 If you have multiple images to filter with the same guided image then use GuidedFilter interface to
 avoid extra computations on initialization stage.
@@ -176,8 +179,11 @@ space into bilateralFilter.
 
 @param dDepth optional depth of the output image.
 
+@param scale subsample factor of Fast Guided Filter, use a scale less than 1 to speeds up computation
+with almost no visible degradation. (e.g. scale==0.5 shrinks the image by 2x inside the filter)
+
 @sa bilateralFilter, dtFilter, amFilter */
-CV_EXPORTS_W void guidedFilter(InputArray guide, InputArray src, OutputArray dst, int radius, double eps, int dDepth = -1);
+CV_EXPORTS_W void guidedFilter(InputArray guide, InputArray src, OutputArray dst, int radius, double eps, int dDepth = -1, double scale = 1.0);
 
 //////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////

--- a/modules/ximgproc/perf/perf_guided_filter.cpp
+++ b/modules/ximgproc/perf/perf_guided_filter.cpp
@@ -7,11 +7,11 @@ namespace opencv_test { namespace {
 
 CV_ENUM(GuideTypes, CV_8UC1, CV_8UC3, CV_32FC1, CV_32FC3);
 CV_ENUM(SrcTypes, CV_8UC1, CV_8UC3, CV_32FC1, CV_32FC3);
-typedef tuple<GuideTypes, SrcTypes, Size> GFParams;
+typedef tuple<GuideTypes, SrcTypes, Size, double> GFParams;
 
 typedef TestBaseWithParam<GFParams> GuidedFilterPerfTest;
 
-PERF_TEST_P( GuidedFilterPerfTest, perf, Combine(GuideTypes::all(), SrcTypes::all(), Values(sz1080p, sz2K)) )
+PERF_TEST_P( GuidedFilterPerfTest, perf, Combine(GuideTypes::all(), SrcTypes::all(), Values(sz1080p, sz2K), Values(1./1, 1./2, 1./3, 1./4)) )
 {
     RNG rng(0);
 
@@ -19,6 +19,7 @@ PERF_TEST_P( GuidedFilterPerfTest, perf, Combine(GuideTypes::all(), SrcTypes::al
     int guideType   = get<0>(params);
     int srcType     = get<1>(params);
     Size sz         = get<2>(params);
+    double scale    = get<3>(params);
 
     Mat guide(sz, guideType);
     Mat src(sz, srcType);
@@ -30,7 +31,7 @@ PERF_TEST_P( GuidedFilterPerfTest, perf, Combine(GuideTypes::all(), SrcTypes::al
     {
         int radius = rng.uniform(5, 30);
         double eps = rng.uniform(0.1, 1e5);
-        guidedFilter(guide, src, dst, radius, eps);
+        guidedFilter(guide, src, dst, radius, eps, -1, scale);
     }
 
     SANITY_CHECK_NOTHING();


### PR DESCRIPTION
This PR implements fast guided filter. The concept is explained in this [paper](https://arxiv.org/pdf/1505.00996.pdf).

TLDR:
Added a 'scale' parameter to the current guided filter interface, allowing resampling inside the algorithm, to speed up computation. The resampling has to be done inside guided filter because the intermediate result has to be combined with original input to generate the final result.
The performance and behavior of the default code path (scale == 1.0) is unaltered. [before](https://pullrequest.opencv.org/buildbot/builders/precommit-contrib_linux64/builds/100981/steps/perf_ximgproc/logs/stdio) vs [after](https://pullrequest.opencv.org/buildbot/builders/precommit-contrib_linux64/builds/100980/steps/perf_ximgproc/logs/stdio)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
~~- [ ] There is a reference to the original bug report and related work~~
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
