### PR TITLE
 Fixed unrichable code with MSVC on x86 32-bit systems.

### DIFF
--- a/modules/gapi/CMakeLists.txt
+++ b/modules/gapi/CMakeLists.txt
@@ -41,9 +41,7 @@ if(MSVC)
     # and IE deprecated code warning C4996
     ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4503 /wd4996)
   endif()
-  if((MSVC_VERSION LESS 1920) OR ARM OR AARCH64) # MSVS 2015/2017 on x86 and ARM
-    ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4702)  # 'unreachable code'
-  endif()
+  ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4702) # MSVS 2015/2017/2019 on x86 and ARM
 endif()
 
 file(GLOB gapi_ext_hdrs


### PR DESCRIPTION
Port of https://github.com/opencv/opencv/pull/27991 to 5.x

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
