### PR TITLE
Fix coverRatio calculation in edge_drawing.cpp

### DIFF
--- a/modules/ximgproc/src/edge_drawing.cpp
+++ b/modules/ximgproc/src/edge_drawing.cpp
@@ -4481,7 +4481,7 @@ void EdgeDrawingImpl::addCircle(Circle* circles, int& noCircles, double xc, doub
     circles[noCircles].yc = yc;
     circles[noCircles].r = r;
     circles[noCircles].circleFitError = circleFitError;
-    circles[noCircles].coverRatio = noPixels / CV_2PI * r;
+    circles[noCircles].coverRatio = noPixels / (CV_2PI * r);
 
     circles[noCircles].x = x;
     circles[noCircles].y = y;


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
