### PR TITLE
Stream waits in corners.cu before textures destruction

### DIFF
--- a/modules/cudaimgproc/src/cuda/corners.cu
+++ b/modules/cudaimgproc/src/cuda/corners.cu
@@ -154,7 +154,9 @@ namespace cv { namespace cuda { namespace device
             cudaSafeCall( cudaGetLastError() );
 
             if (stream == 0)
-                cudaSafeCall( cudaDeviceSynchronize() );
+                cudaSafeCall(cudaDeviceSynchronize());
+            else
+                cudaSafeCall(cudaStreamSynchronize(stream));
         }
 
         /////////////////////////////////////////// Corner Min Eigen Val /////////////////////////////////////////////////
@@ -262,6 +264,8 @@ namespace cv { namespace cuda { namespace device
 
             if (stream == 0)
                 cudaSafeCall(cudaDeviceSynchronize());
+            else
+                cudaSafeCall(cudaStreamSynchronize(stream));
         }
     }
 }}}


### PR DESCRIPTION
Using a texture handle after calling cudaDestroyTextureObject results in undefined behavior.
In GFTT/corners, we had the following sequence:

    Enter function F
    Create texture T
    Launch kernel K on stream S
    Return from function F, which destroys texture T

At step 4, we must guarantee that kernel K launched on stream S has completed and that T is no longer used before it is destroyed. Thats why I added stream synchronization before function return.

Relevant description from the CUDA SDK documentation:

https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TEXTURE__OBJECT.html#group__CUDART__TEXTURE__OBJECT__1_gae41ef138ba69d54b91068247f8f6c4e8:~:text=Use%20of%20the%20handle%20after%20this%20call%20is%20undefined%20behavior.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
