### PR TITLE
Adds 32F disparity support to CUDA DisparityBilateralFilter

### DIFF
--- a/modules/cudastereo/include/opencv2/cudastereo.hpp
+++ b/modules/cudastereo/include/opencv2/cudastereo.hpp
@@ -300,7 +300,7 @@ class CV_EXPORTS_W DisparityBilateralFilter : public cv::Algorithm
 public:
     /** @brief Refines a disparity map using joint bilateral filtering.
 
-    @param disparity Input disparity map. CV_8UC1 and CV_16SC1 types are supported.
+    @param disparity Input disparity map. CV_8UC1, CV_16SC1, and CV_32FC1 types are supported.
     @param image Input image. CV_8UC1 and CV_8UC3 types are supported.
     @param dst Destination disparity map. It has the same size and type as disparity .
     @param stream Stream for the asynchronous version.

--- a/modules/cudastereo/src/cuda/disparity_bilateral_filter.cu
+++ b/modules/cudastereo/src/cuda/disparity_bilateral_filter.cu
@@ -117,11 +117,11 @@ namespace cv { namespace cuda { namespace device
 
                             const T disp_reg = disp_y[xi];
 
-                            cost[0] += ::min(cmax_disc, ::abs(disp_reg - dp[0])) * weight;
-                            cost[1] += ::min(cmax_disc, ::abs(disp_reg - dp[1])) * weight;
-                            cost[2] += ::min(cmax_disc, ::abs(disp_reg - dp[2])) * weight;
-                            cost[3] += ::min(cmax_disc, ::abs(disp_reg - dp[3])) * weight;
-                            cost[4] += ::min(cmax_disc, ::abs(disp_reg - dp[4])) * weight;
+                            cost[0] += ::min((float)cmax_disc, (float)::abs(disp_reg - dp[0])) * weight;
+                            cost[1] += ::min((float)cmax_disc, (float)::abs(disp_reg - dp[1])) * weight;
+                            cost[2] += ::min((float)cmax_disc, (float)::abs(disp_reg - dp[2])) * weight;
+                            cost[3] += ::min((float)cmax_disc, (float)::abs(disp_reg - dp[3])) * weight;
+                            cost[4] += ::min((float)cmax_disc, (float)::abs(disp_reg - dp[4])) * weight;
                         }
                     }
 
@@ -199,6 +199,7 @@ namespace cv { namespace cuda { namespace device
 
         template void disp_bilateral_filter<uchar>(PtrStepSz<uchar> disp, PtrStepSzb img, int channels, int iters, const float *table_color, const float *table_space, size_t table_step, int radius, short, short, cudaStream_t stream);
         template void disp_bilateral_filter<short>(PtrStepSz<short> disp, PtrStepSzb img, int channels, int iters, const float *table_color, const float *table_space, size_t table_step, int radius, short, short, cudaStream_t stream);
+        template void disp_bilateral_filter<float>(PtrStepSz<float> disp, PtrStepSzb img, int channels, int iters, const float *table_color, const float *table_space, size_t table_step, int radius, short, short, cudaStream_t stream);
     } // namespace bilateral_filter
 }}} // namespace cv { namespace cuda { namespace cudev
 

--- a/modules/cudastereo/src/disparity_bilateral_filter.cpp
+++ b/modules/cudastereo/src/disparity_bilateral_filter.cpp
@@ -173,14 +173,14 @@ namespace
                                                     GpuMat& table_color, GpuMat& table_space,
                                                     const GpuMat& disp, const GpuMat& img, OutputArray dst, Stream& stream);
         const bilateral_filter_operator_t operators[] =
-            {disp_bilateral_filter_operator<unsigned char>, 0, 0, disp_bilateral_filter_operator<short>, 0, 0, 0, 0};
+            {disp_bilateral_filter_operator<unsigned char>, 0, 0, disp_bilateral_filter_operator<short>, 0, disp_bilateral_filter_operator<float>, 0, 0};
 
         CV_Assert( 0 < ndisp_ && 0 < radius_ && 0 < iters_ );
 
         GpuMat disp = _disp.getGpuMat();
         GpuMat img = _image.getGpuMat();
 
-        CV_Assert( disp.type() == CV_8U || disp.type() == CV_16S );
+        CV_Assert( disp.type() == CV_8U || disp.type() == CV_16S || disp.type() == CV_32F );
         CV_Assert( img.type() == CV_8UC1 || img.type() == CV_8UC3 );
         CV_Assert( disp.size() == img.size() );
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

Adds 32F disparity support to CUDA DisparityBilateralFilter. There are no existing tests for this class, but because the function is templated, adding a new type does not break existing functionality.

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [N/A] There is a reference to the original bug report and related work
- [N/A] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
