### PR TITLE
Fix documentation for DisparityFilter disparity map types

### DIFF
--- a/modules/ximgproc/include/opencv2/ximgproc/disparity_filter.hpp
+++ b/modules/ximgproc/include/opencv2/ximgproc/disparity_filter.hpp
@@ -62,11 +62,14 @@ public:
     @param left_view left view of the original stereo-pair to guide the filtering process, 8-bit single-channel
     or three-channel image.
 
-    @param filtered_disparity_map output disparity map.
+    @param filtered_disparity_map output disparity map, single-channel CV_16S type,
+    with disparity values scaled by 16.
+
 
     @param disparity_map_right optional argument, some implementations might also use the disparity map
-    of the right view to compute confidence maps. If provided, it must be a single-channel CV_32F matrix,
-    otherwise a runtime assertion will fail.
+    of the right view to compute confidence maps. If provided, it must be a single-channel CV_16S matrix.
+    Disparity values are expected to be scaled by 16 (one-pixel disparity corresponds to the value of 16).  
+
 
     @param ROI region of the disparity map to filter. Optional, usually it should be set automatically.
 


### PR DESCRIPTION
This PR fixes incorrect documentation in ximgproc::DisparityFilter regarding
the expected type of disparity_map_right and clarifies the output disparity
map format. No functional or behavioral changes are included.

This is a documentation-only change.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
