### PR TITLE
FastCV bilateral recursive: test files updated

### DIFF
--- a/modules/fastcv/test/test_smooth.cpp
+++ b/modules/fastcv/test/test_smooth.cpp
@@ -39,7 +39,14 @@ TEST_P(BilateralRecursiveTest, accuracy)
 }
 
 INSTANTIATE_TEST_CASE_P(FastCV_Extension, BilateralRecursiveTest,
-                        ::testing::Combine(::testing::Values(0.01f, 0.03f, 0.1f, 1.f, 5.f),
-                                           ::testing::Values(0.01f, 0.05f, 0.1f, 1.f, 5.f)));
+                        ::testing::Values(
+                            BilateralTestParams {0.01f, 1.00f},
+                            BilateralTestParams {0.10f, 0.01f},
+                            BilateralTestParams {1.00f, 0.01f},
+                            BilateralTestParams {1.00f, 1.00f},
+                            BilateralTestParams {5.00f, 0.01f},
+                            BilateralTestParams {5.00f, 0.10f},
+                            BilateralTestParams {5.00f, 5.00f}
+                        ));
 
 }} // namespaces opencv_test, ::


### PR DESCRIPTION
Test files updated: `baboon` instead of `lena`, amount of files reduced

Connected PR: https://github.com/opencv/opencv_extra/pull/1222

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
