### PR TITLE
Fix gcc11 warning

### DIFF
--- a/modules/ximgproc/src/edge_drawing.cpp
+++ b/modules/ximgproc/src/edge_drawing.cpp
@@ -1366,7 +1366,7 @@ void EdgeDrawingImpl::SplitSegment2Lines(double* x, double* y, int noPixels, int
     {
         // Start by fitting a line to MIN_LINE_LEN pixels
         bool valid = false;
-        double lastA(0), lastB(0), error;
+        double lastA(0), lastB(0), error(0);
         int lastInvert(0);
 
         while (noPixels >= min_line_len)


### PR DESCRIPTION
‘error’ may be used uninitialized. 
We used to declare error uninitialized, pass it to `LineFit`  as OUT parameter, hoping that every path will initialize `error` varible. But there is path, where `error` is kept uninitialized, so it is better to explicitly initialize it here

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
