### PR TITLE
Fix OCRBeamSearchDecoder bug: a risk of assigning value to NULL.

### DIFF
--- a/modules/text/src/ocr_beamsearch_decoder.cpp
+++ b/modules/text/src/ocr_beamsearch_decoder.cpp
@@ -338,9 +338,12 @@ public:
         double lp = score_segmentation( beam[0].segmentation, out_sequence );
 
         // fill other (dummy) output parameters
-        component_rects->push_back(Rect(0,0,src.cols,src.rows));
-        component_texts->push_back(out_sequence);
-        component_confidences->push_back((float)exp(lp));
+        if (component_rects != NULL)
+            component_rects->push_back(Rect(0,0,src.cols,src.rows));
+        if (component_texts != NULL)
+            component_texts->push_back(out_sequence);
+        if (component_confidences != NULL)
+            component_confidences->push_back((float)exp(lp));
 
         return;
     }


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

### Details
In text module, class OCRBeamSearchDecoder has some `run` methods:
![image](https://github.com/user-attachments/assets/f1d6ef5b-46d1-4140-b1c8-3a1c0b124755)

These methods will execute OCRBeamSearchDecoderImpl::run:
```cpp
    void run( Mat& src,
              string& out_sequence,
              vector<Rect>* component_rects,
              vector<string>* component_texts,
              vector<float>* component_confidences,
              int component_level) CV_OVERRIDE
```
However, some parameters can be NULL, but this method does not check for this when assigning values to them at the end of the method.
```cpp
        // check NULL
        if (component_rects != NULL)
            component_rects->clear();
        if (component_texts != NULL)
            component_texts->clear();
        if (component_confidences != NULL)
            component_confidences->clear();

        // ....

        // not check, RISK
        component_rects->push_back(Rect(0,0,src.cols,src.rows));
        component_texts->push_back(out_sequence);
        component_confidences->push_back((float)exp(lp));
```

Actually, some OCRBeamSearchDecoder::run methods must fail because they indeed pass one parameter as NULL when executing the upper method:
```cpp
CV_WRAP String OCRBeamSearchDecoder::run(InputArray image, int min_confidence, int component_level)
{
    std::string output1;
    std::string output2;
    vector<string> component_texts;
    vector<float> component_confidences;
    Mat image_m = image.getMat();
    // NULL as a parameter
    run(image_m, output1, NULL, &component_texts, &component_confidences, component_level);
    // ...
}
```

What's worse, `python` can only some warp methods which execute upper methods . Using OCRBeamSearch in python must fail.
![image](https://github.com/user-attachments/assets/6a2b81ad-0c04-4b18-8b64-96311a7d7136)
![image](https://github.com/user-attachments/assets/63d404ab-a26f-4d06-a320-7cfefd7f7abf)


The following code must throw error: Unknown C++ exception from OpenCV code.
```python
import cv2
chartables = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"

classifier = cv2.text.loadOCRBeamSearchClassifierCNN('OCRBeamSearch_CNN_model_data.xml.gz')

fs = cv2.FileStorage('OCRHMM_transitions_table.xml',cv2.FILE_STORAGE_READ)
transition_p = fs.getNode('transition_probabilities').mat()
emission_p = np.eye(len(chartables), len(chartables)).astype(float)

decoder = cv2.text.OCRBeamSearchDecoder.create(
    classifier, 
    vocabulary=chartables, 
    transition_probabilities_table=transition_p,
    emission_probabilities_table=emission_p
)
src = cv2.imread(f'scenetext_word01.jpg', -1)
src = cv2.cvtColor(src, cv2.COLOR_BGR2GRAY)
# Error: Unknown C++ exception from OpenCV code
text = decoder.run(src, min_confidence=0)
```

