### PR TITLE
remove redundant move calls

### DIFF
--- a/modules/face/src/facemarkLBF.cpp
+++ b/modules/face/src/facemarkLBF.cpp
@@ -667,7 +667,7 @@ Mat FacemarkLBFImpl::BBox::project(const Mat &shape) const {
         res(i, 0) = (shape_(i, 0) - x_center) / x_scale;
         res(i, 1) = (shape_(i, 1) - y_center) / y_scale;
     }
-    return std::move(res);
+    return res;
 }
 
 // Project relative shape to absolute shape binding to this bbox
@@ -678,7 +678,7 @@ Mat FacemarkLBFImpl::BBox::reproject(const Mat &shape) const {
         res(i, 0) = shape_(i, 0)*x_scale + x_center;
         res(i, 1) = shape_(i, 1)*y_scale + y_center;
     }
-    return std::move(res);
+    return res;
 }
 
 Mat FacemarkLBFImpl::getMeanShape(std::vector<Mat> &gt_shapes, std::vector<BBox> &bboxes) {
@@ -1039,7 +1039,7 @@ Mat FacemarkLBFImpl::RandomForest::generateLBF(Mat &img, Mat &current_shape, BBo
             lbf_feat(i*trees_n + j) = (i*trees_n + j)*base + code;
         }
     }
-    return std::move(lbf_feat);
+    return lbf_feat;
 }
 
 void FacemarkLBFImpl::RandomForest::write(FileStorage fs, int k) {
@@ -1381,7 +1381,7 @@ Mat FacemarkLBFImpl::Regressor::globalRegressionPredict(const Mat &lbf, int stag
         for (int j = 0; j < lbf.cols; j++) y += w_ptr[lbf_ptr[j]];
         delta_shape(i, 1) = y;
     }
-    return std::move(delta_shape);
+    return delta_shape;
 } // Regressor::globalRegressionPredict
 
 Mat FacemarkLBFImpl::Regressor::predict(Mat &img, BBox &bbox) {

--- a/modules/face/src/mace.cpp
+++ b/modules/face/src/mace.cpp
@@ -106,7 +106,7 @@ struct MACEImpl CV_FINAL : MACE {
         complexInput.copyTo(dftImg(Rect(0,0,IMGSIZE,IMGSIZE)));
 
         dft(dftImg, dftImg);
-        return std::move(dftImg);
+        return dftImg;
     }
 
 

--- a/modules/videostab/src/global_motion.cpp
+++ b/modules/videostab/src/global_motion.cpp
@@ -113,7 +113,7 @@ static Mat normalizePoints(int npoints, Point2f *points)
     T(0,0) = T(1,1) = s;
     T(0,2) = -cx*s;
     T(1,2) = -cy*s;
-    return std::move(T);
+    return T;
 }
 
 
@@ -138,7 +138,7 @@ static Mat estimateGlobMotionLeastSquaresTranslation(
         *rmse = std::sqrt(*rmse / npoints);
     }
 
-    return std::move(M);
+    return M;
 }
 
 
@@ -219,7 +219,7 @@ static Mat estimateGlobMotionLeastSquaresRotation(
         *rmse = std::sqrt(*rmse / npoints);
     }
 
-    return std::move(M);
+    return M;
 }
 
 static Mat  estimateGlobMotionLeastSquaresRigid(
@@ -273,7 +273,7 @@ static Mat  estimateGlobMotionLeastSquaresRigid(
         *rmse = std::sqrt(*rmse / npoints);
     }
 
-    return std::move(M);
+    return M;
 }
 
 
@@ -484,7 +484,7 @@ Mat estimateGlobalMotionRansac(
     if (ninliers)
         *ninliers = ninliersMax;
 
-    return std::move(bestM);
+    return bestM;
 }
 
 
@@ -527,7 +527,7 @@ Mat MotionEstimatorRansacL2::estimate(InputArray points0, InputArray points1, bo
         if (ok) *ok = false;
     }
 
-    return std::move(M);
+    return M;
 }
 
 
@@ -681,7 +681,7 @@ Mat FromFileMotionReader::estimate(const Mat &/*frame0*/, const Mat &/*frame1*/,
           >> M(1,0) >> M(1,1) >> M(1,2)
           >> M(2,0) >> M(2,1) >> M(2,2) >> ok_;
     if (ok) *ok = ok_;
-    return std::move(M);
+    return M;
 }
 
 
@@ -701,7 +701,7 @@ Mat ToFileMotionWriter::estimate(const Mat &frame0, const Mat &frame1, bool *ok)
           << M(1,0) << " " << M(1,1) << " " << M(1,2) << " "
           << M(2,0) << " " << M(2,1) << " " << M(2,2) << " " << ok_ << std::endl;
     if (ok) *ok = ok_;
-    return std::move(M);
+    return M;
 }
 
 

--- a/modules/ximgproc/test/test_sparse_match_interpolator.cpp
+++ b/modules/ximgproc/test/test_sparse_match_interpolator.cpp
@@ -20,12 +20,12 @@ Mat readOpticalFlow( const String& path )
     Mat_<Point2f> flow;
     std::ifstream file(path.c_str(), std::ios_base::binary);
     if ( !file.good() )
-        return std::move(flow); // no file - return empty matrix
+        return flow; // no file - return empty matrix
 
     float tag;
     file.read((char*) &tag, sizeof(float));
     if ( tag != FLOW_TAG_FLOAT )
-        return std::move(flow);
+        return flow;
 
     int width, height;
 
@@ -44,14 +44,14 @@ Mat readOpticalFlow( const String& path )
             if ( !file.good() )
             {
                 flow.release();
-                return std::move(flow);
+                return flow;
             }
 
             flow(i, j) = u;
         }
     }
     file.close();
-    return std::move(flow);
+    return flow;
 }
 
 CV_ENUM(GuideTypes, CV_8UC1, CV_8UC3)


### PR DESCRIPTION
detected by latest gcc.
e.g. warning: redundant move in return statement [-Wredundant-move]
  return std::move(T);### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
