### PR TITLE
wechat_qrcode: fix ineffective decoding retrial after inverting image

### DIFF
--- a/modules/wechat_qrcode/src/zxing/qrcode/qrcode_reader.cpp
+++ b/modules/wechat_qrcode/src/zxing/qrcode/qrcode_reader.cpp
@@ -49,7 +49,8 @@ vector<Ref<Result>> QRCodeReader::decode(Ref<BinaryBitmap> image, DecodeHints hi
         Ref<BitMatrix> invertedMatrix = image->getInvertedMatrix(err_handler);
         if (err_handler.ErrCode() || invertedMatrix == NULL) return result_list;
         vector<Ref<Result>> tmp_rst = decodeMore(image, invertedMatrix, hints, err_handler);
-        if (err_handler.ErrCode() || tmp_rst.empty()) return tmp_rst;
+        if (err_handler.ErrCode() || tmp_rst.empty()) return result_list;
+        return tmp_rst;
     }
 
     return rst;


### PR DESCRIPTION
This PR fixes a logic error in the `QRCodeReader::decode` function
when handling inverted images. Previously, the function would return
an empty result list even when successful decoding occurred on an
inverted image. The change ensure that:

1. If decoding fails on the original image, we attempt decoding on an inverted image.
2. If decoding succeeds on the inverted image, we now correctly return those results.
3. We maintain the behavior of returning an empty list if both original and inverted image decoding fail.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake