### PR TITLE
build: suppress warning

### DIFF
--- a/modules/cudalegacy/include/opencv2/cudalegacy/private.hpp
+++ b/modules/cudalegacy/include/opencv2/cudalegacy/private.hpp
@@ -91,6 +91,6 @@ namespace cv { namespace cuda
 
 //! @endcond
 
-#endif HAVE_CUDA
+#endif // HAVE_CUDA
 
 #endif // OPENCV_CORE_CUDALEGACY_PRIVATE_HPP


### PR DESCRIPTION
### Pull Request Readiness Checklist

This line generates unnecessary warning


```
/opencv_contrib/modules/cudalegacy/include/opencv2/cudalegacy/private.hpp:94:8: warning: extra tokens at end of #endif directive [-Wendif-labels]
   94 | #endif HAVE_CUDA
      |        ^~~~~~~~~   
```

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
