### PR TITLE
`cudaimgproc`: remove incorrectly added `NppStreamHandler` from `cv::cuda:evenLevels`

### DIFF
--- a/modules/cudaimgproc/src/histogram.cpp
+++ b/modules/cudaimgproc/src/histogram.cpp
@@ -553,24 +553,6 @@ namespace
     };
 }
 
-class OldNppStreamHandlerForEvenLevels
-{
-public:
-    explicit OldNppStreamHandlerForEvenLevels(Stream& newStream)
-    {
-        oldStream = nppGetStream();
-        nppSafeSetStream(oldStream, StreamAccessor::getStream(newStream));
-    }
-
-    ~OldNppStreamHandlerForEvenLevels()
-    {
-        nppSafeSetStream(nppGetStream(), oldStream);
-    }
-
-private:
-    cudaStream_t oldStream;
-};
-
 void cv::cuda::evenLevels(OutputArray _levels, int nLevels, int lowerLevel, int upperLevel, Stream& stream)
 {
     const int kind = _levels.kind();
@@ -582,9 +564,6 @@ void cv::cuda::evenLevels(OutputArray _levels, int nLevels, int lowerLevel, int 
         host_levels.create(1, nLevels, CV_32SC1);
     else
         host_levels = _levels.getMat();
-
-    // Update to use NppStreamHandler when nppiEvenLevelsHost_32s_Ctx is included in nppist.lib and libnppist.so
-    OldNppStreamHandlerForEvenLevels h(stream);
 
     nppSafeCall( nppiEvenLevelsHost_32s(host_levels.ptr<Npp32s>(), nLevels, lowerLevel, upperLevel) );
 


### PR DESCRIPTION
In https://github.com/opencv/opencv_contrib/pull/3803 the `NppStreamHandler` was added for the `nppiEvenLevelsHost_32s`  due to the documentation having a streaming version (_Ctx see https://docs.nvidia.com/cuda/archive/11.0/npp/group__image__histogrameven.html#ga1586db7ec07d9a7b5929b981e99676e0).  I have since found out that this is a host-only function and the header for the streaming version will be removed in the next version of CUDA so unnecessary delay from the call to `NppStreamHandler` can be removed.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
