### PR TITLE
bgsegm: Enable __popcnt intrinsic for MSVC on ARM to fix LSBP test failure

### DIFF
--- a/modules/bgsegm/src/bgfg_gsoc.cpp
+++ b/modules/bgsegm/src/bgfg_gsoc.cpp
@@ -70,7 +70,7 @@ const float LSBPtau = 0.05f;
 inline int LSBPDist32(unsigned n) {
 #if defined(__GNUC__) || defined(__clang__)
     return __builtin_popcount(n);
-#elif defined(_MSC_VER) && !(defined(_M_ARM) || defined(_M_ARM64))
+#elif defined(_MSC_VER)
     return __popcnt(n);
 #else
     // Taken from http://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetParallel


### PR DESCRIPTION
This PR enables use of the `__popcnt` intrinsic for ARM/ARM64 targets when building with MSVC. Previously, these targets(ARM/ARM64) were explicitly excluded using macro guards.

When building OpenCV on Windows on ARM64 with MSVC (cl.exe), the BackgroundSubtractor_LSBP.Accuracy test fails because the code falls into the else block using different bit counting method, which leads to incorrect results and causes the test to fail.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
