### PR TITLE
fix not merging when there are only two segs on one line

### DIFF
--- a/modules/ximgproc/src/fast_line_detector.cpp
+++ b/modules/ximgproc/src/fast_line_detector.cpp
@@ -581,7 +581,7 @@ void FastLineDetectorImpl::lineDetection(const Mat& src, std::vector<SEGMENT>& s
     bool is_merged = false;
     int ith = (int)segments_tmp.size() - 1;
     int jth = ith - 1;
-    while(ith > 1 || jth > 0)
+    while(ith > 1 || jth >= 0)
     {
         seg1 = segments_tmp[ith];
         seg2 = segments_tmp[jth];


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv_contrib/issues/3715

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

This bug can be recurrent when there are only two segments on one line , if `do_merge` is set to be true. 
The `while` loop will not enter in , then output has still two segments but not one merged one segment. 