### PR TITLE
Get cudalegacy dependents to build without CUDA

### DIFF
--- a/modules/cudalegacy/include/opencv2/cudalegacy/private.hpp
+++ b/modules/cudalegacy/include/opencv2/cudalegacy/private.hpp
@@ -50,9 +50,7 @@
 
 #include "opencv2/core/private.cuda.hpp"
 
-#ifndef HAVE_CUDA
-#  error cudalegacy module requires CUDA
-#endif
+#ifdef HAVE_CUDA
 
 #include "opencv2/cudalegacy.hpp"
 
@@ -92,5 +90,7 @@ namespace cv { namespace cuda
 #define ncvSafeCall(expr)  cv::cuda::checkNcvError(expr, __FILE__, __LINE__, CV_Func)
 
 //! @endcond
+
+#endif HAVE_CUDA
 
 #endif // OPENCV_CORE_CUDALEGACY_PRIVATE_HPP


### PR DESCRIPTION
This was actually forgotten in https://github.com/opencv/opencv_contrib/pull/3843

This is useful for some modules because of https://github.com/opencv/opencv_contrib/blob/1b841632ef188078ae545d2755556cbb7f06b084/modules/cudaobjdetect/src/precomp.hpp#L59

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
