### PR TITLE
Fix: Restore MATLAB Module Compilation for OpenCV 4.x

### DIFF
--- a/modules/matlab/CMakeLists.txt
+++ b/modules/matlab/CMakeLists.txt
@@ -113,6 +113,8 @@ ocv_add_module(matlab   BINDINGS
                                  opencv_calib opencv_calib3d
                                  opencv_stitching opencv_superres
                                  opencv_xfeatures2d
+				 opencv_optflow
+				 opencv_xphoto
 )
 
 # get the commit information
@@ -156,6 +158,8 @@ endforeach()
 # add extra headers by hand
 list(APPEND opencv_extra_hdrs "core=${OPENCV_MODULE_opencv_core_LOCATION}/include/opencv2/core/base.hpp")
 list(APPEND opencv_extra_hdrs "video=${OPENCV_MODULE_opencv_video_LOCATION}/include/opencv2/video/tracking.hpp")
+list(APPEND opencv_extra_hdrs "optflow=${OPENCV_MODULE_opencv_optflow_LOCATION}/include/opencv2/optflow.hpp")
+
 
 # pass the OPENCV_CXX_EXTRA_FLAGS through to the mex compiler
 # remove the visibility modifiers, so the mex gateway is visible

--- a/modules/matlab/generator/parse_tree.py
+++ b/modules/matlab/generator/parse_tree.py
@@ -1,4 +1,10 @@
-import collections
+import sys
+if sys.version_info >= (3, 10):
+    import collections.abc
+    IterableType = collections.abc.Iterable
+else:
+    import collections
+    IterableType = collections.Iterable
 from textwrap import fill
 from filters import *
 try:
@@ -371,7 +377,7 @@ def todict(obj):
         return obj
     elif isinstance(obj, dict):
         return dict((key, todict(val)) for key, val in obj.items())
-    elif isinstance(obj, collections.Iterable):
+    elif isinstance(obj, IterableType):
         return [todict(val) for val in obj]
     elif hasattr(obj, '__dict__'):
         return todict(vars(obj))

--- a/modules/matlab/include/opencv2/matlab/bridge.hpp
+++ b/modules/matlab/include/opencv2/matlab/bridge.hpp
@@ -55,6 +55,21 @@
 #include <opencv2/photo.hpp>
 #include <opencv2/stitching.hpp>
 #include <opencv2/video.hpp>
