### PR TITLE
Faster thinning implementation

### DIFF
--- a/modules/ximgproc/perf/perf_thining.cpp
+++ b/modules/ximgproc/perf/perf_thining.cpp
@@ -1,0 +1,36 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "perf_precomp.hpp"
+
+namespace opencv_test { namespace {
+
+typedef tuple<Size, int> ThinningPerfParam;
+typedef TestBaseWithParam<ThinningPerfParam> ThinningPerfTest;
+
+PERF_TEST_P(ThinningPerfTest, perf,
+    Combine(
+        Values(sz1080p, sz720p, szVGA),
+        Values(THINNING_ZHANGSUEN, THINNING_GUOHALL)
+    )
+)
+{
+    ThinningPerfParam params = GetParam();
+    Size size = get<0>(params);
+    int type  = get<1>(params);
+
+    Mat src = Mat::zeros(size, CV_8UC1);
+    for (int x = 50; x < src.cols - 50; x += 50)
+        cv::circle(src, Point(x, x/2), 30 + x/2, Scalar(255), 5);
+
+    Mat dst;
+    TEST_CYCLE()
+    {
+        thinning(src, dst, type);
+    }
+
+    SANITY_CHECK_NOTHING();
+}
+
+}} // namespace

--- a/modules/ximgproc/src/thinning.cpp
+++ b/modules/ximgproc/src/thinning.cpp
@@ -5,65 +5,175 @@ using namespace std;
 namespace cv {
 namespace ximgproc {
 
+// look up table - there is one entry for each of the 2^8=256 possible
+// combinations of 8 binary neighbors.
+static uint8_t lut_zhang_iter0[] = {
+    1, 1, 1, 0, 1, 1, 0, 0, 1, 1, 1, 1, 0, 1,
+    0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1,
+    0, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1,
+    0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    0, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 0, 1,
+    1, 1, 1, 0, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1,
+    1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 0,
+    1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    0, 0, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1,
+    1, 1, 0, 0, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1};
+
+static uint8_t lut_zhang_iter1[] = {
+    1, 1, 1, 0, 1, 1, 0, 0, 1, 1, 1, 1, 0, 1,
+    0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1,
+    0, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1,
+    0, 1, 1, 1, 0, 1, 0, 0, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    0, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 0, 1,
+    0, 1, 1, 0, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 0,
+    1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1,
+    0, 1, 1, 1};
+
+static uint8_t lut_guo_iter0[] = {
+    1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 0, 1, 1,
+    0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0,
+    0, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1,
+    0, 0, 0, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1,
+    0, 1, 0, 0, 0, 1, 0, 0, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 1, 0, 1,
+    0, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 1,
+    0, 1, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 0,
+    1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1};
+
+static uint8_t lut_guo_iter1[] = {
+    1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    0, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0,
+    1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1,
+    1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0,
+    1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    0, 0, 0, 0, 1, 1, 0, 0, 1, 1, 1, 1, 1, 1,
+    1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 1, 1,
+    1, 1, 1, 1};
+
 // Applies a thinning iteration to a binary image
 static void thinningIteration(Mat img, int iter, int thinningType){
     Mat marker = Mat::zeros(img.size(), CV_8UC1);
+    int rows = img.rows;
+    int cols = img.cols;
 
     if(thinningType == THINNING_ZHANGSUEN){
-        for (int i = 1; i < img.rows-1; i++)
-        {
-            for (int j = 1; j < img.cols-1; j++)
-            {
-                uchar p2 = img.at<uchar>(i-1, j);
-                uchar p3 = img.at<uchar>(i-1, j+1);
-                uchar p4 = img.at<uchar>(i, j+1);
-                uchar p5 = img.at<uchar>(i+1, j+1);
-                uchar p6 = img.at<uchar>(i+1, j);
-                uchar p7 = img.at<uchar>(i+1, j-1);
-                uchar p8 = img.at<uchar>(i, j-1);
-                uchar p9 = img.at<uchar>(i-1, j-1);
+        marker.forEach<uchar>([=](uchar& value, const int postion[]) {
+            int i = postion[0];
+            int j = postion[1];
+            if (i == 0 || j == 0 || i == rows - 1 || j == cols - 1)
+                return;
 
-                int A  = (p2 == 0 && p3 == 1) + (p3 == 0 && p4 == 1) +
-                         (p4 == 0 && p5 == 1) + (p5 == 0 && p6 == 1) +
-                         (p6 == 0 && p7 == 1) + (p7 == 0 && p8 == 1) +
-                         (p8 == 0 && p9 == 1) + (p9 == 0 && p2 == 1);
-                int B  = p2 + p3 + p4 + p5 + p6 + p7 + p8 + p9;
-                int m1 = iter == 0 ? (p2 * p4 * p6) : (p2 * p4 * p8);
-                int m2 = iter == 0 ? (p4 * p6 * p8) : (p2 * p6 * p8);
+            auto ptr = img.ptr(i, j); // p1
 
-                if (A == 1 && (B >= 2 && B <= 6) && m1 == 0 && m2 == 0)
-                    marker.at<uchar>(i,j) = 1;
-            }
-        }
+            // p9 p2 p3
+            // p8 p1 p4
+            // p7 p6 p5
+            uchar p2 = ptr[-cols];
+            uchar p3 = ptr[-cols + 1];
+            uchar p4 = ptr[1];
+            uchar p5 = ptr[cols + 1];
+            uchar p6 = ptr[cols];
+            uchar p7 = ptr[cols - 1];
+            uchar p8 = ptr[-1];
+            uchar p9 = ptr[-cols - 1];
+
+            int neighbors = p9 | (p2 << 1) | (p3 << 2) | (p4 << 3) | (p5 << 4) | (p6 << 5) | (p7 << 6) | (p8 << 7);
+
+            if (iter == 0)
+                value = lut_zhang_iter0[neighbors];
+            else
+                value = lut_zhang_iter1[neighbors];
+
+            //int A  = (p2 == 0 && p3 == 1) + (p3 == 0 && p4 == 1) +
+            //         (p4 == 0 && p5 == 1) + (p5 == 0 && p6 == 1) +
+            //         (p6 == 0 && p7 == 1) + (p7 == 0 && p8 == 1) +
+            //         (p8 == 0 && p9 == 1) + (p9 == 0 && p2 == 1);
+            //int B  = p2 + p3 + p4 + p5 + p6 + p7 + p8 + p9;
+            //int m1 = iter == 0 ? (p2 * p4 * p6) : (p2 * p4 * p8);
+            //int m2 = iter == 0 ? (p4 * p6 * p8) : (p2 * p6 * p8);
+            //if (A == 1 && (B >= 2 && B <= 6) && m1 == 0 && m2 == 0) value = 0;
+        });
     }
     if(thinningType == THINNING_GUOHALL){
-        for (int i = 1; i < img.rows-1; i++)
-        {
-            for (int j = 1; j < img.cols-1; j++)
-            {
-                uchar p2 = img.at<uchar>(i-1, j);
-                uchar p3 = img.at<uchar>(i-1, j+1);
-                uchar p4 = img.at<uchar>(i, j+1);
-                uchar p5 = img.at<uchar>(i+1, j+1);
-                uchar p6 = img.at<uchar>(i+1, j);
-                uchar p7 = img.at<uchar>(i+1, j-1);
-                uchar p8 = img.at<uchar>(i, j-1);
-                uchar p9 = img.at<uchar>(i-1, j-1);
+        marker.forEach<uchar>([=](uchar& value, const int postion[]) {
+            int i = postion[0];
+            int j = postion[1];
+            if (i == 0 || j == 0 || i == rows - 1 || j == cols - 1)
+                return;
 
-                int C  = ((!p2) & (p3 | p4)) + ((!p4) & (p5 | p6)) +
-                         ((!p6) & (p7 | p8)) + ((!p8) & (p9 | p2));
-                int N1 = (p9 | p2) + (p3 | p4) + (p5 | p6) + (p7 | p8);
-                int N2 = (p2 | p3) + (p4 | p5) + (p6 | p7) + (p8 | p9);
-                int N  = N1 < N2 ? N1 : N2;
-                int m  = iter == 0 ? ((p6 | p7 | (!p9)) & p8) : ((p2 | p3 | (!p5)) & p4);
+            auto ptr = img.ptr(i, j); // p1
 
-                if ((C == 1) && ((N >= 2) && ((N <= 3)) & (m == 0)))
-                    marker.at<uchar>(i,j) = 1;
-            }
-        }
+            // p9 p2 p3
+            // p8 p1 p4
+            // p7 p6 p5
+            uchar p2 = ptr[-cols];
+            uchar p3 = ptr[-cols + 1];
+            uchar p4 = ptr[1];
+            uchar p5 = ptr[cols + 1];
+            uchar p6 = ptr[cols];
+            uchar p7 = ptr[cols - 1];
+            uchar p8 = ptr[-1];
+            uchar p9 = ptr[-cols - 1];
+
+            int neighbors = p9 | (p2 << 1) | (p3 << 2) | (p4 << 3) | (p5 << 4) | (p6 << 5) | (p7 << 6) | (p8 << 7);
+
+            if (iter == 0)
+                value = lut_guo_iter0[neighbors];
+            else
+                value = lut_guo_iter1[neighbors];
+
+            //int C  = ((!p2) & (p3 | p4)) + ((!p4) & (p5 | p6)) +
+            //         ((!p6) & (p7 | p8)) + ((!p8) & (p9 | p2));
+            //int N1 = (p9 | p2) + (p3 | p4) + (p5 | p6) + (p7 | p8);
+            //int N2 = (p2 | p3) + (p4 | p5) + (p6 | p7) + (p8 | p9);
+            //int N  = N1 < N2 ? N1 : N2;
+            //int m  = iter == 0 ? ((p6 | p7 | (!p9)) & p8) : ((p2 | p3 | (!p5)) & p4);
+            //if ((C == 1) && ((N >= 2) && ((N <= 3)) & (m == 0))) value = 0;
+        });
     }
 
-    img &= ~marker;
+    img &= marker;
 }
 
 // Apply the thinning procedure to a given image


### PR DESCRIPTION
This implement of `cv::ximgproc::thinning` achieves the same results as the original codes but with improvement in efficiency(10x speedup).

However, there are a few issues with this PR:

- Loss of Code Readability: The implementation sacrifices code readability for performance. To mitigate this, I have retained the original code and commented it out, so it remains accessible for reference.

- Lack of Expertise in OpenCV Development: The implementation may seem inelegant, I am uncertain whether this approach is good enough.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
