### PR TITLE
Build warning fix on Windows.

### DIFF
--- a/modules/wechat_qrcode/src/zxing/zxing.hpp
+++ b/modules/wechat_qrcode/src/zxing/zxing.hpp
@@ -55,8 +55,8 @@ typedef unsigned char boolean;
 #include <cmath>
 
 namespace zxing {
-inline bool isnan(float v) { return (bool)cvIsNaN(v); }
-inline bool isnan(double v) { return (bool)cvIsNaN(v); }
+inline bool isnan(float v) { return cvIsNaN(v) != 0; }
+inline bool isnan(double v) { return cvIsNaN(v) != 0; }
 inline float nan() { return std::numeric_limits<float>::quiet_NaN(); }
 }  // namespace zxing
 


### PR DESCRIPTION
Address CI warning:
```
c:\build\precommit_windows64\4.x\opencv_contrib\modules\wechat_qrcode\src\zxing\common\../zxing.hpp(58): warning C4800: 'int': forcing value to bool 'true' or 'false' (performance warning) [C:\build\precommit_windows64\build\modules\wechat_qrcode\opencv_wechat_qrcode.vcxproj]
c:\build\precommit_windows64\4.x\opencv_contrib\modules\wechat_qrcode\src\zxing\common\../zxing.hpp(59): warning C4800: 'int': forcing value to bool 'true' or 'false' (performance warning) [C:\build\precommit_windows64\build\modules\wechat_qrcode\opencv_wechat_qrcode.vcxproj]
```

Introduced in https://github.com/opencv/opencv_contrib/pull/3490

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
