### PR TITLE
Fix findEllipses

### DIFF
--- a/modules/ximgproc/src/find_ellipses.cpp
+++ b/modules/ximgproc/src/find_ellipses.cpp
@@ -1301,12 +1301,12 @@ void EllipseDetectorImpl::preProcessing(Mat1b &src, Mat1b &dp, Mat1b &dn) {
     // 2 - the pixel does belong to an edge
     for (int i = 0; i <= imgSize.height; i++) {
         int *tmpMag = magBuffer[(i > 0) + 1] + 1;
-        const short *tmpDx = dx.ptr<short>(i);
-        const short *tmpDy = dy.ptr<short>(i);
         uchar *tmpMap;
         int prevFlag = 0;
 
         if (i < imgSize.height) {
+            const short *tmpDx = dx.ptr<short>(i);
+            const short *tmpDy = dy.ptr<short>(i);
             tmpMag[-1] = tmpMag[imgSize.width] = 0;
             for (int j = 0; j < imgSize.width; j++)
                 tmpMag[j] = abs(tmpDx[j]) + abs(tmpDy[j]);
@@ -1322,8 +1322,8 @@ void EllipseDetectorImpl::preProcessing(Mat1b &src, Mat1b &dp, Mat1b &dn) {
         tmpMap[-1] = tmpMap[imgSize.width] = 1;
 
         tmpMag = magBuffer[1] + 1; // take the central row
-        tmpDx = (short *) (dx[i - 1]);
-        tmpDy = (short *) (dy[i - 1]);
+        const short *tmpDx = dx.ptr<short>(i - 1);
+        const short *tmpDy = dy.ptr<short>(i - 1);
 
         ptrdiff_t magStep1, magStep2;
         magStep1 = magBuffer[2] - magBuffer[1];


### PR DESCRIPTION
### Pull Request Readiness Checklist

Fix #3525
Fix #3817
Fix #4022

The problem was that for `i = imgSize.height` there was access to `dx.ptr<short>(i)` or `dy.ptr<short>(i)`, but they were not used later in this case

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
