### PR TITLE
fixes #25081:Latch input corruption fix

### DIFF
--- a/modules/xfeatures2d/src/latch.cpp
+++ b/modules/xfeatures2d/src/latch.cpp
@@ -519,7 +519,7 @@ namespace cv
             switch (image.type())
             {
             case CV_8UC1:
-                grayImage = image.clone();
+                grayImage = sigma_ ? image.clone() : image;
                 break;
             case CV_8UC3:
                 cvtColor(image, grayImage, COLOR_BGR2GRAY);

--- a/modules/xfeatures2d/src/latch.cpp
+++ b/modules/xfeatures2d/src/latch.cpp
@@ -519,7 +519,7 @@ namespace cv
             switch (image.type())
             {
             case CV_8UC1:
-                grayImage = image;
+                grayImage = image.clone();
                 break;
             case CV_8UC3:
                 cvtColor(image, grayImage, COLOR_BGR2GRAY);


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv/issues/25081

As mentioned by WennPaper making it `grayImage = image.clone();` will make a deep copy. It prevents the `InputArray` from being modified.

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [X] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
