### PR TITLE
fix bugs in checker_detector.cpp after resolving conflicts from PR #3599

### DIFF
--- a/modules/mcc/src/checker_detector.cpp
+++ b/modules/mcc/src/checker_detector.cpp
@@ -234,8 +234,8 @@ bool CCheckerDetectorImpl::
                     {
                         const std::vector<cv::Point2f>& checkerBox = checker->getBox();
                         std::vector<cv::Point2f> restore_box(checkerBox.size());
-                        for (size_t i = 0; i < checkerBox.size(); ++i) {
-                            restore_box[i] = checkerBox[i] + static_cast<cv::Point2f>(region.tl());
+                        for (size_t a = 0; a < checkerBox.size(); ++a) {
+                            restore_box[a] = checkerBox[a] + static_cast<cv::Point2f>(region.tl());
                         }
                         checker->setBox(restore_box);
                         {
@@ -458,8 +458,8 @@ bool CCheckerDetectorImpl::
                             {
                                 const std::vector<cv::Point2f>& checkerBox = checker->getBox();
                                 std::vector<cv::Point2f> restore_box(checkerBox.size());
-                                for (size_t i = 0; i < checkerBox.size(); ++i) {
-                                    restore_box[i] = checkerBox[i] + static_cast<cv::Point2f>(region.tl() + innerRegion.tl());
+                                for (size_t a = 0; a < checkerBox.size(); ++a) {
+                                    restore_box[a] = checkerBox[a] + static_cast<cv::Point2f>(region.tl() + innerRegion.tl());
                                 }
                                 checker->setBox(restore_box);
                                 {

--- a/modules/mcc/src/checker_detector.cpp
+++ b/modules/mcc/src/checker_detector.cpp
@@ -232,10 +232,10 @@ bool CCheckerDetectorImpl::
 #endif
                     for (Ptr<CChecker> checker : checkers)
                     {
-                        std::vector<cv::Point2f> restore_box;
-                        for (cv::Point2f &corner : checker->getBox()){
-                            corner += static_cast<cv::Point2f>(region.tl());
-                            restore_box.emplace_back(corner);
+                        const std::vector<cv::Point2f>& checkerBox = checker->getBox();
+                        std::vector<cv::Point2f> restore_box(checkerBox.size());
+                        for (size_t i = 0; i < checkerBox.size(); ++i) {
+                            restore_box[i] = checkerBox[i] + static_cast<cv::Point2f>(region.tl());
                         }
                         checker->setBox(restore_box);
                         {
@@ -456,10 +456,10 @@ bool CCheckerDetectorImpl::
 #endif
                             for (Ptr<CChecker> checker : checkers)
                             {
-                                std::vector<cv::Point2f> restore_box;
-                                for (cv::Point2f &corner : checker->getBox()){
-                                    corner += static_cast<cv::Point2f>(region.tl() + innerRegion.tl());
-                                    restore_box.emplace_back(corner);
+                                const std::vector<cv::Point2f>& checkerBox = checker->getBox();
+                                std::vector<cv::Point2f> restore_box(checkerBox.size());
+                                for (size_t i = 0; i < checkerBox.size(); ++i) {
+                                    restore_box[i] = checkerBox[i] + static_cast<cv::Point2f>(region.tl() + innerRegion.tl());
                                 }
                                 checker->setBox(restore_box);
                                 {

--- a/modules/mcc/src/checker_detector.cpp
+++ b/modules/mcc/src/checker_detector.cpp
@@ -232,9 +232,12 @@ bool CCheckerDetectorImpl::
 #endif
                     for (Ptr<CChecker> checker : checkers)
                     {
-                        for (cv::Point2f &corner : checker->getBox())
+                        std::vector<cv::Point2f> restore_box;
+                        for (cv::Point2f &corner : checker->getBox()){
                             corner += static_cast<cv::Point2f>(region.tl());
-
+                            restore_box.emplace_back(corner);
+                        }
+                        checker->setBox(restore_box);
                         {
                             cv::AutoLock lock(mtx);
                             m_checkers.push_back(checker);
@@ -453,9 +456,12 @@ bool CCheckerDetectorImpl::
 #endif
                             for (Ptr<CChecker> checker : checkers)
                             {
-                                for (cv::Point2f &corner : checker->getBox())
+                                std::vector<cv::Point2f> restore_box;
+                                for (cv::Point2f &corner : checker->getBox()){
                                     corner += static_cast<cv::Point2f>(region.tl() + innerRegion.tl());
-
+                                    restore_box.emplace_back(corner);
+                                }
+                                checker->setBox(restore_box);
                                 {
                                     cv::AutoLock lock(mtx);
                                     m_checkers.push_back(checker);


### PR DESCRIPTION
### This is the pull request for fixing some bugs in "Color Checker detection"

+ The link to pretrained tensorflow model for detecting Macbeth Color-checker:
 https://drive.google.com/drive/folders/1JNWlmyfZKxiYQoYk6f0RzcGtHuiZq1Pz

#### 1, Detecting color-checker using Neural network
 When loading the pretrained Macbeth color-checker detector model, and set it successfully to CCheckerDetector,
```
Ptr<CCheckerDetector> detector = CCheckerDetector::create();
    if (!detector->setNet(net))
    {
         cout << "Loading Model failed: Aborting" << endl;
         return 0;
    }
```
then 
```
if(!detector->process(image, cv::mcc::MCC24, color_checker_roi, 1, true, params)) {
        std::cout<<"Color-checker not found\n";
}
Ptr<mcc::CChecker> checker = detector->getBestColorChecker();
Ptr<CCheckerDraw> cdraw = CCheckerDraw::create(checker);
cdraw->draw(image);
```
+ problem 1:
cdraw function failed to draw the correct result due to the following code block failed to update box in checker:
```
for (Ptr<CChecker> checker : checkers){
  for (cv::Point2f &corner : checker->getBox())
      corner += static_cast<cv::Point2f>(region.tl() + innerRegion.tl());
   ...
}
```
the corrected and test pass version is:
```
for (Ptr<CChecker>& checker : checkers){
    std::vector<cv::Point2f> restore_box;
    for (cv::Point2f& corner : checker->getBox()) {
       corner += static_cast<cv::Point2f>(region.tl() + innerRegion.tl());
       restore_box.emplace_back(corner);
    }
   checker->setBox(restore_box);
}
...
```
See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
