### PR TITLE
Add cv::cuda::cvtColorTwoPlane

### DIFF
--- a/modules/cudaimgproc/include/opencv2/cudaimgproc.hpp
+++ b/modules/cudaimgproc/include/opencv2/cudaimgproc.hpp
@@ -90,6 +90,24 @@ performance.
  */
 CV_EXPORTS_W void cvtColor(InputArray src, OutputArray dst, int code, int dcn = 0, Stream& stream = Stream::Null());
 
+/** @brief Converts an image from one color space to another where the source image is stored in two planes.
+
+This function currently only supports YUV420 in NV12 format to RGB/BGR conversion. The conversion used is:
+- R=1.163999557*(Y-16) + 1.5959997177(V-128)
+- G=1.163999557*(Y-16) -0.812999725(V-128) -0.390999794(U-128)
+- B=1.163999557*(Y-16) + 2.017999649(U-128)
+
+@param src1 8-bit image (CV_8U) of the Y plane.
+@param src2 image containing interleaved (CV_8UC2) U/V plane.
+@param dst Destination image.
+@param code Color space conversion code. It can take any of the following values:
+- #COLOR_YUV2BGR_NV12
+- #COLOR_YUV2RGB_NV12
+@param stream Stream for the asynchronous version.
+
+ */
+CV_EXPORTS_W void cvtColorTwoPlane(InputArray src1, InputArray src2, OutputArray dst, int code, Stream& stream = Stream::Null());
+
 enum DemosaicTypes
 {
     //! Bayer Demosaicing (Malvar, He, and Cutler)

--- a/modules/cudaimgproc/test/test_color.cpp
+++ b/modules/cudaimgproc/test/test_color.cpp
@@ -2292,6 +2292,67 @@ INSTANTIATE_TEST_CASE_P(CUDA_ImgProc, CvtColor, testing::Combine(
     WHOLE_SUBMAT));
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
+// cvtColorTwoPlane
+
+PARAM_TEST_CASE(CvtColorTwoPlane, cv::cuda::DeviceInfo, cv::Size, MatDepth, UseRoi)
+{
+    cv::cuda::DeviceInfo devInfo;
+    cv::Size size;
+    int depth;
+    bool useRoi;
+
+    virtual void SetUp()
+    {
+        devInfo = GET_PARAM(0);
+        size = GET_PARAM(1);
+        depth = GET_PARAM(2);
+        useRoi = GET_PARAM(3);
+
+        cv::cuda::setDevice(devInfo.deviceID());
+    }
+};
+
+CUDA_TEST_P(CvtColorTwoPlane, YUV2BGR_NV12)
+{
+    if ((depth != CV_8U) || useRoi)
+        return;
+
+    cv::Mat src1 = randomMat(size, depth, 16.0, 235.0);
+    cv::Mat src2 = randomMat(size/2, CV_MAKE_TYPE(depth, 2), 16.0, 240.0);
+
+    cv::cuda::GpuMat dst;
+    cv::cuda::cvtColorTwoPlane(loadMat(src1, useRoi), loadMat(src2, useRoi), dst, cv::COLOR_YUV2BGR_NV12);
+
+    cv::Mat dst_gold;
+    cv::cvtColorTwoPlane(src1, src2, dst_gold, cv::COLOR_YUV2BGR_NV12);
+
+    EXPECT_MAT_NEAR(dst_gold(cv::Rect(1, 1, dst.cols - 2, dst.rows - 2)), dst(cv::Rect(1, 1, dst.cols - 2, dst.rows - 2)), 2);
+}
+
+CUDA_TEST_P(CvtColorTwoPlane, YUV2RGB_NV12)
+{
+    if ((depth != CV_8U) || useRoi)
+        return;
+
+    cv::Mat src1 = randomMat(size, depth, 16.0, 235.0);
+    cv::Mat src2 = randomMat(size/2, CV_MAKE_TYPE(depth, 2), 16.0, 240.0);
+
+    cv::cuda::GpuMat dst;
+    cv::cuda::cvtColorTwoPlane(loadMat(src1, useRoi), loadMat(src2, useRoi), dst, cv::COLOR_YUV2RGB_NV12);
+
+    cv::Mat dst_gold;
+    cv::cvtColorTwoPlane(src1, src2, dst_gold, cv::COLOR_YUV2RGB_NV12);
+
+    EXPECT_MAT_NEAR(dst_gold(cv::Rect(1, 1, dst.cols - 2, dst.rows - 2)), dst(cv::Rect(1, 1, dst.cols - 2, dst.rows - 2)), 2);
+}
+
+INSTANTIATE_TEST_CASE_P(CUDA_ImgProc, CvtColorTwoPlane, testing::Combine(
+    ALL_DEVICES,
+    testing::Values(cv::Size(128, 128)),
+    testing::Values(MatDepth(CV_8U)),
+    WHOLE_SUBMAT));
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////
 // Demosaicing
 
 struct Demosaicing : testing::TestWithParam<testing::tuple<cv::cuda::DeviceInfo, bool>>


### PR DESCRIPTION
This PR adds cv::cuda::cvtColorTwoPlane, similar to cv::cvtColorTwoPlane. 

Currently it supports COLOR_YUV2BGR_NV12 and COLOR_YUV2RGB_NV12 for CV_8U only. Unfortunately there doesn't appear to be a npp function supporting RGBA.

It requires NPP v13 or greater, as nppiNV12ToRGB_8u_ColorTwist32f_P2C3R_Ctx is buggy in earlier versions of NPP.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [] There is a reference to the original bug report and related work
- [] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

No patch to opencv_extra - but test is included that compares cv::cuda::cvtColorTwoPlane to cv::cvtColorTwoPlane.
