### PR TITLE
5.x merge 4.x

### DIFF
--- a/modules/gapi/src/backends/ov/govbackend.cpp
+++ b/modules/gapi/src/backends/ov/govbackend.cpp
@@ -185,7 +185,7 @@ static void copyFromOV(const ov::Tensor &tensor, cv::Mat &mat) {
                                        mat.ptr<int>(),
                                        total);
     } else {
-        std::copy_n(reinterpret_cast<uint8_t*>(tensor.data()),
+        std::copy_n(reinterpret_cast<const uint8_t*>(tensor.data()),
                     tensor.get_byte_size(),
                     mat.ptr<uint8_t>());
     }

--- a/modules/xfeatures2d/src/brisk.cpp
+++ b/modules/xfeatures2d/src/brisk.cpp
@@ -627,7 +627,7 @@ BRISK_Impl::smoothedIntensity(const cv::Mat& image, const cv::Mat& integral, con
     ret_val = A * int(*ptr);
     ptr += dx + 1;
     ret_val += B * int(*ptr);
-    ptr += dy * imagecols + 1;
+    ptr += (dy + 1) * imagecols;
     ret_val += C * int(*ptr);
     ptr -= dx + 1;
     ret_val += D * int(*ptr);


### PR DESCRIPTION
OpenCV: https://github.com/opencv/opencv/pull/28116

#4040 from asmorkalov:as/cvv_demo_warn_fix

Manually ported from main repo:
#28029 from StefaniaHergane:hs/govbackend_update_ov_tensor_data_usage
#28091 from ParalYAO:fix/brisk/descriptor-calculation-pointer-bug

Previous "Merge 4.x": #4036