### PR TITLE
support C++20 standard

### DIFF
--- a/modules/text/src/erfilter.cpp
+++ b/modules/text/src/erfilter.cpp
@@ -1038,7 +1038,7 @@ double ERClassifierNM1::eval(const ERStat& stat)
                      (float)(1-stat.euler), //number of holes
                      stat.med_crossings);
 
-    float votes = boost->predict( sample, noArray(), DTrees::PREDICT_SUM | StatModel::RAW_OUTPUT);
+    float votes = boost->predict( sample, noArray(), (int)DTrees::PREDICT_SUM | (int)StatModel::RAW_OUTPUT);
 
     // Logistic Correction returns a probability value (in the range(0,1))
     return (double)1-(double)1/(1+exp(-2*votes));
@@ -1070,7 +1070,7 @@ double ERClassifierNM2::eval(const ERStat& stat)
                      stat.med_crossings, stat.hole_area_ratio,
                      stat.convex_hull_ratio, stat.num_inflexion_points);
 
-    float votes = boost->predict( sample, noArray(), DTrees::PREDICT_SUM | StatModel::RAW_OUTPUT);
+    float votes = boost->predict( sample, noArray(), (int)DTrees::PREDICT_SUM | (int)StatModel::RAW_OUTPUT);
 
     // Logistic Correction returns a probability value (in the range(0,1))
     return (double)1-(double)1/(1+exp(-2*votes));
@@ -2152,6 +2152,11 @@ void MaxMeaningfulClustering::build_merge_info(double *Z, double *X, int N, int 
     {
         HCluster cluster;
         cluster.num_elem = (int)Z[i+3]; //number of elements
+        cluster.nfa = 0;
+        cluster.dist_ext = 0.0f;
+        cluster.max_meaningful = false;
+        cluster.min_nfa_in_branch = 0;
+        cluster.probability = 0.0;
 
         int node1  = (int)Z[i];
         int node2  = (int)Z[i+1];
@@ -2611,7 +2616,7 @@ double MaxMeaningfulClustering::probability(vector<int> &cluster)
     sample.push_back((float)mean[0]);
     sample.push_back((float)std[0]);
 
-    float votes_group = group_boost->predict( Mat(sample), noArray(), DTrees::PREDICT_SUM | StatModel::RAW_OUTPUT);
+    float votes_group = group_boost->predict( Mat(sample), noArray(), (int)DTrees::PREDICT_SUM | (int)StatModel::RAW_OUTPUT);
 
     return (double)1-(double)1/(1+exp(-2*votes_group));
 }


### PR DESCRIPTION
- cast to calicurate mixing different enums
- initilize member variables

related https://github.com/opencv/opencv/pull/26590

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
