### PR TITLE
added getColorCharts()

### DIFF
--- a/modules/mcc/include/opencv2/mcc/checker_model.hpp
+++ b/modules/mcc/include/opencv2/mcc/checker_model.hpp
@@ -89,6 +89,15 @@ public:
 
     CV_WRAP virtual TYPECHART getTarget() = 0;
     CV_WRAP virtual std::vector<Point2f> getBox() = 0;
+
+    /** @brief Computes and returns the coordinates of the central parts of the charts modules.
+     *
+     * This method computes transformation matrix from the checkers's coordinates (`cv::mcc::CChecker::getBox()`)
+     * and find by this the coordinates of the central parts of the charts modules.
+     * It is used in `cv::mcc::CCheckerDraw::draw()` and in `ChartsRGB` calculation.
+     */
+    CV_WRAP virtual std::vector<Point2f> getColorCharts() = 0;
+
     CV_WRAP virtual Mat getChartsRGB() = 0;
     CV_WRAP virtual Mat getChartsYCbCr() = 0;
     CV_WRAP virtual float getCost() = 0;

--- a/modules/mcc/src/checker_detector.cpp
+++ b/modules/mcc/src/checker_detector.cpp
@@ -1177,31 +1177,6 @@ void CCheckerDetectorImpl::
 }
 
 void CCheckerDetectorImpl::
-    transform_points_forward(InputArray T, const std::vector<cv::Point2f> &X, std::vector<cv::Point2f> &Xt)
-{
-    size_t N = X.size();
-    if (N == 0)
-        return;
-
-    Xt.clear();
-    Xt.resize(N);
-    cv::Matx31f p, xt;
-    cv::Point2f pt;
-
-    cv::Matx33f _T = T.getMat();
-    for (int i = 0; i < (int)N; i++)
-    {
-        p(0, 0) = X[i].x;
-        p(1, 0) = X[i].y;
-        p(2, 0) = 1;
-        xt = _T * p;
-        pt.x = xt(0, 0) / xt(2, 0);
-        pt.y = xt(1, 0) / xt(2, 0);
-        Xt[i] = pt;
-    }
-}
-
-void CCheckerDetectorImpl::
     transform_points_inverse(InputArray T, const std::vector<cv::Point2f> &X, std::vector<cv::Point2f> &Xt)
 {
     cv::Matx33f _T = T.getMat();

--- a/modules/mcc/src/checker_detector.hpp
+++ b/modules/mcc/src/checker_detector.hpp
@@ -171,11 +171,6 @@ private: // methods aux
         std::vector<float> &x_new,
         float tol);
 
-    void transform_points_forward(
-        InputArray T,
-        const std::vector<cv::Point2f> &X,
-        std::vector<cv::Point2f> &Xt);
-
     void transform_points_inverse(
         InputArray T,
         const std::vector<cv::Point2f> &X,

--- a/modules/mcc/src/checker_model.hpp
+++ b/modules/mcc/src/checker_model.hpp
@@ -137,6 +137,7 @@ public:
 
     TYPECHART getTarget() CV_OVERRIDE;
     std::vector<Point2f> getBox() CV_OVERRIDE;
+    std::vector<Point2f> getColorCharts() CV_OVERRIDE;
     Mat getChartsRGB() CV_OVERRIDE;
     Mat getChartsYCbCr() CV_OVERRIDE;
     float getCost() CV_OVERRIDE;
@@ -173,15 +174,10 @@ private:
     Ptr<CChecker> m_pChecker;
     cv::Scalar m_color;
     int m_thickness;
-
-private:
-    /** \brief transformation perspetive*/
-    void transform_points_forward(
-        InputArray T,
-        const std::vector<cv::Point2f> &X,
-        std::vector<cv::Point2f> &Xt);
 };
 // @}
+
+void transform_points_forward(const Matx33f& T, const std::vector<Point2f> &X, std::vector<Point2f> &Xt);
 
 } // namespace mcc
 } // namespace cv


### PR DESCRIPTION
merge this PR after https://github.com/opencv/opencv_contrib/pull/3647
Computes and returns the coordinates of the central parts of the charts modules.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
