### PR TITLE
[cudacodec][NVSurfaceToColorConverter] Add python bindings and fix redundant flag

### DIFF
--- a/modules/cudacodec/include/opencv2/cudacodec.hpp
+++ b/modules/cudacodec/include/opencv2/cudacodec.hpp
@@ -392,10 +392,9 @@ public:
      * @param outputFormat The requested output color format.
      * @param bitDepth The requested bit depth of the output frame.
      * @param planar Request seperate planes for each color plane.
-     * @param videoFullRangeFlag Indicates if the black level, luma and chroma of the source are represented using the full or limited range (AKA TV or "analogue" range) of values as defined in Annex E of the ITU-T Specification.
      * @param stream Stream for the asynchronous version.
      */
-    virtual bool convert(InputArray yuv, OutputArray color, const SurfaceFormat surfaceFormat, const ColorFormat outputFormat, const BitDepth bitDepth = BitDepth::UNCHANGED, const bool planar = false, const bool videoFullRangeFlag = false, cuda::Stream& stream = cuda::Stream::Null()) = 0;
+    CV_WRAP virtual bool convert(InputArray yuv, OutputArray color, const SurfaceFormat surfaceFormat, const ColorFormat outputFormat, const BitDepth bitDepth = BitDepth::UNCHANGED, const bool planar = false, cuda::Stream& stream = cuda::Stream::Null()) = 0;
 };
 
 /** @brief Creates a NVSurfaceToColorConverter.

--- a/modules/cudacodec/misc/python/test/test_cudacodec.py
+++ b/modules/cudacodec/misc/python/test/test_cudacodec.py
@@ -60,8 +60,8 @@ class cudacodec_test(NewOpenCVTests):
 
             # Change color format
             ret, colour_code = reader.getVideoReaderProps(cv.cudacodec.VideoReaderProps_PROP_COLOR_FORMAT)
-            self.assertTrue(ret and colour_code == cv.cudacodec.ColorFormat_BGRA)
-            colour_code_gs = cv.cudacodec.ColorFormat_GRAY
+            self.assertTrue(ret and colour_code == cv.cudacodec.BGRA)
+            colour_code_gs = cv.cudacodec.GRAY
             reader.set(colour_code_gs)
             ret, colour_code = reader.getVideoReaderProps(cv.cudacodec.VideoReaderProps_PROP_COLOR_FORMAT)
             self.assertTrue(ret and colour_code == colour_code_gs)
@@ -91,6 +91,14 @@ class cudacodec_test(NewOpenCVTests):
             else:
                 self.skipTest(e.err)
 
+    def test_NVSurfaceToColorConverter(self):
+        converter = cv.cudacodec.createNVSurfaceToColorConverter(cv.cudacodec.ColorSpaceStandard_BT601,False)
+        bgr_sz = (1920,1080)
+        nv12_sz = (1920, int(1.5*1080))
+        blank_nv12_frame = cv.cuda.GpuMat(nv12_sz,cv.CV_8U)
+        ret, bgr = converter.convert(blank_nv12_frame, cv.cudacodec.SF_NV12, cv.cudacodec.BGR)
+        self.assertTrue(ret == True and bgr.size() == bgr_sz)
+
     def test_map_histogram(self):
         hist = cv.cuda_GpuMat((1,256), cv.CV_8UC1)
         hist.setTo(1)
@@ -107,7 +115,7 @@ class cudacodec_test(NewOpenCVTests):
             encoder_params_in.gopLength = 10
             stream = cv.cuda.Stream()
             sz = (1920,1080)
-            writer = cv.cudacodec.createVideoWriter(fname, sz, cv.cudacodec.H264, 30, cv.cudacodec.ColorFormat_BGR,
+            writer = cv.cudacodec.createVideoWriter(fname, sz, cv.cudacodec.H264, 30, cv.cudacodec.BGR,
                                                     encoder_params_in, stream=stream)
             blankFrameIn = cv.cuda.GpuMat(sz,cv.CV_8UC3)
             writer.write(blankFrameIn)

--- a/modules/cudacodec/src/nvidia_surface_format_to_color_converter.cpp
+++ b/modules/cudacodec/src/nvidia_surface_format_to_color_converter.cpp
@@ -154,7 +154,9 @@ void SetMatYuv2Rgb(int iMatrix, ColorMatrix& matYuv2Color, bool fullRange = fals
 
 class NVSurfaceToColorConverterImpl : public NVSurfaceToColorConverter {
 public:
-    NVSurfaceToColorConverterImpl(ColorSpaceStandard colorSpace, bool fullColorRange = false) {
+    NVSurfaceToColorConverterImpl(ColorSpaceStandard colorSpace, bool fullColorRange = false) :
+        videoFullRangeFlag(fullColorRange)
+    {
         SetMatYuv2Rgb(static_cast<int>(colorSpace), matYuv2Color, fullColorRange);
     }
 
@@ -194,7 +196,7 @@ public:
         }
     }
 
-    bool convert(const InputArray yuv, const OutputArray out, const SurfaceFormat surfaceFormat, const ColorFormat outputFormat, const BitDepth bitDepth, const bool planar, const bool videoFullRangeFlag, cuda::Stream& stream) {
+    bool convert(const InputArray yuv, const OutputArray out, const SurfaceFormat surfaceFormat, const ColorFormat outputFormat, const BitDepth bitDepth, const bool planar, cuda::Stream& stream) {
         CV_Assert(outputFormat == ColorFormat::BGR || outputFormat == ColorFormat::BGRA || outputFormat == ColorFormat::RGB || outputFormat == ColorFormat::RGBA || outputFormat == ColorFormat::GRAY);
         CV_Assert(yuv.depth() == CV_8U || yuv.depth() == CV_16U);
         const bool yuv420 = surfaceFormat == SurfaceFormat::SF_NV12 || surfaceFormat == SurfaceFormat::SF_P016;
@@ -341,6 +343,7 @@ public:
 
 private:
     ColorMatrix matYuv2Color;
+    bool videoFullRangeFlag;
 };
 
 Ptr<NVSurfaceToColorConverter> cv::cudacodec::createNVSurfaceToColorConverter(const ColorSpaceStandard colorSpace, const bool videoFullRangeFlag) {

--- a/modules/cudacodec/src/video_reader.cpp
+++ b/modules/cudacodec/src/video_reader.cpp
@@ -92,7 +92,7 @@ namespace
         void releaseFrameInfo(const std::pair<CUVIDPARSERDISPINFO, CUVIDPROCPARAMS>& frameInfo);
         bool internalGrab(GpuMat & frame, GpuMat & histogram, Stream & stream);
         void waitForDecoderInit();
-        void cvtFromYuv(const GpuMat& decodedFrame, GpuMat& outFrame, const SurfaceFormat surfaceFormat, const bool videoFullRangeFlag, Stream& stream);
+        void cvtFromYuv(const GpuMat& decodedFrame, GpuMat& outFrame, const SurfaceFormat surfaceFormat, Stream& stream);
 
         Ptr<VideoSource> videoSource_;
 
@@ -260,7 +260,7 @@ namespace
                 cuSafeCall(cuMemcpyDtoDAsync((CUdeviceptr)(histogram.data), cuHistogramPtr, histogramSz, StreamAccessor::getStream(stream)));
             }
 
-            cvtFromYuv(decodedFrame, frame, videoDecoder_->format().surfaceFormat, videoDecoder_->format().videoFullRangeFlag, stream);
+            cvtFromYuv(decodedFrame, frame, videoDecoder_->format().surfaceFormat, stream);
             // unmap video frame
             // unmapFrame() synchronizes with the VideoDecode API (ensures the frame has finished decoding)
             videoDecoder_->unmapFrame(decodedFrame);
@@ -414,13 +414,13 @@ namespace
         return true;
     }
 
-    void VideoReaderImpl::cvtFromYuv(const GpuMat& decodedFrame, GpuMat& outFrame, const SurfaceFormat surfaceFormat, const bool videoFullRangeFlag, Stream& stream)
+    void VideoReaderImpl::cvtFromYuv(const GpuMat& decodedFrame, GpuMat& outFrame, const SurfaceFormat surfaceFormat, Stream& stream)
     {
         if (colorFormat == ColorFormat::NV_YUV_SURFACE_FORMAT) {
             decodedFrame.copyTo(outFrame, stream);
             return;
         }
-        yuvConverter->convert(decodedFrame, outFrame, surfaceFormat, colorFormat, bitDepth, planar, videoFullRangeFlag, stream);
+        yuvConverter->convert(decodedFrame, outFrame, surfaceFormat, colorFormat, bitDepth, planar, stream);
     }
 }
 

--- a/modules/cudacodec/test/test_video.cpp
+++ b/modules/cudacodec/test/test_video.cpp
@@ -998,7 +998,7 @@ CUDA_TEST_P(YuvConverter, Reader)
     Mat nv12Interleaved, bgrFromYuv;
     generateTestImages(bgr, nv12Interleaved, bgrFromYuv, surfaceFormat, outputFormat, bitDepth, planar, fullRange);
     GpuMat nv12Device(nv12Interleaved), bgrDevice(bgrFromYuv.size(), bgrFromYuv.type());
-    yuvConverter->convert(nv12Device, bgrDevice, surfaceFormat, outputFormat, bitDepth, planar, fullRange);
+    yuvConverter->convert(nv12Device, bgrDevice, surfaceFormat, outputFormat, bitDepth, planar);
     bgrDevice.download(bgrHost);
     EXPECT_MAT_NEAR(bgrFromYuv, bgrHost, bitDepth == cudacodec::BitDepth::EIGHT ? 2 :512);
 }


### PR DESCRIPTION
Fix issues identified in https://github.com/opencv/opencv_contrib/issues/3982 by adding python bindings to `NVSurfaceToColorConverter::convert` and removing unecessary `videoFullRangeFlag` argument which is passed to the constructor.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
