### PR TITLE
Modified QcAllocator to store File Descriptor

### DIFF
--- a/modules/fastcv/include/opencv2/fastcv/allocator.hpp
+++ b/modules/fastcv/include/opencv2/fastcv/allocator.hpp
@@ -36,12 +36,15 @@ private:
 /**
  * @brief Qualcomm's custom allocator.
  * This allocator uses Qualcomm's memory management functions.
+ *
+ * Note: The userdata field of cv::UMatData is used to store the file descriptor (fd) of the allocated memory.
+ *
  */
 class QcAllocator : public cv::MatAllocator {
     public:
         QcAllocator();
         ~QcAllocator();
-    
+
         cv::UMatData* allocate(int dims, const int* sizes, int type, void* data0, size_t* step, cv::AccessFlag flags, cv::UMatUsageFlags usageFlags) const CV_OVERRIDE;
         bool allocate(cv::UMatData* u, cv::AccessFlag accessFlags, cv::UMatUsageFlags usageFlags) const CV_OVERRIDE;
         void deallocate(cv::UMatData* u) const CV_OVERRIDE;

--- a/modules/fastcv/src/allocator.cpp
+++ b/modules/fastcv/src/allocator.cpp
@@ -55,12 +55,18 @@ cv::UMatData* QcAllocator::allocate(int dims, const int* sizes, int type,
         }
         total *= sizes[i];
     }
-    uchar* data = data0 ? (uchar*)data0 : (uchar*)fcvHwMemAlloc(total, 16);
+
+    int fd = -1;
+    uchar* data = data0 ? (uchar*)data0 : (uchar*)fcvHwMemAlloc(total, 16, &fd);
     cv::UMatData* u = new cv::UMatData(this);
     u->data = u->origdata = data;
     u->size = total;
     if(data0)
         u->flags |= cv::UMatData::USER_ALLOCATED;
+
+    // Store FD in userdata (cast to void*)
+    if (fd >= 0)
+    u->userdata = reinterpret_cast<void*>(static_cast<intptr_t>(fd));
 
     // Add to active allocations
     cv::fastcv::QcResourceManager::getInstance().addAllocation(data);


### PR DESCRIPTION
Add support to store the file descriptor (fd) of the allocated memory in the userdata field of cv::UMatData
fcvHwMemAlloc API has been updated to support fd.

Updated Hash: [opencv/opencv#27525](https://github.com/opencv/opencv/pull/27525)
Updated libs PR [opencv/opencv_3rdparty#101](https://github.com/opencv/opencv_3rdparty/pull/101)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
