### PR TITLE
Made imgcodecs optional for ximgproc module.

### DIFF
--- a/modules/ximgproc/CMakeLists.txt
+++ b/modules/ximgproc/CMakeLists.txt
@@ -1,2 +1,2 @@
 set(the_description "Extended image processing module. It includes edge-aware filters and etc.")
-ocv_define_module(ximgproc opencv_core opencv_imgproc opencv_calib3d opencv_imgcodecs opencv_video WRAP python java objc js)
+ocv_define_module(ximgproc opencv_core opencv_imgproc opencv_calib3d opencv_video OPTIONAL opencv_imgcodecs WRAP python java objc js)

--- a/modules/ximgproc/src/disparity_filters.cpp
+++ b/modules/ximgproc/src/disparity_filters.cpp
@@ -36,9 +36,12 @@
 
 #include "precomp.hpp"
 #include "opencv2/ximgproc/disparity_filter.hpp"
-#include "opencv2/imgcodecs.hpp"
 #include <math.h>
 #include <vector>
+
+#ifdef HAVE_OPENCV_IMGCODECS
+#  include "opencv2/imgcodecs.hpp"
+#endif
 
 namespace cv {
 namespace ximgproc {
@@ -492,8 +495,9 @@ Ptr<DisparityWLSFilter> createDisparityWLSFilterGeneric(bool use_confidence)
 
 #define UNKNOWN_DISPARITY 16320
 
-int readGT(String src_path,OutputArray dst)
+int readGT(String src_path, OutputArray dst)
 {
+#ifdef HAVE_OPENCV_IMGCODECS
     Mat src = imread(src_path,IMREAD_UNCHANGED);
     dst.create(src.rows,src.cols,CV_16S);
     Mat& dstMat = dst.getMatRef();
@@ -525,6 +529,9 @@ int readGT(String src_path,OutputArray dst)
     }
     else
         return 1;
+#else
+    CV_Error(Error::StsNotImplemented, "The requested function/feature is not implemented");
+#endif
 }
 
 double computeMSE(InputArray GT, InputArray src, Rect ROI)


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
