### PR TITLE
Reduce the buffer usage in `QualitySSIM::compute`

### DIFF
--- a/modules/quality/src/qualityssim.cpp
+++ b/modules/quality/src/qualityssim.cpp
@@ -78,9 +78,6 @@ std::pair<cv::Scalar, _mat_type> QualitySSIM::_mat_data::compute(const _mat_data
     mat_type
         I1_I2
         , mu1_mu2
-        , t1
-        , t2
-        , t3
         , sigma12
         ;
 
@@ -89,13 +86,16 @@ std::pair<cv::Scalar, _mat_type> QualitySSIM::_mat_data::compute(const _mat_data
     cv::subtract(::blur(I1_I2), mu1_mu2, sigma12);
 
     // t3 = ((2*mu1_mu2 + C1).*(2*sigma12 + C2))
+    mat_type& t1 = I1_I2;
     cv::multiply(mu1_mu2, 2., t1);
     cv::add(t1, C1, t1);// t1 += C1
 
+    mat_type& t2 = mu1_mu2;
     cv::multiply(sigma12, 2., t2);
     cv::add(t2, C2, t2);// t2 += C2
 
     // t3 = t1 * t2
+    mat_type& t3 = sigma12;
     cv::multiply(t1, t2, t3);
 
     // t1 =((mu1_2 + mu2_2 + C1).*(sigma1_2 + sigma2_2 + C2))


### PR DESCRIPTION
Reduce the buffer usage in `QualitySSIM::compute` by safely reusing `I1_I2`, `mu1_mu2` and `sigma12`.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
