### PR TITLE
`cudacodec`: update `VideoWriter` to correctly set the PTS inside the encapsulated video stream

### DIFF
--- a/modules/cudacodec/include/opencv2/cudacodec.hpp
+++ b/modules/cudacodec/include/opencv2/cudacodec.hpp
@@ -208,8 +208,15 @@ public:
     /** @brief Callback function to signal that the encoded bitstream for one or more frames is ready.
 
     @param vPacket The raw bitstream for one or more frames.
+    @param pts Presentation timestamps for each frame in vPacket using the FPS time base.  e.g. fps = 25, pts = 3, presentation time = 3/25 seconds.
     */
-    virtual void onEncoded(const std::vector<std::vector<uint8_t>>& vPacket) = 0;
+    virtual void onEncoded(const std::vector<std::vector<uint8_t>>& vPacket, const std::vector<uint64_t>& pts) = 0;
+
+    /** @brief Set the GOP pattern used by the encoder.
+
+     @param frameIntervalP Specify the GOP pattern as follows : \p frameIntervalP = 0: I, 1 : IPP, 2 : IBP, 3 : IBBP.
+    */
+    virtual bool setFrameIntervalP(const int frameIntervalP) = 0;
 
     /** @brief Callback function to that the encoding has finished.
     * */

--- a/modules/cudacodec/src/NvEncoder.cpp
+++ b/modules/cudacodec/src/NvEncoder.cpp
@@ -305,9 +305,10 @@ void NvEncoder::MapResources(uint32_t bfrIdx)
     m_vMappedInputBuffers[bfrIdx] = mapInputResource.mappedResource;
 }
 
