### PR TITLE
Added CUDA 12.4+ support

### DIFF
--- a/modules/cudaarithm/src/cuda/polar_cart.cu
+++ b/modules/cudaarithm/src/cuda/polar_cart.cu
@@ -132,24 +132,24 @@ void cv::cuda::cartToPolar(InputArray _x, InputArray _y, OutputArray _mag, Outpu
     GpuMat_<float> magc(mag.reshape(1));
     GpuMat_<float> anglec(angle.reshape(1));
 
-    if (angleInDegrees)
-    {
-        gridTransformTuple(zipPtr(xc, yc),
-                           tie(magc, anglec),
-                           make_tuple(
-                               binaryTupleAdapter<0, 1>(magnitude_func<float>()),
-                               binaryTupleAdapter<0, 1>(direction_func<float, true>())),
-                           stream);
-    }
-    else
-    {
-        gridTransformTuple(zipPtr(xc, yc),
-                           tie(magc, anglec),
-                           make_tuple(
-                               binaryTupleAdapter<0, 1>(magnitude_func<float>()),
-                               binaryTupleAdapter<0, 1>(direction_func<float, false>())),
-                           stream);
-    }
+//     if (angleInDegrees)
+//     {
+//         gridTransformTuple(zipPtr(xc, yc),
+//                            tie(magc, anglec),
+//                            make_tuple(
+//                                binaryTupleAdapter<0, 1>(magnitude_func<float>()),
+//                                binaryTupleAdapter<0, 1>(direction_func<float, true>())),
+//                            stream);
+//     }
+//     else
+//     {
+//         gridTransformTuple(zipPtr(xc, yc),
+//                            tie(magc, anglec),
+//                            make_tuple(
+//                                binaryTupleAdapter<0, 1>(magnitude_func<float>()),
+//                                binaryTupleAdapter<0, 1>(direction_func<float, false>())),
+//                            stream);
+//     }
 
     syncOutput(mag, _mag, stream);
     syncOutput(angle, _angle, stream);

--- a/modules/cudaarithm/src/cuda/polar_cart.cu
+++ b/modules/cudaarithm/src/cuda/polar_cart.cu
@@ -132,24 +132,10 @@ void cv::cuda::cartToPolar(InputArray _x, InputArray _y, OutputArray _mag, Outpu
     GpuMat_<float> magc(mag.reshape(1));
     GpuMat_<float> anglec(angle.reshape(1));
 
-//     if (angleInDegrees)
-//     {
-//         gridTransformTuple(zipPtr(xc, yc),
-//                            tie(magc, anglec),
-//                            make_tuple(
-//                                binaryTupleAdapter<0, 1>(magnitude_func<float>()),
-//                                binaryTupleAdapter<0, 1>(direction_func<float, true>())),
-//                            stream);
-//     }
-//     else
-//     {
-//         gridTransformTuple(zipPtr(xc, yc),
-//                            tie(magc, anglec),
-//                            make_tuple(
-//                                binaryTupleAdapter<0, 1>(magnitude_func<float>()),
-//                                binaryTupleAdapter<0, 1>(direction_func<float, false>())),
-//                            stream);
-//     }
+    if (angleInDegrees)
+        gridTransformBinary(xc, yc, magc, anglec, magnitude_func<float>(), direction_func<float, true>(), stream);
+    else
+        gridTransformBinary(xc, yc, magc, anglec, magnitude_func<float>(), direction_func<float, false>(), stream);
 
     syncOutput(mag, _mag, stream);
     syncOutput(angle, _angle, stream);

--- a/modules/cudaarithm/src/cuda/split_merge.cu
+++ b/modules/cudaarithm/src/cuda/split_merge.cu
@@ -67,7 +67,8 @@ namespace
     {
         static void call(const GpuMat* src, GpuMat& dst, Stream& stream)
         {
-            gridMerge(zipPtr(globPtr<T>(src[0]), globPtr<T>(src[1])),
+            const std::vector<GlobPtrSz<T>> d_src = {globPtr<T>(src[0]), globPtr<T>(src[1])};
+            gridMerge(d_src,
                     globPtr<typename MakeVec<T, 2>::type>(dst),
                     stream);
         }
@@ -77,7 +78,8 @@ namespace
     {
         static void call(const GpuMat* src, GpuMat& dst, Stream& stream)
         {
-            gridMerge(zipPtr(globPtr<T>(src[0]), globPtr<T>(src[1]), globPtr<T>(src[2])),
+            const std::vector<GlobPtrSz<T>> d_src = {globPtr<T>(src[0]), globPtr<T>(src[1]), globPtr<T>(src[2])};
+            gridMerge(d_src,
                     globPtr<typename MakeVec<T, 3>::type>(dst),
                     stream);
         }
@@ -87,7 +89,8 @@ namespace
     {
         static void call(const GpuMat* src, GpuMat& dst, Stream& stream)
         {
-            gridMerge(zipPtr(globPtr<T>(src[0]), globPtr<T>(src[1]), globPtr<T>(src[2]), globPtr<T>(src[3])),
+            const std::vector<GlobPtrSz<T> > d_src = {globPtr<T>(src[0]), globPtr<T>(src[1]), globPtr<T>(src[2]), globPtr<T>(src[3])};
+            gridMerge(d_src,
                     globPtr<typename MakeVec<T, 4>::type>(dst),
                     stream);
         }

--- a/modules/cudaarithm/src/cuda/split_merge.cu
+++ b/modules/cudaarithm/src/cuda/split_merge.cu
@@ -67,7 +67,7 @@ namespace
     {
         static void call(const GpuMat* src, GpuMat& dst, Stream& stream)
         {
-            const std::vector<GlobPtrSz<T>> d_src = {globPtr<T>(src[0]), globPtr<T>(src[1])};
+            const std::array<GlobPtrSz<T>, 2> d_src = {globPtr<T>(src[0]), globPtr<T>(src[1])};
             gridMerge(d_src,
                     globPtr<typename MakeVec<T, 2>::type>(dst),
                     stream);
@@ -78,7 +78,7 @@ namespace
     {
         static void call(const GpuMat* src, GpuMat& dst, Stream& stream)
         {
-            const std::vector<GlobPtrSz<T>> d_src = {globPtr<T>(src[0]), globPtr<T>(src[1]), globPtr<T>(src[2])};
+            const std::array<GlobPtrSz<T>, 3> d_src = {globPtr<T>(src[0]), globPtr<T>(src[1]), globPtr<T>(src[2])};
             gridMerge(d_src,
                     globPtr<typename MakeVec<T, 3>::type>(dst),
                     stream);
@@ -89,7 +89,7 @@ namespace
     {
         static void call(const GpuMat* src, GpuMat& dst, Stream& stream)
         {
-            const std::vector<GlobPtrSz<T> > d_src = {globPtr<T>(src[0]), globPtr<T>(src[1]), globPtr<T>(src[2]), globPtr<T>(src[3])};
+            const std::array<GlobPtrSz<T>, 4 > d_src = {globPtr<T>(src[0]), globPtr<T>(src[1]), globPtr<T>(src[2]), globPtr<T>(src[3])};
             gridMerge(d_src,
                     globPtr<typename MakeVec<T, 4>::type>(dst),
                     stream);

--- a/modules/cudev/include/opencv2/cudev/block/detail/reduce.hpp
+++ b/modules/cudev/include/opencv2/cudev/block/detail/reduce.hpp
@@ -154,6 +154,17 @@ namespace block_reduce_detail
         val = smem[tid];
     }
 
+
+    // merge
+
+    template <typename T, class Op>
+    __device__ __forceinline__ void merge(volatile T* smem, T& val, uint tid, uint delta, const Op& op)
+    {
+        T reg = smem[tid + delta];
+        smem[tid] = val = op(val, reg);
+    }
+
+#if (CUDART_VERSION < 12040)
     template <typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6, typename P7, typename P8, typename P9,
               typename R0, typename R1, typename R2, typename R3, typename R4, typename R5, typename R6, typename R7, typename R8, typename R9>
     __device__ __forceinline__ void loadToSmem(const tuple<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>& smem,
@@ -170,15 +181,6 @@ namespace block_reduce_detail
                                                      uint tid)
     {
         For<0, tuple_size<tuple<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9> >::value>::loadFromSmem(smem, val, tid);
-    }
-
-    // merge
-
-    template <typename T, class Op>
-    __device__ __forceinline__ void merge(volatile T* smem, T& val, uint tid, uint delta, const Op& op)
-    {
-        T reg = smem[tid + delta];
-        smem[tid] = val = op(val, reg);
     }
 
     template <typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6, typename P7, typename P8, typename P9,
@@ -211,6 +213,41 @@ namespace block_reduce_detail
                                               const tuple<Op0, Op1, Op2, Op3, Op4, Op5, Op6, Op7, Op8, Op9>& op)
     {
         For<0, tuple_size<tuple<R0, R1, R2, R3, R4, R5, R6, R7, R8, R9> >::value>::mergeShfl(val, delta, width, op);
+    }
+#endif
+
+#else
+    template <typename... P, typename... R>
+    __device__ __forceinline__ void loadToSmem(const tuple<P...>& smem, const tuple<R...>& val, uint tid)
+    {
+        For<0, tuple_size<tuple<P...> >::value>::loadToSmem(smem, val, tid);
+    }
+
+    template <typename... P, typename... R>
+    __device__ __forceinline__ void loadFromSmem(const tuple<P...>& smem, const tuple<R...>& val, uint tid)
+    {
+        For<0, tuple_size<tuple<P...> >::value>::loadFromSmem(smem, val, tid);
+    }
+
+    template <typename P..., typename... R, class... Op>
+    __device__ __forceinline__ void merge(const tuple<P...>& smem, const tuple<R...>& val, uint tid, uint delta, const tuple<Op...>& op)
+    {
+        For<0, tuple_size<tuple<P...> >::value>::merge(smem, val, tid, delta, op);
+    }
+
+    // mergeShfl
+
+    template <typename T, class Op>
+    __device__ __forceinline__ void mergeShfl(T& val, uint delta, uint width, const Op& op)
+    {
+        T reg = shfl_down(val, delta, width);
+        val = op(val, reg);
+    }
+
+    template <typename... R, class... Op>
+    __device__ __forceinline__ void mergeShfl(const tuple<R...>& val, uint delta, uint width, const tuple<Op...>& op)
+    {
+        For<0, tuple_size<tuple<R...> >::value>::mergeShfl(val, delta, width, op);
     }
 #endif
 

--- a/modules/cudev/include/opencv2/cudev/block/detail/reduce.hpp
+++ b/modules/cudev/include/opencv2/cudev/block/detail/reduce.hpp
@@ -229,7 +229,7 @@ namespace block_reduce_detail
         For<0, tuple_size<tuple<P...> >::value>::loadFromSmem(smem, val, tid);
     }
 
-    template <typename P..., typename... R, class... Op>
+    template <typename... P, typename... R, class... Op>
     __device__ __forceinline__ void merge(const tuple<P...>& smem, const tuple<R...>& val, uint tid, uint delta, const tuple<Op...>& op)
     {
         For<0, tuple_size<tuple<P...> >::value>::merge(smem, val, tid, delta, op);

--- a/modules/cudev/include/opencv2/cudev/block/reduce.hpp
+++ b/modules/cudev/include/opencv2/cudev/block/reduce.hpp
@@ -51,6 +51,7 @@
 #include "../warp/reduce.hpp"
 #include "detail/reduce.hpp"
 #include "detail/reduce_key_val.hpp"
+#include <cuda_runtime_api.h>
 
 namespace cv { namespace cudev {
 
@@ -65,6 +66,7 @@ __device__ __forceinline__ void blockReduce(volatile T* smem, T& val, uint tid, 
     block_reduce_detail::Dispatcher<N>::reductor::template reduce<volatile T*, T&, const Op&>(smem, val, tid, op);
 }
 
+#if (CUDART_VERSION < 12040)
 template <int N,
           typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6, typename P7, typename P8, typename P9,
           typename R0, typename R1, typename R2, typename R3, typename R4, typename R5, typename R6, typename R7, typename R8, typename R9,
@@ -125,6 +127,39 @@ __device__ __forceinline__ void blockReduceKeyVal(const tuple<KP0, KP1, KP2, KP3
             const tuple<Cmp0, Cmp1, Cmp2, Cmp3, Cmp4, Cmp5, Cmp6, Cmp7, Cmp8, Cmp9>&
             >(skeys, key, svals, val, tid, cmp);
 }
+
+#else
+
+template <int N, typename... P, typename... R, typename... Op>
+__device__ __forceinline__ void blockReduce(const tuple<P...>& smem,
+                                            const tuple<R...>& val,
+                                            uint tid,
+                                            const tuple<Op..>& op)
+{
+    block_reduce_detail::Dispatcher<N>::reductor::template reduce<const tuple<P...>&, const tuple<R...>&, const tuple<Op...>&>(smem, val, tid, op);
+}
+
+// blockReduceKeyVal
+
+template <int N, typename K, typename V, class Cmp>
+__device__ __forceinline__ void blockReduceKeyVal(volatile K* skeys, K& key, volatile V* svals, V& val, uint tid, const Cmp& cmp)
+{
+    block_reduce_key_val_detail::Dispatcher<N>::reductor::template reduce<volatile K*, K&, volatile V*, V&, const Cmp&>(skeys, key, svals, val, tid, cmp);
+}
+
+template <int N, typename K, typename... VP, typename... VR, class Cmp>
+__device__ __forceinline__ void blockReduceKeyVal(volatile K* skeys, K& key, const tuple<VP...>& svals, const tuple<VR...>& val, uint tid, const Cmp& cmp)
+{
+    block_reduce_key_val_detail::Dispatcher<N>::reductor::template reduce<volatile K*, K&, const tuple<VP...>&, const tuple<VR...>&, const Cmp&>(skeys, key, svals, val, tid, cmp);
+}
+
+template <int N, typename... KP, typename... KR, typename... VP, typename... VR, class... Cmp>
+__device__ __forceinline__ void blockReduceKeyVal(const tuple<KP...>& skeys, const tuple<KR...>& key, const tuple<VP...>& svals, const tuple<VR...>& val, uint tid, const tuple<Cmp...>& cmp)
+{
+    block_reduce_key_val_detail::Dispatcher<N>::reductor::template reduce< const tuple<KP...>&, const tuple<KR...>&, const tuple<VP...>&, const tuple<VR...>&, const tuple<Cmp...>&>(skeys, key, svals, val, tid, cmp);
+}
+
+#endif
 
 //! @}
 

--- a/modules/cudev/include/opencv2/cudev/block/reduce.hpp
+++ b/modules/cudev/include/opencv2/cudev/block/reduce.hpp
@@ -134,7 +134,7 @@ template <int N, typename... P, typename... R, typename... Op>
 __device__ __forceinline__ void blockReduce(const tuple<P...>& smem,
                                             const tuple<R...>& val,
                                             uint tid,
-                                            const tuple<Op..>& op)
+                                            const tuple<Op...>& op)
 {
     block_reduce_detail::Dispatcher<N>::reductor::template reduce<const tuple<P...>&, const tuple<R...>&, const tuple<Op...>&>(smem, val, tid, op);
 }

--- a/modules/cudev/include/opencv2/cudev/grid/detail/split_merge.hpp
+++ b/modules/cudev/include/opencv2/cudev/grid/detail/split_merge.hpp
@@ -157,27 +157,46 @@ namespace grid_split_merge_detail
     template <class Policy> struct MergeImpl<2, Policy>
     {
         template <class SrcPtrTuple, typename DstType, class MaskPtr>
-        __host__ static void merge(const SrcPtrTuple& src, const GlobPtr<DstType>& dst, const MaskPtr& mask, int rows, int cols, cudaStream_t stream)
+        __host__ static void mergeTuple(const SrcPtrTuple& src, const GlobPtr<DstType>& dst, const MaskPtr& mask, int rows, int cols, cudaStream_t stream)
         {
             mergeC2<Policy>(get<0>(src), get<1>(src), dst, mask, rows, cols, stream);
         }
+
+        template <typename VecType, typename DstType, class MaskPtr>
+        __host__ static void mergeVector(const std::vector<VecType>& src, const GlobPtr<DstType>& dst, const MaskPtr& mask, int rows, int cols, cudaStream_t stream)
+        {
+            mergeC2<Policy>(src[0], src[1], dst, mask, rows, cols, stream);
+        }
+
     };
 
     template <class Policy> struct MergeImpl<3, Policy>
     {
         template <class SrcPtrTuple, typename DstType, class MaskPtr>
-        __host__ static void merge(const SrcPtrTuple& src, const GlobPtr<DstType>& dst, const MaskPtr& mask, int rows, int cols, cudaStream_t stream)
+        __host__ static void mergeTuple(const SrcPtrTuple& src, const GlobPtr<DstType>& dst, const MaskPtr& mask, int rows, int cols, cudaStream_t stream)
         {
             mergeC3<Policy>(get<0>(src), get<1>(src), get<2>(src), dst, mask, rows, cols, stream);
+        }
+
+        template <typename VecType, typename DstType, class MaskPtr>
+        __host__ static void mergeVector(const std::vector<VecType>& src, const GlobPtr<DstType>& dst, const MaskPtr& mask, int rows, int cols, cudaStream_t stream)
+        {
+            mergeC3<Policy>(src[0], src[1], src[2], dst, mask, rows, cols, stream);
         }
     };
 
     template <class Policy> struct MergeImpl<4, Policy>
     {
         template <class SrcPtrTuple, typename DstType, class MaskPtr>
-        __host__ static void merge(const SrcPtrTuple& src, const GlobPtr<DstType>& dst, const MaskPtr& mask, int rows, int cols, cudaStream_t stream)
+        __host__ static void mergeTuple(const SrcPtrTuple& src, const GlobPtr<DstType>& dst, const MaskPtr& mask, int rows, int cols, cudaStream_t stream)
         {
             mergeC4<Policy>(get<0>(src), get<1>(src), get<2>(src), get<3>(src), dst, mask, rows, cols, stream);
+        }
+
+        template <typename VecType, typename DstType, class MaskPtr>
+        __host__ static void mergeVector(const std::vector<VecType>& src, const GlobPtr<DstType>& dst, const MaskPtr& mask, int rows, int cols, cudaStream_t stream)
+        {
+            mergeC4<Policy>(src[0], src[1], src[2], src[3], dst, mask, rows, cols, stream);
         }
     };
 

--- a/modules/cudev/include/opencv2/cudev/grid/detail/split_merge.hpp
+++ b/modules/cudev/include/opencv2/cudev/grid/detail/split_merge.hpp
@@ -162,8 +162,8 @@ namespace grid_split_merge_detail
             mergeC2<Policy>(get<0>(src), get<1>(src), dst, mask, rows, cols, stream);
         }
 
-        template <typename VecType, typename DstType, class MaskPtr>
-        __host__ static void mergeVector(const std::vector<VecType>& src, const GlobPtr<DstType>& dst, const MaskPtr& mask, int rows, int cols, cudaStream_t stream)
+        template <class SrcPtrArray, typename DstType, class MaskPtr>
+        __host__ static void mergeArray(const SrcPtrArray& src, const GlobPtr<DstType>& dst, const MaskPtr& mask, int rows, int cols, cudaStream_t stream)
         {
             mergeC2<Policy>(src[0], src[1], dst, mask, rows, cols, stream);
         }
@@ -178,8 +178,8 @@ namespace grid_split_merge_detail
             mergeC3<Policy>(get<0>(src), get<1>(src), get<2>(src), dst, mask, rows, cols, stream);
         }
 
-        template <typename VecType, typename DstType, class MaskPtr>
-        __host__ static void mergeVector(const std::vector<VecType>& src, const GlobPtr<DstType>& dst, const MaskPtr& mask, int rows, int cols, cudaStream_t stream)
+        template <class SrcPtrArray, typename DstType, class MaskPtr>
+        __host__ static void mergeArray(const SrcPtrArray& src, const GlobPtr<DstType>& dst, const MaskPtr& mask, int rows, int cols, cudaStream_t stream)
         {
             mergeC3<Policy>(src[0], src[1], src[2], dst, mask, rows, cols, stream);
         }
@@ -193,8 +193,8 @@ namespace grid_split_merge_detail
             mergeC4<Policy>(get<0>(src), get<1>(src), get<2>(src), get<3>(src), dst, mask, rows, cols, stream);
         }
 
-        template <typename VecType, typename DstType, class MaskPtr>
-        __host__ static void mergeVector(const std::vector<VecType>& src, const GlobPtr<DstType>& dst, const MaskPtr& mask, int rows, int cols, cudaStream_t stream)
+        template <class SrcPtrArray, typename DstType, class MaskPtr>
+        __host__ static void mergeArray(const SrcPtrArray& src, const GlobPtr<DstType>& dst, const MaskPtr& mask, int rows, int cols, cudaStream_t stream)
         {
             mergeC4<Policy>(src[0], src[1], src[2], src[3], dst, mask, rows, cols, stream);
         }

--- a/modules/cudev/include/opencv2/cudev/grid/detail/transform.hpp
+++ b/modules/cudev/include/opencv2/cudev/grid/detail/transform.hpp
@@ -180,7 +180,8 @@ namespace grid_transform_detail
     }
 
     // transformSimple, 2 outputs
-
+    // The overloads are added for polar_cart.cu to compute magnitude and phase with single call
+    // the previous implementation with touple causes cuda namespace clash. See https://github.com/opencv/opencv_contrib/issues/3690
     template <class SrcPtr1, class SrcPtr2, typename DstType1, typename DstType2, class BinOp1, class BinOp2, class MaskPtr>
     __global__ void transformSimple(const SrcPtr1 src1, const SrcPtr2 src2, GlobPtr<DstType1> dst1, GlobPtr<DstType2> dst2,
                                     const BinOp1 op1, const BinOp2 op2, const MaskPtr mask, const int rows, const int cols)
@@ -265,7 +266,8 @@ namespace grid_transform_detail
     }
 
     // transformSmart, 2 outputs
-
+    // The overloads are added for polar_cart.cu to compute magnitude and phase with single call
+    // the previous implementation with touple causes cuda namespace clash. See https://github.com/opencv/opencv_contrib/issues/3690
     template <int SHIFT, typename SrcType1, typename SrcType2, typename DstType1, typename DstType2, class BinOp1, class BinOp2, class MaskPtr>
     __global__ void transformSmart(const GlobPtr<SrcType1> src1_, const GlobPtr<SrcType2> src2_,
                                    GlobPtr<DstType1> dst1_, GlobPtr<DstType2> dst2_,

--- a/modules/cudev/include/opencv2/cudev/grid/detail/transform.hpp
+++ b/modules/cudev/include/opencv2/cudev/grid/detail/transform.hpp
@@ -179,6 +179,22 @@ namespace grid_transform_detail
         dst(y, x) = saturate_cast<DstType>(op(src1(y, x), src2(y, x)));
     }
 
+    // transformSimple, 2 outputs
+
+    template <class SrcPtr1, class SrcPtr2, typename DstType1, typename DstType2, class BinOp1, class BinOp2, class MaskPtr>
+    __global__ void transformSimple(const SrcPtr1 src1, const SrcPtr2 src2, GlobPtr<DstType1> dst1, GlobPtr<DstType2> dst2,
+                                    const BinOp1 op1, const BinOp2 op2, const MaskPtr mask, const int rows, const int cols)
+    {
+        const int x = blockIdx.x * blockDim.x + threadIdx.x;
+        const int y = blockIdx.y * blockDim.y + threadIdx.y;
+
+        if (x >= cols || y >= rows || !mask(y, x))
+            return;
+
+        dst1(y, x) = saturate_cast<DstType1>(op1(src1(y, x), src2(y, x)));
+        dst2(y, x) = saturate_cast<DstType2>(op2(src1(y, x), src2(y, x)));
+    }
+
     // transformSmart
 
     template <int SHIFT, typename SrcType, typename DstType, class UnOp, class MaskPtr>
@@ -248,6 +264,51 @@ namespace grid_transform_detail
         }
     }
 
+    // transformSmart, 2 outputs
+
+    template <int SHIFT, typename SrcType1, typename SrcType2, typename DstType1, typename DstType2, class BinOp1, class BinOp2, class MaskPtr>
+    __global__ void transformSmart(const GlobPtr<SrcType1> src1_, const GlobPtr<SrcType2> src2_,
+                                   GlobPtr<DstType1> dst1_, GlobPtr<DstType2> dst2_,
+                                   const BinOp1 op1, const BinOp2 op2, const MaskPtr mask, const int rows, const int cols)
+    {
+        typedef typename MakeVec<SrcType1, SHIFT>::type read_type1;
+        typedef typename MakeVec<SrcType2, SHIFT>::type read_type2;
+        typedef typename MakeVec<DstType1, SHIFT>::type write_type1;
+        typedef typename MakeVec<DstType2, SHIFT>::type write_type2;
+
+        const int x = blockIdx.x * blockDim.x + threadIdx.x;
+        const int y = blockIdx.y * blockDim.y + threadIdx.y;
+        const int x_shifted = x * SHIFT;
+
+        if (y < rows)
+        {
+            const SrcType1* src1 = src1_.row(y);
+            const SrcType2* src2 = src2_.row(y);
+            DstType1* dst1 = dst1_.row(y);
+            DstType2* dst2 = dst2_.row(y);
+
+            if (x_shifted + SHIFT - 1 < cols)
+            {
+                const read_type1 src1_n_el = ((const read_type1*)src1)[x];
+                const read_type2 src2_n_el = ((const read_type2*)src2)[x];
+
+                OpUnroller<SHIFT>::unroll(src1_n_el, src2_n_el, ((write_type1*)dst1)[x], op1, mask, x_shifted, y);
+                OpUnroller<SHIFT>::unroll(src1_n_el, src2_n_el, ((write_type2*)dst2)[x], op2, mask, x_shifted, y);
+            }
+            else
+            {
+                for (int real_x = x_shifted; real_x < cols; ++real_x)
+                {
+                    if (mask(y, real_x))
+                    {
+                        dst1[real_x] = op1(src1[real_x], src2[real_x]);
+                        dst2[real_x] = op2(src1[real_x], src2[real_x]);
+                    }
+                }
+            }
+        }
+    }
+
     // TransformDispatcher
 
     template <bool UseSmart, class Policy> struct TransformDispatcher;
@@ -274,6 +335,20 @@ namespace grid_transform_detail
             const dim3 grid(divUp(cols, block.x), divUp(rows, block.y));
 
             transformSimple<<<grid, block, 0, stream>>>(src1, src2, dst, op, mask, rows, cols);
+            CV_CUDEV_SAFE_CALL( cudaGetLastError() );
+
+            if (stream == 0)
+                CV_CUDEV_SAFE_CALL( cudaDeviceSynchronize() );
+        }
+
+        template <class SrcPtr1, class SrcPtr2, typename DstType1, typename DstType2, class BinOp1, class BinOp2, class MaskPtr>
+        __host__ static void call(const SrcPtr1& src1, const SrcPtr2& src2, const GlobPtr<DstType1>& dst1, const GlobPtr<DstType2>& dst2,
+                                  const BinOp1& op1, const BinOp2& op2, const MaskPtr& mask, int rows, int cols, cudaStream_t stream)
+        {
+            const dim3 block(Policy::block_size_x, Policy::block_size_y);
+            const dim3 grid(divUp(cols, block.x), divUp(rows, block.y));
+
+            transformSimple<<<grid, block, 0, stream>>>(src1, src2, dst1, dst2, op1, op2, mask, rows, cols);
             CV_CUDEV_SAFE_CALL( cudaGetLastError() );
 
             if (stream == 0)
@@ -336,6 +411,33 @@ namespace grid_transform_detail
             if (stream == 0)
                 CV_CUDEV_SAFE_CALL( cudaDeviceSynchronize() );
         }
+
+        template <typename SrcType1, typename SrcType2, typename DstType1, typename DstType2, class BinOp1, class BinOp2, class MaskPtr>
+        __host__ static void call(const GlobPtr<SrcType1>& src1, const GlobPtr<SrcType2>& src2,
+                                  const GlobPtr<DstType1>& dst1, const GlobPtr<DstType2>& dst2,
+                                  const BinOp1& op1, const BinOp2& op2, const MaskPtr& mask, int rows, int cols, cudaStream_t stream)
+        {
+            if (Policy::shift == 1 ||
+                !isAligned(src1.data, Policy::shift * sizeof(SrcType1))  || !isAligned(src1.step, Policy::shift * sizeof(SrcType1)) ||
+                !isAligned(src2.data, Policy::shift * sizeof(SrcType2))  || !isAligned(src2.step, Policy::shift * sizeof(SrcType2)) ||
+                !isAligned(dst1.data,  Policy::shift * sizeof(DstType1)) || !isAligned(dst1.step,  Policy::shift * sizeof(DstType1))||
+                !isAligned(dst2.data,  Policy::shift * sizeof(DstType2)) || !isAligned(dst2.step,  Policy::shift * sizeof(DstType2))
+            )
+            {
+                TransformDispatcher<false, Policy>::call(src1, src2, dst1, dst2, op1, op2, mask, rows, cols, stream);
+                return;
+            }
+
+            const dim3 block(Policy::block_size_x, Policy::block_size_y);
+            const dim3 grid(divUp(cols, block.x * Policy::shift), divUp(rows, block.y));
+
+            transformSmart<Policy::shift><<<grid, block, 0, stream>>>(src1, src2, dst1, dst2, op1, op2, mask, rows, cols);
+            CV_CUDEV_SAFE_CALL( cudaGetLastError() );
+
+            if (stream == 0)
+                CV_CUDEV_SAFE_CALL( cudaDeviceSynchronize() );
+        }
+
     };
 
     template <class Policy, class SrcPtr, typename DstType, class UnOp, class MaskPtr>
@@ -350,6 +452,13 @@ namespace grid_transform_detail
         TransformDispatcher<false, Policy>::call(src1, src2, dst, op, mask, rows, cols, stream);
     }
 
+    template <class Policy, class SrcPtr1, class SrcPtr2, typename DstType1, typename DstType2, class BinOp1, class BinOp2, class MaskPtr>
+    __host__ void transform_binary(const SrcPtr1& src1, const SrcPtr2& src2, const GlobPtr<DstType1>& dst1, const GlobPtr<DstType2>& dst2,
+                                   const BinOp1& op1, const BinOp2& op2, const MaskPtr& mask, int rows, int cols, cudaStream_t stream)
+    {
+        TransformDispatcher<false, Policy>::call(src1, src2, dst1, dst2, op1, op2, mask, rows, cols, stream);
+    }
+
     template <class Policy, typename SrcType, typename DstType, class UnOp, class MaskPtr>
     __host__ void transform_unary(const GlobPtr<SrcType>& src, const GlobPtr<DstType>& dst, const UnOp& op, const MaskPtr& mask, int rows, int cols, cudaStream_t stream)
     {
@@ -360,6 +469,15 @@ namespace grid_transform_detail
     __host__ void transform_binary(const GlobPtr<SrcType1>& src1, const GlobPtr<SrcType2>& src2, const GlobPtr<DstType>& dst, const BinOp& op, const MaskPtr& mask, int rows, int cols, cudaStream_t stream)
     {
         TransformDispatcher<VecTraits<SrcType1>::cn == 1 && VecTraits<SrcType2>::cn == 1 && VecTraits<DstType>::cn == 1 && Policy::shift != 1, Policy>::call(src1, src2, dst, op, mask, rows, cols, stream);
+    }
+
+    template <class Policy, typename SrcType1, typename SrcType2, typename DstType1, typename DstType2, class BinOp1, class BinOp2, class MaskPtr>
+    __host__ void transform_binary(const GlobPtr<SrcType1>& src1, const GlobPtr<SrcType2>& src2, const GlobPtr<DstType1>& dst1, const GlobPtr<DstType2>& dst2,
+                                   const BinOp1& op1, const BinOp2& op2, const MaskPtr& mask, int rows, int cols, cudaStream_t stream)
+    {
+        TransformDispatcher<VecTraits<SrcType1>::cn == 1 && VecTraits<SrcType2>::cn == 1 &&
+                            VecTraits<DstType1>::cn == 1 && VecTraits<DstType2>::cn == 1 &&
+                            Policy::shift != 1, Policy>::call(src1, src2, dst1, dst2, op1, op2, mask, rows, cols, stream);
     }
 
     // transform_tuple

--- a/modules/cudev/include/opencv2/cudev/grid/split_merge.hpp
+++ b/modules/cudev/include/opencv2/cudev/grid/split_merge.hpp
@@ -72,11 +72,11 @@ __host__ void gridMerge_(const SrcPtrTuple& src, GpuMat_<DstType>& dst, const Ma
 
     dst.create(rows, cols);
 
-    grid_split_merge_detail::MergeImpl<VecTraits<DstType>::cn, Policy>::merge(shrinkPtr(src),
-                                                                              shrinkPtr(dst),
-                                                                              shrinkPtr(mask),
-                                                                              rows, cols,
-                                                                              StreamAccessor::getStream(stream));
+    grid_split_merge_detail::MergeImpl<VecTraits<DstType>::cn, Policy>::mergeTuple(shrinkPtr(src),
+                                                                                   shrinkPtr(dst),
+                                                                                   shrinkPtr(mask),
+                                                                                   rows, cols,
+                                                                                   StreamAccessor::getStream(stream));
 }
 
 template <class Policy, class SrcPtrTuple, typename DstType, class MaskPtr>
@@ -90,7 +90,7 @@ __host__ void gridMerge_(const SrcPtrTuple& src, const GlobPtrSz<DstType>& dst, 
     CV_Assert( getRows(dst) == rows && getCols(dst) == cols );
     CV_Assert( getRows(mask) == rows && getCols(mask) == cols );
 
-    grid_split_merge_detail::MergeImpl<VecTraits<DstType>::cn, Policy>::merge(shrinkPtr(src),
+    grid_split_merge_detail::MergeImpl<VecTraits<DstType>::cn, Policy>::mergeTuple(shrinkPtr(src),
                                                                               shrinkPtr(dst),
                                                                               shrinkPtr(mask),
                                                                               rows, cols,
@@ -107,29 +107,103 @@ __host__ void gridMerge_(const SrcPtrTuple& src, GpuMat_<DstType>& dst, Stream& 
 
     dst.create(rows, cols);
 
-    grid_split_merge_detail::MergeImpl<VecTraits<DstType>::cn, Policy>::merge(shrinkPtr(src),
-                                                                              shrinkPtr(dst),
-                                                                              WithOutMask(),
-                                                                              rows, cols,
-                                                                              StreamAccessor::getStream(stream));
+    grid_split_merge_detail::MergeImpl<VecTraits<DstType>::cn, Policy>::mergeTuple(shrinkPtr(src),
+                                                                                   shrinkPtr(dst),
+                                                                                   WithOutMask(),
+                                                                                   rows, cols,
+                                                                                   StreamAccessor::getStream(stream));
 }
 
 template <class Policy, class SrcPtrTuple, typename DstType>
 __host__ void gridMerge_(const SrcPtrTuple& src, const GlobPtrSz<DstType>& dst, Stream& stream = Stream::Null())
 {
-    //CV_StaticAssert( VecTraits<DstType>::cn == tuple_size<SrcPtrTuple>::value, "" );
+    CV_StaticAssert( VecTraits<DstType>::cn == tuple_size<SrcPtrTuple>::value, "" );
 
     const int rows = getRows(src);
     const int cols = getCols(src);
 
     CV_Assert( getRows(dst) == rows && getCols(dst) == cols );
 
-    grid_split_merge_detail::MergeImpl<VecTraits<DstType>::cn, Policy>::merge(shrinkPtr(src),
-                                                                              shrinkPtr(dst),
-                                                                              WithOutMask(),
-                                                                              rows, cols,
-                                                                              StreamAccessor::getStream(stream));
+    grid_split_merge_detail::MergeImpl<VecTraits<DstType>::cn, Policy>::mergeTuple(shrinkPtr(src),
+                                                                                   shrinkPtr(dst),
+                                                                                   WithOutMask(),
+                                                                                   rows, cols,
+                                                                                   StreamAccessor::getStream(stream));
 }
+
+template <class Policy, typename VecType, typename DstType, class MaskPtr>
+__host__ void gridMergeVector_(const std::vector<VecType>& src, GpuMat_<DstType>& dst, const MaskPtr& mask, Stream& stream = Stream::Null())
+{
+    CV_Assert( VecTraits<DstType>::cn == src.size() );
+
+    const int rows = getRows(src);
+    const int cols = getCols(src);
+
+    CV_Assert( getRows(mask) == rows && getCols(mask) == cols );
+
+    dst.create(rows, cols);
+
+    grid_split_merge_detail::MergeImpl<VecTraits<DstType>::cn, Policy>::mergeVector(src,
+                                                                                   shrinkPtr(dst),
+                                                                                   shrinkPtr(mask),
+                                                                                   rows, cols,
+                                                                                   StreamAccessor::getStream(stream));
+}
+
+template <class Policy, typename VecType, typename DstType, class MaskPtr>
+__host__ void gridMergeVector_(const std::vector<VecType>& src, const GlobPtrSz<DstType>& dst, const MaskPtr& mask, Stream& stream = Stream::Null())
+{
+    CV_Assert( VecTraits<DstType>::cn == src.size() );
+
+    const int rows = src[0].rows;
+    const int cols = src[0].cols;
+
+    CV_Assert( getRows(dst) == rows && getCols(dst) == cols );
+    CV_Assert( getRows(mask) == rows && getCols(mask) == cols );
+
+    grid_split_merge_detail::MergeImpl<VecTraits<DstType>::cn, Policy>::mergeVector(src,
+                                                                                   shrinkPtr(dst),
+                                                                                   shrinkPtr(mask),
+                                                                                   rows, cols,
+                                                                                   StreamAccessor::getStream(stream));
+}
+
+template <class Policy, typename VecType, typename DstType>
+__host__ void gridMergeVector_(const std::vector<VecType>& src, GpuMat_<DstType>& dst, Stream& stream = Stream::Null())
+{
+    CV_Assert( VecTraits<DstType>::cn == src.size() );
+
+    const int rows = src[0].rows;
+    const int cols = src[0].cols;
+
+    dst.create(rows, cols);
+
+    grid_split_merge_detail::MergeImpl<VecTraits<DstType>::cn, Policy>::mergeVector(src,
+                                                                                   shrinkPtr(dst),
+                                                                                   WithOutMask(),
+                                                                                   rows, cols,
+                                                                                   StreamAccessor::getStream(stream));
+}
+
+template <class Policy, typename VecType, typename DstType>
+__host__ void gridMergeVector_(const std::vector<VecType>& src, const GlobPtrSz<DstType>& dst, Stream& stream = Stream::Null())
+{
+    CV_Assert( VecTraits<DstType>::cn == src.size() );
+
+    const int rows = src[0].rows;
+    const int cols = src[0].cols;
+
+    CV_Assert( getRows(dst) == rows && getCols(dst) == cols );
+
+    grid_split_merge_detail::MergeImpl<VecTraits<DstType>::cn, Policy>::mergeVector(src,
+                                                                                   shrinkPtr(dst),
+                                                                                   WithOutMask(),
+                                                                                   rows, cols,
+                                                                                   StreamAccessor::getStream(stream));
+}
+
+
+///////////////////////////////////////////////////////////////
 
 template <class Policy, class SrcPtr, typename DstType, class MaskPtr>
 __host__ void gridSplit_(const SrcPtr& src, const tuple< GpuMat_<DstType>&, GpuMat_<DstType>& >& dst, const MaskPtr& mask, Stream& stream = Stream::Null())
@@ -520,6 +594,30 @@ template <class SrcPtrTuple, typename DstType>
 __host__ void gridMerge(const SrcPtrTuple& src, const GlobPtrSz<DstType>& dst, Stream& stream = Stream::Null())
 {
     gridMerge_<DefaultSplitMergePolicy>(src, dst, stream);
+}
+
+template <typename VecType, typename DstType, class MaskPtr>
+__host__ void gridMergeVector(const std::vector<VecType>& src, GpuMat_<DstType>& dst, const MaskPtr& mask, Stream& stream = Stream::Null())
+{
+    gridMergeVector_<DefaultSplitMergePolicy>(src, dst, mask, stream);
+}
+
+template <typename VecType, typename DstType, class MaskPtr>
+__host__ void gridMerge(const std::vector<VecType>& src, const GlobPtrSz<DstType>& dst, const MaskPtr& mask, Stream& stream = Stream::Null())
+{
+    gridMergeVector_<DefaultSplitMergePolicy>(src, dst, mask, stream);
+}
+
+template <typename VecType, typename DstType>
+__host__ void gridMerge(const std::vector<VecType>& src, GpuMat_<DstType>& dst, Stream& stream = Stream::Null())
+{
+    gridMergeVector_<DefaultSplitMergePolicy>(src, dst, stream);
+}
+
+template <typename VecType, typename DstType>
+__host__ void gridMerge(const std::vector<VecType>& src, const GlobPtrSz<DstType>& dst, Stream& stream = Stream::Null())
+{
+    gridMergeVector_<DefaultSplitMergePolicy>(src, dst, stream);
 }
 
 template <class SrcPtr, typename DstType, class MaskPtr>

--- a/modules/cudev/include/opencv2/cudev/grid/split_merge.hpp
+++ b/modules/cudev/include/opencv2/cudev/grid/split_merge.hpp
@@ -117,7 +117,7 @@ __host__ void gridMerge_(const SrcPtrTuple& src, GpuMat_<DstType>& dst, Stream& 
 template <class Policy, class SrcPtrTuple, typename DstType>
 __host__ void gridMerge_(const SrcPtrTuple& src, const GlobPtrSz<DstType>& dst, Stream& stream = Stream::Null())
 {
-    CV_StaticAssert( VecTraits<DstType>::cn == tuple_size<SrcPtrTuple>::value, "" );
+    //CV_StaticAssert( VecTraits<DstType>::cn == tuple_size<SrcPtrTuple>::value, "" );
 
     const int rows = getRows(src);
     const int cols = getCols(src);

--- a/modules/cudev/include/opencv2/cudev/grid/split_merge.hpp
+++ b/modules/cudev/include/opencv2/cudev/grid/split_merge.hpp
@@ -131,8 +131,8 @@ __host__ void gridMerge_(const SrcPtrTuple& src, const GlobPtrSz<DstType>& dst, 
                                                                                    StreamAccessor::getStream(stream));
 }
 
-template <class Policy, typename VecType, typename DstType, class MaskPtr>
-__host__ void gridMergeVector_(const std::vector<VecType>& src, GpuMat_<DstType>& dst, const MaskPtr& mask, Stream& stream = Stream::Null())
+template <class Policy, class ArrayType, size_t ArraySize, typename DstType, class MaskPtr>
+__host__ void gridMergeArray_(const std::array<ArrayType, ArraySize>& src, GpuMat_<DstType>& dst, const MaskPtr& mask, Stream& stream = Stream::Null())
 {
     CV_Assert( VecTraits<DstType>::cn == src.size() );
 
@@ -143,15 +143,15 @@ __host__ void gridMergeVector_(const std::vector<VecType>& src, GpuMat_<DstType>
 
     dst.create(rows, cols);
 
-    grid_split_merge_detail::MergeImpl<VecTraits<DstType>::cn, Policy>::mergeVector(src,
+    grid_split_merge_detail::MergeImpl<VecTraits<DstType>::cn, Policy>::mergeArray(src,
                                                                                    shrinkPtr(dst),
                                                                                    shrinkPtr(mask),
                                                                                    rows, cols,
                                                                                    StreamAccessor::getStream(stream));
 }
 
-template <class Policy, typename VecType, typename DstType, class MaskPtr>
-__host__ void gridMergeVector_(const std::vector<VecType>& src, const GlobPtrSz<DstType>& dst, const MaskPtr& mask, Stream& stream = Stream::Null())
+template <class Policy, class ArrayType, size_t ArraySize, typename DstType, class MaskPtr>
+__host__ void gridMergeArray_(const std::array<ArrayType, ArraySize>& src, const GlobPtrSz<DstType>& dst, const MaskPtr& mask, Stream& stream = Stream::Null())
 {
     CV_Assert( VecTraits<DstType>::cn == src.size() );
 
@@ -161,15 +161,15 @@ __host__ void gridMergeVector_(const std::vector<VecType>& src, const GlobPtrSz<
     CV_Assert( getRows(dst) == rows && getCols(dst) == cols );
     CV_Assert( getRows(mask) == rows && getCols(mask) == cols );
 
-    grid_split_merge_detail::MergeImpl<VecTraits<DstType>::cn, Policy>::mergeVector(src,
+    grid_split_merge_detail::MergeImpl<VecTraits<DstType>::cn, Policy>::mergeArray(src,
                                                                                    shrinkPtr(dst),
                                                                                    shrinkPtr(mask),
                                                                                    rows, cols,
                                                                                    StreamAccessor::getStream(stream));
 }
 
-template <class Policy, typename VecType, typename DstType>
-__host__ void gridMergeVector_(const std::vector<VecType>& src, GpuMat_<DstType>& dst, Stream& stream = Stream::Null())
+template <class Policy, class ArrayType, size_t ArraySize, typename DstType>
+__host__ void gridMergeArray_(const std::array<ArrayType, ArraySize>& src, GpuMat_<DstType>& dst, Stream& stream = Stream::Null())
 {
     CV_Assert( VecTraits<DstType>::cn == src.size() );
 
@@ -178,15 +178,15 @@ __host__ void gridMergeVector_(const std::vector<VecType>& src, GpuMat_<DstType>
 
     dst.create(rows, cols);
 
-    grid_split_merge_detail::MergeImpl<VecTraits<DstType>::cn, Policy>::mergeVector(src,
+    grid_split_merge_detail::MergeImpl<VecTraits<DstType>::cn, Policy>::mergeArray(src,
                                                                                    shrinkPtr(dst),
                                                                                    WithOutMask(),
                                                                                    rows, cols,
                                                                                    StreamAccessor::getStream(stream));
 }
 
-template <class Policy, typename VecType, typename DstType>
-__host__ void gridMergeVector_(const std::vector<VecType>& src, const GlobPtrSz<DstType>& dst, Stream& stream = Stream::Null())
+template <class Policy, class ArrayType, size_t ArraySize, typename DstType>
+__host__ void gridMergeArray_(const std::array<ArrayType, ArraySize>& src, const GlobPtrSz<DstType>& dst, Stream& stream = Stream::Null())
 {
     CV_Assert( VecTraits<DstType>::cn == src.size() );
 
@@ -195,7 +195,7 @@ __host__ void gridMergeVector_(const std::vector<VecType>& src, const GlobPtrSz<
 
     CV_Assert( getRows(dst) == rows && getCols(dst) == cols );
 
-    grid_split_merge_detail::MergeImpl<VecTraits<DstType>::cn, Policy>::mergeVector(src,
+    grid_split_merge_detail::MergeImpl<VecTraits<DstType>::cn, Policy>::mergeArray(src,
                                                                                    shrinkPtr(dst),
                                                                                    WithOutMask(),
                                                                                    rows, cols,
@@ -596,28 +596,28 @@ __host__ void gridMerge(const SrcPtrTuple& src, const GlobPtrSz<DstType>& dst, S
     gridMerge_<DefaultSplitMergePolicy>(src, dst, stream);
 }
 
-template <typename VecType, typename DstType, class MaskPtr>
-__host__ void gridMergeVector(const std::vector<VecType>& src, GpuMat_<DstType>& dst, const MaskPtr& mask, Stream& stream = Stream::Null())
+template <class ArrayType, size_t ArraySize, typename DstType, class MaskPtr>
+__host__ void gridMergeArray(const std::array<ArrayType, ArraySize>& src, GpuMat_<DstType>& dst, const MaskPtr& mask, Stream& stream = Stream::Null())
 {
-    gridMergeVector_<DefaultSplitMergePolicy>(src, dst, mask, stream);
+    gridMergeArray_<DefaultSplitMergePolicy>(src, dst, mask, stream);
 }
 
-template <typename VecType, typename DstType, class MaskPtr>
-__host__ void gridMerge(const std::vector<VecType>& src, const GlobPtrSz<DstType>& dst, const MaskPtr& mask, Stream& stream = Stream::Null())
+template <class ArrayType, size_t ArraySize, typename DstType, class MaskPtr>
+__host__ void gridMerge(const std::array<ArrayType, ArraySize>& src, const GlobPtrSz<DstType>& dst, const MaskPtr& mask, Stream& stream = Stream::Null())
 {
-    gridMergeVector_<DefaultSplitMergePolicy>(src, dst, mask, stream);
+    gridMergeArray_<DefaultSplitMergePolicy>(src, dst, mask, stream);
 }
 
-template <typename VecType, typename DstType>
-__host__ void gridMerge(const std::vector<VecType>& src, GpuMat_<DstType>& dst, Stream& stream = Stream::Null())
+template <class ArrayType, size_t ArraySize, typename DstType>
+__host__ void gridMerge(const std::array<ArrayType, ArraySize>& src, GpuMat_<DstType>& dst, Stream& stream = Stream::Null())
 {
-    gridMergeVector_<DefaultSplitMergePolicy>(src, dst, stream);
+    gridMergeArray_<DefaultSplitMergePolicy>(src, dst, stream);
 }
 
-template <typename VecType, typename DstType>
-__host__ void gridMerge(const std::vector<VecType>& src, const GlobPtrSz<DstType>& dst, Stream& stream = Stream::Null())
+template <class ArrayType, size_t ArraySize, typename DstType>
+__host__ void gridMerge(const std::array<ArrayType, ArraySize>& src, const GlobPtrSz<DstType>& dst, Stream& stream = Stream::Null())
 {
-    gridMergeVector_<DefaultSplitMergePolicy>(src, dst, stream);
+    gridMergeArray_<DefaultSplitMergePolicy>(src, dst, stream);
 }
 
 template <class SrcPtr, typename DstType, class MaskPtr>

--- a/modules/cudev/include/opencv2/cudev/grid/transform.hpp
+++ b/modules/cudev/include/opencv2/cudev/grid/transform.hpp
@@ -121,6 +121,22 @@ __host__ void gridTransformBinary_(const SrcPtr1& src1, const SrcPtr2& src2, Gpu
     grid_transform_detail::transform_binary<Policy>(shrinkPtr(src1), shrinkPtr(src2), shrinkPtr(dst), op, shrinkPtr(mask), rows, cols, StreamAccessor::getStream(stream));
 }
 
+template <class Policy, class SrcPtr1, class SrcPtr2, typename DstType1, typename DstType2, class BinOp1, class BinOp2, class MaskPtr>
+__host__ void gridTransformBinary_(const SrcPtr1& src1, const SrcPtr2& src2, GpuMat_<DstType1>& dst1, GpuMat_<DstType2>& dst2,
+                                   const BinOp1& op1, const BinOp2& op2, const MaskPtr& mask, Stream& stream = Stream::Null())
+{
+    const int rows = getRows(src1);
+    const int cols = getCols(src1);
+
+    CV_Assert( getRows(src2) == rows && getCols(src2) == cols );
+    CV_Assert( getRows(mask) == rows && getCols(mask) == cols );
+
+    dst1.create(rows, cols);
+    dst2.create(rows, cols);
+
+    grid_transform_detail::transform_binary<Policy>(shrinkPtr(src1), shrinkPtr(src2), shrinkPtr(dst1), shrinkPtr(dst2), op1, op2, shrinkPtr(mask), rows, cols, StreamAccessor::getStream(stream));
+}
+
 template <class Policy, class SrcPtr1, class SrcPtr2, typename DstType, class BinOp, class MaskPtr>
 __host__ void gridTransformBinary_(const SrcPtr1& src1, const SrcPtr2& src2, const GlobPtrSz<DstType>& dst, const BinOp& op, const MaskPtr& mask, Stream& stream = Stream::Null())
 {
@@ -133,6 +149,22 @@ __host__ void gridTransformBinary_(const SrcPtr1& src1, const SrcPtr2& src2, con
 
     grid_transform_detail::transform_binary<Policy>(shrinkPtr(src1), shrinkPtr(src2), shrinkPtr(dst), op, shrinkPtr(mask), rows, cols, StreamAccessor::getStream(stream));
 }
+
+template <class Policy, class SrcPtr1, class SrcPtr2, typename DstType1, typename DstType2, class BinOp1, class BinOp2, class MaskPtr>
+__host__ void gridTransformBinary_(const SrcPtr1& src1, const SrcPtr2& src2, const GlobPtrSz<DstType1>& dst1, const GlobPtrSz<DstType2>& dst2,
+                                   const BinOp1& op1, const BinOp2& op2, const MaskPtr& mask, Stream& stream = Stream::Null())
+{
+    const int rows = getRows(src1);
+    const int cols = getCols(src1);
+
+    CV_Assert( getRows(dst1) == rows && getCols(dst1) == cols );
+    CV_Assert( getRows(dst2) == rows && getCols(dst2) == cols );
+    CV_Assert( getRows(src2) == rows && getCols(src2) == cols );
+    CV_Assert( getRows(mask) == rows && getCols(mask) == cols );
+
+    grid_transform_detail::transform_binary<Policy>(shrinkPtr(src1), shrinkPtr(src2), shrinkPtr(dst1), shrinkPtr(dst2), op1, op2, shrinkPtr(mask), rows, cols, StreamAccessor::getStream(stream));
+}
+
 
 template <class Policy, class SrcPtr1, class SrcPtr2, typename DstType, class BinOp>
 __host__ void gridTransformBinary_(const SrcPtr1& src1, const SrcPtr2& src2, GpuMat_<DstType>& dst, const BinOp& op, Stream& stream = Stream::Null())
@@ -147,6 +179,21 @@ __host__ void gridTransformBinary_(const SrcPtr1& src1, const SrcPtr2& src2, Gpu
     grid_transform_detail::transform_binary<Policy>(shrinkPtr(src1), shrinkPtr(src2), shrinkPtr(dst), op, WithOutMask(), rows, cols, StreamAccessor::getStream(stream));
 }
 
+template <class Policy, class SrcPtr1, class SrcPtr2, typename DstType1, typename DstType2, class BinOp1, class BinOp2>
+__host__ void gridTransformBinary_(const SrcPtr1& src1, const SrcPtr2& src2, GpuMat_<DstType1>& dst1, GpuMat_<DstType2>& dst2,
+                                   const BinOp1& op1, const BinOp2& op2, Stream& stream = Stream::Null())
+{
+    const int rows = getRows(src1);
+    const int cols = getCols(src1);
+
+    CV_Assert( getRows(src2) == rows && getCols(src2) == cols );
+
+    dst1.create(rows, cols);
+    dst2.create(rows, cols);
+
+    grid_transform_detail::transform_binary<Policy>(shrinkPtr(src1), shrinkPtr(src2), shrinkPtr(dst1), shrinkPtr(dst2), op1, op2, WithOutMask(), rows, cols, StreamAccessor::getStream(stream));
+}
+
 template <class Policy, class SrcPtr1, class SrcPtr2, typename DstType, class BinOp>
 __host__ void gridTransformBinary_(const SrcPtr1& src1, const SrcPtr2& src2, const GlobPtrSz<DstType>& dst, const BinOp& op, Stream& stream = Stream::Null())
 {
@@ -157,6 +204,20 @@ __host__ void gridTransformBinary_(const SrcPtr1& src1, const SrcPtr2& src2, con
     CV_Assert( getRows(src2) == rows && getCols(src2) == cols );
 
     grid_transform_detail::transform_binary<Policy>(shrinkPtr(src1), shrinkPtr(src2), shrinkPtr(dst), op, WithOutMask(), rows, cols, StreamAccessor::getStream(stream));
+}
+
+template <class Policy, class SrcPtr1, class SrcPtr2, typename DstType1, typename DstType2, class BinOp1, class BinOp2>
+__host__ void gridTransformBinary_(const SrcPtr1& src1, const SrcPtr2& src2, const GlobPtrSz<DstType1>& dst1, const GlobPtrSz<DstType2>& dst2,
+                                   const BinOp1& op1, const BinOp2& op2, Stream& stream = Stream::Null())
+{
+    const int rows = getRows(src1);
+    const int cols = getCols(src1);
+
+    CV_Assert( getRows(dst1) == rows && getCols(dst1) == cols );
+    CV_Assert( getRows(dst2) == rows && getCols(dst2) == cols );
+    CV_Assert( getRows(src2) == rows && getCols(src2) == cols );
+
+    grid_transform_detail::transform_binary<Policy>(shrinkPtr(src1), shrinkPtr(src2), shrinkPtr(dst1), shrinkPtr(dst2), op1, op2, WithOutMask(), rows, cols, StreamAccessor::getStream(stream));
 }
 
 template <class Policy, class SrcPtr, typename D0, typename D1, class OpTuple, class MaskPtr>
@@ -449,10 +510,24 @@ __host__ void gridTransformBinary(const SrcPtr1& src1, const SrcPtr2& src2, GpuM
     gridTransformBinary_<DefaultTransformPolicy>(src1, src2, dst, op, mask, stream);
 }
 
+template <class SrcPtr1, class SrcPtr2, typename DstType1, typename DstType2, class Op1, class Op2, class MaskPtr>
+__host__ void gridTransformBinary(const SrcPtr1& src1, const SrcPtr2& src2, GpuMat_<DstType1>& dst1, GpuMat_<DstType2>& dst2,
+                                  const Op1& op1, const Op2& op2, const MaskPtr& mask, Stream& stream = Stream::Null())
+{
+    gridTransformBinary_<DefaultTransformPolicy>(src1, src2, dst1, dst2, op1, op2, mask, stream);
+}
+
 template <class SrcPtr1, class SrcPtr2, typename DstType, class Op, class MaskPtr>
 __host__ void gridTransformBinary(const SrcPtr1& src1, const SrcPtr2& src2, const GlobPtrSz<DstType>& dst, const Op& op, const MaskPtr& mask, Stream& stream = Stream::Null())
 {
     gridTransformBinary_<DefaultTransformPolicy>(src1, src2, dst, op, mask, stream);
+}
+
+template <class SrcPtr1, class SrcPtr2, typename DstType1, typename DstType2, class Op1, class Op2, class MaskPtr>
+__host__ void gridTransformBinary(const SrcPtr1& src1, const SrcPtr2& src2, const GlobPtrSz<DstType2>& dst1, const GlobPtrSz<DstType2>& dst2,
+                                  const Op1& op1, const Op2& op2, const MaskPtr& mask, Stream& stream = Stream::Null())
+{
+    gridTransformBinary_<DefaultTransformPolicy>(src1, src2, dst1, dst2, op1, op2, mask, stream);
 }
 
 template <class SrcPtr1, class SrcPtr2, typename DstType, class Op>
@@ -461,10 +536,26 @@ __host__ void gridTransformBinary(const SrcPtr1& src1, const SrcPtr2& src2, GpuM
     gridTransformBinary_<DefaultTransformPolicy>(src1, src2, dst, op, stream);
 }
 
+template <class SrcPtr1, class SrcPtr2, typename DstType1, typename DstType2, class Op1, class Op2>
+__host__ void gridTransformBinary(const SrcPtr1& src1, const SrcPtr2& src2,
+                                  GpuMat_<DstType1>& dst1, GpuMat_<DstType2>& dst2,
+                                  const Op1& op1, const Op2& op2, Stream& stream = Stream::Null())
+{
+    gridTransformBinary_<DefaultTransformPolicy>(src1, src2, dst1, dst2, op1, op2, stream);
+}
+
 template <class SrcPtr1, class SrcPtr2, typename DstType, class Op>
 __host__ void gridTransformBinary(const SrcPtr1& src1, const SrcPtr2& src2, const GlobPtrSz<DstType>& dst, const Op& op, Stream& stream = Stream::Null())
 {
     gridTransformBinary_<DefaultTransformPolicy>(src1, src2, dst, op, stream);
+}
+
+template <class SrcPtr1, class SrcPtr2, typename DstType1, typename DstType2, class Op1, class Op2>
+__host__ void gridTransformBinary(const SrcPtr1& src1, const SrcPtr2& src2,
+                                  const GlobPtrSz<DstType1>& dst1, const GlobPtrSz<DstType2>& dst2,
+                                  const Op1& op1, const Op2& op2, Stream& stream = Stream::Null())
+{
+    gridTransformBinary_<DefaultTransformPolicy>(src1, src2, dst1, dst2, op1, op2, stream);
 }
 
 template <class SrcPtr, typename D0, typename D1, class OpTuple, class MaskPtr>

--- a/modules/cudev/include/opencv2/cudev/ptr2d/glob.hpp
+++ b/modules/cudev/include/opencv2/cudev/ptr2d/glob.hpp
@@ -118,6 +118,18 @@ __host__ GlobPtrSz<T> globPtr(const GpuMat& mat)
     return p;
 }
 
+template <typename T>
+__host__ GlobPtrSz<T> globPtr(const GpuMat_<T>& mat)
+{
+    GlobPtrSz<T> p;
+    p.data = (T*) mat.data;
+    p.step = mat.step;
+    p.rows = mat.rows;
+    p.cols = mat.cols;
+    return p;
+}
+
+
 template <typename T> struct PtrTraits< GlobPtrSz<T> > : PtrTraitsBase<GlobPtrSz<T>, GlobPtr<T> >
 {
 };

--- a/modules/cudev/include/opencv2/cudev/ptr2d/zip.hpp
+++ b/modules/cudev/include/opencv2/cudev/ptr2d/zip.hpp
@@ -49,6 +49,7 @@
 #include "../common.hpp"
 #include "../util/tuple.hpp"
 #include "traits.hpp"
+#include <cuda/std/tuple>
 
 namespace cv { namespace cudev {
 
@@ -174,5 +175,26 @@ template <class PtrTuple> struct PtrTraits< ZipPtrSz<PtrTuple> > : PtrTraitsBase
 //! @}
 
 }}
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+template< class... Types >
+struct tuple_size< cv::cudev::ZipPtr<tuple<Types...> > >
+: tuple_size<tuple<Types...> > { };
+
+template< class... Types >
+struct tuple_size< cv::cudev::ZipPtrSz<tuple<Types...> > >
+: tuple_size<tuple<Types...> > { };
+
+
+template<size_t N, class... Types >
+struct tuple_element<N, cv::cudev::ZipPtr<tuple<Types...> > >
+: tuple_element<N, tuple<Types...> > { };
+
+template<size_t N, class... Types >
+struct tuple_element<N, cv::cudev::ZipPtrSz<tuple<Types...> > >
+: tuple_element<N, tuple<Types...> > { };
+
+_LIBCUDACXX_END_NAMESPACE_STD
 
 #endif

--- a/modules/cudev/test/test_split_merge.cu
+++ b/modules/cudev/test/test_split_merge.cu
@@ -70,7 +70,8 @@ public:
         GpuMat_<T> d_src2(src2);
 
         GpuMat_<typename MakeVec<T, 2>::type> dst;
-        gridMerge(zipPtr(d_src1, d_src2), dst);
+        std::vector<GlobPtrSz<T> > d_src = {globPtr(d_src1), globPtr(d_src2)};
+        gridMerge(d_src, dst);
 
         Mat dst_gold;
         Mat srcs[] = {src1, src2};
@@ -93,8 +94,10 @@ public:
         GpuMat_<T> d_src2(src2);
         GpuMat_<T> d_src3(src3);
 
+        std::vector<GlobPtrSz<T> > d_src = {globPtr(d_src1), globPtr(d_src2), globPtr(d_src3)};
+
         GpuMat_<typename MakeVec<T, 3>::type> dst;
-        gridMerge(zipPtr(d_src1, d_src2, d_src3), dst);
+        gridMerge(d_src, dst);
 
         Mat dst_gold;
         Mat srcs[] = {src1, src2, src3};

--- a/modules/cudev/test/test_split_merge.cu
+++ b/modules/cudev/test/test_split_merge.cu
@@ -70,7 +70,7 @@ public:
         GpuMat_<T> d_src2(src2);
 
         GpuMat_<typename MakeVec<T, 2>::type> dst;
-        std::vector<GlobPtrSz<T> > d_src = {globPtr(d_src1), globPtr(d_src2)};
+        std::array<GlobPtrSz<T>, 2 > d_src = {globPtr(d_src1), globPtr(d_src2)};
         gridMerge(d_src, dst);
 
         Mat dst_gold;
@@ -94,7 +94,7 @@ public:
         GpuMat_<T> d_src2(src2);
         GpuMat_<T> d_src3(src3);
 
-        std::vector<GlobPtrSz<T> > d_src = {globPtr(d_src1), globPtr(d_src2), globPtr(d_src3)};
+        std::array<GlobPtrSz<T>, 3 > d_src = {globPtr(d_src1), globPtr(d_src2), globPtr(d_src3)};
 
         GpuMat_<typename MakeVec<T, 3>::type> dst;
         gridMerge(d_src, dst);


### PR DESCRIPTION
Tries to fix https://github.com/opencv/opencv_contrib/issues/3690 for CUDA 12.4+
Related patch to main repo: https://github.com/opencv/opencv/pull/25658

Changes:
- Added branches to support new variadic implementation of thrust::tuple
- Added branch with std::array instead of std::tuple in split-merge and grid operations. The new branch got rid of namespace clash: cv::cuda in OpenCV and ::cuda in CUDA standard library (injected by Thrust). Old tuple branches presumed for compatibility with old code and CUDA versions before 12.4.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
