### PR TITLE
add CV_16F support in hdf5

### DIFF
--- a/modules/hdf/CMakeLists.txt
+++ b/modules/hdf/CMakeLists.txt
@@ -1,5 +1,7 @@
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR})
-
+if(WITH_HDF5_F16_SUPPORT)
+  add_definitions(-DOPENCV_REQUIRE_HDF5_F16_SUPPORT)
+endif()
 if(WIN32)
   # windows cmake internal lookups are broken for now
   # will lookup for headers and shared libs given HDF_DIR env
@@ -17,7 +19,11 @@ if(WIN32)
   endif()
 else()
   if(NOT CMAKE_CROSSCOMPILING) # iOS build should not reuse OSX package
-    find_package(HDF5)
+    if(WITH_HDF5_F16_SUPPORT)
+      find_package(HDF5 2.0 REQUIRED)
+    else()
+      find_package(HDF5)
+    endif()
   endif()
 endif()
 
@@ -26,6 +32,7 @@ if(NOT HDF5_FOUND)
 endif()
 
 set(HAVE_HDF5 1)
+
 
 ocv_warnings_disable(CMAKE_CXX_FLAGS -Winvalid-offsetof)
 

--- a/modules/hdf/include/opencv2/hdf/hdf5.hpp
+++ b/modules/hdf/include/opencv2/hdf/hdf5.hpp
@@ -35,6 +35,7 @@
 #ifndef __OPENCV_HDF5_HPP__
 #define __OPENCV_HDF5_HPP__
 
+#include "opencv2/core/cvdef.h"
 #include <vector>
 #include <opencv2/core.hpp>
 
@@ -47,6 +48,10 @@ using namespace std;
 //! @addtogroup hdf5
 //! @{
 
+
+/** @brief Returns true if HDF5 float16 support is available.
+*/
+CV_EXPORTS_W bool HDF5_has_f16_support();
 
 /** @brief Hierarchical Data Format version 5 interface.
 
@@ -67,6 +72,11 @@ public:
     };
 
     virtual ~HDF5() {}
+
+    /**
+     * @brief Returns true if HDF5 float16 support is available.
+     */
+    CV_WRAP virtual bool has_f16_support() const = 0;
 
     /** @brief Close and release hdf5 object.
      */

--- a/modules/hdf/src/hdf5.cpp
+++ b/modules/hdf/src/hdf5.cpp
@@ -35,13 +35,13 @@
 
 #include <cstdio>
 #include <hdf5.h>
-
+#if defined(H5T_IEEE_F16LE)
 #if defined(__BYTE_ORDER__)&&(__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
     constexpr bool is_big_endian = true;
 #else
     constexpr bool is_big_endian = false;
 #endif
-
+#endif
 using namespace std;
 
 namespace cv
