### PR TITLE
Fix issue #28407: cv::cuda::resize fails with continuous GpuMat

### DIFF
--- a/modules/cudawarping/test/test_resize.cpp
+++ b/modules/cudawarping/test/test_resize.cpp
@@ -261,5 +261,59 @@ INSTANTIATE_TEST_CASE_P(CUDA_Warping, ResizeTextures, testing::Combine(
     testing::Values(Interpolation(cv::INTER_NEAREST), Interpolation(cv::INTER_LINEAR), Interpolation(cv::INTER_CUBIC))));
 
 
+
+// Test for issue #28407: cv::cuda::resize fails with continuous GpuMat
+PARAM_TEST_CASE(ResizeContinuous, cv::cuda::DeviceInfo, cv::Size, MatType, Interpolation)
+{
+    cv::cuda::DeviceInfo devInfo;
+    cv::Size size;
+    int type;
+    int interpolation;
+
+    virtual void SetUp()
+    {
+        devInfo = GET_PARAM(0);
+        size = GET_PARAM(1);
+        type = GET_PARAM(2);
+        interpolation = GET_PARAM(3);
+
+        cv::cuda::setDevice(devInfo.deviceID());
+    }
+};
+
+CUDA_TEST_P(ResizeContinuous, Regression_Issue28407)
+{
+    // Test both regular and continuous GpuMat
+    cv::Mat src = randomMat(size, type);
+
+    // Test 1: Regular GpuMat (should work)
+    cv::cuda::GpuMat d_src_regular(src);
+    cv::cuda::GpuMat d_dst_regular;
+    EXPECT_NO_THROW(
+        cv::cuda::resize(d_src_regular, d_dst_regular, cv::Size(size.width * 2, size.height * 2), 0, 0, interpolation)
+    );
+
+    // Test 2: Continuous GpuMat (this is the bug - should work but currently fails)
+    cv::cuda::GpuMat d_src_continuous = cv::cuda::createContinuous(size.height, size.width, type);
+    d_src_continuous.upload(src);
+    cv::cuda::GpuMat d_dst_continuous;
+    EXPECT_NO_THROW(
+        cv::cuda::resize(d_src_continuous, d_dst_continuous, cv::Size(size.width * 2, size.height * 2), 0, 0, interpolation)
+    );
+
+    // Verify both produce the same result
+    cv::Mat h_dst_regular, h_dst_continuous;
+    d_dst_regular.download(h_dst_regular);
+    d_dst_continuous.download(h_dst_continuous);
+
+    EXPECT_MAT_NEAR(h_dst_regular, h_dst_continuous, 0.0);
+}
+
+INSTANTIATE_TEST_CASE_P(CUDA_Warping, ResizeContinuous, testing::Combine(
+    ALL_DEVICES,
+    testing::Values(cv::Size(10, 10), cv::Size(64, 64), cv::Size(128, 128)),
+    testing::Values(MatType(CV_8UC1), MatType(CV_8UC3), MatType(CV_32FC1)),
+    testing::Values(Interpolation(cv::INTER_NEAREST), Interpolation(cv::INTER_LINEAR), Interpolation(cv::INTER_CUBIC))));
+
 }} // namespace
 #endif // HAVE_CUDA

--- a/modules/cudev/include/opencv2/cudev/ptr2d/texture.hpp
+++ b/modules/cudev/include/opencv2/cudev/ptr2d/texture.hpp
@@ -175,8 +175,11 @@ namespace cv {  namespace cudev {
             texRes.resType = cudaResourceTypePitch2D;
             texRes.res.pitch2D.height = rows;
             texRes.res.pitch2D.width = cols;
-            // temporary fix for single row/columns until TexturePtr is reworked
-            if (rows == 1 || cols == 1) {
+            const size_t minPitch = cols * sizeof(T1);
+            const size_t alignment = 32;
+            const bool isPitchAligned = (step % alignment == 0);
+            const bool needsReallocation = (rows == 1) || (cols == 1) || (step < minPitch) || (!isPitchAligned);
+            if (needsReallocation) {
                 size_t dStep = 0;
                 CV_CUDEV_SAFE_CALL(cudaMallocPitch(&internalSrc, &dStep, cols * sizeof(T1), rows));
                 CV_CUDEV_SAFE_CALL(cudaMemcpy2D(internalSrc, dStep, data, step, cols * sizeof(T1), rows, cudaMemcpyDeviceToDevice));


### PR DESCRIPTION

## Summary
Fixes issue where `cv::cuda::resize` fails with error "invalid argument in function 'createTextureObject'" when using GpuMat created via `cv::cuda::createContinuous()`.

## Root Cause
- CUDA texture objects require properly aligned pitch values
- `createContinuous()` GpuMat may have pitch that doesn't meet alignment requirements
- Previous code only handled single row/column cases, not invalid pitch

## Changes
- **texture.hpp**: Added validation to check if step/pitch meets CUDA requirements
- **test_resize.cpp**: Added regression test `ResizeContinuous` that verifies:
  - Regular GpuMat works (baseline)
  - Continuous GpuMat works (previously failed)
  - Both produce identical results

## Testing
- Test covers multiple sizes (10x10, 64x64, 128x128)
- Multiple data types (CV_8UC1, CV_8UC3, CV_32FC1)
- Multiple interpolation methods (NEAREST, LINEAR, CUBIC)

Fixes opencv/opencv#28407



### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
