### PR TITLE
imgproc: use double to determine whether the corners points are within src

### DIFF
--- a/modules/face/samples/sample_face_swapping.cpp
+++ b/modules/face/samples/sample_face_swapping.cpp
@@ -47,7 +47,9 @@ void divideIntoTriangles(Rect rect, vector<Point2f> &points, vector< vector<int>
         pt[0] = Point2f(triangle[0], triangle[1]);
         pt[1] = Point2f(triangle[2], triangle[3]);
         pt[2] = Point2f(triangle[4], triangle[5]);
-        if ( rect.contains(pt[0]) && rect.contains(pt[1]) && rect.contains(pt[2])){
+        // Workaround for https://github.com/opencv/opencv/issues/26016
+        // To keep its behaviour, pt casts to Point_<int>.
+        if ( rect.contains(Point_<int>(pt[0])) && rect.contains(Point_<int>(pt[1])) && rect.contains(Point_<int>(pt[2]))){
             for(int j = 0; j < 3; j++)
                 for(size_t k = 0; k < points.size(); k++)
                     if(abs(pt[j].x - points[k].x) < 1.0 && abs(pt[j].y - points[k].y) < 1)

--- a/modules/rapid/src/rapid.cpp
+++ b/modules/rapid/src/rapid.cpp
@@ -16,7 +16,9 @@ static std::vector<int> getSilhoutteVertices(const Size& imsize, const std::vect
     Mat_<int> img1(imsize, 0);
     Rect img_rect({0, 0}, imsize);
     for (int i = 0; i < pts2d.rows; i++) {
-        if (img_rect.contains(pts2d(i))) {
+        // Workaround for https://github.com/opencv/opencv/issues/26016
+        // To keep its behaviour, pts2d casts to Point_<int>.
+        if (img_rect.contains(Point_<int>(pts2d(i)))) {
             img1(pts2d(i)) = i + 1;
         }
     }
@@ -132,7 +134,10 @@ static void sampleControlPoints(int num, Contour3DSampler& sampler, const Rect& 
         auto pt2d = sampler.current2D();
 
         // skip points too close to border
-        if (!roi.contains(pt2d))
+        //
+        // Workaround for https://github.com/opencv/opencv/issues/26016
+        // To keep its behaviour, pt2d casts to Point_<int>.
+        if (!roi.contains(Point_<int>(pt2d)))
             continue;
 
         opts3d.push_back(sampler.current3D());

--- a/modules/xfeatures2d/test/test_features2d.cpp
+++ b/modules/xfeatures2d/test/test_features2d.cpp
@@ -438,7 +438,9 @@ protected:
 
                 for(size_t k=0; k<points.size(); ++k)
                 {
-                    if ( !whiteArea.contains(points[k]) )
+                    // Workaround for https://github.com/opencv/opencv/issues/26016
+                    // To keep its behaviour, points casts to Point_<int>.
+                    if ( !whiteArea.contains(Point_<int>(points[k])) )
                     {
                         ts->printf(cvtest::TS::LOG, "The feature point is outside of the mask.");
                         ts->set_failed_test_info(cvtest::TS::FAIL_INVALID_OUTPUT);

--- a/modules/xfeatures2d/test/test_keypoints.cpp
+++ b/modules/xfeatures2d/test/test_keypoints.cpp
@@ -86,7 +86,9 @@ protected:
         {
             const KeyPoint& kp = keypoints[i];
 
-            if(!r.contains(kp.pt))
+            // Workaround for https://github.com/opencv/opencv/issues/26016
+            // To keep its behaviour, kp.pt casts to Point_<int>.
+            if(!r.contains(Point_<int>(kp.pt)))
             {
                 ts->printf(cvtest::TS::LOG, "KeyPoint::pt is out of image (x=%f, y=%f).\n", kp.pt.x, kp.pt.y);
                 ts->set_failed_test_info(cvtest::TS::FAIL_INVALID_OUTPUT);


### PR DESCRIPTION
Related https://github.com/opencv/opencv/pull/26022

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
