### PR TITLE
Force to use dnn_supperres module to the use classic engine

### DIFF
--- a/modules/dnn_superres/src/dnn_superres.cpp
+++ b/modules/dnn_superres/src/dnn_superres.cpp
@@ -63,7 +63,7 @@ void DnnSuperResImpl::readModel(const String& path)
 {
     if ( path.size() )
     {
-        this->net = dnn::readNetFromTensorflow(path);
+        this->net = dnn::readNetFromTensorflow(path, std::string(), dnn::ENGINE_CLASSIC);
         CV_LOG_INFO(NULL, "Successfully loaded model: " << path);
     }
     else
@@ -76,7 +76,7 @@ void DnnSuperResImpl::readModel(const String& weights, const String& definition)
 {
     if ( weights.size() && definition.size() )
     {
-        this->net = dnn::readNetFromTensorflow(weights, definition);
+        this->net = dnn::readNetFromTensorflow(weights, definition, dnn::ENGINE_CLASSIC);
         CV_LOG_INFO(NULL, "Successfully loaded model: " << weights << " " << definition);
     }
     else


### PR DESCRIPTION
Workaround for https://github.com/opencv/opencv_contrib/issues/3833

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
