### PR TITLE
cleanup some cuda module warnings

### DIFF
--- a/modules/cudacodec/include/opencv2/cudacodec.hpp
+++ b/modules/cudacodec/include/opencv2/cudacodec.hpp
@@ -385,6 +385,8 @@ struct CV_EXPORTS_W_SIMPLE FormatInfo
  */
 class CV_EXPORTS_W NVSurfaceToColorConverter {
 public:
+    virtual ~NVSurfaceToColorConverter() = default;
+
     /** @brief Performs the conversion from the raw YUV Surface output from VideoReader to the requested color format. Use this function when you want to convert the raw YUV Surface output from VideoReader to more than one color format or you want both the raw Surface output in addition to a color frame.
      * @param yuv The raw YUV Surface output from VideoReader see @ref SurfaceFormat.
      * @param color The converted frame.

--- a/modules/cudafeatures2d/include/opencv2/cudafeatures2d.hpp
+++ b/modules/cudafeatures2d/include/opencv2/cudafeatures2d.hpp
@@ -118,11 +118,11 @@ public:
 
     /** @brief Clears the train descriptor collection.
      */
-    CV_WRAP virtual void clear() = 0;
+    CV_WRAP virtual void clear() override = 0;
 
     /** @brief Returns true if there are no train descriptors in the collection.
      */
-    CV_WRAP virtual bool empty() const = 0;
+    CV_WRAP virtual bool empty() const override = 0;
 
     /** @brief Trains a descriptor matcher.
 


### PR DESCRIPTION
This just cleans up some warnings seen when compiling some of the cuda modules. There are no functional changes. 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

fixes #4082 