### PR TITLE
Remove deprecated linalg.linalg

### DIFF
--- a/modules/optflow/src/learn_prior.py
+++ b/modules/optflow/src/learn_prior.py
@@ -110,7 +110,7 @@ if len(w1) > 1:
         try:
             L1 = np.linalg.cholesky(Q1)
             break
-        except np.linalg.linalg.LinAlgError:
+        except np.linalg.LinAlgError:
             mev = min(np.linalg.eig(Q1)[0]).real
             assert (mev < 0)
             print('Q1', mev)
@@ -122,7 +122,7 @@ if len(w1) > 1:
         try:
             L2 = np.linalg.cholesky(Q2)
             break
-        except np.linalg.linalg.LinAlgError:
+        except np.linalg.LinAlgError:
             mev = min(np.linalg.eig(Q2)[0]).real
             assert (mev < 0)
             print('Q2', mev)


### PR DESCRIPTION
numpy.linalg.linalg is a deprecated alias for numpy.linalg, removed in NumPy 2.4.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