@@ -50,7 +50,7 @@ namespace hdf
 {
 inline void print_type_info(hid_t type, const String& prefix = "")
 {
-    printf("%s Type: %lld, class=%d, size=%d, order=%d, is valid=%d\n", prefix.c_str(), (long long)type, H5Tget_class(type), H5Tget_size(type), H5Tget_order(type), H5Iis_valid(type));
+    printf("%s Type: %lld, class=%d, size=%zu, order=%d, is valid=%d\n", prefix.c_str(), (long long)type, H5Tget_class(type), H5Tget_size(type), H5Tget_order(type), H5Iis_valid(type));
 }
 
 bool HDF5_has_f16_support()
@@ -566,7 +566,7 @@ void HDF5Impl::atread(OutputArray value, const String& atlabel)
     vector<int> dim_vec(dim_vec_.begin(), dim_vec_.end());
 
     int nchannels = 1;
-    hid_t h5type;
+
     int dtype;
     if (H5Tget_class(atype) == H5T_ARRAY)
     {
@@ -575,11 +575,11 @@ void HDF5Impl::atread(OutputArray value, const String& atlabel)
         nchannels = (int) dims;
 
         hid_t super_type = H5Tget_super(atype);
-        h5type = GetSafeMemType(super_type, dtype);
+        GetSafeMemType(super_type, dtype);
         H5Tclose(super_type);
     }
     else
-        h5type = GetSafeMemType(atype, dtype);
+        GetSafeMemType(atype, dtype);
     value.create(rank, dim_vec.data(), CV_MAKETYPE(dtype, nchannels));
     H5Aread(attr, atype, value.getMat().data);
 

--- a/modules/hdf/src/hdf5.cpp
+++ b/modules/hdf/src/hdf5.cpp
@@ -258,7 +258,7 @@ inline hid_t HDF5Impl::GetH5type( int cvType ) const
         break;
       #if defined(H5T_IEEE_F16LE)
       case CV_16F:
-        h5Type = H5T_IEEE_F16LE;
+        h5Type = is_big_endian? H5T_IEEE_F16BE : H5T_IEEE_F16LE;
         break;
       #endif
       case CV_32S:

--- a/modules/hdf/src/hdf5.cpp
+++ b/modules/hdf/src/hdf5.cpp
@@ -32,9 +32,18 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
+#include "opencv2/core/cvstd.hpp"
 #include "precomp.hpp"
 
+#include <H5Tpublic.h>
+#include <cstdio>
 #include <hdf5.h>
+
+#if defined(__BYTE_ORDER__)&&(__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+    constexpr bool is_big_endian = true;
+#else
+    constexpr bool is_big_endian = false;
+#endif
 
 using namespace std;
 
@@ -42,6 +51,17 @@ namespace cv
 {
 namespace hdf
 {
+inline void print_type_info(hid_t type, const String& prefix = "") {
+
+    printf("%s Type: %lld, class=%d, size=%d, order=%d, is valid=%d\n", prefix.c_str(), (long long)type, H5Tget_class(type), H5Tget_size(type), H5Tget_order(type), H5Iis_valid(type));
+    #if defined(CV_BIG_ENDIAN)
+      return H5Tcopy(H5T_IEEE_F16BE);
+  #elif defined(CV_LITTLE_ENDIAN)
+      // Default to Little Endian (x86, ARM, etc.)
+      return H5Tcopy(H5T_IEEE_F16LE);
+  #endif
+}
+
 
 class HDF5Impl CV_FINAL : public HDF5
 {
@@ -203,6 +223,8 @@ private:
     //! translate h5Type -> cvType
     inline int GetCVtype( hid_t h5Type ) const;
 
+    //! h5Type -> native h5Type with safety checks for 16-bit float and get cvType
+    inline hid_t GetSafeMemType(hid_t dstype, int& cvType) const;
 };
 
 inline hid_t HDF5Impl::GetH5type( int cvType ) const
@@ -229,6 +251,11 @@ inline hid_t HDF5Impl::GetH5type( int cvType ) const
       case CV_16S:
         h5Type = H5T_NATIVE_SHORT;
         break;
+      #if defined(H5T_IEEE_F16LE)
+      case CV_16F:
+        h5Type = H5T_IEEE_F16LE;
+        break;
+      #endif
       case CV_32S:
         h5Type = H5T_NATIVE_INT;
         break;
@@ -254,12 +281,40 @@ inline int HDF5Impl::GetCVtype( hid_t h5Type ) const
       cvType = CV_16U;
     else if ( H5Tequal( h5Type, H5T_NATIVE_SHORT  ) )
       cvType = CV_16S;
+    #if defined(H5T_IEEE_F16LE)
+    else if ( H5Tequal( h5Type, H5T_IEEE_F16LE ) )
+      cvType = CV_16F;
+    #endif
+    #if defined(H5T_IEEE_F16BE)
+    else if ( H5Tequal( h5Type, H5T_IEEE_F16BE ) )
+      cvType = CV_16F;
+    #endif
+    #if defined(H5T_NATIVE_FLOAT16)
+    else if (H5Iis_valid(H5T_NATIVE_FLOAT16) && H5Tequal( h5Type, H5T_NATIVE_FLOAT16 ) )
+      cvType = CV_16F;
+    #endif
     else if ( H5Tequal( h5Type, H5T_NATIVE_INT    ) )
       cvType = CV_32S;
     else
       CV_Error_(Error::StsInternal, ("Unknown H5Type: %lld.", (long long)h5Type));
-
+    print_type_info(h5Type, "GetCVtype");
     return cvType;
+}
+
+inline hid_t HDF5Impl::GetSafeMemType(hid_t dstype, int& cvType) const
+{
+    hid_t h5_native_type = H5Tget_native_type(dstype, H5T_DIR_ASCEND);
+    #if defined(H5T_IEEE_F16LE) && defined(H5T_IEEE_F16BE)
+    if (H5Tget_class(dstype) == H5T_FLOAT && H5Tget_size(dstype) == 2) 
+    {
+      cvType = CV_16F;
+      if (H5Tget_class(h5_native_type) == H5T_FLOAT && H5Tget_size(h5_native_type) ==2)
+        return h5_native_type; // H2T_NATIVE_FLOAT16, use it directly
+      return is_big_endian? H5Tcopy(H5T_IEEE_F16BE) : H5Tcopy(H5T_IEEE_F16LE);
+    }
+    #endif
+    cvType = GetCVtype(h5_native_type);
+    return h5_native_type; 
 }
 
 HDF5Impl::HDF5Impl( const String& _hdf5_filename )
@@ -508,6 +563,7 @@ void HDF5Impl::atread(OutputArray value, const String& atlabel)
 
     int nchannels = 1;
     hid_t h5type;
+    int dtype;
     if (H5Tget_class(atype) == H5T_ARRAY)
     {
         hsize_t dims;
@@ -515,14 +571,11 @@ void HDF5Impl::atread(OutputArray value, const String& atlabel)
         nchannels = (int) dims;
 
         hid_t super_type = H5Tget_super(atype);
-        h5type = H5Tget_native_type(super_type, H5T_DIR_ASCEND);
+        h5type = GetSafeMemType(super_type, dtype);
         H5Tclose(super_type);
     }
     else
-        h5type = H5Tget_native_type(atype, H5T_DIR_ASCEND);
-
-    int dtype = GetCVtype(h5type);
-
+        h5type = GetSafeMemType(atype, dtype);
     value.create(rank, dim_vec.data(), CV_MAKETYPE(dtype, nchannels));
     H5Aread(attr, atype, value.getMat().data);
 
@@ -817,7 +870,7 @@ void HDF5Impl::dsread( OutputArray Array, const String& dslabel,
 
     // get data type
     hid_t dstype = H5Dget_type( dsdata );
-
+    int dType;
     int channs = 1;
     if ( H5Tget_class( dstype ) == H5T_ARRAY )
     {
@@ -827,13 +880,9 @@ void HDF5Impl::dsread( OutputArray Array, const String& dslabel,
       channs = (int) ardims[0];
       // fetch depth
       hid_t tsuper = H5Tget_super( dstype );
-      h5type = H5Tget_native_type( tsuper, H5T_DIR_ASCEND );
-      H5Tclose( tsuper );
+      h5type = GetSafeMemType(tsuper, dType);
     } else
-      h5type = H5Tget_native_type( dstype, H5T_DIR_ASCEND );
-
-    int dType = GetCVtype( h5type );
-
+      h5type = GetSafeMemType(dstype, dType);
     // get file space
     hid_t fspace = H5Dget_space( dsdata );
 

--- a/modules/hdf/src/hdf5.cpp
+++ b/modules/hdf/src/hdf5.cpp
@@ -309,7 +309,7 @@ inline hid_t HDF5Impl::GetSafeMemType(hid_t dstype, int& cvType) const
 {
     hid_t h5_native_type = H5Tget_native_type(dstype, H5T_DIR_ASCEND);
     #if defined(H5T_IEEE_F16LE) && defined(H5T_IEEE_F16BE)
-    if (H5Tget_class(dstype) == H5T_FLOAT && H5Tget_size(dstype) == 2) 
+    if (H5Tget_class(dstype) == H5T_FLOAT && H5Tget_size(dstype) == 2)
     {
       cvType = CV_16F;
       if (H5Tget_class(h5_native_type) == H5T_FLOAT && H5Tget_size(h5_native_type) ==2)
@@ -318,7 +318,7 @@ inline hid_t HDF5Impl::GetSafeMemType(hid_t dstype, int& cvType) const
     }
     #endif
     cvType = GetCVtype(h5_native_type);
-    return h5_native_type; 
+    return h5_native_type;
 }
 
 HDF5Impl::HDF5Impl( const String& _hdf5_filename )

--- a/modules/hdf/src/hdf5.cpp
+++ b/modules/hdf/src/hdf5.cpp
@@ -31,11 +31,8 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
-
-#include "opencv2/core/cvstd.hpp"
 #include "precomp.hpp"
 
-#include <H5Tpublic.h>
 #include <cstdio>
 #include <hdf5.h>
 
@@ -51,17 +48,19 @@ namespace cv
 {
 namespace hdf
 {
-inline void print_type_info(hid_t type, const String& prefix = "") {
-
+inline void print_type_info(hid_t type, const String& prefix = "")
+{
     printf("%s Type: %lld, class=%d, size=%d, order=%d, is valid=%d\n", prefix.c_str(), (long long)type, H5Tget_class(type), H5Tget_size(type), H5Tget_order(type), H5Iis_valid(type));
-    #if defined(CV_BIG_ENDIAN)
-      return H5Tcopy(H5T_IEEE_F16BE);
-  #elif defined(CV_LITTLE_ENDIAN)
-      // Default to Little Endian (x86, ARM, etc.)
-      return H5Tcopy(H5T_IEEE_F16LE);
-  #endif
 }
 
+bool HDF5_has_f16_support()
+{
+    #if defined(H5T_IEEE_F16LE) && defined(H5T_IEEE_F16BE) && defined(H5T_NATIVE_FLOAT16)
+      return true;
+    #else
+      return false;
+    #endif
+}
 
 class HDF5Impl CV_FINAL : public HDF5
 {
@@ -70,6 +69,8 @@ public:
     HDF5Impl( const String& HDF5Filename );
 
     virtual ~HDF5Impl() CV_OVERRIDE { close(); };
+
+    virtual bool has_f16_support() const CV_OVERRIDE;
 
     // close and release
     virtual void close( ) CV_OVERRIDE;
@@ -227,6 +228,10 @@ private:
     inline hid_t GetSafeMemType(hid_t dstype, int& cvType) const;
 };
 
+bool HDF5Impl::has_f16_support() const
+{
+    return HDF5_has_f16_support();
+}
 inline hid_t HDF5Impl::GetH5type( int cvType ) const
 {
     hid_t h5Type = -1;
@@ -297,7 +302,6 @@ inline int HDF5Impl::GetCVtype( hid_t h5Type ) const
       cvType = CV_32S;
     else
       CV_Error_(Error::StsInternal, ("Unknown H5Type: %lld.", (long long)h5Type));
-    print_type_info(h5Type, "GetCVtype");
     return cvType;
 }
 

--- a/modules/hdf/test/test_hdf5.cpp
+++ b/modules/hdf/test/test_hdf5.cpp
@@ -8,7 +8,9 @@
  * @date December 2017
  */
 #include "opencv2/core/cvdef.h"
+#include "opencv2/hdf/hdf5.hpp"
 #include "test_precomp.hpp"
+#include <iostream>
 
 namespace opencv_test { namespace {
 
@@ -46,7 +48,7 @@ struct HDF5_Test : public testing::Test
     Mat m_single_channel; //!< single channel matrix for test
     Mat m_two_channels; //!< two-channel matrix for test
 };
-/*
+
 TEST_F(HDF5_Test, create_a_single_group)
 {
     reset();
@@ -371,38 +373,129 @@ TEST_F(HDF5_Test, test_attribute_InutArray_OutputArray_2d)
 
     m_hdf_io->close();
 }
-*/
-TEST_F(HDF5_Test, write_read_dataset_CV_16F)
-{
-    reset();
 
 #ifdef CV_16F
+
+TEST_F(HDF5_Test, write_read_dataset_CV_16F)
+{
+    if (!hdf::HDF5_has_f16_support())
+    {
+        std::cout << "HDF5 float16 support is not available in this build." << std::endl;
+        return;
+    }
+    reset();
     String dataset_half = "/half";
     m_hdf_io = hdf::open(m_filename);
-
-    // Create a matrix with CV_16F type (half-precision float)
     int rows = 2, cols = 3;
     Mat mat_half(rows, cols, CV_16F);
     for (int i = 0; i < rows * cols; ++i)
-    {
-        // Fill with increasing values (cast to half)
         ((cv::hfloat*)mat_half.data)[i] = cv::hfloat(i * 0.5f);
-    }
-    // Write and read
     m_hdf_io->dswrite(mat_half, dataset_half);
     EXPECT_EQ(m_hdf_io->hlexists(dataset_half), true);
-
     Mat mat_half_read;
     m_hdf_io->dsread(mat_half_read, dataset_half);
-    EXPECT_EQ(mat_half_read.type(), mat_half.type());
+    EXPECT_EQ(mat_half_read.type(), CV_16F);
     EXPECT_EQ(mat_half_read.size(), mat_half.size());
-    // Compare values (allowing for small error due to half precision)
     double diff = cvtest::norm(mat_half, mat_half_read, NORM_L2);
     EXPECT_LE(diff, 1e-3);
-
     m_hdf_io->close();
-#else
-    std::cout << "CV_16F is not supported in this build." << std::endl;
-#endif
 }
+
+TEST_F(HDF5_Test, write_read_dataset_CV_16FC2)
+{
+    if (!hdf::HDF5_has_f16_support())
+    {
+        std::cout << "HDF5 float16 support is not available in this build." << std::endl;
+        return;
+    }
+    reset();
+    String dataset_half_array = "/halfc2";
+    m_hdf_io = hdf::open(m_filename);
+    int rows = 2, cols = 3, channels = 2;
+    Mat mat_half(rows, cols, CV_MAKETYPE(CV_16F, channels));
+    for (int i = 0; i < rows * cols * channels; ++i)
+        ((cv::hfloat*)mat_half.data)[i] = cv::hfloat(i * 0.125f);
+    m_hdf_io->dscreate(rows, cols, mat_half.type(), dataset_half_array);
+    m_hdf_io->dswrite(mat_half, dataset_half_array);
+    Mat mat_half_read;
+    m_hdf_io->dsread(mat_half_read, dataset_half_array, NULL, NULL);
+    EXPECT_EQ(mat_half_read.type(), mat_half.type());
+    EXPECT_EQ(mat_half_read.size(), mat_half.size());
+    double diff = cvtest::norm(mat_half, mat_half_read, NORM_L2);
+    EXPECT_LE(diff, 1e-3);
+    m_hdf_io->close();
+}
+
+TEST_F(HDF5_Test, attribute_CV_16FC2_matrix)
+{
+    if (!hdf::HDF5_has_f16_support())
+    {
+        std::cout << "HDF5 float16 support is not available in this build." << std::endl;
+        return;
+    }
+    reset();
+    String attr_name = "half_array";
+    int rows = 2, cols = 3, channels = 2;
+    Mat mat_half(rows, cols, CV_MAKETYPE(CV_16F, channels));
+    for (int i = 0; i < rows * cols * channels; ++i)
+        ((cv::hfloat*)mat_half.data)[i] = cv::hfloat(i * 0.25f);
+    m_hdf_io = hdf::open(m_filename);
+    m_hdf_io->atwrite(mat_half, attr_name);
+    Mat mat_half_read;
+    m_hdf_io->atread(mat_half_read, attr_name);
+    EXPECT_EQ(mat_half_read.type(), mat_half.type());
+    EXPECT_EQ(mat_half_read.size(), mat_half.size());
+    double diff = cvtest::norm(mat_half, mat_half_read, NORM_L2);
+    EXPECT_LE(diff, 1e-3);
+    m_hdf_io->close();
+}
+
+TEST_F(HDF5_Test, attribute_CV_16F_matrix)
+{
+    if (!hdf::HDF5_has_f16_support())
+    {
+        std::cout << "HDF5 float16 support is not available in this build." << std::endl;
+        return;
+    }
+    reset();
+    String attr_name = "half_array";
+    int rows = 2, cols = 3, channels = 2;
+    Mat mat_half(rows, cols, CV_16F);
+    for (int i = 0; i < rows * cols * channels; ++i)
+        ((cv::hfloat*)mat_half.data)[i] = cv::hfloat(i * 0.25f);
+    m_hdf_io = hdf::open(m_filename);
+    m_hdf_io->atwrite(mat_half, attr_name);
+    Mat mat_half_read;
+    m_hdf_io->atread(mat_half_read, attr_name);
+    EXPECT_EQ(mat_half_read.type(), mat_half.type());
+    EXPECT_EQ(mat_half_read.size(), mat_half.size());
+    double diff = cvtest::norm(mat_half, mat_half_read, NORM_L2);
+    EXPECT_LE(diff, 1e-3);
+    m_hdf_io->close();
+}
+
+TEST_F(HDF5_Test, attribute_CV_16F_scalar)
+{
+    if (!hdf::HDF5_has_f16_support())
+    {
+        std::cout << "HDF5 float16 support is not available in this build." << std::endl;
+        return;
+    }
+    reset();
+    String attr_name = "half_float";
+    cv::hfloat attr_value = cv::hfloat(123.456789f);
+
+    m_hdf_io = hdf::open(m_filename);
+
+    m_hdf_io->atwrite(attr_value, attr_name);
+
+    double expected_attr_value;
+    m_hdf_io->atread(&expected_attr_value, attr_name);
+    EXPECT_NEAR(attr_value, expected_attr_value, 1e-9);
+    m_hdf_io->close();
+
+}
+
+#endif
+
 }} // namespace

--- a/modules/hdf/test/test_hdf5.cpp
+++ b/modules/hdf/test/test_hdf5.cpp
@@ -10,7 +10,6 @@
 #include "opencv2/core/cvdef.h"
 #include "opencv2/hdf/hdf5.hpp"
 #include "test_precomp.hpp"
-#include <iostream>
 
 namespace opencv_test { namespace {
 
@@ -379,10 +378,7 @@ TEST_F(HDF5_Test, test_attribute_InutArray_OutputArray_2d)
 TEST_F(HDF5_Test, write_read_dataset_CV_16F)
 {
     if (!hdf::HDF5_has_f16_support())
-    {
-        std::cout << "HDF5 float16 support is not available in this build." << std::endl;
         return;
-    }
     reset();
     String dataset_half = "/half";
     m_hdf_io = hdf::open(m_filename);
@@ -404,10 +400,7 @@ TEST_F(HDF5_Test, write_read_dataset_CV_16F)
 TEST_F(HDF5_Test, write_read_dataset_CV_16FC2)
 {
     if (!hdf::HDF5_has_f16_support())
-    {
-        std::cout << "HDF5 float16 support is not available in this build." << std::endl;
         return;
-    }
     reset();
     String dataset_half_array = "/halfc2";
     m_hdf_io = hdf::open(m_filename);
@@ -429,10 +422,7 @@ TEST_F(HDF5_Test, write_read_dataset_CV_16FC2)
 TEST_F(HDF5_Test, attribute_CV_16FC2_matrix)
 {
     if (!hdf::HDF5_has_f16_support())
-    {
-        std::cout << "HDF5 float16 support is not available in this build." << std::endl;
         return;
-    }
     reset();
     String attr_name = "half_array";
     int rows = 2, cols = 3, channels = 2;
@@ -453,10 +443,7 @@ TEST_F(HDF5_Test, attribute_CV_16FC2_matrix)
 TEST_F(HDF5_Test, attribute_CV_16F_matrix)
 {
     if (!hdf::HDF5_has_f16_support())
-    {
-        std::cout << "HDF5 float16 support is not available in this build." << std::endl;
         return;
-    }
     reset();
     String attr_name = "half_array";
     int rows = 2, cols = 3, channels = 2;
@@ -477,10 +464,7 @@ TEST_F(HDF5_Test, attribute_CV_16F_matrix)
 TEST_F(HDF5_Test, attribute_CV_16F_scalar)
 {
     if (!hdf::HDF5_has_f16_support())
-    {
-        std::cout << "HDF5 float16 support is not available in this build." << std::endl;
         return;
-    }
     reset();
     String attr_name = "half_float";
     cv::hfloat attr_value = cv::hfloat(123.456789f);

--- a/modules/hdf/test/test_hdf5.cpp
+++ b/modules/hdf/test/test_hdf5.cpp
@@ -378,7 +378,11 @@ TEST_F(HDF5_Test, test_attribute_InutArray_OutputArray_2d)
 TEST_F(HDF5_Test, write_read_dataset_CV_16F)
 {
     if (!hdf::HDF5_has_f16_support())
+    #ifdef OPENCV_REQUIRE_HDF5_F16_SUPPORT
+        CV_Error(Error::StsNotImplemented, "HDF5 library with half float support is required for this test.");
+    #else
         return;
+    #endif
     reset();
     String dataset_half = "/half";
     m_hdf_io = hdf::open(m_filename);
@@ -400,7 +404,11 @@ TEST_F(HDF5_Test, write_read_dataset_CV_16F)
 TEST_F(HDF5_Test, write_read_dataset_CV_16FC2)
 {
     if (!hdf::HDF5_has_f16_support())
+    #ifdef OPENCV_REQUIRE_HDF5_F16_SUPPORT
+        CV_Error(Error::StsNotImplemented, "HDF5 library with half float support is required for this test.");
+    #else
         return;
+    #endif
     reset();
     String dataset_half_array = "/halfc2";
     m_hdf_io = hdf::open(m_filename);
@@ -422,7 +430,11 @@ TEST_F(HDF5_Test, write_read_dataset_CV_16FC2)
 TEST_F(HDF5_Test, attribute_CV_16FC2_matrix)
 {
     if (!hdf::HDF5_has_f16_support())
+    #ifdef OPENCV_REQUIRE_HDF5_F16_SUPPORT
+        CV_Error(Error::StsNotImplemented, "HDF5 library with half float support is required for this test.");
+    #else
         return;
+    #endif
     reset();
     String attr_name = "half_array";
     int rows = 2, cols = 3, channels = 2;
@@ -443,7 +455,11 @@ TEST_F(HDF5_Test, attribute_CV_16FC2_matrix)
 TEST_F(HDF5_Test, attribute_CV_16F_matrix)
 {
     if (!hdf::HDF5_has_f16_support())
+    #ifdef OPENCV_REQUIRE_HDF5_F16_SUPPORT
+        CV_Error(Error::StsNotImplemented, "HDF5 library with half float support is required for this test.");
+    #else
         return;
+    #endif
     reset();
     String attr_name = "half_array";
     int rows = 2, cols = 3, channels = 2;
@@ -464,7 +480,11 @@ TEST_F(HDF5_Test, attribute_CV_16F_matrix)
 TEST_F(HDF5_Test, attribute_CV_16F_scalar)
 {
     if (!hdf::HDF5_has_f16_support())
+    #ifdef OPENCV_REQUIRE_HDF5_F16_SUPPORT
+        CV_Error(Error::StsNotImplemented, "HDF5 library with half float support is required for this test.");
+    #else
         return;
+    #endif
     reset();
     String attr_name = "half_float";
     cv::hfloat attr_value = cv::hfloat(123.456789f);

--- a/modules/hdf/test/test_hdf5.cpp
+++ b/modules/hdf/test/test_hdf5.cpp
@@ -7,6 +7,7 @@
  * @author Fangjun Kuang <csukuangfj dot at gmail dot com>
  * @date December 2017
  */
+#include "opencv2/core/cvdef.h"
 #include "test_precomp.hpp"
 
 namespace opencv_test { namespace {
@@ -45,7 +46,7 @@ struct HDF5_Test : public testing::Test
     Mat m_single_channel; //!< single channel matrix for test
     Mat m_two_channels; //!< two-channel matrix for test
 };
-
+/*
 TEST_F(HDF5_Test, create_a_single_group)
 {
     reset();
@@ -370,5 +371,38 @@ TEST_F(HDF5_Test, test_attribute_InutArray_OutputArray_2d)
 
     m_hdf_io->close();
 }
+*/
+TEST_F(HDF5_Test, write_read_dataset_CV_16F)
+{
+    reset();
 
+#ifdef CV_16F
+    String dataset_half = "/half";
+    m_hdf_io = hdf::open(m_filename);
+
+    // Create a matrix with CV_16F type (half-precision float)
+    int rows = 2, cols = 3;
+    Mat mat_half(rows, cols, CV_16F);
+    for (int i = 0; i < rows * cols; ++i)
+    {
+        // Fill with increasing values (cast to half)
+        ((cv::hfloat*)mat_half.data)[i] = cv::hfloat(i * 0.5f);
+    }
+    // Write and read
+    m_hdf_io->dswrite(mat_half, dataset_half);
+    EXPECT_EQ(m_hdf_io->hlexists(dataset_half), true);
+
+    Mat mat_half_read;
+    m_hdf_io->dsread(mat_half_read, dataset_half);
+    EXPECT_EQ(mat_half_read.type(), mat_half.type());
+    EXPECT_EQ(mat_half_read.size(), mat_half.size());
+    // Compare values (allowing for small error due to half precision)
+    double diff = cvtest::norm(mat_half, mat_half_read, NORM_L2);
+    EXPECT_LE(diff, 1e-3);
+
+    m_hdf_io->close();
+#else
+    std::cout << "CV_16F is not supported in this build." << std::endl;
+#endif
+}
 }} // namespace


### PR DESCRIPTION
### Pull Request Readiness Checklist
HDF5 v2.0.0 finally introduced Float16 support. So we should take the advantage to allow save/load CV_16F in opencv.

https://github.com/opencv/opencv_contrib/issues/4075

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
