### PR TITLE
Adding FastCV extension for normalizeLocalBox u8 and f32

### DIFF
--- a/modules/fastcv/include/opencv2/fastcv/blur.hpp
+++ b/modules/fastcv/include/opencv2/fastcv/blur.hpp
@@ -65,8 +65,8 @@ CV_EXPORTS_W void sepFilter2D(InputArray _src, OutputArray _dst, int ddepth, Inp
  * @brief Calculates the local subtractive and contrastive normalization of the image.
  *        Each pixel of the image is normalized by the mean and standard deviation of the patch centred at the pixel.
  *        It is optimized for Qualcomm's processors.
- * @param src Input image, should have one channel CV_8U or CV_32F
- * @param dst Output array, should be one channel, CV_8S if src of type CV_8U, or CV_32F if src of CV_32F
+ * @param _src Input image, should have one channel CV_8U or CV_32F
+ * @param _dst Output array, should be one channel, CV_8S if src of type CV_8U, or CV_32F if src of CV_32F
  * @param pSize Patch size for mean and std dev calculation
  * @param useStdDev If 1, bot mean and std dev will be used for normalization, if 0, only mean used
  */

--- a/modules/fastcv/include/opencv2/fastcv/blur.hpp
+++ b/modules/fastcv/include/opencv2/fastcv/blur.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+ * Copyright (c) 2024-2025 Qualcomm Innovation Center, Inc. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
 */
 
@@ -56,6 +56,22 @@ CV_EXPORTS_W void filter2D(InputArray _src, OutputArray _dst, int ddepth, InputA
  * @sa sepFilter2D
  */
 CV_EXPORTS_W void sepFilter2D(InputArray _src, OutputArray _dst, int ddepth, InputArray _kernelX, InputArray _kernelY);
+//! @}
+
+//! @addtogroup fastcv
+//! @{
+
+/**
+ * @brief Calculates the local subtractive and contrastive normalization of the image.
+ *        Each pixel of the image is normalized by the mean and standard deviation of the patch centred at the pixel.
+ *        It is optimized for Qualcomm's processors.
+ * @param src Input image, should have one channel CV_8U or CV_32F
+ * @param dst Output array, should be one channel, CV_8S if src of type CV_8U, or CV_32F if src of CV_32F
+ * @param pSize Patch size for mean and std dev calculation
+ * @param useStdDev If 1, bot mean and std dev will be used for normalization, if 0, only mean used
+ */
+CV_EXPORTS_W void normalizeLocalBox(InputArray _src, OutputArray _dst, Size pSize, bool useStdDev);
+
 //! @}
 
 } // fastcv::

--- a/modules/fastcv/perf/perf_blur.cpp
+++ b/modules/fastcv/perf/perf_blur.cpp
@@ -125,7 +125,7 @@ typedef perf::TestBaseWithParam<tuple<Size, int, Size, int>> NormalizeLocalBoxPe
 PERF_TEST_P(NormalizeLocalBoxPerfTest, run,
     ::testing::Combine(::testing::Values(perf::szVGA, perf::sz720p, perf::sz1080p), // image size
                        ::testing::Values(CV_8U,CV_32F),                             // src image depth
-					   ::testing::Values(Size(3,3),Size(5,5)),                      // patch size
+                       ::testing::Values(Size(3,3),Size(5,5)),                      // patch size
                        ::testing::Values(0,1)                                       // use std dev or not
                        )
            )
@@ -140,12 +140,7 @@ PERF_TEST_P(NormalizeLocalBoxPerfTest, run,
     RNG& rng = cv::theRNG();
     cvtest::randUni(rng, src, Scalar::all(0), Scalar::all(255));
 
-    while (next())
-    {
-        startTimer();
-        cv::fastcv::normalizeLocalBox(src, dst, sz, useStdDev);
-        stopTimer();
-    }
+    TEST_CYCLE() cv::fastcv::normalizeLocalBox(src, dst, sz, useStdDev);
 
     SANITY_CHECK_NOTHING();
 }

--- a/modules/fastcv/perf/perf_blur.cpp
+++ b/modules/fastcv/perf/perf_blur.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+ * Copyright (c) 2024-2025 Qualcomm Innovation Center, Inc. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
 */
 
@@ -114,6 +114,36 @@ PERF_TEST_P(SepFilter2DPerfTest, run,
     {
         startTimer();
         cv::fastcv::sepFilter2D(src, dst, ddepth, kernel, kernel);
+        stopTimer();
+    }
+
+    SANITY_CHECK_NOTHING();
+}
+
+typedef perf::TestBaseWithParam<tuple<Size, int, Size, int>> NormalizeLocalBoxPerfTest;
+
+PERF_TEST_P(NormalizeLocalBoxPerfTest, run,
+    ::testing::Combine(::testing::Values(perf::szVGA, perf::sz720p, perf::sz1080p), // image size
+                       ::testing::Values(CV_8U,CV_32F),                             // src image depth
+					   ::testing::Values(Size(3,3),Size(5,5)),                      // patch size
+                       ::testing::Values(0,1)                                       // use std dev or not
+                       )
+           )
+{
+    cv::Size srcSize = get<0>(GetParam());
+    int depth = get<1>(GetParam());
+    Size sz = get<2>(GetParam());
+    bool useStdDev = get<3>(GetParam());
+
+    cv::Mat src(srcSize, depth);
+    cv::Mat dst;
+    RNG& rng = cv::theRNG();
+    cvtest::randUni(rng, src, Scalar::all(0), Scalar::all(255));
+
+    while (next())
+    {
+        startTimer();
+        cv::fastcv::normalizeLocalBox(src, dst, sz, useStdDev);
         stopTimer();
     }
 

--- a/modules/fastcv/src/blur.cpp
+++ b/modules/fastcv/src/blur.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+ * Copyright (c) 2024-2025 Qualcomm Innovation Center, Inc. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
 */
 
@@ -359,6 +359,27 @@ void sepFilter2D(InputArray _src, OutputArray _dst, int ddepth, InputArray _kern
             break;
         }
     }
+}
+
+void normalizeLocalBox(InputArray _src, OutputArray _dst, Size pSize, bool useStdDev)
+{
+    CV_Assert(!_src.empty());
+    int type = _src.type();
+    CV_Assert(type == CV_8UC1 || type == CV_32FC1);
+
+    Size size = _src.size();
+    int dst_type = type == CV_8UC1 ? CV_8SC1 : CV_32FC1; 
+    _dst.create(size, dst_type);
+
+    Mat src = _src.getMat();
+    Mat dst = _dst.getMat();
+
+    if(type == CV_8UC1)
+        fcvNormalizeLocalBoxu8(src.data, src.cols, src.rows, src.step[0],
+                              pSize.width, pSize.height, useStdDev, (int8_t*)dst.data, dst.step[0]);
+    else if(type == CV_32FC1)
+        fcvNormalizeLocalBoxf32((float*)src.data, src.cols, src.rows, src.step[0],
+                              pSize.width, pSize.height, useStdDev, (float*)dst.data, dst.step[0]);
 }
 
 } // fastcv::

