### PR TITLE
supports empty kernels in cuda::SeparableLinearFilters

### DIFF
--- a/modules/cudafilters/include/opencv2/cudafilters.hpp
+++ b/modules/cudafilters/include/opencv2/cudafilters.hpp
@@ -142,12 +142,14 @@ CV_EXPORTS_W Ptr<Filter> createLaplacianFilter(int srcType, int dstType, int ksi
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Separable Linear Filter
 
-/** @brief Creates a separable linear filter.
+/** @brief Creates a separable linear filter. In-place processing is supported.
 
 @param srcType Source array type.
 @param dstType Destination array type.
 @param rowKernel Horizontal filter coefficients. Support kernels with size \<= 32 .
+noArray() is supported to ignore the row filtering.
 @param columnKernel Vertical filter coefficients. Support kernels with size \<= 32 .
+noArray() is supported to ignore the column filtering.
 @param anchor Anchor position within the kernel. Negative values mean that anchor is positioned at
 the aperture center.
 @param rowBorderMode Pixel extrapolation method in the vertical direction For details, see

--- a/modules/cudafilters/src/filtering.cpp
+++ b/modules/cudafilters/src/filtering.cpp
@@ -448,7 +448,6 @@ namespace
         if (needsSrcAdaptation)
             src.convertTo(buf_, bufType_, _stream);
         GpuMat& srcAdapted = needsSrcAdaptation ? buf_ : src;
-        GpuMat& dstAdapted = needsDstAdaptation ? buf_ : dst;
 
         DeviceInfo devInfo;
         const int cc = devInfo.majorVersion() * 10 + devInfo.minorVersion();
@@ -466,7 +465,7 @@ namespace
 
             if (hasRowKernel)
                 rowFilter_(rowFilterSrc, rowFilterDst, rowKernel_.ptr<float>(), rowKernel_.cols, anchor_.x, rowBorderMode_, cc, stream);
-            else if (hasColKernel && needsBufForIntermediateStorage)
+            else if (hasColKernel && (needsBufForIntermediateStorage && !needsSrcAdaptation))
                 rowFilterSrc.convertTo(buf_, bufType_, _stream);
 
             if (hasColKernel)

--- a/modules/cudafilters/src/filtering.cpp
+++ b/modules/cudafilters/src/filtering.cpp
@@ -384,28 +384,38 @@ namespace
         const int cn = CV_MAT_CN(srcType);
         const int ddepth = CV_MAT_DEPTH(dstType);
 
-        Mat rowKernel = _rowKernel.getMat();
-        Mat columnKernel = _columnKernel.getMat();
+        CV_Assert( _rowKernel.empty() || _rowKernel.isMat() );
+        CV_Assert( _columnKernel.empty() || _columnKernel.isMat() );
+        Mat rowKernel = _rowKernel.empty() ? cv::Mat() : _rowKernel.getMat();
+        Mat columnKernel = _columnKernel.empty() ? cv::Mat() : _columnKernel.getMat();
 
         CV_Assert( sdepth <= CV_64F && cn <= 4 );
-        CV_Assert( rowKernel.channels() == 1 );
-        CV_Assert( columnKernel.channels() == 1 );
+        CV_Assert( rowKernel.empty() || rowKernel.channels() == 1 );
+        CV_Assert( columnKernel.empty() || columnKernel.channels() == 1 );
         CV_Assert( rowBorderMode == BORDER_REFLECT101 || rowBorderMode == BORDER_REPLICATE || rowBorderMode == BORDER_CONSTANT || rowBorderMode == BORDER_REFLECT || rowBorderMode == BORDER_WRAP );
         CV_Assert( columnBorderMode == BORDER_REFLECT101 || columnBorderMode == BORDER_REPLICATE || columnBorderMode == BORDER_CONSTANT || columnBorderMode == BORDER_REFLECT || columnBorderMode == BORDER_WRAP );
 
         Mat kernel32F;
 
-        rowKernel.convertTo(kernel32F, CV_32F);
-        rowKernel_.upload(kernel32F.reshape(1, 1));
+        if (!rowKernel.empty())
+        {
+            rowKernel.convertTo(kernel32F, CV_32F);
+            rowKernel_.upload(kernel32F.reshape(1, 1));
+        }
 
-        columnKernel.convertTo(kernel32F, CV_32F);
-        columnKernel_.upload(kernel32F.reshape(1, 1));
+        if (!columnKernel.empty())
+        {
+            columnKernel.convertTo(kernel32F, CV_32F);
+            columnKernel_.upload(kernel32F.reshape(1, 1));
+        }
 
-        CV_Assert( rowKernel_.cols > 0 && rowKernel_.cols <= 32 );
-        CV_Assert( columnKernel_.cols > 0 && columnKernel_.cols <= 32 );
+        CV_Assert( rowKernel_.empty() || (rowKernel_.cols > 0 && rowKernel_.cols <= 32 ));
+        CV_Assert( columnKernel_.empty() || (columnKernel_.cols > 0 && columnKernel_.cols <= 32 ));
 
-        normalizeAnchor(anchor_.x, rowKernel_.cols);
-        normalizeAnchor(anchor_.y, columnKernel_.cols);
+        if (!rowKernel_.empty())
+          normalizeAnchor(anchor_.x, rowKernel_.cols);
+        if (!columnKernel_.empty())
+          normalizeAnchor(anchor_.y, columnKernel_.cols);
 
         bufType_ = CV_MAKE_TYPE(CV_32F, cn);
 
@@ -424,15 +434,38 @@ namespace
         _dst.create(src.size(), dstType_);
         GpuMat dst = _dst.getGpuMat();
 
-        ensureSizeIsEnough(src.size(), bufType_, buf_);
+        const bool isInPlace = (src.data == dst.data);
+        const bool hasRowKernel = !rowKernel_.empty();
+        const bool hasColKernel = !columnKernel_.empty();
+        const bool hasSingleKernel = (hasRowKernel ^ hasColKernel);
+        const bool needsBuf = (hasRowKernel && hasColKernel) || (hasSingleKernel && isInPlace);
+        if (needsBuf)
+            ensureSizeIsEnough(src.size(), bufType_, buf_);
 
         DeviceInfo devInfo;
         const int cc = devInfo.majorVersion() * 10 + devInfo.minorVersion();
 
         cudaStream_t stream = StreamAccessor::getStream(_stream);
 
-        rowFilter_(src, buf_, rowKernel_.ptr<float>(), rowKernel_.cols, anchor_.x, rowBorderMode_, cc, stream);
-        columnFilter_(buf_, dst, columnKernel_.ptr<float>(), columnKernel_.cols, anchor_.y, columnBorderMode_, cc, stream);
+        if (!hasRowKernel && !hasColKernel && !isInPlace)
+          src.copyTo(dst, _stream);
+        else if (hasRowKernel || hasColKernel)
+        {
+            GpuMat& rowFilterSrc = src;
+            GpuMat& rowFilterDst = !hasRowKernel ? src : needsBuf ? buf_ : dst;
+            GpuMat& colFilterSrc = hasColKernel && needsBuf ? buf_ : src;
+            GpuMat& colFilterTo = dst;
+
+            if (hasRowKernel)
+                rowFilter_(rowFilterSrc, rowFilterDst, rowKernel_.ptr<float>(), rowKernel_.cols, anchor_.x, rowBorderMode_, cc, stream);
+            else if (hasColKernel && needsBuf)
+                rowFilterSrc.copyTo(buf_, _stream);
+
+            if (hasColKernel)
+                columnFilter_(colFilterSrc, colFilterTo, columnKernel_.ptr<float>(), columnKernel_.cols, anchor_.y, columnBorderMode_, cc, stream);
+            else if (needsBuf)
+                buf_.copyTo(dst, _stream);
+        }
     }
 }
 

--- a/modules/cudafilters/test/test_filters.cpp
+++ b/modules/cudafilters/test/test_filters.cpp
@@ -299,7 +299,7 @@ PARAM_TEST_CASE(SeparableLinearFilterWithEmptyKernels, cv::cuda::DeviceInfo, Mat
 
     virtual void SetUp()
     {
-        devInfo = GET_PARAM(0);        
+        devInfo = GET_PARAM(0);
         srcDepth = GET_PARAM(1);
         cn = GET_PARAM(2);
         dstDepth = GET_PARAM(3);


### PR DESCRIPTION
[#25408](https://github.com/opencv/opencv/issues/25408)

When only 1D convolution is needed (row or column filter only), `cuda::LinearFilter` might be slower than `cuda::SeparableLinearFilter`
Using `cuda::SeparableLinearFilter` for 1D convolution can be done by using a `(1)` kernel for the ignored dimension.
By supporting empty kernels in `cuda::SeparableLinearFilter`, there is no need for that `(1)` kernel any more.
Additionaly, the inner `_buf ` used to store the intermediate convolution result can be saved when a single convolution is needed.

In "legacy" usage (row+col kernels), there is no regression in `cuda::SeparableLinearFilter` performance.
As soon as an empty kernel is used, the performance is largely increased.

Devil in the details : the "in-place" processing is supported and might need intermediate buf, but still no regression.

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [X] There is a reference to the original bug report and related work
- [X] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X] The feature is well documented and sample code can be built with the project CMake