-void NvEncoder::EncodeFrame(std::vector<std::vector<uint8_t>>& vPacket, NV_ENC_PIC_PARAMS* pPicParams)
+void NvEncoder::EncodeFrame(std::vector<std::vector<uint8_t>>& vPacket, std::vector<uint64_t>& outputTimeStamps, NV_ENC_PIC_PARAMS* pPicParams)
 {
     vPacket.clear();
+    outputTimeStamps.clear();
     if (!IsHWEncoderInitialized())
     {
         NVENC_THROW_ERROR("Encoder device not found", NV_ENC_ERR_NO_ENCODE_DEVICE);
@@ -322,7 +323,7 @@ void NvEncoder::EncodeFrame(std::vector<std::vector<uint8_t>>& vPacket, NV_ENC_P
     if (nvStatus == NV_ENC_SUCCESS || nvStatus == NV_ENC_ERR_NEED_MORE_INPUT)
     {
         m_iToSend++;
-        GetEncodedPacket(m_vBitstreamOutputBuffer, vPacket, true);
+        GetEncodedPacket(m_vBitstreamOutputBuffer, vPacket, outputTimeStamps, true);
     }
     else
     {
@@ -353,6 +354,7 @@ NVENCSTATUS NvEncoder::DoEncode(NV_ENC_INPUT_PTR inputBuffer, NV_ENC_OUTPUT_PTR 
     {
         picParams = *pPicParams;
     }
+    picParams.inputTimeStamp = m_iInputFrame++;
     picParams.version = NV_ENC_PIC_PARAMS_VER;
     picParams.pictureStruct = NV_ENC_PIC_STRUCT_FRAME;
     picParams.inputBuffer = inputBuffer;
@@ -376,7 +378,7 @@ void NvEncoder::SendEOS()
     NVENC_API_CALL(m_nvenc.nvEncEncodePicture(m_hEncoder, &picParams));
 }
 
-void NvEncoder::EndEncode(std::vector<std::vector<uint8_t>>& vPacket)
+void NvEncoder::EndEncode(std::vector<std::vector<uint8_t>>& vPacket, std::vector<uint64_t>& outputTimeStamps)
 {
     vPacket.clear();
     if (!IsHWEncoderInitialized())
@@ -386,10 +388,10 @@ void NvEncoder::EndEncode(std::vector<std::vector<uint8_t>>& vPacket)
 
     SendEOS();
 
-    GetEncodedPacket(m_vBitstreamOutputBuffer, vPacket, false);
+    GetEncodedPacket(m_vBitstreamOutputBuffer, vPacket, outputTimeStamps, false);
 }
 
-void NvEncoder::GetEncodedPacket(std::vector<NV_ENC_OUTPUT_PTR>& vOutputBuffer, std::vector<std::vector<uint8_t>>& vPacket, bool bOutputDelay)
+void NvEncoder::GetEncodedPacket(std::vector<NV_ENC_OUTPUT_PTR>& vOutputBuffer, std::vector<std::vector<uint8_t>>& vPacket, std::vector<uint64_t>& outputTimeStamps, bool bOutputDelay)
 {
     unsigned i = 0;
     int iEnd = bOutputDelay ? m_iToSend - m_nOutputDelay : m_iToSend;
@@ -402,6 +404,7 @@ void NvEncoder::GetEncodedPacket(std::vector<NV_ENC_OUTPUT_PTR>& vOutputBuffer, 
         lockBitstreamData.doNotWait = false;
         NVENC_API_CALL(m_nvenc.nvEncLockBitstream(m_hEncoder, &lockBitstreamData));
 
+        outputTimeStamps.push_back(lockBitstreamData.outputTimeStamp);
         uint8_t* pData = (uint8_t*)lockBitstreamData.bitstreamBufferPtr;
         if (vPacket.size() < i + 1)
         {
@@ -499,7 +502,8 @@ void NvEncoder::FlushEncoder()
     try
     {
         std::vector<std::vector<uint8_t>> vPacket;
-        EndEncode(vPacket);
+        std::vector<uint64_t> outputTimeStamps;
+        EndEncode(vPacket, outputTimeStamps);
     }
     catch (...)
     {

--- a/modules/cudacodec/src/NvEncoder.h
+++ b/modules/cudacodec/src/NvEncoder.h
@@ -100,7 +100,7 @@ public:
     * data, which has been copied to an input buffer obtained from the
     * GetNextInputFrame() function.
     */
-    virtual void EncodeFrame(std::vector<std::vector<uint8_t>>& vPacket, NV_ENC_PIC_PARAMS* pPicParams = nullptr);
+    virtual void EncodeFrame(std::vector<std::vector<uint8_t>>& vPacket, std::vector<uint64_t>& outputTimeStamps, NV_ENC_PIC_PARAMS* pPicParams = nullptr);
 
     /**
     * @brief This function to flush the encoder queue.
@@ -109,7 +109,7 @@ public:
     * from the encoder. The application must call this function before destroying
     * an encoder session.
     */
-    virtual void EndEncode(std::vector<std::vector<uint8_t>>& vPacket);
+    virtual void EndEncode(std::vector<std::vector<uint8_t>>& vPacket, std::vector<uint64_t>& outputTimeStamps);
 
     /**
     * @brief This function is used to query hardware encoder capabilities.
@@ -317,7 +317,7 @@ private:
     * This is called by DoEncode() function. If there is buffering enabled,
     * this may return without any output data.
     */
-    void GetEncodedPacket(std::vector<NV_ENC_OUTPUT_PTR>& vOutputBuffer, std::vector<std::vector<uint8_t>>& vPacket, bool bOutputDelay);
+    void GetEncodedPacket(std::vector<NV_ENC_OUTPUT_PTR>& vOutputBuffer, std::vector<std::vector<uint8_t>>& vPacket, std::vector<uint64_t>& outputTimeStamps, bool bOutputDelay);
 
     /**
     * @brief This is a private function which is used to initialize the bitstream buffers.
@@ -369,6 +369,7 @@ protected:
     int32_t m_iGot = 0;
     int32_t m_nEncoderBuffer = 0;
     int32_t m_nOutputDelay = 0;
+    int32_t m_iInputFrame = 0;
 
 private:
     void* m_pDevice;

--- a/modules/cudacodec/test/test_video.cpp
+++ b/modules/cudacodec/test/test_video.cpp
@@ -650,6 +650,9 @@ struct TransCode : testing::TestWithParam<cv::cuda::DeviceInfo>
     }
 };
 
+#if defined(WIN32)  // remove when FFmpeg wrapper includes PR25874
+#define WIN32_WAIT_FOR_FFMPEG_WRAPPER_UPDATE
+#endif
 
 CUDA_TEST_P(TransCode, H264ToH265)
 {
@@ -691,6 +694,10 @@ CUDA_TEST_P(TransCode, H264ToH265)
         for (int i = 0; i < nFrames; ++i) {
             cap >> frame;
             ASSERT_FALSE(frame.empty());
+#if !defined(WIN32_WAIT_FOR_FFMPEG_WRAPPER_UPDATE)
+            const int pts = static_cast<int>(cap.get(CAP_PROP_PTS));
+            ASSERT_EQ(i, pts > 0 ? pts : 0); // FFmpeg back end returns dts if pts is zero.
+#endif
         }
     }
     ASSERT_EQ(0, remove(outputFile.c_str()));
@@ -773,6 +780,10 @@ CUDA_TEST_P(Write, Writer)
         for (int i = 0; i < nFrames; ++i) {
             cap >> frame;
             ASSERT_FALSE(frame.empty());
+#if !defined(WIN32_WAIT_FOR_FFMPEG_WRAPPER_UPDATE)
+            const int pts = static_cast<int>(cap.get(CAP_PROP_PTS));
+            ASSERT_EQ(i, pts > 0 ? pts : 0); // FFmpeg back end returns dts if pts is zero.
+#endif
         }
     }
     ASSERT_EQ(0, remove(outputFile.c_str()));
@@ -867,6 +878,10 @@ CUDA_TEST_P(EncoderParams, Writer)
                 const bool keyFrameActual = capRaw.get(CAP_PROP_LRF_HAS_KEY_FRAME) == 1.0;
                 const bool keyFrameReference = i % idrPeriod == 0;
                 ASSERT_EQ(keyFrameActual, keyFrameReference);
+#if !defined(WIN32_WAIT_FOR_FFMPEG_WRAPPER_UPDATE)
+                const int pts = static_cast<int>(cap.get(CAP_PROP_PTS));
+                ASSERT_EQ(i, pts > 0 ? pts : 0); // FFmpeg back end returns dts if pts is zero.
+#endif
             }
         }
     }


### PR DESCRIPTION
Update `cudacodec::VideoWriter` to set the correct PTS when using P frames using properties (`CAP_PROP_PTS` and `CAP_PROP_DTS_DELAY`) added in https://github.com/opencv/opencv/pull/25874

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
