### PR TITLE
cudev: fix CUDA texture pitch alignment for createContinuous GpuMat

### DIFF
--- a/modules/cudev/include/opencv2/cudev/ptr2d/texture.hpp
+++ b/modules/cudev/include/opencv2/cudev/ptr2d/texture.hpp
@@ -176,17 +176,28 @@ namespace cv {  namespace cudev {
             texRes.res.pitch2D.height = rows;
             texRes.res.pitch2D.width = cols;
             // temporary fix for single row/columns until TexturePtr is reworked
-            if (rows == 1 || cols == 1) {
+            int currentDevice = 0;
+            CV_CUDEV_SAFE_CALL(cudaGetDevice(&currentDevice));
+
+            cudaDeviceProp prop;
+            CV_CUDEV_SAFE_CALL(cudaGetDeviceProperties(&prop, currentDevice));
+
+            if (rows == 1 || cols == 1 ||
+                (step % prop.texturePitchAlignment) != 0)
+            {
                 size_t dStep = 0;
                 CV_CUDEV_SAFE_CALL(cudaMallocPitch(&internalSrc, &dStep, cols * sizeof(T1), rows));
-                CV_CUDEV_SAFE_CALL(cudaMemcpy2D(internalSrc, dStep, data, step, cols * sizeof(T1), rows, cudaMemcpyDeviceToDevice));
+                CV_CUDEV_SAFE_CALL(cudaMemcpy2D(internalSrc, dStep, data, step,
+                                               cols * sizeof(T1), rows,
+                                               cudaMemcpyDeviceToDevice));
                 texRes.res.pitch2D.devPtr = internalSrc;
                 texRes.res.pitch2D.pitchInBytes = dStep;
+           }
+           else {
+               texRes.res.pitch2D.devPtr = data;
+               texRes.res.pitch2D.pitchInBytes = step;
             }
-            else {
-                texRes.res.pitch2D.devPtr = data;
-                texRes.res.pitch2D.pitchInBytes = step;
-            }
+
             texRes.res.pitch2D.desc = cudaCreateChannelDesc<T1>();
             createTextureObject(texRes, normalizedCoords, filterMode, addressMode, readMode);
         }


### PR DESCRIPTION
### Summary
This PR fixes a CUDA texture creation failure when using `cv::cuda::createContinuous()`.

`createContinuous()` may produce a `GpuMat` with a pitch that is not aligned to
`cudaDeviceProp::texturePitchAlignment`. When such a matrix is used in CUDA
texture-backed operations (e.g. `cv::cuda::resize`), `createTextureObject()`
fails with an `invalid argument` error.

The fix extends the existing fallback logic to also handle misaligned pitch
values by copying the data into an aligned pitched buffer when required.

### Root Cause
`createContinuous()` allocates memory via `cudaMalloc` and reshapes it, which
can result in an unaligned `step`. CUDA Pitch2D textures require the pitch to be
aligned to `texturePitchAlignment`, but the previous logic only handled
single-row or single-column cases.

### Changes
- Extend the texture fallback condition to also check pitch alignment
- Preserve the fast path for already-aligned pitched allocations
- No behavior change for correctly aligned `GpuMat` instances

### Testing
- Verified locally with a minimal reproducer using `cv::cuda::resize`
- Existing behavior remains unchanged for pitched `GpuMat` allocations


