### PR TITLE
cudacodec: fix black/white/uvWhite of BT2020/BT2020C

### DIFF
--- a/modules/cudacodec/src/nvidia_surface_format_to_color_converter.cpp
+++ b/modules/cudacodec/src/nvidia_surface_format_to_color_converter.cpp
@@ -126,7 +126,9 @@ void GetConstants(int iMatrix, float& wr, float& wb, int& black, int& white, int
     case cv::cudacodec::ColorSpaceStandard::BT2020C:
         wr = 0.2627f; wb = 0.0593f;
         // 10-bit only
-        black = 64 << 6; white = 940 << 6;
+        black <<= 8;
+        white <<= 8;
+        uvWhite <<= 8;
         max = (1 << 16) - 1;
         break;
     }

--- a/modules/cudacodec/test/test_video.cpp
+++ b/modules/cudacodec/test/test_video.cpp
@@ -233,7 +233,197 @@ void generateYuv444(Mat bgr, Mat& yuv444, Mat& bgrFromYuv, const bool fullRange)
     bgrFromYuv32F.convertTo(bgrFromYuv, CV_8UC3);
 }
 
-void generateTestImages(Mat bgrIn, Mat& testImg, Mat& out, const cudacodec::SurfaceFormat inputFormat, const cudacodec::ColorFormat outputFormat, const cudacodec::BitDepth outputBitDepth = cudacodec::BitDepth::EIGHT, bool planar = false, const bool fullRange = false) {
+// convert BGR16 to the requested output format, apply bit depth conversion and planar layout
+void convertBT2020Output(const Mat& bgrOut16, const Mat& y16, Mat& out,
+    const cudacodec::ColorFormat outputFormat, const cudacodec::BitDepth outputBitDepth,
+    const cv::cudacodec::ColorSpaceStandard colorSpace, bool planar, bool fullRange, int max)
+{
+    Mat imgOut16;
+    switch (outputFormat)
+    {
+    case cudacodec::ColorFormat::BGR:
+        imgOut16 = bgrOut16;
+        break;
+    case cudacodec::ColorFormat::BGRA:
+        cv::cvtColor(bgrOut16, imgOut16, COLOR_BGR2BGRA);
+        break;
+    case cudacodec::ColorFormat::RGB:
+        cv::cvtColor(bgrOut16, imgOut16, COLOR_BGR2RGB);
+        break;
+    case cudacodec::ColorFormat::RGBA:
+        cv::cvtColor(bgrOut16, imgOut16, COLOR_BGR2RGBA);
+        break;
+    case cudacodec::ColorFormat::GRAY: {
+        const int low = fullRange ? 0 : (1 << 12);
+        std::array<std::array<float, 3>, 3> invMatrix = getYuv2RgbMatrixEx(colorSpace, fullRange);
+        const float lumaCoeff = invMatrix[0][0];
+        Mat yF;
+        y16.convertTo(yF, CV_32F);
+        yF -= low;
+        yF = lumaCoeff * yF;
+        yF = cv::max(yF, 0);
+        yF = cv::min(yF, (double)max);
+        Mat grayFromY;
+        yF.convertTo(grayFromY, CV_16U);
+        imgOut16 = grayFromY;
+        break;
+    }
+    default:
+       CV_Error(Error::StsUnsupportedFormat, "Unsupported output format");
+    }
+
+    // Handle bit depth conversion
+    if (outputBitDepth == cudacodec::BitDepth::EIGHT) {
+        Mat imgOut8;
+        imgOut16.convertTo(imgOut8, outputFormat == cudacodec::ColorFormat::GRAY ? CV_8U : CV_8UC(imgOut16.channels()), 1.0 / 256.0);
+        imgOut16 = imgOut8;
+    }
+
+    if (planar && outputFormat != cudacodec::ColorFormat::GRAY) {
+        std::vector<Mat> splits;
+        cv::split(imgOut16, splits);
+        const int type = CV_MAKE_TYPE(CV_MAT_DEPTH(imgOut16.flags), 1);
+        out = Mat(imgOut16.rows * imgOut16.channels(), imgOut16.cols, type);
+        for (int i = 0; i < imgOut16.channels(); i++)
+            splits[i].copyTo(out(Rect(0, i * imgOut16.rows, imgOut16.cols, imgOut16.rows)));
+    }
+    else {
+        imgOut16.copyTo(out);
+    }
+}
+
+// inverse YUV to BGR conversion using the given matrix
+Mat inverseBT2020ToBgr16(const Mat& yQ, const Mat& uQ, const Mat& vQ,
+    const cv::cudacodec::ColorSpaceStandard colorSpace, bool fullRange, int max)
+{
+    std::array<std::array<float, 3>, 3> invMatrix = getYuv2RgbMatrixEx(colorSpace, fullRange);
+    Mat bgrSplitOut[3];
+    bgrSplitOut[2] = invMatrix[0][0] * yQ + invMatrix[0][2] * vQ;
+    bgrSplitOut[1] = invMatrix[1][0] * yQ + invMatrix[1][1] * uQ + invMatrix[1][2] * vQ;
+    bgrSplitOut[0] = invMatrix[2][0] * yQ + invMatrix[2][1] * uQ;
+
+    Mat bgrOut32F;
+    cv::merge(bgrSplitOut, 3, bgrOut32F);
+    bgrOut32F = cv::max(bgrOut32F, 0);
+    bgrOut32F = cv::min(bgrOut32F, (double)max);
+    Mat bgrOut16;
+    bgrOut32F.convertTo(bgrOut16, CV_16UC3);
+    return bgrOut16;
+}
+
+void generateTestImagesBT2020(Mat bgrIn, Mat& testImg, Mat& out, const cudacodec::SurfaceFormat inputFormat,
+    const cudacodec::ColorFormat outputFormat, const cudacodec::ColorSpaceStandard colorSpace,
+    const cudacodec::BitDepth outputBitDepth = cudacodec::BitDepth::SIXTEEN, bool planar = false, const bool fullRange = false)
+{
+    float wr, wb;
+    int black, white, uvWhite, max;
+    GetConstantsEx(static_cast<int>(colorSpace), wr, wb, black, white, uvWhite, max, fullRange);
+
+    const int yAdj = fullRange ? 0 : black;
+    const int uvAdj = (uvWhite + (fullRange ? 0 : black)) / 2 + (fullRange ? 0 : 1);
+
+    // Convert input BGR (8-bit) to float and then to YUV using BT2020 matrix
+    Mat bgr32F;
+    bgrIn.convertTo(bgr32F, CV_32F);
+    // Scale to full 16-bit range
+    bgr32F *= max / 255.0;
+    Mat bgrSplit32F[3];
+    cv::split(bgr32F, bgrSplit32F);
+
+    std::array<std::array<float, 3>, 3> fwdMatrix = getRgb2YuvMatrixEx(colorSpace, fullRange);
+
+    Mat Y = fwdMatrix[0][0] * bgrSplit32F[2] + fwdMatrix[0][1] * bgrSplit32F[1] + fwdMatrix[0][2] * bgrSplit32F[0] + yAdj;
+    Mat U = fwdMatrix[1][0] * bgrSplit32F[2] + fwdMatrix[1][1] * bgrSplit32F[1] + fwdMatrix[1][2] * bgrSplit32F[0] + uvAdj;
+    Mat V = fwdMatrix[2][0] * bgrSplit32F[2] + fwdMatrix[2][1] * bgrSplit32F[1] + fwdMatrix[2][2] * bgrSplit32F[0] + uvAdj;
+
+    // Clamp to valid range
+    Y = cv::max(Y, 0); Y = cv::min(Y, (double)max);
+    U = cv::max(U, 0); U = cv::min(U, (double)max);
+    V = cv::max(V, 0); V = cv::min(V, (double)max);
+
+    Mat yuv16;
+    Mat y16;
+    Y.convertTo(y16, CV_16U);
+
+    switch (inputFormat) {
+    case cudacodec::SurfaceFormat::SF_P016: {
+        // P016: NV12-like layout with 16-bit samples
+        // Subsample U and V for 4:2:0
+        Mat uSub, vSub;
+        cv::resize(U, uSub, Size(bgrIn.cols / 2, bgrIn.rows / 2), 0, 0, INTER_AREA);
+        cv::resize(V, vSub, Size(bgrIn.cols / 2, bgrIn.rows / 2), 0, 0, INTER_AREA);
+
+        Mat u16, v16;
+        uSub.convertTo(u16, CV_16U);
+        vSub.convertTo(v16, CV_16U);
+
+        // Interleave UV
+        Mat uvInterleaved;
+        Mat uvArr[2] = { u16, v16 };
+        cv::merge(uvArr, 2, uvInterleaved);
+        Mat uvFlat(uvInterleaved.rows, uvInterleaved.cols * 2, CV_16U, uvInterleaved.data, uvInterleaved.step);
+
+        yuv16 = Mat(static_cast<int>(bgrIn.rows * 1.5), bgrIn.cols, CV_16U);
+        y16.copyTo(yuv16(Rect(0, 0, bgrIn.cols, bgrIn.rows)));
+        uvFlat.copyTo(yuv16(Rect(0, bgrIn.rows, bgrIn.cols, bgrIn.rows / 2)));
+
+        // Reconstruct U/V at full resolution for reference
+        Mat uFull, vFull;
+        cv::resize(uSub, uFull, bgrIn.size(), 0, 0, INTER_NEAREST);
+        cv::resize(vSub, vFull, bgrIn.size(), 0, 0, INTER_NEAREST);
+
+        // Convert quantized YUV back to float for inverse
+        Mat yQ, uQ, vQ;
+        y16.convertTo(yQ, CV_32F);
+        uFull.convertTo(uQ, CV_32F);
+        vFull.convertTo(vQ, CV_32F);
+
+        yQ -= yAdj;
+        uQ -= uvAdj;
+        vQ -= uvAdj;
+
+        Mat bgrOut16 = inverseBT2020ToBgr16(yQ, uQ, vQ, colorSpace, fullRange, max);
+        convertBT2020Output(bgrOut16, y16, out, outputFormat, outputBitDepth, colorSpace, planar, fullRange, max);
+        break;
+    }
+    case cudacodec::SurfaceFormat::SF_YUV444_16Bit: {
+        Mat u16, v16;
+        U.convertTo(u16, CV_16U);
+        V.convertTo(v16, CV_16U);
+
+        yuv16 = Mat(bgrIn.rows * 3, bgrIn.cols, CV_16U);
+        y16.copyTo(yuv16(Rect(0, 0, bgrIn.cols, bgrIn.rows)));
+        u16.copyTo(yuv16(Rect(0, bgrIn.rows, bgrIn.cols, bgrIn.rows)));
+        v16.copyTo(yuv16(Rect(0, 2 * bgrIn.rows, bgrIn.cols, bgrIn.rows)));
+
+        // Convert quantized YUV back to float for inverse
+        Mat yQ, uQ, vQ;
+        y16.convertTo(yQ, CV_32F);
+        u16.convertTo(uQ, CV_32F);
+        v16.convertTo(vQ, CV_32F);
+
+        yQ -= yAdj;
+        uQ -= uvAdj;
+        vQ -= uvAdj;
+
+        Mat bgrOut16 = inverseBT2020ToBgr16(yQ, uQ, vQ, colorSpace, fullRange, max);
+        convertBT2020Output(bgrOut16, y16, out, outputFormat, outputBitDepth, colorSpace, planar, fullRange, max);
+        break;
+    }
+    default:
+        CV_Error(Error::StsUnsupportedFormat, "BT2020 test only supports 16-bit surface formats");
+    }
+
+    testImg = yuv16;
+}
+
+void generateTestImages(Mat bgrIn, Mat& testImg, Mat& out, const cudacodec::SurfaceFormat inputFormat, const cudacodec::ColorFormat outputFormat, const cudacodec::BitDepth outputBitDepth = cudacodec::BitDepth::EIGHT, bool planar = false, const bool fullRange = false, const cv::cudacodec::ColorSpaceStandard colorSpace = cv::cudacodec::ColorSpaceStandard::BT601) {
+    const bool isBT601 = (colorSpace == cv::cudacodec::ColorSpaceStandard::BT601 || colorSpace == cv::cudacodec::ColorSpaceStandard::BT470);
+    if (!isBT601) {
+        generateTestImagesBT2020(bgrIn, testImg, out, inputFormat, outputFormat, colorSpace, outputBitDepth, planar, fullRange);
+        return;
+    }
+
     Mat imgOutFromYuv, imgOut8;
     Mat yuv8;
 
@@ -1426,7 +1616,7 @@ INSTANTIATE_TEST_CASE_P(CUDA_Codec, Seek, ALL_DEVICES);
 
 #if defined(HAVE_CUDA)
 
-PARAM_TEST_CASE(YuvConverter, cv::cuda::DeviceInfo, SurfaceFormats, ColorFormats, BitDepths, bool, bool)
+PARAM_TEST_CASE(YuvConverter, cv::cuda::DeviceInfo, SurfaceFormats, ColorFormats, BitDepths, bool, bool, int)
 {
 };
 
@@ -1438,21 +1628,31 @@ CUDA_TEST_P(YuvConverter, Reader)
     const cudacodec::BitDepth bitDepth = static_cast<cudacodec::BitDepth>(static_cast<int>(GET_PARAM(3)));
     const bool planar = GET_PARAM(4);
     const bool fullRange = GET_PARAM(5);
-    Ptr<cv::cudacodec::NVSurfaceToColorConverter> yuvConverter = cudacodec::createNVSurfaceToColorConverter(cv::cudacodec::ColorSpaceStandard::BT601, fullRange);
+    const cudacodec::ColorSpaceStandard colorSpace = static_cast<cudacodec::ColorSpaceStandard>(GET_PARAM(6));
+    Ptr<cv::cudacodec::NVSurfaceToColorConverter> yuvConverter = cudacodec::createNVSurfaceToColorConverter(colorSpace, fullRange);
     const int rows = 64, cols = 128;
     Mat bgr(rows, cols, CV_8UC3);
     cv::randu(bgr, Scalar(0, 0, 0), Scalar(255, 255, 255));
     Mat bgrHost;
-    Mat nv12Interleaved, bgrFromYuv;
-    generateTestImages(bgr, nv12Interleaved, bgrFromYuv, surfaceFormat, outputFormat, bitDepth, planar, fullRange);
-    GpuMat nv12Device(nv12Interleaved), bgrDevice(bgrFromYuv.size(), bgrFromYuv.type());
-    yuvConverter->convert(nv12Device, bgrDevice, surfaceFormat, outputFormat, bitDepth, planar);
-    bgrDevice.download(bgrHost);
-    EXPECT_MAT_NEAR(bgrFromYuv, bgrHost, bitDepth == cudacodec::BitDepth::EIGHT ? 2 : 512);
+    Mat yuvInterleaved, bgrFromYuv;
+    generateTestImages(bgr, yuvInterleaved, bgrFromYuv, surfaceFormat, outputFormat, bitDepth, planar, fullRange, colorSpace);
+    GpuMat yuvDevice(yuvInterleaved), outDevice(bgrFromYuv.size(), bgrFromYuv.type());
+    yuvConverter->convert(yuvDevice, outDevice, surfaceFormat, outputFormat, bitDepth, planar);
+    outDevice.download(bgrHost);
+    const double tolerance = bitDepth == cudacodec::BitDepth::EIGHT ? 2 : 512;
+    EXPECT_MAT_NEAR(bgrFromYuv, bgrHost, tolerance);
 }
 
 #define BIT_DEPTHS testing::Values(BitDepths(cudacodec::BitDepth::EIGHT), BitDepths(cudacodec::BitDepth::SIXTEEN))
-INSTANTIATE_TEST_CASE_P(CUDA_Codec, YuvConverter, testing::Combine(
-    ALL_DEVICES, SurfaceFormats::all(), ColorFormats::all(), BIT_DEPTHS, testing::Bool(), testing::Bool()));
+INSTANTIATE_TEST_CASE_P(CUDA_Codec_BT601, YuvConverter, testing::Combine(
+    ALL_DEVICES, SurfaceFormats::all(), ColorFormats::all(), BIT_DEPTHS, testing::Bool(), testing::Bool(),
+    testing::Values(static_cast<int>(cudacodec::ColorSpaceStandard::BT601))));
+
+INSTANTIATE_TEST_CASE_P(CUDA_Codec_BT2020, YuvConverter, testing::Combine(
+    ALL_DEVICES,
+    testing::Values(SurfaceFormats(cudacodec::SurfaceFormat::SF_P016), SurfaceFormats(cudacodec::SurfaceFormat::SF_YUV444_16Bit)),
+    ColorFormats::all(), BIT_DEPTHS, testing::Bool(), testing::Bool(),
+    testing::Values(static_cast<int>(cudacodec::ColorSpaceStandard::BT2020))));
 
 #endif // HAVE_CUDA
+}} // namespace

