### PR TITLE
Legacy modules port from main 4.x to 5.x contrib

### DIFF
--- a/modules/gapi/include/opencv2/gapi/infer/ov.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/ov.hpp
@@ -214,7 +214,7 @@ public:
 
     This function is used to ensure that all tensors in the model have names.
     It goes through all input and output nodes of the model and sets the names
-    if they are not set. This is neccessary for models with nameless tensors.
+    if they are not set. This is necessary for models with nameless tensors.
 
     If a tensor does not have a name, it will be assigned a default name
     based on the producer node's friendly name. If the producer node has multiple

--- a/modules/gapi/src/3rdparty/vasot/src/components/ot/mtt/rgb_histogram.cpp
+++ b/modules/gapi/src/3rdparty/vasot/src/components/ot/mtt/rgb_histogram.cpp
@@ -11,7 +11,7 @@ namespace ot {
 
 RgbHistogram::RgbHistogram(int32_t rgb_bin_size)
     : rgb_bin_size_(rgb_bin_size), rgb_num_bins_(256 / rgb_bin_size),
-      rgb_hist_size_(static_cast<int32_t>(pow(rgb_num_bins_, 3))) {
+      rgb_hist_size_(static_cast<int32_t>(std::pow(rgb_num_bins_, 3))) {
 }
 
 RgbHistogram::~RgbHistogram(void) {

--- a/modules/gapi/src/streaming/onevpl/utils.cpp
+++ b/modules/gapi/src/streaming/onevpl/utils.cpp
@@ -401,10 +401,10 @@ std::string ext_mem_frame_type_to_cstr(int type) {
     std::stringstream ss;
     APPEND_STRINGIFY_MASK_N_ERASE(type, "|", MFX_MEMTYPE_DXVA2_DECODER_TARGET);
     APPEND_STRINGIFY_MASK_N_ERASE(type, "|", MFX_MEMTYPE_DXVA2_PROCESSOR_TARGET);
-    // NB: according to VPL source the commented MFX_* constane below are belong to the
+    // NB: according to VPL source the commented MFX_* constant below are belong to the
     // same actual integral value as condition abobe. So it is impossible
     // to distinct them in condition branch.  Just put this comment and possible
-    // constans here...
+    // constants here...
     //APPEND_STRINGIFY_MASK_N_ERASE(type, "|", MFX_MEMTYPE_VIDEO_MEMORY_DECODER_TARGET);
     //APPEND_STRINGIFY_MASK_N_ERASE(type, "|", MFX_MEMTYPE_VIDEO_MEMORY_PROCESSOR_TARGET);
     APPEND_STRINGIFY_MASK_N_ERASE(type, "|", MFX_MEMTYPE_SYSTEM_MEMORY);

--- a/modules/gapi/test/infer/gapi_infer_ie_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_ie_test.cpp
@@ -3174,7 +3174,7 @@ TEST_F(AgeGenderInferTest, ChangeOutputPrecision) {
     validate();
 }
 
-TEST_F(AgeGenderInferTest, ChangeSpecificOutputPrecison) {
+TEST_F(AgeGenderInferTest, ChangeSpecificOutputPrecision) {
     auto pp = cv::gapi::ie::Params<AgeGender> {
         m_params.model_path, m_params.weights_path, m_params.device_id
     }.cfgOutputLayers({ "age_conv3", "prob" })

--- a/modules/ml/src/ann_mlp.cpp
+++ b/modules/ml/src/ann_mlp.cpp
@@ -277,7 +277,7 @@ public:
         {
             int n1 = layer_sizes[i-1];
             int n2 = layer_sizes[i];
-            double val = 0, G = n2 > 2 ? 0.7*pow((double)n1,1./(n2-1)) : 1.;
+            double val = 0, G = n2 > 2 ? 0.7*std::pow(n1,1./(n2-1)) : 1.;
             double* w = weights[i].ptr<double>();
 
             // initialize weights using Nguyen-Widrow algorithm


### PR DESCRIPTION
Main OpenCV: https://github.com/opencv/opencv/pull/28560

Port from main repo, 4.x branch:
#28537 from reeseliao:fix-typo-gapi
#28362 from vrabaud:lsh