### PR TITLE
sfm: add opencv.sfm prefix for static libraries

### DIFF
--- a/modules/sfm/CMakeLists.txt
+++ b/modules/sfm/CMakeLists.txt
@@ -88,16 +88,16 @@ set(LIBMV_LIGHT_INCLUDES
 )
 
 set(LIBMV_LIGHT_LIBS
-  correspondence
-  multiview
-  numeric
+  opencv.sfm.correspondence
+  opencv.sfm.multiview
+  opencv.sfm.numeric
   ${GLOG_LIBRARIES}
   ${GFLAGS_LIBRARIES}
 )
 
 if(Ceres_FOUND)
   add_definitions("-DCERES_FOUND=1")
-  list(APPEND LIBMV_LIGHT_LIBS simple_pipeline)
+  list(APPEND LIBMV_LIGHT_LIBS opencv.sfm.simple_pipeline)
   if(Ceres_VERSION VERSION_LESS 2.0.0)
     list(APPEND LIBMV_LIGHT_INCLUDES "${CERES_INCLUDE_DIRS}")
   endif()

--- a/modules/sfm/src/libmv_light/libmv/correspondence/CMakeLists.txt
+++ b/modules/sfm/src/libmv_light/libmv/correspondence/CMakeLists.txt
@@ -6,12 +6,12 @@ SET(CORRESPONDENCE_SRC feature_matching.cc
 # define the header files (make the headers appear in IDEs.)
 FILE(GLOB CORRESPONDENCE_HDRS *.h)
 
-ADD_LIBRARY(correspondence STATIC ${CORRESPONDENCE_SRC} ${CORRESPONDENCE_HDRS})
+ADD_LIBRARY(opencv.sfm.correspondence STATIC ${CORRESPONDENCE_SRC} ${CORRESPONDENCE_HDRS})
 
-ocv_target_link_libraries(correspondence LINK_PRIVATE ${GLOG_LIBRARIES} multiview opencv_imgcodecs)
+ocv_target_link_libraries(opencv.sfm.correspondence LINK_PRIVATE ${GLOG_LIBRARIES} opencv.sfm.multiview opencv_imgcodecs)
 IF(TARGET Eigen3::Eigen)
-  TARGET_LINK_LIBRARIES(correspondence LINK_PUBLIC Eigen3::Eigen)
+  TARGET_LINK_LIBRARIES(opencv.sfm.correspondence LINK_PUBLIC Eigen3::Eigen)
 ENDIF()
 
 
-LIBMV_INSTALL_LIB(correspondence)
+LIBMV_INSTALL_LIB(opencv.sfm.correspondence)

--- a/modules/sfm/src/libmv_light/libmv/multiview/CMakeLists.txt
+++ b/modules/sfm/src/libmv_light/libmv/multiview/CMakeLists.txt
@@ -16,13 +16,13 @@ SET(MULTIVIEW_SRC conditioning.cc
 # define the header files (make the headers appear in IDEs.)
 FILE(GLOB MULTIVIEW_HDRS *.h)
 
-ADD_LIBRARY(multiview STATIC ${MULTIVIEW_SRC} ${MULTIVIEW_HDRS})
-TARGET_LINK_LIBRARIES(multiview LINK_PRIVATE ${GLOG_LIBRARIES} numeric)
+ADD_LIBRARY(opencv.sfm.multiview STATIC ${MULTIVIEW_SRC} ${MULTIVIEW_HDRS})
+TARGET_LINK_LIBRARIES(opencv.sfm.multiview LINK_PRIVATE ${GLOG_LIBRARIES} opencv.sfm.numeric)
 IF(TARGET Eigen3::Eigen)
-  TARGET_LINK_LIBRARIES(multiview LINK_PUBLIC Eigen3::Eigen)
+  TARGET_LINK_LIBRARIES(opencv.sfm.multiview LINK_PUBLIC Eigen3::Eigen)
 ENDIF()
 IF(CERES_LIBRARIES)
-  TARGET_LINK_LIBRARIES(multiview LINK_PRIVATE ${CERES_LIBRARIES})
+  TARGET_LINK_LIBRARIES(opencv.sfm.multiview LINK_PRIVATE ${CERES_LIBRARIES})
 ENDIF()
 
-LIBMV_INSTALL_LIB(multiview)
+LIBMV_INSTALL_LIB(opencv.sfm.multiview)

--- a/modules/sfm/src/libmv_light/libmv/numeric/CMakeLists.txt
+++ b/modules/sfm/src/libmv_light/libmv/numeric/CMakeLists.txt
@@ -5,10 +5,10 @@ SET(NUMERIC_SRC numeric.cc
 # define the header files (make the headers appear in IDEs.)
 FILE(GLOB NUMERIC_HDRS *.h)
 
-ADD_LIBRARY(numeric STATIC ${NUMERIC_SRC} ${NUMERIC_HDRS})
+ADD_LIBRARY(opencv.sfm.numeric STATIC ${NUMERIC_SRC} ${NUMERIC_HDRS})
 
 IF(TARGET Eigen3::Eigen)
-  TARGET_LINK_LIBRARIES(numeric LINK_PUBLIC Eigen3::Eigen)
+  TARGET_LINK_LIBRARIES(opencv.sfm.numeric LINK_PUBLIC Eigen3::Eigen)
 ENDIF()
 
-LIBMV_INSTALL_LIB(numeric)
+LIBMV_INSTALL_LIB(opencv.sfm.numeric)

--- a/modules/sfm/src/libmv_light/libmv/simple_pipeline/CMakeLists.txt
+++ b/modules/sfm/src/libmv_light/libmv/simple_pipeline/CMakeLists.txt
@@ -15,8 +15,8 @@ SET(SIMPLE_PIPELINE_SRC
 # Define the header files so that they appear in IDEs.
 FILE(GLOB SIMPLE_PIPELINE_HDRS *.h)
 
-ADD_LIBRARY(simple_pipeline STATIC ${SIMPLE_PIPELINE_SRC} ${SIMPLE_PIPELINE_HDRS})
+ADD_LIBRARY(opencv.sfm.simple_pipeline STATIC ${SIMPLE_PIPELINE_SRC} ${SIMPLE_PIPELINE_HDRS})
 
-TARGET_LINK_LIBRARIES(simple_pipeline LINK_PRIVATE multiview ${CERES_LIBRARIES})
+TARGET_LINK_LIBRARIES(opencv.sfm.simple_pipeline LINK_PRIVATE opencv.sfm.multiview ${CERES_LIBRARIES})
 
-LIBMV_INSTALL_LIB(simple_pipeline)
+LIBMV_INSTALL_LIB(opencv.sfm.simple_pipeline)


### PR DESCRIPTION
Fix https://github.com/opencv/opencv/issues/24890

```
kmtr@ubuntu:~/work/build4-full$ ls lib/*.a
lib/libopencv.sfm.correspondence.a  lib/libopencv.sfm.numeric.a
lib/libopencv.sfm.multiview.a       lib/libopencv.sfm.simple_pipeline.a
```

- At creating pull request, this issue is located at opencv issue, not opencv_contrib issue.
- My test is to check build only, because this fix changes only CMakeLists.txt

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
