### PR TITLE
Fix a bug in knnMatchConvert when a feature couldn't be matched

### DIFF
--- a/modules/cudafeatures2d/src/brute_force_matcher.cpp
+++ b/modules/cudafeatures2d/src/brute_force_matcher.cpp
@@ -791,20 +791,13 @@ namespace
             for (int i = 0; i < k; ++i)
             {
                 const int trainIdx = *trainIdxPtr;
-                if (trainIdx == -1){
-                    ++trainIdxPtr;
-                    ++distancePtr;
-                    if (imgIdxPtr)
-                        ++imgIdxPtr;
-                    continue;
+                if (trainIdx != -1)
+                {
+                    const int imgIdx = imgIdxPtr ? *imgIdxPtr : 0;
+                    const float distance = *distancePtr;
+                    DMatch m(queryIdx, trainIdx, imgIdx, distance);
+                    curMatches.push_back(m);
                 }
-
-                const int imgIdx = imgIdxPtr ? *imgIdxPtr : 0;
-                const float distance = *distancePtr;
-
-                DMatch m(queryIdx, trainIdx, imgIdx, distance);
-
-                curMatches.push_back(m);
 
                 ++trainIdxPtr;
                 ++distancePtr;

--- a/modules/cudafeatures2d/src/brute_force_matcher.cpp
+++ b/modules/cudafeatures2d/src/brute_force_matcher.cpp
@@ -791,8 +791,13 @@ namespace
             for (int i = 0; i < k; ++i)
             {
                 const int trainIdx = *trainIdxPtr;
-                if (trainIdx == -1)
+                if (trainIdx == -1){
+                    ++trainIdxPtr;
+                    ++distancePtr;
+                    if (imgIdxPtr)
+                        ++imgIdxPtr;
                     continue;
+                }
 
                 const int imgIdx = imgIdxPtr ? *imgIdxPtr : 0;
                 const float distance = *distancePtr;


### PR DESCRIPTION
After I started using a mask with `knnMatchAsync`, I found that the result from `knnMatchConvert` would be clipped at random.

Investigating the issue, I found that `knnMatchAsync` will initialize all `trainIdx` to `-1`, which will be overwritten by the CUDA kernel. A mask can be used to prevent certain features from being matched and this will prevent the CUDA kernel from setting the match distance. `knnMatchConvert` is not properly incrementing the pointers when `trainIdx == -1`, so an unmatched feature will get it stuck at `if (trainIdx == -1)`. Eventually the outer for-loop finishes and returns a vector with the matches up until the first missing match distance.

My solution is to increment the counters the same way as a succesful iteration would.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
