### PR TITLE
Fix Unused Variable Warning in `test_rotation_and_scale_invariance.cpp`

### DIFF
--- a/modules/xfeatures2d/test/test_rotation_and_scale_invariance.cpp
+++ b/modules/xfeatures2d/test/test_rotation_and_scale_invariance.cpp
@@ -10,8 +10,9 @@
 namespace opencv_test { namespace {
 
 static const char* const IMAGE_TSUKUBA = "features2d/tsukuba.png";
-// static const char* const IMAGE_BIKES = "detectors_descriptors_evaluation/images_datasets/bikes/img1.png";
-
+#ifdef OPENCV_ENABLE_NONFREE
+static const char* const IMAGE_BIKES = "detectors_descriptors_evaluation/images_datasets/bikes/img1.png";
+#endif // OPENCV_ENABLE_NONFREE
 // ========================== ROTATION INVARIANCE =============================
 
 #ifdef OPENCV_ENABLE_NONFREE

--- a/modules/xfeatures2d/test/test_rotation_and_scale_invariance.cpp
+++ b/modules/xfeatures2d/test/test_rotation_and_scale_invariance.cpp
@@ -10,7 +10,7 @@
 namespace opencv_test { namespace {
 
 static const char* const IMAGE_TSUKUBA = "features2d/tsukuba.png";
-static const char* const IMAGE_BIKES = "detectors_descriptors_evaluation/images_datasets/bikes/img1.png";
+// static const char* const IMAGE_BIKES = "detectors_descriptors_evaluation/images_datasets/bikes/img1.png";
 
 // ========================== ROTATION INVARIANCE =============================
 


### PR DESCRIPTION
### Description:
This PR resolves a warning caused by an unused variable `IMAGE_BIKES` in the file `test_rotation_and_scale_invariance.cpp` within the `xfeatures2d` module of the OpenCV contrib repository.

- **Issue:** The variable `IMAGE_BIKES` was declared but not used in the test file, leading to a compiler warning (`-Wunused-const-variable`).

```
warning: unused variable 'IMAGE_BIKES' [-Wunused-const-variable]
static const char* const IMAGE_BIKES = "detectors_descriptors_evaluation/
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
