### PR TITLE
Fixed out-of-bound access in CUDA Otsu threshold implementation.

### DIFF
--- a/modules/cudaarithm/src/cuda/threshold.cu
+++ b/modules/cudaarithm/src/cuda/threshold.cu
@@ -178,7 +178,7 @@ otsu_score(uint *otsu_threshold, uint *threshold_sums, float2 *variance)
 {
     const uint32_t n_thresholds = 256;
 
-    __shared__ float shared_memory[n_thresholds / WARP_SIZE];
+    __shared__ float shared_memory[n_thresholds];
 
     int threshold = threadIdx.x;
 


### PR DESCRIPTION
The issue introduced in https://github.com/opencv/opencv_contrib/pull/3943
Fixes https://github.com/opencv/opencv_contrib/issues/3962

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
