### PR TITLE
Mcc add perf tests improve performance

### DIFF
--- a/modules/mcc/perf/perf_main.cpp
+++ b/modules/mcc/perf/perf_main.cpp
@@ -1,0 +1,3 @@
+#include "perf_precomp.hpp"
+
+CV_PERF_TEST_MAIN(mcc)

--- a/modules/mcc/perf/perf_mcc.cpp
+++ b/modules/mcc/perf/perf_mcc.cpp
@@ -36,7 +36,8 @@ PERF_TEST(CV_mcc_perf, infer) {
     ColorCorrectionModel model(chartsRGB.col(1).clone().reshape(3, chartsRGB.rows/3) / 255., COLORCHECKER_Macbeth);
     model.run();
 
-    Mat img = randomMat(Size(4000, 1000), CV_8UC3);
+    Mat img(1000, 4000, CV_8UC3);
+    randu(img, 0, 255);
     img.convertTo(img, CV_64F, 1. / 255.);
 
     TEST_CYCLE() {

--- a/modules/mcc/perf/perf_mcc.cpp
+++ b/modules/mcc/perf/perf_mcc.cpp
@@ -1,0 +1,50 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "perf_precomp.hpp"
+
+namespace opencv_test
+{
+namespace
+{
+
+using namespace std;
+
+PERF_TEST(CV_mcc_perf, detect) {
+    string path = cvtest::findDataFile("cv/mcc/mcc_ccm_test.jpg");
+    Mat img = imread(path, IMREAD_COLOR);
+    Ptr<CCheckerDetector> detector = CCheckerDetector::create();
+
+    // detect MCC24 board
+    TEST_CYCLE() {
+        ASSERT_TRUE(detector->process(img, MCC24, 1, false));
+    }
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST(CV_mcc_perf, infer) {
+    // read gold chartsRGB
+    string path = cvtest::findDataFile("cv/mcc/mcc_ccm_test.yml");
+    FileStorage fs(path, FileStorage::READ);
+    Mat chartsRGB;
+    FileNode node = fs["chartsRGB"];
+    node >> chartsRGB;
+    fs.release();
+
+    // compute CCM
+    ColorCorrectionModel model(chartsRGB.col(1).clone().reshape(3, chartsRGB.rows/3) / 255., COLORCHECKER_Macbeth);
+    model.run();
+
+    Mat img = randomMat(Size(4000, 1000), CV_8UC3);
+    img.convertTo(img, CV_64F, 1. / 255.);
+
+    TEST_CYCLE() {
+        model.infer(img);
+    }
+
+    SANITY_CHECK_NOTHING();
+}
+
+} // namespace
+} // namespace opencv_test

--- a/modules/mcc/perf/perf_precomp.hpp
+++ b/modules/mcc/perf/perf_precomp.hpp
@@ -1,0 +1,19 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#ifndef __OPENCV_PERF_PRECOMP_HPP__
+#define __OPENCV_PERF_PRECOMP_HPP__
+
+#include "opencv2/ts.hpp"
+#include "opencv2/ts/cuda_test.hpp"
+#include "opencv2/mcc.hpp"
+#include "opencv2/mcc/ccm.hpp"
+
+namespace opencv_test
+{
+using namespace cv::mcc;
+using namespace cv::ccm;
+}
+
+#endif

--- a/modules/mcc/perf/perf_precomp.hpp
+++ b/modules/mcc/perf/perf_precomp.hpp
@@ -1,19 +1,14 @@
-// This file is part of OpenCV project.
-// It is subject to the license terms in the LICENSE file found in the top-level directory
-// of this distribution and at http://opencv.org/license.html.
-
 #ifndef __OPENCV_PERF_PRECOMP_HPP__
 #define __OPENCV_PERF_PRECOMP_HPP__
 
 #include "opencv2/ts.hpp"
-#include "opencv2/ts/cuda_test.hpp"
 #include "opencv2/mcc.hpp"
-#include "opencv2/mcc/ccm.hpp"
 
 namespace opencv_test
 {
 using namespace cv::mcc;
 using namespace cv::ccm;
+using namespace perf;
 }
 
 #endif

--- a/modules/mcc/src/ccm.cpp
+++ b/modules/mcc/src/ccm.cpp
@@ -289,14 +289,13 @@ Mat ColorCorrectionModel::infer(const Mat& img, bool islinear)
         CV_Error(Error::StsBadArg, "No CCM values!" );
     }
     Mat img_lin = (p->linear)->linearize(img);
-    Mat img_ccm(img_lin.size(), img_lin.type());
-    Mat ccm_ = p->ccm.reshape(0, p->shape / 3);
-    img_ccm = multiple(p->prepare(img_lin), ccm_);
+    Mat ccm = p->ccm.reshape(0, p->shape / 3);
+    Mat img_ccm = multiple(p->prepare(img_lin), ccm);
     if (islinear == true)
     {
         return img_ccm;
     }
-    return p->cs.fromLFunc(img_ccm);
+    return p->cs.fromLFunc(img_ccm, img_lin);
 }
 
 void ColorCorrectionModel::Impl::getColor(CONST_COLOR constcolor)

--- a/modules/mcc/src/ccm.cpp
+++ b/modules/mcc/src/ccm.cpp
@@ -296,7 +296,7 @@ Mat ColorCorrectionModel::infer(const Mat& img, bool islinear)
     {
         return img_ccm;
     }
-    return p->cs.fromL(img_ccm);
+    return p->cs.fromLFunc(img_ccm);
 }
 
 void ColorCorrectionModel::Impl::getColor(CONST_COLOR constcolor)