+#include <opencv2/optflow.hpp>
+#include <opencv2/xphoto.hpp>
+
+/* This 'using' line was added in order to fix the following Error.
+ * Failed to compile currentUIFramework:
+ * modules/matlab/src/currentUIFramework.cpp:
+ * In function void mexFunction(int, mxArray**, int, const mxArray**)
+ * error: string was not declared in this scope
+ * string retval; in line 41
+ *
+ * This error happens at the last stage of opencv build, when compiling the mex bindings
+ * TODO: This is NOT the optimal fix, and needs to be addressed
+ */
+using std::string;
+
 
 namespace cv {
 namespace bridge {
@@ -85,17 +100,21 @@ typedef cv::Ptr<AlignMTB> Ptr_AlignMTB;
 typedef cv::Ptr<CalibrateDebevec> Ptr_CalibrateDebevec;
 typedef cv::Ptr<CalibrateRobertson> Ptr_CalibrateRobertson;
 typedef cv::Ptr<DenseOpticalFlow> Ptr_DenseOpticalFlow;
-typedef cv::Ptr<DualTVL1OpticalFlow> Ptr_DualTVL1OpticalFlow;
+typedef cv::Ptr<cv::optflow::DualTVL1OpticalFlow> Ptr_DualTVL1OpticalFlow;
 typedef cv::Ptr<MergeDebevec> Ptr_MergeDebevec;
 typedef cv::Ptr<MergeMertens> Ptr_MergeMertens;
 typedef cv::Ptr<MergeRobertson> Ptr_MergeRobertson;
 typedef cv::Ptr<Stitcher> Ptr_Stitcher;
 typedef cv::Ptr<Tonemap> Ptr_Tonemap;
 typedef cv::Ptr<TonemapDrago> Ptr_TonemapDrago;
-typedef cv::Ptr<TonemapDurand> Ptr_TonemapDurand;
+typedef cv::Ptr<cv::xphoto::TonemapDurand> Ptr_TonemapDurand;
 typedef cv::Ptr<TonemapMantiuk> Ptr_TonemapMantiuk;
 typedef cv::Ptr<TonemapReinhard> Ptr_TonemapReinhard;
 typedef cv::Ptr<float> Ptr_float;
+typedef cv::Ptr<cv::GeneralizedHoughBallard> Ptr_GeneralizedHoughBallard;
+typedef cv::Ptr<cv::GeneralizedHoughGuil> Ptr_GeneralizedHoughGuil;
+
+
 
 // ----------------------------------------------------------------------------
 //                          PREDECLARATIONS
@@ -527,6 +546,15 @@ public:
   Bridge& operator=(const Ptr_float& ) { return *this; }
   Ptr_float toPtrFloat() { return Ptr_float(); }
   operator Ptr_float() { return toPtrFloat(); }
+
+  // ---------------------------   Ptr_GeneralizedHoughBallard   --------------
+  Bridge& operator=(const Ptr_GeneralizedHoughBallard& obj) { return *this; }
+  operator Ptr_GeneralizedHoughBallard() { return Ptr_GeneralizedHoughBallard(); }
+
+  // ---------------------------   Ptr_GeneralizedHoughGuil   ----------------------
+  Bridge& operator=(const Ptr_GeneralizedHoughGuil& obj) { return *this; }
+  operator Ptr_GeneralizedHoughGuil() { return Ptr_GeneralizedHoughGuil(); }
+
 }; // class Bridge
 
 


### PR DESCRIPTION
This PR resolves a VERY long-standing issue where the `MATLAB` module in opencv_contrib fails to compile due to namespace changes in `cv::optflow` and `cv::xphoto`. The MATLAB module has been broken since OpenCV **4.0.0-rc** due to these changes, and this fix restores compilation compatibility.

* Clarification: This fix aims to and restores **compilation** of the MATLAB module, but I have not tested full functionality within MATLAB itself.


#### **Issue Details**  
1. **Namespace Changes**  
   - The **DualTVL1OpticalFlow** algorithm was moved from `opencv` to `opencv_contrib/optflow`, breaking references in the MATLAB module.  This was done during `4.0.0-beta` and `4.0.0-rc`, but never reflected in `cv::matlab`
   - `cv::xphoto` also underwent similar changes, but I am yet to find the exact version such change was made in.
   - In Python 3.10 and above, `collections.Iterable` was changed into `collections.abc.Iterable`, which causes `parse_tree.py` to break. I added fixes for build to work for both versions.

2. **Reported Issues**  
   - **[#3781](https://github.com/opencv/opencv_contrib/issues/3781)** (reported **7 months ago**)
   - **[#3886](https://github.com/opencv/opencv_contrib/issues/3886)** (reported by me 2 weeks ago)

#### **Fix Implementation**  
- Updated the MATLAB module to reflect the **new namespaces** introduced in OpenCV contrib.  
- **Verified working on OpenCV 4.11.0** (latest non-alpha release).  
- **Tested environments**:  
  - **RHEL 9.1**  
  - **Ubuntu 22.04**  
  - **Built using default `make` and `gcc`**  

#### **Request to Maintainers**  
I acknowledge that the MATLAB module has not been actively maintained for nearly 7 years, which, I find, is quite unusual for an active project like opencv.
If the devs do not intend to support the MATLAB module anymore, I request the maintainers to officially mark it as deprecated, or disable its inclusion using CMake scripts rather than leaving it in a permanently broken state.  
Even if the PR is to be rejected, I hope at least a deprecation notice of the module will be considered.  
