### PR TITLE
Add INTER_AREA interpolation method on `resize` Doxygen string

### DIFF
--- a/modules/cudawarping/include/opencv2/cudawarping.hpp
+++ b/modules/cudawarping/include/opencv2/cudawarping.hpp
@@ -105,8 +105,8 @@ Either dsize or both fx and fy must be non-zero.
 \f[\texttt{(double)dsize.width/src.cols}\f]
 @param fy Scale factor along the vertical axis. If it is zero, it is computed as:
 \f[\texttt{(double)dsize.height/src.rows}\f]
-@param interpolation Interpolation method. INTER_NEAREST , INTER_LINEAR and INTER_CUBIC are
-supported for now.
+@param interpolation Interpolation method. INTER_NEAREST , INTER_LINEAR , INTER_CUBIC , and INTER_AREA are
+supported.
 @param stream Stream for the asynchronous version.
 
 @sa resize


### PR DESCRIPTION
## Summary

The issue was reported first at:
https://github.com/opencv/opencv_contrib/issues/3973

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
