### PR TITLE
ximgproc: optimize guidedfilter function for ARM64 using NEON intrinsics

### DIFF
--- a/modules/ximgproc/src/edgeaware_filters_common.cpp
+++ b/modules/ximgproc/src/edgeaware_filters_common.cpp
@@ -60,6 +60,19 @@ inline bool CPU_SUPPORT_SSE1()
 }  // end
 #endif
 
+#if CV_NEON
+namespace
+{
+
+inline bool CPU_SUPPORT_NEON()
+{
+    static const bool is_supported = cv::checkHardwareSupport(CV_CPU_NEON);
+    return is_supported;
+}
+
+}  // end
+#endif
+
 namespace cv
 {
 namespace ximgproc
@@ -286,6 +299,20 @@ void add_mul(float *dst, float *src1, float *src2, int w)
             c = _mm_loadu_ps(dst + j);
             c = _mm_add_ps(c, b);
             _mm_storeu_ps(dst + j, c);
+        }
+    }
+#elif CV_NEON
+    if (CPU_SUPPORT_NEON())
+    {
+        float32x4_t a, b, c;
+        for (; j < w - 3; j += 4)
+        {
+            a = vld1q_f32(src1 + j);
+            b = vld1q_f32(src2 + j);
+            b = vmulq_f32(b, a);
+            c = vld1q_f32(dst + j);
+            c = vaddq_f32(c, b);
+            vst1q_f32(dst + j, c);
         }
     }
 #endif

--- a/modules/ximgproc/src/edgeaware_filters_common.cpp
+++ b/modules/ximgproc/src/edgeaware_filters_common.cpp
@@ -60,9 +60,6 @@ inline bool CPU_SUPPORT_SSE1()
 }  // end
 #endif
 
-}  // end
-#endif
-
 namespace cv
 {
 namespace ximgproc

--- a/modules/ximgproc/src/edgeaware_filters_common.cpp
+++ b/modules/ximgproc/src/edgeaware_filters_common.cpp
@@ -60,16 +60,6 @@ inline bool CPU_SUPPORT_SSE1()
 }  // end
 #endif
 
-#if CV_NEON
-namespace
-{
-
-inline bool CPU_SUPPORT_NEON()
-{
-    static const bool is_supported = cv::checkHardwareSupport(CV_CPU_NEON);
-    return is_supported;
-}
-
 }  // end
 #endif
 
@@ -302,7 +292,7 @@ void add_mul(float *dst, float *src1, float *src2, int w)
         }
     }
 #elif CV_NEON
-    if (CPU_SUPPORT_NEON())
+    if (CV_CPU_HAS_SUPPORT_NEON)
     {
         float32x4_t a, b, c;
         for (; j < w - 3; j += 4)


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch

- This PR introduces an ARM64-specific optimization for the add_mul function in edgeaware_filters_common.cpp using NEON intrinsics.
- The optimization is applied only when CV_NEON is defined and the runtime NEON check (cv::checkHardwareSupport(CV_CPU_NEON)) passes.
- The SIMD implementation leverages NEON instructions (vld1q_f32, vmulq_f32, vaddq_f32, vst1q_f32) to accelerate the fused multiply-add operation on 4-element float vectors.
- This brings parity with existing x64 SIMD optimizations using SSE1.
- The addition of the ARM64 NEON optimization for the add_mul function in edgeaware_filters_common.cpp has led to  performance improvements in some tests of GuidedFilter function.
<img width="730" height="507" alt="image" src="https://github.com/user-attachments/assets/5f9e6912-1de3-4f9e-8793-14b8d6b96646" />

