### PR TITLE
Mark advanced configurations in cudacodecs as unstable as not all GPUs support it 

### DIFF
--- a/modules/cudacodec/test/test_video.cpp
+++ b/modules/cudacodec/test/test_video.cpp
@@ -1070,6 +1070,13 @@ CUDA_TEST_P(YUVFormats, Transcode)
     const std::string inputFile = std::string(cvtest::TS::ptr()->get_data_path()) + "../highgui/video/big_buck_bunny.h265";
     const cv::cudacodec::ColorFormat writerColorFormat = static_cast<cudacodec::ColorFormat>(static_cast<int>(GET_PARAM(1)));
     const bool fullRange = GET_PARAM(2);
+
+    if (cvtest::skipUnstableTests &&
+        (writerColorFormat == cudacodec::ColorFormat::NV_YUV444 || writerColorFormat == cudacodec::ColorFormat::NV_YUV444_10BIT))
+    {
+        throw SkipTestException("Not all GPUs support NV_YUV444 and NV_YUV444_10BIT color space");
+    }
+
     constexpr double fps = 25;
     const cudacodec::Codec codec = cudacodec::Codec::HEVC;
     const std::string ext = ".mp4";


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
