### PR TITLE
Move GpuMat initialization to a more suitable scope.

### DIFF
--- a/modules/cudaoptflow/src/nvidiaOpticalFlow.cpp
+++ b/modules/cudaoptflow/src/nvidiaOpticalFlow.cpp
@@ -1020,9 +1020,6 @@ void NvidiaOpticalFlowImpl_2::calc(InputArray _frame0, InputArray _frame1, Input
     GpuMat flowXYGpuMat(Size((m_width + m_hwGridSize - 1) / m_hwGridSize,
         (m_height + m_hwGridSize - 1) / m_hwGridSize), CV_16SC2,
         (void*)m_flowXYcuDevPtr, m_outputBufferStrideInfo.strideInfo[0].strideXInBytes);
-    GpuMat flowXYGpuMatUpScaled(Size((m_width + m_gridSize - 1) / m_gridSize,
-        (m_height + m_gridSize - 1) / m_gridSize), CV_16SC2,
-        (void*)m_flowXYUpScaledcuDevPtr, m_outputUpScaledBufferStrideInfo.strideInfo[0].strideXInBytes);
 
     //check whether frame0 is Mat or GpuMat
     if (_frame0.isMat())
@@ -1105,6 +1102,9 @@ void NvidiaOpticalFlowImpl_2::calc(InputArray _frame0, InputArray _frame1, Input
 
     if (m_scaleFactor > 1)
     {
+        GpuMat flowXYGpuMatUpScaled(Size((m_width + m_gridSize - 1) / m_gridSize,
+            (m_height + m_gridSize - 1) / m_gridSize), CV_16SC2,
+            (void*)m_flowXYUpScaledcuDevPtr, m_outputUpScaledBufferStrideInfo.strideInfo[0].strideXInBytes);
         uint32_t nSrcWidth = flowXYGpuMat.size().width;
         uint32_t nSrcHeight = flowXYGpuMat.size().height;
         uint32_t nSrcPitch = m_outputBufferStrideInfo.strideInfo[0].strideXInBytes;


### PR DESCRIPTION
Fix #4059 

I moved the initialization of the upscaled buffer to the scope where it's actually used, ensuring that the stride variable is properly initialized before access.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
