### PR TITLE
[Saliency] Enable Java/Android bindings by adding 'WRAP java' to CMake

### DIFF
--- a/modules/saliency/CMakeLists.txt
+++ b/modules/saliency/CMakeLists.txt
@@ -4,6 +4,6 @@ endif()
 
 set(the_description "Saliency API")
 
-ocv_define_module(saliency opencv_imgproc opencv_features2d WRAP python)
+ocv_define_module(saliency opencv_imgproc opencv_features2d WRAP python java)
 
 ocv_warnings_disable(CMAKE_CXX_FLAGS -Woverloaded-virtual)


### PR DESCRIPTION
Fixes #4016

This addresses the inability to use the `saliency` module in Android (Java/Kotlin) applications. When generated using `build_sdk.py`, the native library compiles, but the Java wrapper class (`org.opencv.saliency.Saliency`) is not generated.

# Technical Fix:
The `ocv_define_module` macro in `modules/saliency/CMakeLists.txt` was missing the `java` flag in its `WRAP` parameter.

**Change in `modules/saliency/CMakeLists.txt`:**

**OLD**
ocv_define_module(saliency opencv_imgproc opencv_features2d WRAP python)

**NEW**
ocv_define_module(saliency opencv_imgproc opencv_features2d WRAP python java)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
