### PR TITLE
speedup random forest getVotes method.

### DIFF
--- a/modules/ml/src/rtrees.cpp
+++ b/modules/ml/src/rtrees.cpp
@@ -388,9 +388,10 @@ public:
             results = output.getMat();
             for( i = 0; i < nsamples; i++ )
             {
+                const Mat sampleRow = samples.row(i);
                 for( j = 0; j < ntrees; j++ )
                 {
-                    float val = predictTrees( Range(j, j+1), samples.row(i), flags);
+                    float val = predictTrees( Range(j, j+1), sampleRow, flags);
                     results.at<float> (i, j) = val;
                 }
             }
@@ -408,9 +409,10 @@ public:
             for( i = 0; i < nsamples; i++ )
             {
                 votes.clear();
+                const Mat sampleRow = samples.row(i);
                 for( j = 0; j < ntrees; j++ )
                 {
-                    int val = (int)predictTrees( Range(j, j+1), samples.row(i), flags);
+                    int val = (int)predictTrees( Range(j, j+1), sampleRow, flags);
                     votes.push_back(val);
                 }
 


### PR DESCRIPTION
Port of https://github.com/opencv/opencv/pull/26046

Speedup `DTreesImplForRTrees::getVotes` method in about x2 times.

`Mat` objects are usually not expensive for creation or copying. But if algorithm itself is fast, operations on `Mat` objects start to take significant time. Naive extraction of loop invariant temporary `Mat` wrapper object creation allows to decrease `getVotes` method run time in about x2 times.