### PR TITLE
Fix MultiTracker.create() Java wrapper generation and add tests

### DIFF
--- a/modules/tracking/include/opencv2/tracking/tracking_legacy.hpp
+++ b/modules/tracking/include/opencv2/tracking/tracking_legacy.hpp
@@ -401,7 +401,7 @@ public:
   /**
   * \brief Returns a pointer to a new instance of MultiTracker
   */
-  CV_WRAP static Ptr<MultiTracker> create();
+  CV_WRAP static Ptr<legacy::MultiTracker> create();
 
 protected:
   //!<  storage for the tracker algorithms.

--- a/modules/tracking/misc/java/test/TrackerCreateLegacyTest.java
+++ b/modules/tracking/misc/java/test/TrackerCreateLegacyTest.java
@@ -2,11 +2,15 @@ package org.opencv.test.tracking;
 
 import org.opencv.core.Core;
 import org.opencv.core.CvException;
+import org.opencv.core.CvType;
+import org.opencv.core.Mat;
+import org.opencv.core.Rect2d;
 import org.opencv.test.OpenCVTestCase;
 
 import org.opencv.tracking.Tracking;
 import org.opencv.tracking.legacy_Tracker;
 import org.opencv.tracking.legacy_TrackerTLD;
+import org.opencv.tracking.legacy_MultiTracker;
 
 public class TrackerCreateLegacyTest extends OpenCVTestCase {
 
@@ -18,6 +22,21 @@ public class TrackerCreateLegacyTest extends OpenCVTestCase {
 
     public void testCreateLegacyTrackerTLD() {
         legacy_Tracker tracker = legacy_TrackerTLD.create();
+    }
+
+    public void testCreateLegacyMultiTracker() {
+        legacy_MultiTracker multiTracker = legacy_MultiTracker.create();
+        assert(multiTracker != null);
+    }
+
+    public void testAddLegacyMultiTracker() {
+        legacy_MultiTracker multiTracker = legacy_MultiTracker.create();
+        legacy_Tracker tracker = legacy_TrackerTLD.create();
+        Mat image = new Mat(100, 100, CvType.CV_8UC3);
+        Rect2d boundingBox = new Rect2d(10, 10, 50, 50);
+
+        boolean result = multiTracker.add(tracker, image, boundingBox);
+        assert(result);
     }
 
 }


### PR DESCRIPTION
- Fix SKIP issue in MultiTracker.create() method Java wrapper generation
- Add Java tests for MultiTracker functionality

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
