### PR TITLE
Clarify disparity_map_right type in DisparityFilter documentation

### DIFF
--- a/modules/ximgproc/include/opencv2/ximgproc/disparity_filter.hpp
+++ b/modules/ximgproc/include/opencv2/ximgproc/disparity_filter.hpp
@@ -65,7 +65,8 @@ public:
     @param filtered_disparity_map output disparity map.
 
     @param disparity_map_right optional argument, some implementations might also use the disparity map
-    of the right view to compute confidence maps, for instance.
+    of the right view to compute confidence maps. If provided, it must be a single-channel CV_32F matrix,
+    otherwise a runtime assertion will fail.
 
     @param ROI region of the disparity map to filter. Optional, usually it should be set automatically.
 


### PR DESCRIPTION
The documentation of cv::ximgproc::DisparityFilter::filter()
did not specify the required type of the optional right disparity map.

In practice, the implementation requires a single-channel CV_32F matrix,
otherwise a runtime assertion is triggered.

This PR clarifies the expected type in the Doxygen comment.