--- a/modules/mcc/src/colorspace.cpp
+++ b/modules/mcc/src/colorspace.cpp
@@ -150,7 +150,7 @@ void RGBBase_::calOperations()
 
 Mat RGBBase_::toLFunc(Mat& /*rgb*/) const { return Mat(); }
 
-Mat RGBBase_::fromLFunc(Mat& /*rgbl*/, Mat dst) const { return Mat(); }
+Mat RGBBase_::fromLFunc(Mat& /*rgbl*/, Mat dst) const { return dst; }
 
 /* @brief Base of Adobe RGB color space;
  */
@@ -159,7 +159,7 @@ Mat AdobeRGBBase_::toLFunc(Mat& rgb) const { return gammaCorrection(rgb, gamma);
 
 Mat AdobeRGBBase_::fromLFunc(Mat& rgbl, Mat dst) const
 {
-    return gammaCorrection(rgbl, 1. / gamma);
+    return gammaCorrection(rgbl, 1. / gamma, dst);
 }
 
 /* @brief Base of sRGB color space;
@@ -203,7 +203,7 @@ Mat sRGBBase_::toLFunc(Mat& rgb) const
 
 /* @brief Used by fromLFunc.
  */
-double sRGBBase_::fromLFuncEW(double& x) const
+double sRGBBase_::fromLFuncEW(const double& x) const
 {
     if (x > beta)
     {
@@ -225,8 +225,7 @@ double sRGBBase_::fromLFuncEW(double& x) const
  */
 Mat sRGBBase_::fromLFunc(Mat& rgbl, Mat dst) const
 {
-    return elementWise(rgbl,
-            [this](double a_) -> double { return fromLFuncEW(a_); });
+    return elementWise(rgbl, [this](double a_) -> double { return fromLFuncEW(a_); }, dst);
 }
 
 /* @brief sRGB color space.

--- a/modules/mcc/src/colorspace.cpp
+++ b/modules/mcc/src/colorspace.cpp
@@ -83,9 +83,9 @@ Operations RGBBase_::relation(const ColorSpace& other) const
     }
     if (linear)
     {
-        return Operations({ Operation(fromL) });
+        return Operations({ Operation([this](Mat rgbl) -> Mat { return fromLFunc(rgbl); }) });
     }
-    return Operations({ Operation(toL) });
+    return Operations({ Operation([this](Mat rgb) -> Mat { return toLFunc(rgb); })});
 }
 
 /* @brief Initial operations.
@@ -134,12 +134,6 @@ void RGBBase_::calM()
  */
 void RGBBase_::calOperations()
 {
-    // rgb -> rgbl
-    toL = [this](Mat rgb) -> Mat { return toLFunc(rgb); };
-
-    // rgbl -> rgb
-    fromL = [this](Mat rgbl) -> Mat { return fromLFunc(rgbl); };
-
     if (linear)
     {
         to = Operations({ Operation(M_to.t()) });
@@ -147,21 +141,23 @@ void RGBBase_::calOperations()
     }
     else
     {
-        to = Operations({ Operation(toL), Operation(M_to.t()) });
-        from = Operations({ Operation(M_from.t()), Operation(fromL) });
+        // rgb -> rgbl
+        to = Operations({ Operation([this](Mat rgb) -> Mat { return toLFunc(rgb); }), Operation(M_to.t()) });
+        // rgbl -> rgb
+        from = Operations({ Operation(M_from.t()), Operation([this](Mat rgbl) -> Mat { return fromLFunc(rgbl); }) });
     }
 }
 
-Mat RGBBase_::toLFunc(Mat& /*rgb*/) { return Mat(); }
+Mat RGBBase_::toLFunc(Mat& /*rgb*/) const { return Mat(); }
 
-Mat RGBBase_::fromLFunc(Mat& /*rgbl*/) { return Mat(); }
+Mat RGBBase_::fromLFunc(Mat& /*rgbl*/, Mat dst) const { return Mat(); }
 
 /* @brief Base of Adobe RGB color space;
  */
 
-Mat AdobeRGBBase_::toLFunc(Mat& rgb) { return gammaCorrection(rgb, gamma); }
+Mat AdobeRGBBase_::toLFunc(Mat& rgb) const { return gammaCorrection(rgb, gamma); }
 
-Mat AdobeRGBBase_::fromLFunc(Mat& rgbl)
+Mat AdobeRGBBase_::fromLFunc(Mat& rgbl, Mat dst) const
 {
     return gammaCorrection(rgbl, 1. / gamma);
 }
@@ -179,7 +175,7 @@ void sRGBBase_::calLinear()
 
 /* @brief Used by toLFunc.
  */
-double sRGBBase_::toLFuncEW(double& x)
+double sRGBBase_::toLFuncEW(double& x) const
 {
     if (x > K0)
     {
@@ -199,7 +195,7 @@ double sRGBBase_::toLFuncEW(double& x)
  * @param rgb the input array, type of cv::Mat.
  * @return the output array, type of cv::Mat.
  */
-Mat sRGBBase_::toLFunc(Mat& rgb)
+Mat sRGBBase_::toLFunc(Mat& rgb) const
 {
     return elementWise(rgb,
             [this](double a_) -> double { return toLFuncEW(a_); });
@@ -207,7 +203,7 @@ Mat sRGBBase_::toLFunc(Mat& rgb)
 
 /* @brief Used by fromLFunc.
  */
-double sRGBBase_::fromLFuncEW(double& x)
+double sRGBBase_::fromLFuncEW(double& x) const
 {
     if (x > beta)
     {
@@ -227,7 +223,7 @@ double sRGBBase_::fromLFuncEW(double& x)
  * @param rgbl the input array, type of cv::Mat.
  * @return the output array, type of cv::Mat.
  */
-Mat sRGBBase_::fromLFunc(Mat& rgbl)
+Mat sRGBBase_::fromLFunc(Mat& rgbl, Mat dst) const
 {
     return elementWise(rgbl,
             [this](double a_) -> double { return fromLFuncEW(a_); });

--- a/modules/mcc/src/colorspace.hpp
+++ b/modules/mcc/src/colorspace.hpp
@@ -167,7 +167,7 @@ private:
 
     /** @brief Used by fromLFunc.
     */
-    double fromLFuncEW(double& x) const;
+    double fromLFuncEW(const double& x) const;
 
     /** @brief Delinearization.
         @param rgbl the input array, type of cv::Mat.

--- a/modules/mcc/src/colorspace.hpp
+++ b/modules/mcc/src/colorspace.hpp
@@ -83,8 +83,6 @@ public:
     double yg;
     double xb;
     double yb;
-    MatFunc toL;
-    MatFunc fromL;
     Mat M_to;
     Mat M_from;
 
@@ -108,6 +106,9 @@ public:
     */
     void bind(RGBBase_& rgbl);
 
+    virtual Mat toLFunc(Mat& /*rgb*/) const;
+
+    virtual Mat fromLFunc(Mat& /*rgbl*/, Mat dst=Mat()) const;
 private:
     virtual void setParameter() {};
 
@@ -120,10 +121,6 @@ private:
     virtual void calOperations();
 
     virtual void calLinear() {};
-
-    virtual Mat toLFunc(Mat& /*rgb*/);
-
-    virtual Mat fromLFunc(Mat& /*rgbl*/);
 };
 
 /** @brief Base of Adobe RGB color space;
@@ -136,8 +133,8 @@ public:
     double gamma;
 
 private:
-    Mat toLFunc(Mat& rgb) CV_OVERRIDE;
-    Mat fromLFunc(Mat& rgbl) CV_OVERRIDE;
+    Mat toLFunc(Mat& rgb) const CV_OVERRIDE;
+    Mat fromLFunc(Mat& rgbl, Mat dst=Mat()) const CV_OVERRIDE;
 };
 
 /** @brief Base of sRGB color space;
@@ -160,23 +157,23 @@ private:
     virtual void calLinear() CV_OVERRIDE;
     /** @brief Used by toLFunc.
     */
-    double toLFuncEW(double& x);
+    double toLFuncEW(double& x) const;
 
     /** @brief Linearization.
         @param rgb the input array, type of cv::Mat.
         @return the output array, type of cv::Mat.
     */
-    Mat toLFunc(Mat& rgb) CV_OVERRIDE;
+    Mat toLFunc(Mat& rgb) const CV_OVERRIDE;
 
     /** @brief Used by fromLFunc.
     */
-    double fromLFuncEW(double& x);
+    double fromLFuncEW(double& x) const;
 
     /** @brief Delinearization.
         @param rgbl the input array, type of cv::Mat.
         @return the output array, type of cv::Mat.
     */
-    Mat fromLFunc(Mat& rgbl) CV_OVERRIDE;
+    Mat fromLFunc(Mat& rgbl, Mat dst=Mat()) const CV_OVERRIDE;
 };
 
 /** @brief sRGB color space.

--- a/modules/mcc/src/utils.cpp
+++ b/modules/mcc/src/utils.cpp
@@ -30,14 +30,14 @@
 namespace cv {
 namespace ccm {
 
-double gammaCorrection_(const double& element, const double& gamma)
+inline double gammaCorrection_(const double& element, const double& gamma)
 {
     return (element >= 0 ? pow(element, gamma) : -pow((-element), gamma));
 }
 
-Mat gammaCorrection(const Mat& src, const double& gamma)
+Mat gammaCorrection(const Mat& src, const double& gamma, Mat dst)
 {
-    return elementWise(src, [gamma](double element) -> double { return gammaCorrection_(element, gamma); });
+    return elementWise(src, [gamma](double element) -> double { return gammaCorrection_(element, gamma); }, dst);
 }
 
 Mat maskCopyTo(const Mat& src, const Mat& mask)


### PR DESCRIPTION
Added perf tests to mcc module.
Also these optimizations have been added:

- added `parallel_for_` to `performThreshold()`
- removed `toL`/`fromL` and added `dst` to avoid copy data
- added `parallel_for_` to `elementWise()` ("batch" optimization improves performance of Windows version, Linux without changes).

Configuration:
Ryzen 5950X, 2x16 GB 3000 MHz DDR4
OS: Windows 10, Ubuntu 20.04.5 LTS

Performance results in milliseconds:

| OS and alg version   | process, ms | infer, ms |
| -------------------- | ----- | ------ |
| win_default          | 63.09 | 457.57 |
| win_optimized_without_batch       | 48.69 | 111.78 |
| win_optimized_batch  | 48.42 | 47.28  |
| linux_default        | 50.88 | 300.7  |
| linux_optimized_batch| 36.06 | 41.62  |

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