--- a/modules/cudacodec/test/test_video.cpp
+++ b/modules/cudacodec/test/test_video.cpp
@@ -259,13 +259,12 @@ void generateTestImages(Mat bgrIn, Mat& testImg, Mat& out, const cudacodec::Surf
         imgOutBitDepthOut = imgOut8;
 
     if (planar && outputFormat != cudacodec::ColorFormat::GRAY) {
-        Mat* bgrSplit = new Mat[imgOutBitDepthOut.channels()];
+        std::vector<Mat> bgrSplit;
         cv::split(imgOutBitDepthOut, bgrSplit);
         const int type = CV_MAKE_TYPE(CV_MAT_DEPTH(imgOutBitDepthOut.flags), 1);
         out = Mat(imgOutBitDepthOut.rows * imgOutBitDepthOut.channels(), imgOutBitDepthOut.cols, type);
         for (int i = 0; i < imgOut8.channels(); i++)
             bgrSplit[i].copyTo(out(Rect(0, i * imgOut8.rows, imgOut8.cols, imgOut8.rows)));
-        delete[] bgrSplit;
     }
     else
         imgOutBitDepthOut.copyTo(out);

--- a/modules/cudacodec/test/test_video.cpp
+++ b/modules/cudacodec/test/test_video.cpp
@@ -44,11 +44,236 @@
 namespace opencv_test {
     namespace {
 
-#if defined(HAVE_NVCUVID) || defined(HAVE_NVCUVENC)
+
+#if defined(HAVE_NVCUVID) || defined(HAVE_NVCUVENC) || defined(HAVE_CUDA)
+
+void inline GetConstants(float& wr, float& wb, int& black, int& white, int& uvWhite, int& max, bool fullRange = false) {
+    if (fullRange) {
+        black = 0; white = 255; uvWhite = 255;
+    }
+    else {
+        black = 16; white = 235; uvWhite = 240;
+    }
+    max = 255;
+    wr = 0.2990f; wb = 0.1140f;
+}
+
+std::array<std::array<float, 3>, 3> getYuv2RgbMatrix(const bool fullRange = false) {
+    float wr, wb;
+    int black, white, uvWhite, max;
+    GetConstants(wr, wb, black, white, uvWhite, max, fullRange);
+    std::array<std::array<float, 3>, 3> mat = { {
+        {1.0f, 0.0f, (1.0f - wr) / 0.5f},
+        {1.0f, -wb * (1.0f - wb) / 0.5f / (1 - wb - wr), -wr * (1 - wr) / 0.5f / (1 - wb - wr)},
+        {1.0f, (1.0f - wb) / 0.5f, 0.0f},
+    } };
+    for (int i = 0; i < 3; i++) {
+        for (int j = 0; j < 3; j++) {
+            if (j == 0)
+                mat[i][j] = (float)(1.0 * max / (white - black) * mat[i][j]);
+            else
+                mat[i][j] = (float)(1.0 * max / (uvWhite - black) * mat[i][j]);
+        }
+    }
+    return mat;
+}
+
+std::array<std::array<float, 3>, 3> getRgb2YuvMatrix(const bool fullRange = false) {
+    float wr, wb;
+    int black, white, max, uvWhite;
+    GetConstants(wr, wb, black, white, uvWhite, max, fullRange);
+    std::array<std::array<float, 3>, 3> mat = { {
+        {wr, 1.0f - wb - wr, wb},
+        {-0.5f * wr / (1.0f - wb), -0.5f * (1 - wb - wr) / (1.0f - wb), 0.5f},
+        {0.5f, -0.5f * (1.0f - wb - wr) / (1.0f - wr), -0.5f * wb / (1.0f - wr)},
+    } };
+    for (int i = 0; i < 3; i++) {
+        for (int j = 0; j < 3; j++) {
+            if (j == 0)
+                mat[i][j] = (float)(1.0 * (white - black) / max * mat[i][j]);
+            else
+                mat[i][j] = (float)(1.0 * (uvWhite - black) / max * mat[i][j]);
+        }
+    }
+    return mat;
+}
+
 CV_ENUM(ColorFormats, cudacodec::ColorFormat::BGR, cudacodec::ColorFormat::BGRA, cudacodec::ColorFormat::RGB, cudacodec::ColorFormat::RGBA, cudacodec::ColorFormat::GRAY)
 CV_ENUM(SurfaceFormats, cudacodec::SurfaceFormat::SF_NV12, cudacodec::SurfaceFormat::SF_P016, cudacodec::SurfaceFormat::SF_YUV444, cudacodec::SurfaceFormat::SF_YUV444_16Bit)
 CV_ENUM(BitDepths, cudacodec::BitDepth::UNCHANGED, cudacodec::BitDepth::EIGHT, cudacodec::BitDepth::SIXTEEN)
 
+void generateGray(Mat bgr, Mat& y, Mat& grayFromY, const bool fullRange) {
+    Mat yuvI420;
+    cv::cvtColor(bgr, yuvI420, COLOR_BGR2YUV_I420);
+    yuvI420(Rect(0, 0, bgr.cols, bgr.rows)).copyTo(y);
+    if (fullRange) {
+        y -= 16;
+        y *= 255.0 / 219.0;
+    }
+    y.copyTo(grayFromY);
+    if (!fullRange) {
+        grayFromY -= 16;
+        grayFromY *= 255.0 / 219.0;
+    }
+}
+
+void generateNv12(Mat bgr, Mat& nv12Interleaved, Mat& bgrFromYuv, const bool fullRange) {
+    Mat yuvI420;
+    cv::cvtColor(bgr, yuvI420, COLOR_BGR2YUV_I420);
+    cv::cvtColor(yuvI420, bgrFromYuv, COLOR_YUV2BGR_I420);
+
+    Mat uv = yuvI420(Rect(0, bgr.rows, bgr.cols, bgr.rows / 2));
+    Mat u0 = uv(Rect(0, 0, uv.cols / 2, uv.rows / 2));
+    Mat u1 = uv(Rect(uv.cols / 2, 0, uv.cols / 2, uv.rows / 2));
+    Mat v0 = uv(Rect(0, uv.rows / 2, uv.cols / 2, uv.rows / 2));
+    Mat v1 = uv(Rect(uv.cols / 2, uv.rows / 2, uv.cols / 2, uv.rows / 2));
+
+    Mat u(uv.rows, uv.cols / 2, CV_8U);
+    Mat ur0(u0.rows, u0.cols, CV_8U, u.data, u0.cols * 2);
+    Mat ur1(u0.rows, u0.cols, CV_8U, u.data + u0.cols, u0.cols * 2);
+    u0.copyTo(ur0);
+    u1.copyTo(ur1);
+
+    Mat v(uv.rows, uv.cols / 2, CV_8U);
+    Mat vr0(v0.rows, v0.cols, CV_8U, v.data, v0.cols * 2);
+    Mat vr1(v0.rows, v0.cols, CV_8U, v.data + v0.cols, v0.cols * 2);
+    v0.copyTo(vr0);
+    v1.copyTo(vr1);
+
+    Mat uv2Channel;
+    Mat uvArray[2] = { u,v };
+    cv::merge(uvArray, 2, uv2Channel);
+
+    Mat y = yuvI420(Rect(0, 0, bgr.cols, bgr.rows));
+    Mat uvInterleaved(uv2Channel.rows, uv2Channel.cols * 2, CV_8U, uv2Channel.data, uv2Channel.step[0]);
+
+    if (fullRange) {
+        Mat y32F;
+        y = (y - 16) * 255.0 / 219.0;
+        uvInterleaved = (uvInterleaved - 128) * 255.0 / 224.0 + 128;
+    }
+
+    nv12Interleaved = Mat(yuvI420.size(), CV_8UC1);
+    y.copyTo(nv12Interleaved(Rect(0, 0, bgr.cols, bgr.rows)));
+    uvInterleaved.copyTo(nv12Interleaved(Rect(0, bgr.rows, uvInterleaved.cols, uvInterleaved.rows)));
+}
+
+void generateYuv444(Mat bgr, Mat& yuv444, Mat& bgrFromYuv, const bool fullRange) {
+    std::array<std::array<float, 3>, 3> matrix = getRgb2YuvMatrix(fullRange);
+    const int yAdj = fullRange ? 0 : 16, uvAdj = 128;
+    Mat bgr32F;
+    bgr.convertTo(bgr32F, CV_32F);
+    Mat bgrSplit32F[3];
+    cv::split(bgr32F, bgrSplit32F);
+    Mat yuv32 = Mat(bgr.rows * 3, bgr.cols, CV_32F);
+    Mat Y = matrix[0][0] * bgrSplit32F[2] + matrix[0][1] * bgrSplit32F[1] + matrix[0][2] * bgrSplit32F[0] + yAdj;
+    Y.copyTo(yuv32(Rect(0, 0, bgr.cols, bgr.rows)));
+    Mat U = matrix[1][0] * bgrSplit32F[2] + matrix[1][1] * bgrSplit32F[1] + matrix[1][2] * bgrSplit32F[0] + uvAdj;
+    U.copyTo(yuv32(Rect(0, bgr.rows, bgr.cols, bgr.rows)));
+    Mat V = matrix[2][0] * bgrSplit32F[2] + matrix[2][1] * bgrSplit32F[1] + matrix[2][2] * bgrSplit32F[0] + uvAdj;
+    V.copyTo(yuv32(Rect(0, 2 * bgr.rows, bgr.cols, bgr.rows)));
+    yuv32.convertTo(yuv444, CV_8UC1);
+
+    Mat y8 = yuv444(Rect(0, 0, bgr.cols, bgr.rows));
+    Mat u8 = yuv444(Rect(0, bgr.rows, bgr.cols, bgr.rows));
+    Mat v8 = yuv444(Rect(0, 2 * bgr.rows, bgr.cols, bgr.rows));
+    y8.convertTo(Y, CV_32F);
+    u8.convertTo(U, CV_32F);
+    v8.convertTo(V, CV_32F);
+
+    if (!fullRange) Y -= 16;
+    U -= 128;
+    V -= 128;
+    matrix = getYuv2RgbMatrix(fullRange);
+    Mat bgrFromYuvSplit32F[3];
+    bgrFromYuvSplit32F[0] = matrix[2][0] * Y + matrix[2][1] * U;
+    bgrFromYuvSplit32F[1] = matrix[1][0] * Y + matrix[1][1] * U + matrix[1][2] * V;
+    bgrFromYuvSplit32F[2] = matrix[0][0] * Y + matrix[0][2] * V;
+    Mat bgrFromYuv32F;
+    cv::merge(bgrFromYuvSplit32F, 3, bgrFromYuv32F);
+    bgrFromYuv32F.convertTo(bgrFromYuv, CV_8UC3);
+}
+
+void generateTestImages(Mat bgrIn, Mat& testImg, Mat& out, const cudacodec::SurfaceFormat inputFormat, const cudacodec::ColorFormat outputFormat, const cudacodec::BitDepth outputBitDepth = cudacodec::BitDepth::EIGHT, bool planar = false, const bool fullRange = false) {
+    Mat imgOutFromYuv, imgOut8;
+    Mat yuv8;
+
+    switch (inputFormat) {
+    case cudacodec::SurfaceFormat::SF_NV12:
+    case cudacodec::SurfaceFormat::SF_P016:
+        if (outputFormat == cudacodec::ColorFormat::GRAY) {
+            yuv8 = Mat(static_cast<int>(bgrIn.rows * 1.5), bgrIn.cols, CV_8U);
+            Mat y = yuv8(Rect(0, 0, bgrIn.cols, bgrIn.rows));
+            generateGray(bgrIn, y, imgOutFromYuv, fullRange);
+        }
+        else
+            generateNv12(bgrIn, yuv8, imgOutFromYuv, fullRange);
+        break;
+    case cudacodec::SurfaceFormat::SF_YUV444:
+    case cudacodec::SurfaceFormat::SF_YUV444_16Bit:
+        if (outputFormat == cudacodec::ColorFormat::GRAY) {
+            yuv8 = Mat(bgrIn.rows * 3, bgrIn.cols, CV_8U);
+            Mat y = yuv8(Rect(0, 0, bgrIn.cols, bgrIn.rows));
+            generateGray(bgrIn, y, imgOutFromYuv, fullRange);
+        }
+        else
+            generateYuv444(bgrIn, yuv8, imgOutFromYuv, fullRange);
+        break;
+    }
+
+    if (inputFormat == cudacodec::SurfaceFormat::SF_P016 || inputFormat == cudacodec::SurfaceFormat::SF_YUV444_16Bit) {
+        yuv8.convertTo(testImg, CV_16U);
+        testImg *= pow(2, 8);
+    }
+    else
+        yuv8.copyTo(testImg);
+
+    switch (outputFormat) {
+    case cudacodec::ColorFormat::BGR:
+        imgOut8 = imgOutFromYuv;
+        break;
+    case cudacodec::ColorFormat::BGRA: {
+        cv::cvtColor(imgOutFromYuv, imgOut8, COLOR_BGR2BGRA);
+        break;
+    }
+    case cudacodec::ColorFormat::RGB: {
+        cv::cvtColor(imgOutFromYuv, imgOut8, COLOR_BGR2RGB);
+        break;
+    }
+    case cudacodec::ColorFormat::RGBA: {
+        cv::cvtColor(imgOutFromYuv, imgOut8, COLOR_BGR2RGBA);
+        break;
+    }
+    case cudacodec::ColorFormat::GRAY: {
+        imgOut8 = imgOutFromYuv;
+        break;
+    }
+    }
+
+    Mat imgOutBitDepthOut;
+    if (outputBitDepth == cudacodec::BitDepth::SIXTEEN) {
+        imgOut8.convertTo(imgOutBitDepthOut, CV_16U);
+        imgOutBitDepthOut *= pow(2, 8);
+    }
+    else
+        imgOutBitDepthOut = imgOut8;
+
+    if (planar && outputFormat != cudacodec::ColorFormat::GRAY) {
+        Mat* bgrSplit = new Mat[imgOutBitDepthOut.channels()];
+        cv::split(imgOutBitDepthOut, bgrSplit);
+        const int type = CV_MAKE_TYPE(CV_MAT_DEPTH(imgOutBitDepthOut.flags), 1);
+        out = Mat(imgOutBitDepthOut.rows * imgOutBitDepthOut.channels(), imgOutBitDepthOut.cols, type);
+        for (int i = 0; i < imgOut8.channels(); i++)
+            bgrSplit[i].copyTo(out(Rect(0, i * imgOut8.rows, imgOut8.cols, imgOut8.rows)));
+        delete[] bgrSplit;
+    }
+    else
+        imgOutBitDepthOut.copyTo(out);
+}
+
+#endif // HAVE_NVCUVID || HAVE_NVCUVENC || HAVE_CUDA
+
+#if defined(HAVE_NVCUVID) || defined(HAVE_NVCUVENC)
 struct SetDevice : testing::TestWithParam<cv::cuda::DeviceInfo>
 {
     cv::cuda::DeviceInfo devInfo;
@@ -133,9 +358,6 @@ struct Seek : SetDevice
 {
 };
 
-PARAM_TEST_CASE(YuvConverter, cv::cuda::DeviceInfo, SurfaceFormats, ColorFormats, BitDepths, bool, bool)
-{
-};
 
 #if defined(HAVE_NVCUVID)
 //////////////////////////////////////////////////////
@@ -764,244 +986,6 @@ CUDA_TEST_P(Seek, Reader)
 }
 
 
-void inline GetConstants(float& wr, float& wb, int& black, int& white, int& uvWhite, int& max, bool fullRange = false) {
-    if (fullRange) {
-        black = 0; white = 255; uvWhite = 255;
-    }
-    else {
-        black = 16; white = 235; uvWhite = 240;
-    }
-    max = 255;
-    wr = 0.2990f; wb = 0.1140f;
-}
-
-std::array<std::array<float, 3>, 3> getYuv2RgbMatrix(const bool fullRange = false) {
-    float wr, wb;
-    int black, white, uvWhite, max;
-    GetConstants(wr, wb, black, white, uvWhite, max, fullRange);
-    std::array<std::array<float, 3>, 3> mat = { {
-        {1.0f, 0.0f, (1.0f - wr) / 0.5f},
-        {1.0f, -wb * (1.0f - wb) / 0.5f / (1 - wb - wr), -wr * (1 - wr) / 0.5f / (1 - wb - wr)},
-        {1.0f, (1.0f - wb) / 0.5f, 0.0f},
-    } };
-    for (int i = 0; i < 3; i++) {
-        for (int j = 0; j < 3; j++) {
-            if (j == 0)
-                mat[i][j] = (float)(1.0 * max / (white - black) * mat[i][j]);
-            else
-                mat[i][j] = (float)(1.0 * max / (uvWhite - black) * mat[i][j]);
-        }
-    }
-    return mat;
-}
-
-std::array<std::array<float, 3>, 3> getRgb2YuvMatrix(const bool fullRange = false) {
-    float wr, wb;
-    int black, white, max, uvWhite;
-    GetConstants(wr, wb, black, white, uvWhite, max, fullRange);
-    std::array<std::array<float, 3>, 3> mat = { {
-        {wr, 1.0f - wb - wr, wb},
-        {-0.5f * wr / (1.0f - wb), -0.5f * (1 - wb - wr) / (1.0f - wb), 0.5f},
-        {0.5f, -0.5f * (1.0f - wb - wr) / (1.0f - wr), -0.5f * wb / (1.0f - wr)},
-    } };
-    for (int i = 0; i < 3; i++) {
-        for (int j = 0; j < 3; j++) {
-            if (j == 0)
-                mat[i][j] = (float)(1.0 * (white - black) / max * mat[i][j]);
-            else
-                mat[i][j] = (float)(1.0 * (uvWhite - black) / max * mat[i][j]);
-        }
-    }
-    return mat;
-}
-
-void generateGray(Mat bgr, Mat& y, Mat& grayFromY, const bool fullRange) {
-    Mat yuvI420;
-    cv::cvtColor(bgr, yuvI420, COLOR_BGR2YUV_I420);
-    yuvI420(Rect(0, 0, bgr.cols, bgr.rows)).copyTo(y);
-    if (fullRange) {
-        y -= 16;
-        y *= 255.0 / 219.0;
-    }
-    y.copyTo(grayFromY);
-    if (!fullRange) {
-        grayFromY -= 16;
-        grayFromY *= 255.0 / 219.0;
-    }
-}
-
-void generateNv12(Mat bgr, Mat& nv12Interleaved, Mat& bgrFromYuv, const bool fullRange) {
-    Mat yuvI420;
-    cv::cvtColor(bgr, yuvI420, COLOR_BGR2YUV_I420);
-    cv::cvtColor(yuvI420, bgrFromYuv, COLOR_YUV2BGR_I420);
-
-    Mat uv = yuvI420(Rect(0, bgr.rows, bgr.cols, bgr.rows / 2));
-    Mat u0 = uv(Rect(0, 0, uv.cols / 2, uv.rows / 2));
-    Mat u1 = uv(Rect(uv.cols / 2, 0, uv.cols / 2, uv.rows / 2));
-    Mat v0 = uv(Rect(0, uv.rows / 2, uv.cols / 2, uv.rows / 2));
-    Mat v1 = uv(Rect(uv.cols / 2, uv.rows / 2, uv.cols / 2, uv.rows / 2));
-
-    Mat u(uv.rows, uv.cols / 2, CV_8U);
-    Mat ur0(u0.rows, u0.cols, CV_8U, u.data, u0.cols * 2);
-    Mat ur1(u0.rows, u0.cols, CV_8U, u.data + u0.cols, u0.cols * 2);
-    u0.copyTo(ur0);
-    u1.copyTo(ur1);
-
-    Mat v(uv.rows, uv.cols / 2, CV_8U);
-    Mat vr0(v0.rows, v0.cols, CV_8U, v.data, v0.cols * 2);
-    Mat vr1(v0.rows, v0.cols, CV_8U, v.data + v0.cols, v0.cols * 2);
-    v0.copyTo(vr0);
-    v1.copyTo(vr1);
-
-    Mat uv2Channel;
-    Mat uvArray[2] = { u,v };
-    cv::merge(uvArray, 2, uv2Channel);
-
-    Mat y = yuvI420(Rect(0, 0, bgr.cols, bgr.rows));
-    Mat uvInterleaved(uv2Channel.rows, uv2Channel.cols * 2, CV_8U, uv2Channel.data, uv2Channel.step[0]);
-
-    if (fullRange) {
-        Mat y32F;
-        y = (y - 16) * 255.0 / 219.0;
-        uvInterleaved = (uvInterleaved - 128) * 255.0 / 224.0 + 128;
-    }
-
-    nv12Interleaved = Mat(yuvI420.size(), CV_8UC1);
-    y.copyTo(nv12Interleaved(Rect(0, 0, bgr.cols, bgr.rows)));
-    uvInterleaved.copyTo(nv12Interleaved(Rect(0, bgr.rows, uvInterleaved.cols, uvInterleaved.rows)));
-}
-
-void generateYuv444(Mat bgr, Mat& yuv444, Mat& bgrFromYuv, const bool fullRange) {
-    std::array<std::array<float, 3>, 3> matrix = getRgb2YuvMatrix(fullRange);
-    const int yAdj = fullRange ? 0 : 16, uvAdj = 128;
-    Mat bgr32F;
-    bgr.convertTo(bgr32F, CV_32F);
-    Mat bgrSplit32F[3];
-    cv::split(bgr32F, bgrSplit32F);
-    Mat yuv32 = Mat(bgr.rows * 3, bgr.cols, CV_32F);
-    Mat Y = matrix[0][0] * bgrSplit32F[2] + matrix[0][1] * bgrSplit32F[1] + matrix[0][2] * bgrSplit32F[0] + yAdj;
-    Y.copyTo(yuv32(Rect(0, 0, bgr.cols, bgr.rows)));
-    Mat U = matrix[1][0] * bgrSplit32F[2] + matrix[1][1] * bgrSplit32F[1] + matrix[1][2] * bgrSplit32F[0] + uvAdj;
-    U.copyTo(yuv32(Rect(0, bgr.rows, bgr.cols, bgr.rows)));
-    Mat V = matrix[2][0] * bgrSplit32F[2] + matrix[2][1] * bgrSplit32F[1] + matrix[2][2] * bgrSplit32F[0] + uvAdj;
-    V.copyTo(yuv32(Rect(0, 2 * bgr.rows, bgr.cols, bgr.rows)));
-    yuv32.convertTo(yuv444, CV_8UC1);
-
-    Mat y8 = yuv444(Rect(0, 0, bgr.cols, bgr.rows));
-    Mat u8 = yuv444(Rect(0, bgr.rows, bgr.cols, bgr.rows));
-    Mat v8 = yuv444(Rect(0, 2 * bgr.rows, bgr.cols, bgr.rows));
-    y8.convertTo(Y, CV_32F);
-    u8.convertTo(U, CV_32F);
-    v8.convertTo(V, CV_32F);
-
-    if (!fullRange) Y -= 16;
-    U -= 128;
-    V -= 128;
-    matrix = getYuv2RgbMatrix(fullRange);
-    Mat bgrFromYuvSplit32F[3];
-    bgrFromYuvSplit32F[0] = matrix[2][0] * Y + matrix[2][1] * U;
-    bgrFromYuvSplit32F[1] = matrix[1][0] * Y + matrix[1][1] * U + matrix[1][2] * V;
-    bgrFromYuvSplit32F[2] = matrix[0][0] * Y + matrix[0][2] * V;
-    Mat bgrFromYuv32F;
-    cv::merge(bgrFromYuvSplit32F, 3, bgrFromYuv32F);
-    bgrFromYuv32F.convertTo(bgrFromYuv, CV_8UC3);
-}
-
-void generateTestImages(Mat bgrIn, Mat& testImg, Mat& out, const cudacodec::SurfaceFormat inputFormat, const cudacodec::ColorFormat outputFormat, const cudacodec::BitDepth outputBitDepth = cudacodec::BitDepth::EIGHT, bool planar = false, const bool fullRange = false) {
-    Mat imgOutFromYuv, imgOut8;
-    Mat yuv8;
-
-    switch (inputFormat) {
-    case cudacodec::SurfaceFormat::SF_NV12:
-    case cudacodec::SurfaceFormat::SF_P016:
-        if (outputFormat == cudacodec::ColorFormat::GRAY) {
-            yuv8 = Mat(static_cast<int>(bgrIn.rows * 1.5), bgrIn.cols, CV_8U);
-            Mat y = yuv8(Rect(0, 0, bgrIn.cols, bgrIn.rows));
-            generateGray(bgrIn, y, imgOutFromYuv, fullRange);
-        }
-        else
-            generateNv12(bgrIn, yuv8, imgOutFromYuv, fullRange);
-        break;
-    case cudacodec::SurfaceFormat::SF_YUV444:
-    case cudacodec::SurfaceFormat::SF_YUV444_16Bit:
-        if (outputFormat == cudacodec::ColorFormat::GRAY) {
-            yuv8 = Mat(bgrIn.rows * 3, bgrIn.cols, CV_8U);
-            Mat y = yuv8(Rect(0, 0, bgrIn.cols, bgrIn.rows));
-            generateGray(bgrIn, y, imgOutFromYuv, fullRange);
-        }
-        else
-            generateYuv444(bgrIn, yuv8, imgOutFromYuv, fullRange);
-        break;
-    }
-
-    if (inputFormat == cudacodec::SurfaceFormat::SF_P016 || inputFormat == cudacodec::SurfaceFormat::SF_YUV444_16Bit) {
-        yuv8.convertTo(testImg, CV_16U);
-        testImg *= pow(2, 8);
-    }
-    else
-        yuv8.copyTo(testImg);
-
-    switch (outputFormat) {
-    case cudacodec::ColorFormat::BGR:
-        imgOut8 = imgOutFromYuv;
-        break;
-    case cudacodec::ColorFormat::BGRA: {
-        cv::cvtColor(imgOutFromYuv, imgOut8, COLOR_BGR2BGRA);
-        break;
-    }
-    case cudacodec::ColorFormat::RGB: {
-        cv::cvtColor(imgOutFromYuv, imgOut8, COLOR_BGR2RGB);
-        break;
-    }
-    case cudacodec::ColorFormat::RGBA: {
-        cv::cvtColor(imgOutFromYuv, imgOut8, COLOR_BGR2RGBA);
-        break;
-    }
-    case cudacodec::ColorFormat::GRAY: {
-        imgOut8 = imgOutFromYuv;
-        break;
-    }
-    }
-
-    Mat imgOutBitDepthOut;
-    if (outputBitDepth == cudacodec::BitDepth::SIXTEEN) {
-        imgOut8.convertTo(imgOutBitDepthOut, CV_16U);
-        imgOutBitDepthOut *= pow(2, 8);
-    }
-    else
-        imgOutBitDepthOut = imgOut8;
-
-    if (planar && outputFormat != cudacodec::ColorFormat::GRAY) {
-        Mat* bgrSplit = new Mat[imgOutBitDepthOut.channels()];
-        cv::split(imgOutBitDepthOut, bgrSplit);
-        const int type = CV_MAKE_TYPE(CV_MAT_DEPTH(imgOutBitDepthOut.flags), 1);
-        out = Mat(imgOutBitDepthOut.rows * imgOutBitDepthOut.channels(), imgOutBitDepthOut.cols, type);
-        for (int i = 0; i < imgOut8.channels(); i++)
-            bgrSplit[i].copyTo(out(Rect(0, i * imgOut8.rows, imgOut8.cols, imgOut8.rows)));
-        delete[] bgrSplit;
-    }
-    else
-        imgOutBitDepthOut.copyTo(out);
-}
-
-CUDA_TEST_P(YuvConverter, Reader)
-{
-    cv::cuda::setDevice(GET_PARAM(0).deviceID());
-    const cudacodec::SurfaceFormat surfaceFormat = static_cast<cudacodec::SurfaceFormat>(static_cast<int>(GET_PARAM(1)));
-    const cudacodec::ColorFormat outputFormat = static_cast<cudacodec::ColorFormat>(static_cast<int>(GET_PARAM(2)));
-    const cudacodec::BitDepth bitDepth = static_cast<cudacodec::BitDepth>(static_cast<int>(GET_PARAM(3)));
-    const bool planar = GET_PARAM(4);
-    const bool fullRange = GET_PARAM(5);
-    std::string imgPath = std::string(cvtest::TS::ptr()->get_data_path()) + "../python/images/baboon.jpg";
-    Ptr<cv::cudacodec::NVSurfaceToColorConverter> yuvConverter = cudacodec::createNVSurfaceToColorConverter(cv::cudacodec::ColorSpaceStandard::BT601, fullRange);
-    Mat bgr = imread(imgPath), bgrHost;
-    Mat nv12Interleaved, bgrFromYuv;
-    generateTestImages(bgr, nv12Interleaved, bgrFromYuv, surfaceFormat, outputFormat, bitDepth, planar, fullRange);
-    GpuMat nv12Device(nv12Interleaved), bgrDevice(bgrFromYuv.size(), bgrFromYuv.type());
-    yuvConverter->convert(nv12Device, bgrDevice, surfaceFormat, outputFormat, bitDepth, planar);
-    bgrDevice.download(bgrHost);
-    EXPECT_MAT_NEAR(bgrFromYuv, bgrHost, bitDepth == cudacodec::BitDepth::EIGHT ? 2 :512);
-}
 
 #endif // HAVE_NVCUVID
 
@@ -1399,9 +1383,36 @@ INSTANTIATE_TEST_CASE_P(CUDA_Codec, CheckInitParams, testing::Combine(
 
 INSTANTIATE_TEST_CASE_P(CUDA_Codec, Seek, ALL_DEVICES);
 
+
+#endif // HAVE_NVCUVID || HAVE_NVCUVENC
+
+#if defined(HAVE_CUDA)
+
+PARAM_TEST_CASE(YuvConverter, cv::cuda::DeviceInfo, SurfaceFormats, ColorFormats, BitDepths, bool, bool)
+{
+};
+
+CUDA_TEST_P(YuvConverter, Reader)
+{
+    cv::cuda::setDevice(GET_PARAM(0).deviceID());
+    const cudacodec::SurfaceFormat surfaceFormat = static_cast<cudacodec::SurfaceFormat>(static_cast<int>(GET_PARAM(1)));
+    const cudacodec::ColorFormat outputFormat = static_cast<cudacodec::ColorFormat>(static_cast<int>(GET_PARAM(2)));
+    const cudacodec::BitDepth bitDepth = static_cast<cudacodec::BitDepth>(static_cast<int>(GET_PARAM(3)));
+    const bool planar = GET_PARAM(4);
+    const bool fullRange = GET_PARAM(5);
+    std::string imgPath = std::string(cvtest::TS::ptr()->get_data_path()) + "../python/images/baboon.jpg";
+    Ptr<cv::cudacodec::NVSurfaceToColorConverter> yuvConverter = cudacodec::createNVSurfaceToColorConverter(cv::cudacodec::ColorSpaceStandard::BT601, fullRange);
+    Mat bgr = imread(imgPath), bgrHost;
+    Mat nv12Interleaved, bgrFromYuv;
+    generateTestImages(bgr, nv12Interleaved, bgrFromYuv, surfaceFormat, outputFormat, bitDepth, planar, fullRange);
+    GpuMat nv12Device(nv12Interleaved), bgrDevice(bgrFromYuv.size(), bgrFromYuv.type());
+    yuvConverter->convert(nv12Device, bgrDevice, surfaceFormat, outputFormat, bitDepth, planar);
+    bgrDevice.download(bgrHost);
+    EXPECT_MAT_NEAR(bgrFromYuv, bgrHost, bitDepth == cudacodec::BitDepth::EIGHT ? 2 :512);
+}
+
 #define BIT_DEPTHS testing::Values(BitDepths(cudacodec::BitDepth::EIGHT), BitDepths(cudacodec::BitDepth::SIXTEEN))
 INSTANTIATE_TEST_CASE_P(CUDA_Codec, YuvConverter, testing::Combine(
     ALL_DEVICES, SurfaceFormats::all(), ColorFormats::all(), BIT_DEPTHS, testing::Bool(), testing::Bool()));
 
-#endif // HAVE_NVCUVID || HAVE_NVCUVENC
-}} // namespace
+#endif // HAVE_CUDA

--- a/modules/cudacodec/test/test_video.cpp
+++ b/modules/cudacodec/test/test_video.cpp
@@ -89,7 +89,7 @@ std::array<std::array<float, 3>, 3> getRgb2YuvMatrix(const bool fullRange = fals
     } };
     for (int i = 0; i < 3; i++) {
         for (int j = 0; j < 3; j++) {
-            if (j == 0)
+            if (i == 0)
                 mat[i][j] = (float)(1.0 * (white - black) / max * mat[i][j]);
             else
                 mat[i][j] = (float)(1.0 * (uvWhite - black) / max * mat[i][j]);

--- a/modules/cudacodec/test/test_video.cpp
+++ b/modules/cudacodec/test/test_video.cpp
@@ -448,6 +448,8 @@ void generateTestImages(Mat bgrIn, Mat& testImg, Mat& out, const cudacodec::Surf
         else
             generateYuv444(bgrIn, yuv8, imgOutFromYuv, fullRange);
         break;
+    default:
+        CV_Error(Error::StsUnsupportedFormat, "Unsupported input surface format");
     }
 
     if (inputFormat == cudacodec::SurfaceFormat::SF_P016 || inputFormat == cudacodec::SurfaceFormat::SF_YUV444_16Bit) {
@@ -477,6 +479,8 @@ void generateTestImages(Mat bgrIn, Mat& testImg, Mat& out, const cudacodec::Surf
         imgOut8 = imgOutFromYuv;
         break;
     }
+    default:
+        CV_Error(Error::StsUnsupportedFormat, "Unsupported output color format");
     }
 
     Mat imgOutBitDepthOut;

--- a/modules/cudacodec/test/test_video.cpp
+++ b/modules/cudacodec/test/test_video.cpp
@@ -47,7 +47,7 @@ namespace opencv_test {
 
 #if defined(HAVE_NVCUVID) || defined(HAVE_NVCUVENC) || defined(HAVE_CUDA)
 
-void inline GetConstants(float& wr, float& wb, int& black, int& white, int& uvWhite, int& max, bool fullRange = false) {
+void inline GetConstantsEx(int iMatrix, float& wr, float& wb, int& black, int& white, int& uvWhite, int& max, bool fullRange = false) {
     if (fullRange) {
         black = 0; white = 255; uvWhite = 255;
     }
@@ -55,13 +55,43 @@ void inline GetConstants(float& wr, float& wb, int& black, int& white, int& uvWh
         black = 16; white = 235; uvWhite = 240;
     }
     max = 255;
-    wr = 0.2990f; wb = 0.1140f;
+    switch (static_cast<cv::cudacodec::ColorSpaceStandard>(iMatrix))
+    {
+    case cv::cudacodec::ColorSpaceStandard::BT709:
+    default:
+        wr = 0.2126f; wb = 0.0722f;
+        break;
+    case cv::cudacodec::ColorSpaceStandard::FCC:
+        wr = 0.30f; wb = 0.11f;
+        break;
+    case cv::cudacodec::ColorSpaceStandard::BT470:
+    case cv::cudacodec::ColorSpaceStandard::BT601:
+        wr = 0.2990f; wb = 0.1140f;
+        break;
+    case cv::cudacodec::ColorSpaceStandard::SMPTE240M:
+        wr = 0.212f; wb = 0.087f;
+        break;
+    case cv::cudacodec::ColorSpaceStandard::BT2020:
+    case cv::cudacodec::ColorSpaceStandard::BT2020C:
+        wr = 0.2627f; wb = 0.0593f;
+        // 10-bit only
+        black <<= 8;
+        white <<= 8;
+        uvWhite <<= 8;
+        max = (1 << 16) - 1;
+        break;
+    }
 }
 
-std::array<std::array<float, 3>, 3> getYuv2RgbMatrix(const bool fullRange = false) {
+void inline GetConstants(float& wr, float& wb, int& black, int& white, int& uvWhite, int& max, bool fullRange = false) {
+    GetConstantsEx(static_cast<int>(cv::cudacodec::ColorSpaceStandard::BT601), wr, wb, black, white, uvWhite, max, fullRange);
+}
+
+
+std::array<std::array<float, 3>, 3> getYuv2RgbMatrixEx(const cv::cudacodec::ColorSpaceStandard colorSpace, const bool fullRange = false) {
     float wr, wb;
     int black, white, uvWhite, max;
-    GetConstants(wr, wb, black, white, uvWhite, max, fullRange);
+    GetConstantsEx(static_cast<int>(colorSpace), wr, wb, black, white, uvWhite, max, fullRange);
     std::array<std::array<float, 3>, 3> mat = { {
         {1.0f, 0.0f, (1.0f - wr) / 0.5f},
         {1.0f, -wb * (1.0f - wb) / 0.5f / (1 - wb - wr), -wr * (1 - wr) / 0.5f / (1 - wb - wr)},
@@ -78,10 +108,15 @@ std::array<std::array<float, 3>, 3> getYuv2RgbMatrix(const bool fullRange = fals
     return mat;
 }
 
-std::array<std::array<float, 3>, 3> getRgb2YuvMatrix(const bool fullRange = false) {
+std::array<std::array<float, 3>, 3> getYuv2RgbMatrix(const bool fullRange = false) {
+    return getYuv2RgbMatrixEx(cv::cudacodec::ColorSpaceStandard::BT601, fullRange);
+}
+
+
+std::array<std::array<float, 3>, 3> getRgb2YuvMatrixEx(const cv::cudacodec::ColorSpaceStandard colorSpace, const bool fullRange = false) {
     float wr, wb;
     int black, white, max, uvWhite;
-    GetConstants(wr, wb, black, white, uvWhite, max, fullRange);
+    GetConstantsEx(static_cast<int>(colorSpace), wr, wb, black, white, uvWhite, max, fullRange);
     std::array<std::array<float, 3>, 3> mat = { {
         {wr, 1.0f - wb - wr, wb},
         {-0.5f * wr / (1.0f - wb), -0.5f * (1 - wb - wr) / (1.0f - wb), 0.5f},
@@ -96,6 +131,10 @@ std::array<std::array<float, 3>, 3> getRgb2YuvMatrix(const bool fullRange = fals
         }
     }
     return mat;
+}
+
+std::array<std::array<float, 3>, 3> getRgb2YuvMatrix(const bool fullRange = false) {
+    return getRgb2YuvMatrixEx(cv::cudacodec::ColorSpaceStandard::BT601, fullRange);
 }
 
 CV_ENUM(ColorFormats, cudacodec::ColorFormat::BGR, cudacodec::ColorFormat::BGRA, cudacodec::ColorFormat::RGB, cudacodec::ColorFormat::RGBA, cudacodec::ColorFormat::GRAY)

--- a/modules/cudacodec/test/test_video.cpp
+++ b/modules/cudacodec/test/test_video.cpp
@@ -1400,15 +1400,17 @@ CUDA_TEST_P(YuvConverter, Reader)
     const cudacodec::BitDepth bitDepth = static_cast<cudacodec::BitDepth>(static_cast<int>(GET_PARAM(3)));
     const bool planar = GET_PARAM(4);
     const bool fullRange = GET_PARAM(5);
-    std::string imgPath = std::string(cvtest::TS::ptr()->get_data_path()) + "../python/images/baboon.jpg";
     Ptr<cv::cudacodec::NVSurfaceToColorConverter> yuvConverter = cudacodec::createNVSurfaceToColorConverter(cv::cudacodec::ColorSpaceStandard::BT601, fullRange);
-    Mat bgr = imread(imgPath), bgrHost;
+    const int rows = 64, cols = 128;
+    Mat bgr(rows, cols, CV_8UC3);
+    cv::randu(bgr, Scalar(0, 0, 0), Scalar(255, 255, 255));
+    Mat bgrHost;
     Mat nv12Interleaved, bgrFromYuv;
     generateTestImages(bgr, nv12Interleaved, bgrFromYuv, surfaceFormat, outputFormat, bitDepth, planar, fullRange);
     GpuMat nv12Device(nv12Interleaved), bgrDevice(bgrFromYuv.size(), bgrFromYuv.type());
     yuvConverter->convert(nv12Device, bgrDevice, surfaceFormat, outputFormat, bitDepth, planar);
     bgrDevice.download(bgrHost);
-    EXPECT_MAT_NEAR(bgrFromYuv, bgrHost, bitDepth == cudacodec::BitDepth::EIGHT ? 2 :512);
+    EXPECT_MAT_NEAR(bgrFromYuv, bgrHost, bitDepth == cudacodec::BitDepth::EIGHT ? 2 : 512);
 }
 
 #define BIT_DEPTHS testing::Values(BitDepths(cudacodec::BitDepth::EIGHT), BitDepths(cudacodec::BitDepth::SIXTEEN))


### PR DESCRIPTION
This patch addresses two critical issues in color conversion:

- The previous implementation caused severe color shifts because uvWhite was handled as an 8-bit value while the luminance was processed as 10-bit P010.

- Additionally, the code was hardcoded to Limited Range.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- x There is a reference to the original bug report and related work
- x There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
