### PR TITLE
Fix: ximgproc::findEllipses modifies src image unexpectedly

### DIFF
--- a/modules/ximgproc/src/find_ellipses.cpp
+++ b/modules/ximgproc/src/find_ellipses.cpp
@@ -1218,9 +1218,10 @@ void EllipseDetectorImpl::getTriplets413(VVP &pi, VVP &pj, VVP &pk,
     }
 }
 
-void EllipseDetectorImpl::preProcessing(Mat1b &image, Mat1b &dp, Mat1b &dn) {
+void EllipseDetectorImpl::preProcessing(Mat1b &src, Mat1b &dp, Mat1b &dn) {
     // smooth image
-    GaussianBlur(image, image, _kernelSize, _sigma);
+    Mat image;
+    GaussianBlur(src, image, _kernelSize, _sigma);
 
     // temp variables
     Mat1b edges;// edge mask


### PR DESCRIPTION
The `ximgproc::findEllipses` function modifies the src image during execution, resulting in a blurred output.
This PR ensures that the source image remains unchanged.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
