### PR TITLE
Fixed missing include chrono in g-api tests

### DIFF
--- a/modules/gapi/test/gapi_sample_pipelines.cpp
+++ b/modules/gapi/test/gapi_sample_pipelines.cpp
@@ -7,6 +7,7 @@
 
 #include "test_precomp.hpp"
 
+#include <chrono>
 #include <stdexcept>
 #include <ade/util/iota_range.hpp>
 #include "logger.hpp"


### PR DESCRIPTION
Port of https://github.com/opencv/opencv/pull/26529

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
