### PR TITLE
Replace deprecated tostring() with tobytes()

### DIFF
--- a/modules/ml/misc/python/test/test_goodfeatures.py
+++ b/modules/ml/misc/python/test/test_goodfeatures.py
@@ -17,7 +17,7 @@ class TestGoodFeaturesToTrack_test(NewOpenCVTests):
 
         results = dict([(t, cv.goodFeaturesToTrack(arr, numPoints, t, 2, useHarrisDetector=True)) for t in threshes])
         # Check that GoodFeaturesToTrack has not modified input image
-        self.assertTrue(arr.tostring() == original.tostring())
+        self.assertTrue(arr.tobytes() == original.tobytes())
         # Check for repeatability
         for i in range(1):
             results2 = dict([(t, cv.goodFeaturesToTrack(arr, numPoints, t, 2, useHarrisDetector=True)) for t in threshes])


### PR DESCRIPTION
Partial port of https://github.com/opencv/opencv/pull/26932

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
