### PR TITLE
Fix clahe build

### DIFF
--- a/modules/cudaimgproc/src/histogram.cpp
+++ b/modules/cudaimgproc/src/histogram.cpp
@@ -64,6 +64,8 @@ void cv::cuda::histRange(InputArray, GpuMat*, const GpuMat*, Stream&) { throw_no
 
 #else /* !defined (HAVE_CUDA) */
 
+#include <opencv2/core/utils/logger.hpp>
+
 ////////////////////////////////////////////////////////////////////////
 // calcHist
 
@@ -163,8 +165,15 @@ namespace
 
         void collectGarbage();
 
-        void setBitShift(int) override {};
-        int getBitShift() const override {return 0;}
+        void setBitShift(int) override
+        {
+            CV_LOG_WARNING(NULL, "CUDA implementation of CLAHE algorithm does not support bit shift option");
+        };
+        int getBitShift() const override
+        {
+            CV_LOG_WARNING(NULL, "CUDA implementation of CLAHE algorithm does not support bit shift option");
+            return 0;
+        }
 
     private:
         double clipLimit_;


### PR DESCRIPTION
### Pull Request Readiness Checklist
Fix the build related to this [PR](https://github.com/opencv/opencv/pull/28014). This inherits from CLAHE, so the `setBitShift` and `getBitShift` functions need to be defined. 

Error this fixes:
```
error: invalid new-expression of abstract class type '{anonymous}::CLAHE_Impl'
opencv/contrib/modules/cudaimgproc/src/histogram.cpp:150:11: note: because the following virtual functions are pure within '{anonymous}::CLAHE_Impl':
    class CLAHE_Impl : public cv::cuda::CLAHE
In file included from opencv_contrib/modules/cudaimgproc/include/opencv2/cudaimgproc.hpp:51
opencv/modules/imgproc/include/opencv2/imgproc.hpp:1074:26: note: 'virtual void cv::CLAHE::setBitShift(int)'
    CV_WRAP virtual void setBitShift(int bitShift) = 0;
opencv/modules/imgproc/include/opencv2/imgproc.hpp:1080:25: note: 'virtual int cv::CLAHE::getBitShift() const'
    CV_WRAP virtual int getBitShift() const = 0;
```

This change was tested on Ubuntu 24.04 with the latest updates from the opencv and opencv_contrib repositories. This resulted in the build being successful. 

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
