### PR TITLE
Fix VGG::getDefaultName unresolved external symbol link error 

### DIFF
--- a/modules/xfeatures2d/src/vgg.cpp
+++ b/modules/xfeatures2d/src/vgg.cpp
@@ -559,12 +559,7 @@ void VGG_Impl::write (FileStorage& fs) const
     }
 }
 
-String VGG::getDefaultName() const
-{
-    return (Feature2D::getDefaultName() + ".VGG");
-}
-
-#endif
+#endif // OPENCV_XFEATURES2D_HAS_VGG_DATA
 
 Ptr<VGG> VGG::create( int desc, float isigma, bool img_normalize, bool use_scale_orientation,
                       float scale_factor, bool dsc_normalize )
@@ -578,6 +573,10 @@ Ptr<VGG> VGG::create( int desc, float isigma, bool img_normalize, bool use_scale
 #endif
 }
 
+String VGG::getDefaultName() const
+{
+    return (Feature2D::getDefaultName() + ".VGG");
+}
 
 } // END NAMESPACE XFEATURES2D
 } // END NAMESPACE CV


### PR DESCRIPTION
## Greetings!

When compiling DSO `xfeatures2d` with option `OPENCV_SKIP_FEATURES2D_DOWNLOADING=ON` on Windows, a problem was discovered:

```
Creating library OpenCV-Release-build/lib/Release/opencv_xfeatures2d4120.lib and object OpenCV-Release-build/lib/Release/opencv_xfeatures2d4120.exp
error LNK2019: unresolved external symbol "public: virtual class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > __cdecl cv::xfeatures2d::VGG::getDefaultName(void)const " (?getDefaultName@VGG@xfeatures2d@cv@@UEBA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@XZ) referenced in function "[thunk]:public: virtual class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > __cdecl cv::xfeatures2d::VGG::getDefaultName`vtordisp{4294967292,0}' (void)const " (?getDefaultName@VGG@xfeatures2d@cv@@$4PPPPPPPM@A@EBA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@XZ) [OpenCV-Release-build\modules\xfeatures2d\opencv_xfeatures2d.vcxproj] [OpenCV-Release.vcxproj]
OpenCV-Release-build\bin\Release\opencv_xfeatures2d4120.dll : fatal error LNK1120: 1 unresolved externals
```

However, this problem does not exist in the boostdesc implementation, which is built on a similar principle.

This patch fixes this behavior by moving the implementation of function `VGG::getDefaultName()` out of the macro `OPENCV_XFEATURES2D_HAS_VGG_DATA` scope.

This bug affects all versions starting with `4.7.0` and up to the current `4.x` and `5.x`.

---

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
