### PR TITLE
xobjdetect: (5.x) fix to build world with xobjdetect

### DIFF
--- a/modules/xobjdetect/CMakeLists.txt
+++ b/modules/xobjdetect/CMakeLists.txt
@@ -3,4 +3,4 @@ ocv_define_module(xobjdetect opencv_core opencv_imgproc opencv_imgcodecs opencv_
 if (BUILD_opencv_apps AND NOT APPLE_FRAMEWORK)
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tools ${CMAKE_CURRENT_BINARY_DIR}/tools)
 endif()
-add_subdirectory(data)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/data ${CMAKE_CURRENT_BINARY_DIR}/data)


### PR DESCRIPTION
Closed https://github.com/opencv/opencv_contrib/issues/3861

This patch is to build `world` module with `xobjdetect` successfully.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
