### PR TITLE
5.x merge 4.x

### DIFF
--- a/modules/cudev/include/opencv2/cudev/warp/shuffle.hpp
+++ b/modules/cudev/include/opencv2/cudev/warp/shuffle.hpp
@@ -334,12 +334,28 @@ __device__ __forceinline__ uint shfl_down(uint val, uint delta, int width = warp
 
 __device__ __forceinline__ signed long long shfl_down(signed long long val, uint delta, int width = warpSize)
 {
+#if defined __CUDACC_VER_MAJOR__ < 9
+    union { long long ll; int2 i2; } u;
+    u.ll = val;
+    u.i2.x = __shfl_down(u.i2.x, delta, width);
+    u.i2.y = __shfl_down(u.i2.y, delta, width);
+    return u.ll;
+#else
     return __shfl_down(val, delta, width);
+#endif
 }
 
 __device__ __forceinline__ unsigned long long shfl_down(unsigned long long val, uint delta, int width = warpSize)
 {
-    return (unsigned long long) __shfl_down(val, delta, width);
+#if defined __CUDACC_VER_MAJOR__ < 9
+    union { unsigned long long ull; uint2 u2; } u;
+    u.ull = val;
+    u.u2.x = __shfl_down(static_cast<int>(u.u2.x), delta, width);
+    u.u2.y = __shfl_down(static_cast<int>(u.u2.y), delta, width);
+    return u.ull;
+#else
+    return __shfl_down(val, delta, width);
+#endif
 }
 
 __device__ __forceinline__ float shfl_down(float val, uint delta, int width = warpSize)

--- a/modules/ximgproc/misc/java/gen_dict.json
+++ b/modules/ximgproc/misc/java/gen_dict.json
@@ -1,0 +1,10 @@
+{
+    "missing_consts": {
+        "Ximgproc": {
+            "public": [
+                ["RO_STRICT", 0],
+                ["RO_IGNORE_BORDERS", 1]
+            ]
+        }
+    }
+}

--- a/modules/ximgproc/misc/java/test/XimgprocTest.java
+++ b/modules/ximgproc/misc/java/test/XimgprocTest.java
@@ -1,0 +1,21 @@
+package org.opencv.test.ximgproc;
+
+import org.opencv.core.Core;
+import org.opencv.core.CvType;
+import org.opencv.core.Mat;
+import org.opencv.core.Point;
+import org.opencv.test.OpenCVTestCase;
+import org.opencv.ximgproc.Ximgproc;
+
+public class XimgprocTest extends OpenCVTestCase {
+
+    public void testHoughPoint2Line() {
+        Mat src = new Mat(80, 80, CvType.CV_8UC1, new org.opencv.core.Scalar(0));
+        Point houghPoint = new Point(40, 40);
+
+        int[] result = Ximgproc.HoughPoint2Line(houghPoint, src, Ximgproc.ARO_315_135, Ximgproc.HDO_DESKEW, Ximgproc.RO_IGNORE_BORDERS);
+
+        assertNotNull(result);
+        assertEquals(4, result.length);
+    }
+}


### PR DESCRIPTION
OpenCV https://github.com/opencv/opencv/pull/27694

#3963 from cudawarped:fix_shufl_down_on_cc_lt_70
#3988 from utibenkei:fix-java-wrapper-missing-vec4i

Previous "Merge 4.x": #3986