### PR TITLE
add missing cudaFree

### DIFF
--- a/modules/cudafeatures2d/src/fast.cpp
+++ b/modules/cudafeatures2d/src/fast.cpp
@@ -141,6 +141,7 @@ namespace
         if (count == 0)
         {
             _keypoints.release();
+            cudaSafeCall( cudaFree(d_counter) );
             return;
         }
 


### PR DESCRIPTION
I found missing memory cudaFree in cv::cuda::FAST_Impl::detectAsync()

I created an issue, but did not receive a response.
https://github.com/opencv/opencv_contrib/issues/3994

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable 
Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake