### PR TITLE
Added assertions and other check for new matrix types in cudaarithm.

### DIFF
--- a/modules/cudaarithm/src/cuda/absdiff_mat.cu
+++ b/modules/cudaarithm/src/cuda/absdiff_mat.cu
@@ -135,7 +135,7 @@ namespace
 void absDiffMat(const GpuMat& src1, const GpuMat& src2, GpuMat& dst, const GpuMat&, double, Stream& stream, int)
 {
     typedef void (*func_t)(const GpuMat& src1, const GpuMat& src2, GpuMat& dst, Stream& stream);
-    static const func_t funcs[] =
+    static const func_t funcs[CV_DEPTH_MAX] =
     {
         absDiffMat_v1<uchar>,
         absDiffMat_v1<schar>,

--- a/modules/cudaarithm/src/cuda/absdiff_scalar.cu
+++ b/modules/cudaarithm/src/cuda/absdiff_scalar.cu
@@ -95,7 +95,7 @@ namespace
 void absDiffScalar(const GpuMat& src, cv::Scalar val, bool, GpuMat& dst, const GpuMat&, double, Stream& stream, int)
 {
     typedef void (*func_t)(const GpuMat& src, cv::Scalar val, GpuMat& dst, Stream& stream);
-    static const func_t funcs[7][4] =
+    static const func_t funcs[CV_DEPTH_MAX][4] =
     {
         {
             absDiffScalarImpl<uchar, float>, absDiffScalarImpl<uchar2, float>, absDiffScalarImpl<uchar3, float>, absDiffScalarImpl<uchar4, float>

--- a/modules/cudaarithm/src/cuda/cmp_scalar.cu
+++ b/modules/cudaarithm/src/cuda/cmp_scalar.cu
@@ -217,7 +217,7 @@ void cmpScalar(const GpuMat& src, cv::Scalar val, bool inv, GpuMat& dst, const G
     const int depth = src.depth();
     const int cn = src.channels();
 
-    CV_DbgAssert( depth <= CV_64F && cn <= 4 );
+    CV_Assert( depth <= CV_64F && cn <= 4 );
 
     funcs[depth][cmpop][cn - 1](src, val, dst, stream);
 }

--- a/modules/cudaarithm/src/cuda/div_mat.cu
+++ b/modules/cudaarithm/src/cuda/div_mat.cu
@@ -120,7 +120,7 @@ namespace
 void divMat(const GpuMat& src1, const GpuMat& src2, GpuMat& dst, const GpuMat&, double scale, Stream& stream, int)
 {
     typedef void (*func_t)(const GpuMat& src1, const GpuMat& src2, const GpuMat& dst, double scale, Stream& stream);
-    static const func_t funcs[7][7] =
+    static const func_t funcs[CV_DEPTH_MAX][CV_DEPTH_MAX] =
     {
         {
             divMatImpl<uchar, float, uchar>,
@@ -189,8 +189,6 @@ void divMat(const GpuMat& src1, const GpuMat& src2, GpuMat& dst, const GpuMat&, 
 
     const int sdepth = src1.depth();
     const int ddepth = dst.depth();
-
-    CV_DbgAssert( sdepth <= CV_64F && ddepth <= CV_64F );
 
     GpuMat src1_ = src1.reshape(1);
     GpuMat src2_ = src2.reshape(1);

--- a/modules/cudaarithm/src/cuda/minmax.cu
+++ b/modules/cudaarithm/src/cuda/minmax.cu
@@ -87,7 +87,7 @@ namespace
 void cv::cuda::findMinMax(InputArray _src, OutputArray _dst, InputArray _mask, Stream& stream)
 {
     typedef void (*func_t)(const GpuMat& _src, const GpuMat& mask, GpuMat& _dst, Stream& stream);
-    static const func_t funcs[] =
+    static const func_t funcs[CV_DEPTH_MAX] =
     {
         minMaxImpl<uchar, int>,
         minMaxImpl<schar, int>,
@@ -110,6 +110,8 @@ void cv::cuda::findMinMax(InputArray _src, OutputArray _dst, InputArray _mask, S
     GpuMat dst = getOutputMat(_dst, 1, 2, dst_depth, stream);
 
     const func_t func = funcs[src.depth()];
+    CV_Assert(func);
+
     func(src, mask, dst, stream);
 
     syncOutput(dst, _dst, stream);
@@ -158,7 +160,7 @@ namespace
 void cv::cuda::device::findMaxAbs(InputArray _src, OutputArray _dst, InputArray _mask, Stream& stream)
 {
     typedef void (*func_t)(const GpuMat& _src, const GpuMat& mask, GpuMat& _dst, Stream& stream);
-    static const func_t funcs[] =
+    static const func_t funcs[CV_DEPTH_MAX] =
     {
         findMaxAbsImpl<uchar, int>,
         findMaxAbsImpl<schar, int>,
@@ -181,6 +183,8 @@ void cv::cuda::device::findMaxAbs(InputArray _src, OutputArray _dst, InputArray 
     GpuMat dst = getOutputMat(_dst, 1, 1, dst_depth, stream);
 
     const func_t func = funcs[src.depth()];
+    CV_Assert(func);
+
     func(src, mask, dst, stream);
 
     syncOutput(dst, _dst, stream);

--- a/modules/cudaarithm/src/cuda/minmaxloc.cu
+++ b/modules/cudaarithm/src/cuda/minmaxloc.cu
@@ -75,7 +75,7 @@ namespace
 void cv::cuda::findMinMaxLoc(InputArray _src, OutputArray _minMaxVals, OutputArray _loc, InputArray _mask, Stream& stream)
 {
     typedef void (*func_t)(const GpuMat& _src, const GpuMat& mask, GpuMat& _valBuf, GpuMat& _locBuf, Stream& stream);
-    static const func_t funcs[] =
+    static const func_t funcs[CV_DEPTH_MAX] =
     {
         minMaxLocImpl<uchar, int>,
         minMaxLocImpl<schar, int>,
@@ -99,6 +99,7 @@ void cv::cuda::findMinMaxLoc(InputArray _src, OutputArray _minMaxVals, OutputArr
     GpuMat locBuf(pool.getAllocator());
 
     const func_t func = funcs[src_depth];
+    CV_Assert(func);
     func(src, mask, valBuf, locBuf, stream);
 
     GpuMat minMaxVals = valBuf.colRange(0, 1);

--- a/modules/cudaarithm/src/cuda/norm.cu
+++ b/modules/cudaarithm/src/cuda/norm.cu
@@ -161,7 +161,7 @@ namespace
 void cv::cuda::device::normL2(InputArray _src, OutputArray _dst, InputArray _mask, Stream& stream)
 {
     typedef void (*func_t)(const GpuMat& _src, const GpuMat& mask, GpuMat& _dst, Stream& stream);
-    static const func_t funcs[] =
+    static const func_t funcs[CV_DEPTH_MAX] =
     {
         normL2Impl<uchar, double>,
         normL2Impl<schar, double>,
@@ -181,6 +181,7 @@ void cv::cuda::device::normL2(InputArray _src, OutputArray _dst, InputArray _mas
     GpuMat dst = getOutputMat(_dst, 1, 1, CV_64FC1, stream);
 
     const func_t func = funcs[src.depth()];
+    CV_Assert(func);
     func(src, mask, dst, stream);
 
     syncOutput(dst, _dst, stream);

--- a/modules/cudaarithm/src/cuda/normalize.cu
+++ b/modules/cudaarithm/src/cuda/normalize.cu
@@ -219,7 +219,7 @@ void cv::cuda::normalize(InputArray _src, OutputArray _dst, double a, double b, 
     typedef void (*func_minmax_t)(const GpuMat& _src, GpuMat& _dst, double a, double b, const GpuMat& mask, Stream& stream);
     typedef void (*func_norm_t)(const GpuMat& _src, GpuMat& _dst, double a, int normType, const GpuMat& mask, Stream& stream);
 
-    static const func_minmax_t funcs_minmax[] =
+    static const func_minmax_t funcs_minmax[CV_DEPTH_MAX] =
     {
         normalizeMinMax<uchar, float, float>,
         normalizeMinMax<schar, float, float>,
@@ -230,7 +230,7 @@ void cv::cuda::normalize(InputArray _src, OutputArray _dst, double a, double b, 
         normalizeMinMax<double, double, double>
     };
 
-    static const func_norm_t funcs_norm[] =
+    static const func_norm_t funcs_norm[CV_DEPTH_MAX] =
     {
         normalizeNorm<uchar, float, float>,
         normalizeNorm<schar, float, float>,
@@ -273,11 +273,13 @@ void cv::cuda::normalize(InputArray _src, OutputArray _dst, double a, double b, 
     if (normType == NORM_MINMAX)
     {
         const func_minmax_t func = funcs_minmax[src_depth];
+        CV_Assert(func);
         func(src, dst, a, b, mask, stream);
     }
     else
     {
         const func_norm_t func = funcs_norm[src_depth];
+        CV_Assert(func);
         func(src, dst, a, normType, mask, stream);
     }
 

--- a/modules/cudaarithm/src/cuda/reduce.cu
+++ b/modules/cudaarithm/src/cuda/reduce.cu
@@ -142,7 +142,7 @@ void cv::cuda::reduce(InputArray _src, OutputArray _dst, int dim, int reduceOp, 
     if (dim == 0)
     {
         typedef void (*func_t)(const GpuMat& _src, GpuMat& _dst, int reduceOp, Stream& stream);
-        static const func_t funcs[7][7] =
+        static const func_t funcs[CV_DEPTH_MAX][CV_DEPTH_MAX] =
         {
             {
                 reduceToRowImpl<uchar, int, uchar>,
@@ -220,7 +220,7 @@ void cv::cuda::reduce(InputArray _src, OutputArray _dst, int dim, int reduceOp, 
     else
     {
         typedef void (*func_t)(const GpuMat& _src, GpuMat& _dst, int reduceOp, Stream& stream);
-        static const func_t funcs[7][7] =
+        static const func_t funcs[CV_DEPTH_MAX][CV_DEPTH_MAX] =
         {
             {
                 reduceToColumnImpl<uchar, int, uchar>,

--- a/modules/cudaarithm/src/cuda/sub_mat.cu
+++ b/modules/cudaarithm/src/cuda/sub_mat.cu
@@ -185,7 +185,7 @@ void subMat(const GpuMat& src1, const GpuMat& src2, GpuMat& dst, const GpuMat& m
     const int sdepth = src1.depth();
     const int ddepth = dst.depth();
 
-    CV_DbgAssert( sdepth <= CV_64F && ddepth <= CV_64F );
+    CV_Assert( sdepth <= CV_64F && ddepth <= CV_64F );
 
     GpuMat src1_ = src1.reshape(1);
     GpuMat src2_ = src2.reshape(1);

--- a/modules/cudaarithm/src/cuda/threshold.cu
+++ b/modules/cudaarithm/src/cuda/threshold.cu
@@ -378,7 +378,7 @@ double cv::cuda::threshold(InputArray _src, OutputArray _dst, double thresh, dou
     else
     {
         typedef void (*func_t)(const GpuMat& src, GpuMat& dst, double thresh, double maxVal, int type, Stream& stream);
-        static const func_t funcs[] =
+        static const func_t funcs[CV_DEPTH_MAX] =
         {
             thresholdImpl<uchar>,
             thresholdImpl<schar>,
@@ -395,7 +395,10 @@ double cv::cuda::threshold(InputArray _src, OutputArray _dst, double thresh, dou
             maxVal = cvRound(maxVal);
         }
 
-        funcs[depth](src, dst, thresh, maxVal, type, stream);
+        auto f = funcs[depth];
+        CV_Assert(f);
+
+        f(src, dst, thresh, maxVal, type, stream);
     }
 
     syncOutput(dst, _dst, stream);

--- a/modules/cudaarithm/test/test_element_operations.cpp
+++ b/modules/cudaarithm/test/test_element_operations.cpp
@@ -1570,13 +1570,16 @@ namespace
     {
         typedef void (*func_t)(const cv::Mat& src, cv::Mat& dst);
 
-        const func_t funcs[] =
+        const func_t funcs[CV_DEPTH_MAX] =
         {
             sqrtImpl<uchar>, sqrtImpl<schar>, sqrtImpl<ushort>, sqrtImpl<short>,
             sqrtImpl<int>, sqrtImpl<float>
         };
 
-        funcs[src.depth()](src, dst);
+        auto f = funcs[src.depth()];
+        CV_Assert(f);
+
+        f(src, dst);
     }
 }
 
@@ -1640,13 +1643,16 @@ namespace
     {
         typedef void (*func_t)(const cv::Mat& src, cv::Mat& dst);
 
-        const func_t funcs[] =
+        const func_t funcs[CV_DEPTH_MAX] =
         {
             logImpl<uchar>, logImpl<schar>, logImpl<ushort>, logImpl<short>,
             logImpl<int>, logImpl<float>
         };
 
-        funcs[src.depth()](src, dst);
+        auto f = funcs[src.depth()];
+        CV_Assert(f);
+
+        f(src, dst);
     }
 }
 
@@ -1720,13 +1726,16 @@ namespace
     {
         typedef void (*func_t)(const cv::Mat& src, cv::Mat& dst);
 
-        const func_t funcs[] =
+        const func_t funcs[CV_DEPTH_MAX] =
         {
             expImpl<uchar>, expImpl<schar>, expImpl<ushort>, expImpl<short>,
             expImpl<int>, expImpl_float
         };
 
-        funcs[src.depth()](src, dst);
+        auto f = funcs[src.depth()];
+        CV_Assert(f);
+
+        f(src, dst);
     }
 }
 
@@ -1921,8 +1930,10 @@ namespace
 
     void compareScalarGold(const cv::Mat& src, cv::Scalar sc, cv::Mat& dst, int cmpop)
     {
+        CV_Assert(cmpop < 6);
+
         typedef void (*func_t)(const cv::Mat& src, cv::Scalar sc, cv::Mat& dst);
-        static const func_t funcs[7][6] =
+        static const func_t funcs[CV_DEPTH_MAX][6] =
         {
             {compareScalarImpl<std::equal_to, unsigned char> , compareScalarImpl<std::greater, unsigned char> , compareScalarImpl<std::greater_equal, unsigned char> , compareScalarImpl<std::less, unsigned char> , compareScalarImpl<std::less_equal, unsigned char> , compareScalarImpl<std::not_equal_to, unsigned char> },
             {compareScalarImpl<std::equal_to, signed char>   , compareScalarImpl<std::greater, signed char>   , compareScalarImpl<std::greater_equal, signed char>   , compareScalarImpl<std::less, signed char>   , compareScalarImpl<std::less_equal, signed char>   , compareScalarImpl<std::not_equal_to, signed char>   },
@@ -1933,7 +1944,10 @@ namespace
             {compareScalarImpl<std::equal_to, double>        , compareScalarImpl<std::greater, double>        , compareScalarImpl<std::greater_equal, double>        , compareScalarImpl<std::less, double>        , compareScalarImpl<std::less_equal, double>        , compareScalarImpl<std::not_equal_to, double>        }
         };
 
-        funcs[src.depth()][cmpop](src, sc, dst);
+        auto f = funcs[src.depth()][cmpop];
+        CV_Assert(f);
+
+        f(src, sc, dst);
     }
 }
 
@@ -2164,12 +2178,14 @@ namespace
     {
         typedef void (*func_t)(const cv::Mat& src, cv::Scalar_<int> val, cv::Mat& dst);
 
-        const func_t funcs[] =
+        const func_t funcs[CV_DEPTH_MAX] =
         {
             rhiftImpl<uchar>, rhiftImpl<schar>, rhiftImpl<ushort>, rhiftImpl<short>, rhiftImpl<int>
         };
 
-        funcs[src.depth()](src, val, dst);
+        auto f = funcs[src.depth()];
+        CV_Assert(f);
+        f(src, val, dst);
     }
 }
 
@@ -2244,12 +2260,15 @@ namespace
     {
         typedef void (*func_t)(const cv::Mat& src, cv::Scalar_<int> val, cv::Mat& dst);
 
-        const func_t funcs[] =
+        const func_t funcs[CV_DEPTH_MAX] =
         {
             lhiftImpl<uchar>, lhiftImpl<schar>, lhiftImpl<ushort>, lhiftImpl<short>, lhiftImpl<int>
         };
 
-        funcs[src.depth()](src, val, dst);
+        auto f = funcs[src.depth()];
+        CV_Assert(f);
+
+        f(src, val, dst);
     }
 }
 

--- a/modules/cudaarithm/test/test_reductions.cpp
+++ b/modules/cudaarithm/test/test_reductions.cpp
@@ -201,7 +201,7 @@ namespace
     {
         typedef cv::Scalar (*func_t)(const cv::Mat& src);
 
-        static const func_t funcs[] =
+        static const func_t funcs[CV_DEPTH_MAX] =
         {
             absSumImpl<uchar>,
             absSumImpl<schar>,
@@ -212,7 +212,10 @@ namespace
             absSumImpl<double>
         };
 
-        return funcs[src.depth()](src);
+        auto f = funcs[src.depth()];
+        CV_Assert(f);
+
+        return f(src);
     }
 
     template <typename T>
@@ -241,7 +244,7 @@ namespace
     {
         typedef cv::Scalar (*func_t)(const cv::Mat& src);
 
-        static const func_t funcs[] =
+        static const func_t funcs[CV_DEPTH_MAX] =
         {
             sqrSumImpl<uchar>,
             sqrSumImpl<schar>,
@@ -252,7 +255,10 @@ namespace
             sqrSumImpl<double>
         };
 
-        return funcs[src.depth()](src);
+        auto f = funcs[src.depth()];
+        CV_Assert(f);
+
+        return f(src);
     }
 }
 
@@ -519,7 +525,7 @@ namespace
     {
         typedef void (*func_t)(const cv::Mat& src, cv::Point loc_gold, cv::Point loc);
 
-        static const func_t funcs[] =
+        static const func_t funcs[CV_DEPTH_MAX] =
         {
             expectEqualImpl<uchar>,
             expectEqualImpl<schar>,
@@ -530,7 +536,10 @@ namespace
             expectEqualImpl<double>
         };
 
-        funcs[src.depth()](src, loc_gold, loc);
+        auto f = funcs[src.depth()];
+        CV_Assert(f);
+
+        f(src, loc_gold, loc);
     }
 }
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
