### PR TITLE
[bgsegm] Fix typo: impemented -> implemented

### DIFF
--- a/modules/bgsegm/include/opencv2/bgsegm.hpp
+++ b/modules/bgsegm/include/opencv2/bgsegm.hpp
@@ -147,7 +147,7 @@ public:
     rate. 0 means that the background model is not updated at all, 1 means that the background model
     is completely reinitialized from the last frame.
 
-    @note This method has a default virtual implementation that throws a "not impemented" error.
+    @note This method has a default virtual implementation that throws a "not implemented" error.
     Foreground masking may not be supported by all background subtractors.
     */
     CV_WRAP virtual void apply(InputArray image, InputArray knownForegroundMask, OutputArray fgmask, double learningRate=-1) CV_OVERRIDE = 0;


### PR DESCRIPTION
Fixed a typo in the documentation comment in bgsegm.hpp.  
Changed "not impemented" to "not implemented" to correct spelling.

This is a small quality-of-life improvement for clarity in the code docs.

