### PR TITLE
`cudacodec`: Enable features available with updated ffmpeg dll

### DIFF
--- a/modules/cudacodec/src/video_writer.cpp
+++ b/modules/cudacodec/src/video_writer.cpp
@@ -53,10 +53,6 @@ Ptr<cudacodec::VideoWriter> createVideoWriter(const String&, const Size, const C
 
 #else // !defined HAVE_NVCUVENC
 
-#if defined(WIN32)  // remove when FFmpeg wrapper includes PR25874
-#define WIN32_WAIT_FOR_FFMPEG_WRAPPER_UPDATE
-#endif
-
 NV_ENC_BUFFER_FORMAT EncBufferFormat(const ColorFormat colorFormat);
 int NChannels(const ColorFormat colorFormat);
 GUID CodecGuid(const Codec codec);
@@ -107,9 +103,7 @@ void FFmpegVideoWriter::onEncoded(const std::vector<std::vector<uint8_t>>& vPack
         Mat wrappedPacket(1, packet.size(), CV_8UC1, (void*)packet.data());
         const double ptsDouble = static_cast<double>(pts.at(i));
         CV_Assert(static_cast<uint64_t>(ptsDouble) == pts.at(i));
-#if !defined(WIN32_WAIT_FOR_FFMPEG_WRAPPER_UPDATE)
         CV_Assert(writer.set(VIDEOWRITER_PROP_PTS, ptsDouble));
-#endif
         writer.write(wrappedPacket);
     }
 }
@@ -337,11 +331,9 @@ void VideoWriterImpl::InitializeEncoder(const GUID codec, const double fps)
     initializeParams.encodeConfig->rcParams.maxBitRate = encoderParams.maxBitRate;
     initializeParams.encodeConfig->rcParams.targetQuality = encoderParams.targetQuality;
     initializeParams.encodeConfig->gopLength = encoderParams.gopLength;
-#if !defined(WIN32_WAIT_FOR_FFMPEG_WRAPPER_UPDATE)
     if (initializeParams.encodeConfig->frameIntervalP > 1) {
         CV_Assert(encoderCallback->setFrameIntervalP(initializeParams.encodeConfig->frameIntervalP));
     }
-#endif
     if (codec == NV_ENC_CODEC_H264_GUID)
         initializeParams.encodeConfig->encodeCodecConfig.h264Config.idrPeriod = encoderParams.idrPeriod;
     else if (codec == NV_ENC_CODEC_HEVC_GUID)

--- a/modules/cudacodec/test/test_video.cpp
+++ b/modules/cudacodec/test/test_video.cpp
@@ -1011,10 +1011,6 @@ struct H264ToH265 : SetDevice
 {
 };
 
-#if defined(WIN32)  // remove when FFmpeg wrapper includes PR25874
-#define WIN32_WAIT_FOR_FFMPEG_WRAPPER_UPDATE
-#endif
-
 CUDA_TEST_P(H264ToH265, Transcode)
 {
     const std::string inputFile = std::string(cvtest::TS::ptr()->get_data_path()) + "../highgui/video/big_buck_bunny.h264";
@@ -1054,10 +1050,8 @@ CUDA_TEST_P(H264ToH265, Transcode)
         for (int i = 0; i < nFrames; ++i) {
             cap >> frame;
             ASSERT_FALSE(frame.empty());
-#if !defined(WIN32_WAIT_FOR_FFMPEG_WRAPPER_UPDATE)
             const int pts = static_cast<int>(cap.get(CAP_PROP_PTS));
             ASSERT_EQ(i, pts > 0 ? pts : 0); // FFmpeg back end returns dts if pts is zero.
-#endif
         }
     }
     ASSERT_EQ(0, remove(outputFile.c_str()));
@@ -1201,10 +1195,8 @@ CUDA_TEST_P(Write, Writer)
         for (int i = 0; i < nFrames; ++i) {
             cap >> frame;
             ASSERT_FALSE(frame.empty());
-#if !defined(WIN32_WAIT_FOR_FFMPEG_WRAPPER_UPDATE)
             const int pts = static_cast<int>(cap.get(CAP_PROP_PTS));
             ASSERT_EQ(i, pts > 0 ? pts : 0); // FFmpeg back end returns dts if pts is zero.
-#endif
         }
     }
     ASSERT_EQ(0, remove(outputFile.c_str()));
@@ -1299,10 +1291,8 @@ CUDA_TEST_P(EncoderParams, Writer)
                 const bool keyFrameActual = capRaw.get(CAP_PROP_LRF_HAS_KEY_FRAME) == 1.0;
                 const bool keyFrameReference = i % idrPeriod == 0;
                 ASSERT_EQ(keyFrameActual, keyFrameReference);
-#if !defined(WIN32_WAIT_FOR_FFMPEG_WRAPPER_UPDATE)
                 const int pts = static_cast<int>(cap.get(CAP_PROP_PTS));
                 ASSERT_EQ(i, pts > 0 ? pts : 0); // FFmpeg back end returns dts if pts is zero.
-#endif
             }
         }
     }


### PR DESCRIPTION
Enable functionality disabled for windows builds in https://github.com/opencv/opencv/pull/25874 now that the windows FFmpeg dll has been updated to include https://github.com/opencv/opencv_contrib/pull/3784.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
