### PR TITLE
Explicitly specify enum type scope to improve Java wrapper generation

### DIFF
--- a/modules/aruco/include/opencv2/aruco/aruco_calib.hpp
+++ b/modules/aruco/include/opencv2/aruco/aruco_calib.hpp
@@ -53,7 +53,7 @@ enum PatternPositionType {
  * @sa PatternPositionType, solvePnP()
  */
 struct CV_EXPORTS_W_SIMPLE EstimateParameters {
-    CV_PROP_RW PatternPositionType pattern;
+    CV_PROP_RW aruco::PatternPositionType pattern;
     CV_PROP_RW bool useExtrinsicGuess;
     CV_PROP_RW int solvePnPMethod;
 


### PR DESCRIPTION
Changed PatternPositionType to aruco::PatternPositionType to explicitly specify its scope. This allows gen_java.py to correctly register disc_type, preventing constructors and methods using this enum type from being skipped during Java wrapper generation.

Related issues
#3506
https://github.com/opencv/opencv/issues/23753

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
