### PR TITLE
Fix: preserve _min_disp in DisparityWLSFilterImpl init()

### DIFF
--- a/modules/ximgproc/src/disparity_filters.cpp
+++ b/modules/ximgproc/src/disparity_filters.cpp
@@ -147,7 +147,6 @@ void DisparityWLSFilterImpl::init(double _lambda, double _sigma_color, bool _use
     min_disp = _min_disp;
     valid_disp_ROI = Rect();
     right_view_valid_disp_ROI = Rect();
-    min_disp=0;
     lambda = _lambda;
     sigma_color = _sigma_color;
     use_confidence = _use_confidence;


### PR DESCRIPTION
Removed incorrect line `min_disp = 0;` in init().
The previous implementation ignored the minimal disparity value passed to the filter,
causing misalignment and artifacts in disparity filtering.
This change ensures correct handling of disparity offsets.
