### PR TITLE
cudev: Add __shfl_down implementation for long long and unsigned long for CUDA Tookit < 9.0

### DIFF
--- a/modules/cudev/include/opencv2/cudev/warp/shuffle.hpp
+++ b/modules/cudev/include/opencv2/cudev/warp/shuffle.hpp
@@ -334,12 +334,28 @@ __device__ __forceinline__ uint shfl_down(uint val, uint delta, int width = warp
 
 __device__ __forceinline__ signed long long shfl_down(signed long long val, uint delta, int width = warpSize)
 {
+#if defined __CUDACC_VER_MAJOR__ < 9
+    union { long long ll; int2 i2; } u;
+    u.ll = val;
+    u.i2.x = __shfl_down(u.i2.x, delta, width);
+    u.i2.y = __shfl_down(u.i2.y, delta, width);
+    return u.ll;
+#else
     return __shfl_down(val, delta, width);
+#endif
 }
 
 __device__ __forceinline__ unsigned long long shfl_down(unsigned long long val, uint delta, int width = warpSize)
 {
-    return (unsigned long long) __shfl_down(val, delta, width);
+#if defined __CUDACC_VER_MAJOR__ < 9
+    union { unsigned long long ull; uint2 u2; } u;
+    u.ull = val;
+    u.u2.x = __shfl_down(static_cast<int>(u.u2.x), delta, width);
+    u.u2.y = __shfl_down(static_cast<int>(u.u2.y), delta, width);
+    return u.ull;
+#else
+    return __shfl_down(val, delta, width);
+#endif
 }
 
 __device__ __forceinline__ float shfl_down(float val, uint delta, int width = warpSize)


### PR DESCRIPTION
Draft fix for https://github.com/opencv/opencv_contrib/issues/3962.

Support for `__shfl_down` on `long long` was not introduced until CUDA Toolkit 9.0.  I don't know if this is just software support or if hardware support was added as well.  Its a long shot but it may be the reason that the tests are failing on Compute Capbability 5.3 devices.  

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