--- a/modules/fastcv/src/blur.cpp
+++ b/modules/fastcv/src/blur.cpp
@@ -368,7 +368,7 @@ void normalizeLocalBox(InputArray _src, OutputArray _dst, Size pSize, bool useSt
     CV_Assert(type == CV_8UC1 || type == CV_32FC1);
 
     Size size = _src.size();
-    int dst_type = type == CV_8UC1 ? CV_8SC1 : CV_32FC1; 
+    int dst_type = type == CV_8UC1 ? CV_8SC1 : CV_32FC1;
     _dst.create(size, dst_type);
 
     Mat src = _src.getMat();

--- a/modules/fastcv/test/test_blur.cpp
+++ b/modules/fastcv/test/test_blur.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+ * Copyright (c) 2024-2025 Qualcomm Innovation Center, Inc. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
 */
 
@@ -108,6 +108,24 @@ TEST_P(SepFilter2DTest, accuracy)
     EXPECT_LT(num_diff_pixels, (src.rows+src.cols)*ksize);
 }
 
+typedef testing::TestWithParam<tuple<int>> NormalizeLocalBoxTest;
+
+TEST_P(NormalizeLocalBoxTest, accuracy)
+{
+    bool use_stddev = get<0>(GetParam());
+    cv::Mat src, dst;
+    src = imread(cvtest::findDataFile("cv/shared/baboon.png"), cv::IMREAD_GRAYSCALE);
+
+    cv::fastcv::normalizeLocalBox(src, dst, Size(5,5), use_stddev);
+    Scalar s = cv::mean(dst);
+
+    if(use_stddev)
+       EXPECT_LT(s[0],1);
+    else
+       EXPECT_LT(s[0],50);
+}
+
+
 INSTANTIATE_TEST_CASE_P(FastCV_Extension, GaussianBlurTest, Combine(
 /*image size*/     ::testing::Values(perf::szVGA, perf::sz720p, perf::sz1080p),
 /*image depth*/    ::testing::Values(CV_8U,CV_16S,CV_32S),
@@ -125,5 +143,8 @@ INSTANTIATE_TEST_CASE_P(FastCV_Extension, SepFilter2DTest, Combine(
 /*image size*/      Values(perf::szVGA, perf::sz720p, perf::sz1080p),
 /*kernel size*/    Values(3, 5, 7, 9, 11)
 ));
+
+INSTANTIATE_TEST_CASE_P(FastCV_Extension, NormalizeLocalBoxTest, Values(0,1));
+
 
 }} // namespaces opencv_test, ::


### PR DESCRIPTION
Fastcv extension for normalizeLocalBox u8 and f32


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
