### PR TITLE
drop convertFp16 in favor of cv::Mat::convertTo.

### DIFF
--- a/modules/cudev/test/test_cvt.cu
+++ b/modules/cudev/test/test_cvt.cu
@@ -102,10 +102,10 @@ public:
 
         // Fp32 -> Fp16
         cv::cuda::convertFp16(g_src, g_dst);
-        cv::convertFp16(src, dst);
+        src.convertTo(dst, CV_16F);
         // Fp16 -> Fp32
         cv::cuda::convertFp16(g_dst.clone(), g_dst);
-        cv::convertFp16(dst, ref);
+        dst.convertTo(ref, CV_32F);
 
         g_dst.download(dst);
         EXPECT_MAT_NEAR(dst, ref, 0.0);
@@ -128,7 +128,7 @@ public:
 
         // Fp32 -> Fp16
         cv::cuda::convertFp16(g_src, g_dst);
-        cv::convertFp16(src, ref);
+        src.convertTo(ref, CV_16F);
 
         g_dst.download(dst);
         EXPECT_MAT_NEAR(dst, ref, 0.0);

--- a/modules/julia/gen/funclist.csv
+++ b/modules/julia/gen/funclist.csv
@@ -7,7 +7,6 @@ cv.divide
 cv.scaleAdd
 cv.addWeighted
 cv.convertScaleAbs
-cv.convertFp16
 cv.LUT
 cv.sum
 cv.countNonZero


### PR DESCRIPTION
Behavour change: cuda::convertFp16 returns CV_16F instead of CV_16S for fp16 values. 

Main PR: https://github.com/opencv/opencv/pull/26327

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
