### PR TITLE
Replace np.NAN by np.nan in test_viz_simple.py

### DIFF
--- a/modules/viz/misc/python/test/test_viz_simple.py
+++ b/modules/viz/misc/python/test/test_viz_simple.py
@@ -179,7 +179,7 @@ class viz_test(NewOpenCVTests):
     def test_viz_show_cloud_masked(self):
         dragon_cloud,_,_  = cv.viz.readCloud(self.find_file("viz/dragon.ply"))
 
-        qnan =  np.NAN
+        qnan =  np.nan
         for idx in range(dragon_cloud.shape[0]):
             if idx % 15 != 0:
                 dragon_cloud[idx,:] = qnan


### PR DESCRIPTION
As per https://numpy.org/doc/stable/numpy_2_0_migration_guide.html for users of NumPy 2.0.

Also https://numpy.org/doc/stable/reference/constants.html#numpy.nan says

> NaN and NAN are aliases of `nan`.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
