### PR TITLE
Enable Java wrapper generation for Vec4i

### DIFF
--- a/modules/ximgproc/misc/java/gen_dict.json
+++ b/modules/ximgproc/misc/java/gen_dict.json
@@ -1,0 +1,10 @@
+{
+    "missing_consts": {
+        "Ximgproc": {
+            "public": [
+                ["RO_STRICT", 0],
+                ["RO_IGNORE_BORDERS", 1]
+            ]
+        }
+    }
+}

--- a/modules/ximgproc/misc/java/test/XimgprocTest.java
+++ b/modules/ximgproc/misc/java/test/XimgprocTest.java
@@ -1,0 +1,21 @@
+package org.opencv.test.ximgproc;
+
+import org.opencv.core.Core;
+import org.opencv.core.CvType;
+import org.opencv.core.Mat;
+import org.opencv.core.Point;
+import org.opencv.test.OpenCVTestCase;
+import org.opencv.ximgproc.Ximgproc;
+
+public class XimgprocTest extends OpenCVTestCase {
+
+    public void testHoughPoint2Line() {
+        Mat src = new Mat(80, 80, CvType.CV_8UC1, new org.opencv.core.Scalar(0));
+        Point houghPoint = new Point(40, 40);
+
+        int[] result = Ximgproc.HoughPoint2Line(houghPoint, src, Ximgproc.ARO_315_135, Ximgproc.HDO_DESKEW, Ximgproc.RO_IGNORE_BORDERS);
+
+        assertNotNull(result);
+        assertEquals(4, result.length);
+    }
+}


### PR DESCRIPTION
Fixes an issue where Java wrapper generation skips methods using Vec4i.
Depends on PR in opencv: https://github.com/opencv/opencv/pull/27567

Add Java wrapper test for HoughPoint2Line in ximgproc module
- Add basic functionality test for HoughPoint2Line in XimgprocTest.java
- Add gen_dict.json to expose RO_STRICT and RO_IGNORE_BORDERS constants in Java wrapper
- Implement minimal test to verify method call and output validity

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
