### PR TITLE
add CV_16F support in hdf5

### DIFF
--- a/modules/hdf/src/hdf5.cpp
+++ b/modules/hdf/src/hdf5.cpp
@@ -38,1399 +38,1395 @@
 
 using namespace std;
 
-namespace cv
-{
-namespace hdf
-{
+namespace cv {
+namespace hdf {
 
-class HDF5Impl CV_FINAL : public HDF5
-{
+class HDF5Impl CV_FINAL : public HDF5 {
 public:
+  HDF5Impl(const String &HDF5Filename);
 
-    HDF5Impl( const String& HDF5Filename );
+  virtual ~HDF5Impl() CV_OVERRIDE { close(); };
 
-    virtual ~HDF5Impl() CV_OVERRIDE { close(); };
+  // close and release
+  virtual void close() CV_OVERRIDE;
 
-    // close and release
-    virtual void close( ) CV_OVERRIDE;
+  /*
+   * h5 generic
+   */
 
-    /*
-     * h5 generic
-     */
+  // check if object / link exists
+  virtual bool hlexists(const String &label) const CV_OVERRIDE;
 
-    // check if object / link exists
-    virtual bool hlexists( const String& label ) const CV_OVERRIDE;
+  virtual bool atexists(const String &atlabel) const CV_OVERRIDE;
+  virtual void atdelete(const String &atlabel) CV_OVERRIDE;
 
-    virtual bool atexists(const String& atlabel) const CV_OVERRIDE;
-    virtual void atdelete(const String& atlabel) CV_OVERRIDE;
+  virtual void atwrite(const int value, const String &atlabel) CV_OVERRIDE;
+  virtual void atread(int *value, const String &atlabel) CV_OVERRIDE;
 
-    virtual void atwrite(const int value, const String& atlabel) CV_OVERRIDE;
-    virtual void atread(int* value, const String& atlabel) CV_OVERRIDE;
+  virtual void atwrite(const double value, const String &atlabel) CV_OVERRIDE;
+  virtual void atread(double *value, const String &atlabel) CV_OVERRIDE;
 
-    virtual void atwrite(const double value, const String& atlabel) CV_OVERRIDE;
-    virtual void atread(double* value, const String& atlabel) CV_OVERRIDE;
+  virtual void atwrite(const String &value, const String &atlabel) CV_OVERRIDE;
+  virtual void atread(String *value, const String &atlabel) CV_OVERRIDE;
 
-    virtual void atwrite(const String& value, const String& atlabel) CV_OVERRIDE;
-    virtual void atread(String* value, const String& atlabel) CV_OVERRIDE;
+  virtual void atwrite(InputArray value, const String &atlabel) CV_OVERRIDE;
+  virtual void atread(OutputArray value, const String &atlabel) CV_OVERRIDE;
 
-    virtual void atwrite(InputArray value, const String& atlabel) CV_OVERRIDE;
-    virtual void atread(OutputArray value, const String& atlabel) CV_OVERRIDE;
+  /*
+   * h5 group
+   */
 
-    /*
-     * h5 group
-     */
+  // create a group
+  virtual void grcreate(const String &grlabel) CV_OVERRIDE;
 
-    // create a group
-    virtual void grcreate( const String& grlabel ) CV_OVERRIDE;
+  /*
+   *  cv::Mat
+   */
 
-    /*
-     *  cv::Mat
-     */
+  // get sizes of dataset
+  virtual vector<int> dsgetsize(const String &dslabel,
+                                int dims_flag = H5_GETDIMS) const CV_OVERRIDE;
 
-    // get sizes of dataset
-    virtual vector<int> dsgetsize( const String& dslabel, int dims_flag = H5_GETDIMS ) const CV_OVERRIDE;
+  /* get data type of dataset */
+  virtual int dsgettype(const String &dslabel) const CV_OVERRIDE;
 
-    /* get data type of dataset */
-    virtual int dsgettype( const String& dslabel ) const CV_OVERRIDE;
+  // overload dscreate() #1
+  virtual void dscreate(const int rows, const int cols, const int type,
+                        const String &dslabel) const CV_OVERRIDE;
 
-    // overload dscreate() #1
-    virtual void dscreate( const int rows, const int cols, const int type, const String& dslabel ) const CV_OVERRIDE;
+  // overload dscreate() #2
+  virtual void dscreate(const int rows, const int cols, const int type,
+                        const String &dslabel,
+                        const int compresslevel) const CV_OVERRIDE;
 
-    // overload dscreate() #2
-    virtual void dscreate( const int rows, const int cols, const int type, const String& dslabel,
-             const int compresslevel ) const CV_OVERRIDE;
+  // overload dscreate() #3
+  virtual void dscreate(const int rows, const int cols, const int type,
+                        const String &dslabel, const int compresslevel,
+                        const vector<int> &dims_chunks) const CV_OVERRIDE;
 
-    // overload dscreate() #3
-    virtual void dscreate( const int rows, const int cols, const int type, const String& dslabel,
-             const int compresslevel, const vector<int>& dims_chunks ) const CV_OVERRIDE;
+  /* create two dimensional single or mutichannel dataset */
+  virtual void dscreate(const int rows, const int cols, const int type,
+                        const String &dslabel, const int compresslevel,
+                        const int *dims_chunks) const CV_OVERRIDE;
 
-    /* create two dimensional single or mutichannel dataset */
-    virtual void dscreate( const int rows, const int cols, const int type, const String& dslabel,
-             const int compresslevel, const int* dims_chunks ) const CV_OVERRIDE;
+  // overload dscreate() #1
+  virtual void dscreate(const int n_dims, const int *sizes, const int type,
+                        const String &dslabel) const CV_OVERRIDE;
 
-    // overload dscreate() #1
-    virtual void dscreate( const int n_dims, const int* sizes, const int type,
-             const String& dslabel ) const CV_OVERRIDE;
+  // overload dscreate() #2
+  virtual void dscreate(const int n_dims, const int *sizes, const int type,
+                        const String &dslabel,
+                        const int compresslevel) const CV_OVERRIDE;
 
-    // overload dscreate() #2
-    virtual void dscreate( const int n_dims, const int* sizes, const int type,
-             const String& dslabel, const int compresslevel ) const CV_OVERRIDE;
+  // overload dscreate() #3
+  virtual void
+  dscreate(const vector<int> &sizes, const int type, const String &dslabel,
+           const int compresslevel = H5_NONE,
+           const vector<int> &dims_chunks = vector<int>()) const CV_OVERRIDE;
 
-    // overload dscreate() #3
-    virtual void dscreate( const vector<int>& sizes, const int type, const String& dslabel,
-             const int compresslevel = H5_NONE, const vector<int>& dims_chunks = vector<int>() ) const CV_OVERRIDE;
+  /* create n-dimensional single or mutichannel dataset */
+  virtual void dscreate(const int n_dims, const int *sizes, const int type,
+                        const String &dslabel, const int compresslevel,
+                        const int *dims_chunks) const CV_OVERRIDE;
 
-    /* create n-dimensional single or mutichannel dataset */
-    virtual void dscreate( const int n_dims, const int* sizes, const int type,
-             const String& dslabel, const int compresslevel, const int* dims_chunks ) const CV_OVERRIDE;
+  // overload dswrite() #1
+  virtual void dswrite(InputArray Array,
+                       const String &dslabel) const CV_OVERRIDE;
 
-    // overload dswrite() #1
-    virtual void dswrite( InputArray Array, const String& dslabel ) const CV_OVERRIDE;
+  // overload dswrite() #2
+  virtual void dswrite(InputArray Array, const String &dslabel,
+                       const int *dims_offset) const CV_OVERRIDE;
 
-    // overload dswrite() #2
-    virtual void dswrite( InputArray Array, const String& dslabel, const int* dims_offset ) const CV_OVERRIDE;
+  // overload dswrite() #3
+  virtual void
+  dswrite(InputArray Array, const String &dslabel,
+          const vector<int> &dims_offset,
+          const vector<int> &dims_counts = vector<int>()) const CV_OVERRIDE;
 
-    // overload dswrite() #3
-    virtual void dswrite( InputArray Array, const String& dslabel, const vector<int>& dims_offset,
-             const vector<int>& dims_counts = vector<int>() ) const CV_OVERRIDE;
+  /* write into dataset */
+  virtual void dswrite(InputArray Array, const String &dslabel,
+                       const int *dims_offset,
+                       const int *dims_counts) const CV_OVERRIDE;
 
-    /* write into dataset */
-    virtual void dswrite( InputArray Array, const String& dslabel,
-             const int* dims_offset, const int* dims_counts ) const CV_OVERRIDE;
+  // overload dsinsert() #1
+  virtual void dsinsert(InputArray Array,
+                        const String &dslabel) const CV_OVERRIDE;
 
-    // overload dsinsert() #1
-    virtual void dsinsert( InputArray Array, const String& dslabel ) const CV_OVERRIDE;
+  // overload dsinsert() #2
+  virtual void dsinsert(InputArray Array, const String &dslabel,
+                        const int *dims_offset) const CV_OVERRIDE;
 
-    // overload dsinsert() #2
-    virtual void dsinsert( InputArray Array, const String& dslabel, const int* dims_offset ) const CV_OVERRIDE;
+  // overload dsinsert() #3
+  virtual void
+  dsinsert(InputArray Array, const String &dslabel,
+           const vector<int> &dims_offset,
+           const vector<int> &dims_counts = vector<int>()) const CV_OVERRIDE;
 
-    // overload dsinsert() #3
-    virtual void dsinsert( InputArray Array, const String& dslabel,
-             const vector<int>& dims_offset, const vector<int>& dims_counts = vector<int>() ) const CV_OVERRIDE;
+  /* append / merge into dataset */
+  virtual void dsinsert(InputArray Array, const String &dslabel,
+                        const int *dims_offset = NULL,
+                        const int *dims_counts = NULL) const CV_OVERRIDE;
 
-    /* append / merge into dataset */
-    virtual void dsinsert( InputArray Array, const String& dslabel,
-             const int* dims_offset = NULL, const int* dims_counts = NULL ) const CV_OVERRIDE;
+  // overload dsread() #1
+  virtual void dsread(OutputArray Array,
+                      const String &dslabel) const CV_OVERRIDE;
 
-    // overload dsread() #1
-    virtual void dsread( OutputArray Array, const String& dslabel ) const CV_OVERRIDE;
+  // overload dsread() #2
+  virtual void dsread(OutputArray Array, const String &dslabel,
+                      const int *dims_offset) const CV_OVERRIDE;
 
-    // overload dsread() #2
-    virtual void dsread( OutputArray Array, const String& dslabel, const int* dims_offset ) const CV_OVERRIDE;
+  // overload dsread() #3
+  virtual void
+  dsread(OutputArray Array, const String &dslabel,
+         const vector<int> &dims_offset,
+         const vector<int> &dims_counts = vector<int>()) const CV_OVERRIDE;
 
-    // overload dsread() #3
-    virtual void dsread( OutputArray Array, const String& dslabel,
-             const vector<int>& dims_offset, const vector<int>& dims_counts = vector<int>() ) const CV_OVERRIDE;
+  // read from dataset
+  virtual void dsread(OutputArray Array, const String &dslabel,
+                      const int *dims_offset,
+                      const int *dims_counts) const CV_OVERRIDE;
 
-    // read from dataset
-    virtual void dsread( OutputArray Array, const String& dslabel,
-             const int* dims_offset, const int* dims_counts ) const CV_OVERRIDE;
+  /*
+   *  std::vector<cv::KeyPoint>
+   */
 
-    /*
-     *  std::vector<cv::KeyPoint>
-     */
+  // get size of keypoints dataset
+  virtual int kpgetsize(const String &kplabel,
+                        int dims_flag = H5_GETDIMS) const CV_OVERRIDE;
 
-    // get size of keypoints dataset
-    virtual int kpgetsize( const String& kplabel, int dims_flag = H5_GETDIMS ) const CV_OVERRIDE;
+  // create KeyPoint structure
+  virtual void kpcreate(const int size, const String &kplabel,
+                        const int compresslevel = H5_NONE,
+                        const int chunks = H5_NONE) const CV_OVERRIDE;
 
-    // create KeyPoint structure
-    virtual void kpcreate( const int size, const String& kplabel,
-             const int compresslevel = H5_NONE, const int chunks = H5_NONE ) const CV_OVERRIDE;
+  // write KeyPoint structures
+  virtual void kpwrite(const vector<KeyPoint> keypoints, const String &kplabel,
+                       const int offset = H5_NONE,
+                       const int counts = H5_NONE) const CV_OVERRIDE;
 
-    // write KeyPoint structures
-    virtual void kpwrite( const vector<KeyPoint> keypoints, const String& kplabel,
-             const int offset = H5_NONE, const int counts = H5_NONE ) const CV_OVERRIDE;
+  // append / merge KeyPoint structures
+  virtual void kpinsert(const vector<KeyPoint> keypoints, const String &kplabel,
+                        const int offset = H5_NONE,
+                        const int counts = H5_NONE) const CV_OVERRIDE;
 
-    // append / merge KeyPoint structures
-    virtual void kpinsert( const vector<KeyPoint> keypoints, const String& kplabel,
-             const int offset = H5_NONE, const int counts = H5_NONE ) const CV_OVERRIDE;
-
-    // read KeyPoint structure
-    virtual void kpread( vector<KeyPoint>& keypoints, const String& kplabel,
-             const int offset = H5_NONE, const int counts = H5_NONE ) const CV_OVERRIDE;
+  // read KeyPoint structure
+  virtual void kpread(vector<KeyPoint> &keypoints, const String &kplabel,
+                      const int offset = H5_NONE,
+                      const int counts = H5_NONE) const CV_OVERRIDE;
 
 private:
+  //! store filename
+  String m_hdf5_filename;
 
-    //! store filename
-    String m_hdf5_filename;
+  //! hdf5 file handler
+  hid_t m_h5_file_id;
 
-    //! hdf5 file handler
-    hid_t m_h5_file_id;
+  //! translate cvType -> h5Type
+  inline hid_t GetH5type(int cvType) const;
 
-    //! translate cvType -> h5Type
-    inline hid_t GetH5type( int cvType ) const;
-
-    //! translate h5Type -> cvType
-    inline int GetCVtype( hid_t h5Type ) const;
-
+  //! translate h5Type -> cvType
+  inline int GetCVtype(hid_t h5Type) const;
 };
 
-inline hid_t HDF5Impl::GetH5type( int cvType ) const
-{
-    hid_t h5Type = -1;
+inline hid_t HDF5Impl::GetH5type(int cvType) const {
+  hid_t h5Type = -1;
 
-    switch ( CV_MAT_DEPTH( cvType ) )
-    {
-      case CV_64F:
-        h5Type = H5T_NATIVE_DOUBLE;
-        break;
-      case CV_32F:
-        h5Type = H5T_NATIVE_FLOAT;
-        break;
-      case CV_8U:
-        h5Type = H5T_NATIVE_UCHAR;
-        break;
-      case CV_8S:
-        h5Type = H5T_NATIVE_CHAR;
-        break;
-      case CV_16U:
-        h5Type = H5T_NATIVE_USHORT;
-        break;
-      case CV_16S:
-        h5Type = H5T_NATIVE_SHORT;
-        break;
-      case CV_32S:
-        h5Type = H5T_NATIVE_INT;
-        break;
-      default:
-        CV_Error_(Error::StsInternal, ("Unknown cvType: %d.", cvType));
-    }
-    return h5Type;
+  switch (CV_MAT_DEPTH(cvType)) {
+  case CV_64F:
+    h5Type = H5T_NATIVE_DOUBLE;
+    break;
+  case CV_32F:
+    h5Type = H5T_NATIVE_FLOAT;
+    break;
+  case CV_8U:
+    h5Type = H5T_NATIVE_UCHAR;
+    break;
+  case CV_8S:
+    h5Type = H5T_NATIVE_CHAR;
+    break;
+  case CV_16U:
+    h5Type = H5T_NATIVE_USHORT;
+    break;
+  case CV_16S:
+    h5Type = H5T_NATIVE_SHORT;
+    break;
+  case CV_32S:
+    h5Type = H5T_NATIVE_INT;
+    break;
+#if H5_VERSION_GE(1, 14, 4)
+  case CV_16F:
+    h5Type = H5T_IEEE_F16LE;
+    break;
+#endif
+  default:
+    CV_Error_(Error::StsInternal, ("Unknown cvType: %d.", cvType));
+  }
+  return h5Type;
 }
 
-inline int HDF5Impl::GetCVtype( hid_t h5Type ) const
-{
-    int cvType = -1;
+inline int HDF5Impl::GetCVtype(hid_t h5Type) const {
+  int cvType = -1;
 
-    if      ( H5Tequal( h5Type, H5T_NATIVE_DOUBLE ) )
-      cvType = CV_64F;
-    else if ( H5Tequal( h5Type, H5T_NATIVE_FLOAT  ) )
-      cvType = CV_32F;
-    else if ( H5Tequal( h5Type, H5T_NATIVE_UCHAR  ) )
-      cvType = CV_8U;
-    else if ( H5Tequal( h5Type, H5T_NATIVE_CHAR   ) )
-      cvType = CV_8S;
-    else if ( H5Tequal( h5Type, H5T_NATIVE_USHORT ) )
-      cvType = CV_16U;
-    else if ( H5Tequal( h5Type, H5T_NATIVE_SHORT  ) )
-      cvType = CV_16S;
-    else if ( H5Tequal( h5Type, H5T_NATIVE_INT    ) )
-      cvType = CV_32S;
-    else
-      CV_Error_(Error::StsInternal, ("Unknown H5Type: %lld.", (long long)h5Type));
+  if (H5Tequal(h5Type, H5T_NATIVE_DOUBLE))
+    cvType = CV_64F;
+  else if (H5Tequal(h5Type, H5T_NATIVE_FLOAT))
+    cvType = CV_32F;
+  else if (H5Tequal(h5Type, H5T_NATIVE_UCHAR))
+    cvType = CV_8U;
+  else if (H5Tequal(h5Type, H5T_NATIVE_CHAR))
+    cvType = CV_8S;
+  else if (H5Tequal(h5Type, H5T_NATIVE_USHORT))
+    cvType = CV_16U;
+  else if (H5Tequal(h5Type, H5T_NATIVE_SHORT))
+    cvType = CV_16S;
+  else if (H5Tequal(h5Type, H5T_NATIVE_INT))
+    cvType = CV_32S;
+#if H5_VERSION_GE(1, 14, 4)
+  else if (H5Tget_class(h5Type) == H5T_FLOAT && H5Tget_size(h5Type) == 2)
+    cvType = CV_16F;
+#endif
+  else
+    CV_Error_(Error::StsInternal, ("Unknown H5Type: %lld.", (long long)h5Type));
 
-    return cvType;
+  return cvType;
 }
 
-HDF5Impl::HDF5Impl( const String& _hdf5_filename )
-                  : m_hdf5_filename( _hdf5_filename )
-{
-    // save old
-    // error handler
-    void *errdata;
-    H5E_auto2_t errfunc;
-    hid_t stackid = H5E_DEFAULT;
-    H5Eget_auto( stackid, &errfunc, &errdata );
+HDF5Impl::HDF5Impl(const String &_hdf5_filename)
+    : m_hdf5_filename(_hdf5_filename) {
+  // save old
+  // error handler
+  void *errdata;
+  H5E_auto2_t errfunc;
+  hid_t stackid = H5E_DEFAULT;
+  H5Eget_auto(stackid, &errfunc, &errdata);
 
-    // turn off error handling
-    H5Eset_auto( stackid, NULL, NULL );
+  // turn off error handling
+  H5Eset_auto(stackid, NULL, NULL);
 
-    // check HDF5 file presence (err suppressed)
-    htri_t check = H5Fis_hdf5( m_hdf5_filename.c_str() );
+  // check HDF5 file presence (err suppressed)
+  htri_t check = H5Fis_hdf5(m_hdf5_filename.c_str());
 
-    // restore previous error handler
-    H5Eset_auto( stackid, errfunc, errdata );
+  // restore previous error handler
+  H5Eset_auto(stackid, errfunc, errdata);
 
-    if ( check == 1 || check == 0 )
-      // open the HDF5 file
-      m_h5_file_id = H5Fopen( m_hdf5_filename.c_str(),
-                            H5F_ACC_RDWR, H5P_DEFAULT );
-    else if ( check == -1 )
-      // file does not exist
-      m_h5_file_id = H5Fcreate( m_hdf5_filename.c_str(),
-                     H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT );
-    else
-      CV_Error( Error::StsInternal, "Unknown file state." );
+  if (check == 1 || check == 0)
+    // open the HDF5 file
+    m_h5_file_id = H5Fopen(m_hdf5_filename.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
+  else if (check == -1)
+    // file does not exist
+    m_h5_file_id = H5Fcreate(m_hdf5_filename.c_str(), H5F_ACC_TRUNC,
+                             H5P_DEFAULT, H5P_DEFAULT);
+  else
+    CV_Error(Error::StsInternal, "Unknown file state.");
 }
 
-void HDF5Impl::close()
-{
-    if ( m_h5_file_id != -1 )
-      H5Fclose( m_h5_file_id );
-    // mark closed
-    m_h5_file_id = -1;
+void HDF5Impl::close() {
+  if (m_h5_file_id != -1)
+    H5Fclose(m_h5_file_id);
+  // mark closed
+  m_h5_file_id = -1;
 }
 
 /*
  * h5 generic
  */
 
-bool HDF5Impl::hlexists( const String& label ) const
-{
-    bool exists = false;
+bool HDF5Impl::hlexists(const String &label) const {
+  bool exists = false;
 
-    hid_t lid = H5Pcreate( H5P_LINK_ACCESS );
-    if ( H5Lexists(m_h5_file_id, label.c_str(), lid) == 1 )
-      exists = true;
+  hid_t lid = H5Pcreate(H5P_LINK_ACCESS);
+  if (H5Lexists(m_h5_file_id, label.c_str(), lid) == 1)
+    exists = true;
 
-    H5Pclose(lid);
-    return exists;
+  H5Pclose(lid);
+  return exists;
 }
 
-bool HDF5Impl::atexists(const String& atlabel) const
-{
-    bool res = false;
+bool HDF5Impl::atexists(const String &atlabel) const {
+  bool res = false;
 
-    // save old error handler
-    void *errdata;
-    H5E_auto2_t errfunc;
-    hid_t stackid = H5E_DEFAULT;
-    H5Eget_auto(stackid, &errfunc, &errdata);
+  // save old error handler
+  void *errdata;
+  H5E_auto2_t errfunc;
+  hid_t stackid = H5E_DEFAULT;
+  H5Eget_auto(stackid, &errfunc, &errdata);
 
-    // turn off error handling
-    H5Eset_auto(stackid, NULL, NULL);
+  // turn off error handling
+  H5Eset_auto(stackid, NULL, NULL);
 
-    hid_t attr = H5Aopen_name(m_h5_file_id, atlabel.c_str());
-    if (attr >= 0)
-    {
-        res = true;
-        H5Aclose(attr);
-    }
-
-    // restore previous error handler
-    H5Eset_auto(stackid, errfunc, errdata);
-
-    return res;
-}
-
-void HDF5Impl::atdelete(const String& atlabel)
-{
-    if (!atexists(atlabel))
-        CV_Error_(Error::StsInternal,("The attribute '%s' does not exist!", atlabel.c_str()));
-
-    H5Adelete(m_h5_file_id, atlabel.c_str());
-}
-
-void HDF5Impl::atwrite(const int value, const String& atlabel)
-{
-    if (atexists(atlabel))
-        CV_Error_(Error::StsInternal,("The attribute '%s' already exists!", atlabel.c_str()));
-
-    hid_t aid = H5Screate(H5S_SCALAR);;
-    hid_t attr = H5Acreate2(m_h5_file_id, atlabel.c_str(), H5T_NATIVE_INT, aid,
-                            H5P_DEFAULT, H5P_DEFAULT);
-    H5Awrite(attr, H5T_NATIVE_INT, &value);
-
-    H5Sclose(aid);
+  hid_t attr = H5Aopen_name(m_h5_file_id, atlabel.c_str());
+  if (attr >= 0) {
+    res = true;
     H5Aclose(attr);
+  }
+
+  // restore previous error handler
+  H5Eset_auto(stackid, errfunc, errdata);
+
+  return res;
 }
 
-void HDF5Impl::atread(int* value, const String& atlabel)
-{
-    if (!value)
-        CV_Error(Error::StsBadArg, "NULL pointer");
+void HDF5Impl::atdelete(const String &atlabel) {
+  if (!atexists(atlabel))
+    CV_Error_(Error::StsInternal,
+              ("The attribute '%s' does not exist!", atlabel.c_str()));
 
-    if (!atexists(atlabel))
-        CV_Error_(Error::StsInternal, ("Attribute '%s' does not exist!", atlabel.c_str()));
-
-    hid_t attr = H5Aopen(m_h5_file_id, atlabel.c_str(), H5P_DEFAULT);
-    H5Aread(attr, H5T_NATIVE_INT, value);
-    H5Aclose(attr);
+  H5Adelete(m_h5_file_id, atlabel.c_str());
 }
 
-void HDF5Impl::atwrite(const double value, const String& atlabel)
-{
-    if (atexists(atlabel))
-        CV_Error_(Error::StsInternal,("The attribute '%s' already exists!", atlabel.c_str()));
+void HDF5Impl::atwrite(const int value, const String &atlabel) {
+  if (atexists(atlabel))
+    CV_Error_(Error::StsInternal,
+              ("The attribute '%s' already exists!", atlabel.c_str()));
 
-    hid_t aid = H5Screate(H5S_SCALAR);;
-    hid_t attr = H5Acreate2(m_h5_file_id, atlabel.c_str(), H5T_NATIVE_DOUBLE, aid,
-                            H5P_DEFAULT, H5P_DEFAULT);
-    H5Awrite(attr, H5T_NATIVE_DOUBLE, &value);
+  hid_t aid = H5Screate(H5S_SCALAR);
+  ;
+  hid_t attr = H5Acreate2(m_h5_file_id, atlabel.c_str(), H5T_NATIVE_INT, aid,
+                          H5P_DEFAULT, H5P_DEFAULT);
+  H5Awrite(attr, H5T_NATIVE_INT, &value);
 
-    H5Sclose(aid);
-    H5Aclose(attr);
+  H5Sclose(aid);
+  H5Aclose(attr);
 }
 
-void HDF5Impl::atread(double* value, const String& atlabel)
-{
-    if (!value)
-        CV_Error(Error::StsBadArg, "NULL pointer");
+void HDF5Impl::atread(int *value, const String &atlabel) {
+  if (!value)
+    CV_Error(Error::StsBadArg, "NULL pointer");
 
-    if (!atexists(atlabel))
-        CV_Error_(Error::StsInternal, ("Attribute '%s' does not exist!", atlabel.c_str()));
+  if (!atexists(atlabel))
+    CV_Error_(Error::StsInternal,
+              ("Attribute '%s' does not exist!", atlabel.c_str()));
 
-    hid_t attr = H5Aopen(m_h5_file_id, atlabel.c_str(), H5P_DEFAULT);
-    H5Aread(attr, H5T_NATIVE_DOUBLE, value);
-    H5Aclose(attr);
+  hid_t attr = H5Aopen(m_h5_file_id, atlabel.c_str(), H5P_DEFAULT);
+  H5Aread(attr, H5T_NATIVE_INT, value);
+  H5Aclose(attr);
 }
 
-void HDF5Impl::atwrite(const String& value, const String& atlabel)
-{
-    if (atexists(atlabel))
-        CV_Error_(Error::StsInternal,("The attribute '%s' already exists!", atlabel.c_str()));
+void HDF5Impl::atwrite(const double value, const String &atlabel) {
+  if (atexists(atlabel))
+    CV_Error_(Error::StsInternal,
+              ("The attribute '%s' already exists!", atlabel.c_str()));
 
-    hid_t aid = H5Screate(H5S_SCALAR);
-    hid_t atype = H5Tcopy(H5T_C_S1);
-    H5Tset_size(atype, value.size()+1);
-    H5Tset_strpad(atype, H5T_STR_NULLTERM);
+  hid_t aid = H5Screate(H5S_SCALAR);
+  ;
+  hid_t attr = H5Acreate2(m_h5_file_id, atlabel.c_str(), H5T_NATIVE_DOUBLE, aid,
+                          H5P_DEFAULT, H5P_DEFAULT);
+  H5Awrite(attr, H5T_NATIVE_DOUBLE, &value);
 
-    hid_t attr = H5Acreate2(m_h5_file_id, atlabel.c_str(), atype, aid, H5P_DEFAULT, H5P_DEFAULT);
-    H5Awrite(attr, atype, value.c_str());
+  H5Sclose(aid);
+  H5Aclose(attr);
+}
 
-    H5Sclose(aid);
+void HDF5Impl::atread(double *value, const String &atlabel) {
+  if (!value)
+    CV_Error(Error::StsBadArg, "NULL pointer");
+
+  if (!atexists(atlabel))
+    CV_Error_(Error::StsInternal,
+              ("Attribute '%s' does not exist!", atlabel.c_str()));
+
+  hid_t attr = H5Aopen(m_h5_file_id, atlabel.c_str(), H5P_DEFAULT);
+  H5Aread(attr, H5T_NATIVE_DOUBLE, value);
+  H5Aclose(attr);
+}
+
+void HDF5Impl::atwrite(const String &value, const String &atlabel) {
+  if (atexists(atlabel))
+    CV_Error_(Error::StsInternal,
+              ("The attribute '%s' already exists!", atlabel.c_str()));
+
+  hid_t aid = H5Screate(H5S_SCALAR);
+  hid_t atype = H5Tcopy(H5T_C_S1);
+  H5Tset_size(atype, value.size() + 1);
+  H5Tset_strpad(atype, H5T_STR_NULLTERM);
+
+  hid_t attr = H5Acreate2(m_h5_file_id, atlabel.c_str(), atype, aid,
+                          H5P_DEFAULT, H5P_DEFAULT);
+  H5Awrite(attr, atype, value.c_str());
+
+  H5Sclose(aid);
+  H5Tclose(atype);
+  H5Aclose(attr);
+}
+
+void HDF5Impl::atread(String *value, const String &atlabel) {
+  if (!value)
+    CV_Error(Error::StsBadArg, "NULL pointer");
+
+  if (!atexists(atlabel))
+    CV_Error_(Error::StsInternal,
+              ("Attribute '%s' does not exist!", atlabel.c_str()));
+
+  hid_t attr = H5Aopen(m_h5_file_id, atlabel.c_str(), H5P_DEFAULT);
+  hid_t atype = H5Aget_type(attr);
+  H5T_class_t type_class = H5Tget_class(atype);
+  if (type_class != H5T_STRING) {
     H5Tclose(atype);
     H5Aclose(attr);
+    CV_Error_(Error::StsInternal,
+              ("Attribute '%s' is not of string type!", atlabel.c_str()));
+  }
+  size_t size = H5Tget_size(atype);
+  AutoBuffer<char> buf(size);
+
+  hid_t atype_mem = H5Tget_native_type(atype, H5T_DIR_ASCEND);
+  H5Aread(attr, atype_mem, buf.data());
+  if (size > 0 && buf[size - 1] == '\0')
+    size--;
+  value->assign(buf.data(), size);
+
+  H5Tclose(atype_mem);
+  H5Tclose(atype);
+  H5Aclose(attr);
 }
 
-void HDF5Impl::atread(String* value, const String& atlabel)
-{
-    if (!value)
-        CV_Error(Error::StsBadArg, "NULL pointer");
+void HDF5Impl::atwrite(InputArray value, const String &atlabel) {
+  if (atexists(atlabel))
+    CV_Error_(Error::StsInternal,
+              ("The attribute '%s' already exists!", atlabel.c_str()));
 
-    if (!atexists(atlabel))
-        CV_Error_(Error::StsInternal, ("Attribute '%s' does not exist!", atlabel.c_str()));
+  Mat value_ = value.getMat();
 
-    hid_t attr = H5Aopen(m_h5_file_id, atlabel.c_str(), H5P_DEFAULT);
-    hid_t atype = H5Aget_type(attr);
-    H5T_class_t type_class = H5Tget_class(atype);
-    if (type_class != H5T_STRING)
-    {
-        H5Tclose(atype);
-        H5Aclose(attr);
-        CV_Error_(Error::StsInternal, ("Attribute '%s' is not of string type!", atlabel.c_str()));
-    }
-    size_t size = H5Tget_size(atype);
-    AutoBuffer<char> buf(size);
+  if (!value_.isContinuous())
+    CV_Error(Error::StsInternal, "Only continuous array are implemented. "
+                                 "Current array is not continuous!");
 
-    hid_t atype_mem = H5Tget_native_type(atype, H5T_DIR_ASCEND);
-    H5Aread(attr, atype_mem, buf.data());
-    if (size > 0 && buf[size - 1] == '\0')
-        size--;
-    value->assign(buf.data(), size);
+  int ndims = value_.dims;
 
-    H5Tclose(atype_mem);
-    H5Tclose(atype);
-    H5Aclose(attr);
+  vector<hsize_t> dim_vec(ndims);
+  for (int i = 0; i < ndims; i++)
+    dim_vec[i] = value_.size[i];
+
+  hid_t dtype = GetH5type(value_.type());
+  if (value_.channels() > 1) {
+    hsize_t dims[1] = {(hsize_t)value_.channels()};
+    dtype = H5Tarray_create(dtype, 1, dims);
+  }
+
+  hid_t aid = H5Screate(H5S_SIMPLE);
+  H5Sset_extent_simple(aid, ndims, dim_vec.data(), NULL);
+
+  hid_t attr = H5Acreate2(m_h5_file_id, atlabel.c_str(), dtype, aid,
+                          H5P_DEFAULT, H5P_DEFAULT);
+
+  H5Awrite(attr, dtype, value_.data);
+
+  if (value_.channels() > 1)
+    H5Tclose(dtype);
+
+  H5Sclose(aid);
+  H5Aclose(attr);
 }
 
-void HDF5Impl::atwrite(InputArray value, const String& atlabel)
-{
-    if (atexists(atlabel))
-        CV_Error_(Error::StsInternal,("The attribute '%s' already exists!", atlabel.c_str()));
+void HDF5Impl::atread(OutputArray value, const String &atlabel) {
+  if (!atexists(atlabel))
+    CV_Error_(Error::StsInternal,
+              ("Attribute '%s' does not exist!", atlabel.c_str()));
 
-    Mat value_ = value.getMat();
+  hid_t attr = H5Aopen(m_h5_file_id, atlabel.c_str(), H5P_DEFAULT);
+  hid_t atype = H5Aget_type(attr);
+  hid_t aspace = H5Aget_space(attr);
+  int rank = H5Sget_simple_extent_ndims(aspace);
 
-    if (!value_.isContinuous())
-        CV_Error(Error::StsInternal, "Only continuous array are implemented. Current array is not continuous!");
+  vector<hsize_t> dim_vec_(rank);
+  H5Sget_simple_extent_dims(aspace, dim_vec_.data(), NULL);
+  vector<int> dim_vec(dim_vec_.begin(), dim_vec_.end());
 
-    int ndims = value_.dims;
+  int nchannels = 1;
+  hid_t h5type;
+  if (H5Tget_class(atype) == H5T_ARRAY) {
+    hsize_t dims;
+    H5Tget_array_dims(atype, &dims);
+    nchannels = (int)dims;
 
-    vector<hsize_t> dim_vec(ndims);
-    for (int i = 0; i < ndims; i++)
-        dim_vec[i] = value_.size[i];
-
-    hid_t dtype = GetH5type(value_.type());
-    if (value_.channels() > 1)
-    {
-        hsize_t dims[1] = { (hsize_t)value_.channels()};
-        dtype = H5Tarray_create(dtype, 1, dims);
-    }
-
-    hid_t aid = H5Screate(H5S_SIMPLE);
-    H5Sset_extent_simple(aid, ndims, dim_vec.data(), NULL);
-
-    hid_t attr = H5Acreate2(m_h5_file_id, atlabel.c_str(), dtype,
-                            aid, H5P_DEFAULT, H5P_DEFAULT);
-
-    H5Awrite(attr, dtype, value_.data);
-
-    if (value_.channels() > 1)
-        H5Tclose(dtype);
-
-    H5Sclose(aid);
-    H5Aclose(attr);
-}
-
-void HDF5Impl::atread(OutputArray value, const String& atlabel)
-{
-    if (!atexists(atlabel))
-        CV_Error_(Error::StsInternal, ("Attribute '%s' does not exist!", atlabel.c_str()));
-
-    hid_t attr = H5Aopen(m_h5_file_id, atlabel.c_str(), H5P_DEFAULT);
-    hid_t atype  = H5Aget_type(attr);
-    hid_t aspace = H5Aget_space(attr);
-    int rank = H5Sget_simple_extent_ndims(aspace);
-
-    vector<hsize_t> dim_vec_(rank);
-    H5Sget_simple_extent_dims(aspace, dim_vec_.data(), NULL);
-    vector<int> dim_vec(dim_vec_.begin(), dim_vec_.end());
-
-    int nchannels = 1;
-    hid_t h5type;
-    if (H5Tget_class(atype) == H5T_ARRAY)
-    {
-        hsize_t dims;
-        H5Tget_array_dims(atype, &dims);
-        nchannels = (int) dims;
-
-        hid_t super_type = H5Tget_super(atype);
-        h5type = H5Tget_native_type(super_type, H5T_DIR_ASCEND);
-        H5Tclose(super_type);
-    }
+    hid_t super_type = H5Tget_super(atype);
+#if H5_VERSION_GE(1, 14, 4)
+    if (H5Tget_class(super_type) == H5T_FLOAT && H5Tget_size(super_type) == 2)
+      h5type = H5Tcopy(super_type);
     else
-        h5type = H5Tget_native_type(atype, H5T_DIR_ASCEND);
+#endif
+      h5type = H5Tget_native_type(super_type, H5T_DIR_ASCEND);
+    H5Tclose(super_type);
+  } else {
+#if H5_VERSION_GE(1, 14, 4)
+    if (H5Tget_class(atype) == H5T_FLOAT && H5Tget_size(atype) == 2)
+      h5type = H5Tcopy(atype);
+    else
+#endif
+      h5type = H5Tget_native_type(atype, H5T_DIR_ASCEND);
+  }
 
-    int dtype = GetCVtype(h5type);
+  int dtype = GetCVtype(h5type);
 
-    value.create(rank, dim_vec.data(), CV_MAKETYPE(dtype, nchannels));
-    H5Aread(attr, atype, value.getMat().data);
+  value.create(rank, dim_vec.data(), CV_MAKETYPE(dtype, nchannels));
+  H5Aread(attr, atype, value.getMat().data);
 
-    H5Sclose(aspace);
-    H5Tclose(atype);
-    H5Aclose(attr);
+  H5Sclose(aspace);
+  H5Tclose(atype);
+  H5Aclose(attr);
 }
 
 /*
  * h5 group
  */
 
-void HDF5Impl::grcreate( const String& grlabel )
-{
-    if (hlexists(grlabel))
-        CV_Error_(Error::StsInternal, ("Requested group '%s' already exists.", grlabel.c_str()));
+void HDF5Impl::grcreate(const String &grlabel) {
+  if (hlexists(grlabel))
+    CV_Error_(Error::StsInternal,
+              ("Requested group '%s' already exists.", grlabel.c_str()));
 
-    hid_t gid = H5Gcreate(m_h5_file_id, grlabel.c_str(),
-                          H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-    H5Gclose(gid);
+  hid_t gid = H5Gcreate(m_h5_file_id, grlabel.c_str(), H5P_DEFAULT, H5P_DEFAULT,
+                        H5P_DEFAULT);
+  H5Gclose(gid);
 }
 
 /*
  * cv:Mat
  */
 
-vector<int> HDF5Impl::dsgetsize( const String& dslabel, int dims_flag ) const
-{
-    // open dataset
-    hid_t dsdata = H5Dopen( m_h5_file_id, dslabel.c_str(), H5P_DEFAULT );
+vector<int> HDF5Impl::dsgetsize(const String &dslabel, int dims_flag) const {
+  // open dataset
+  hid_t dsdata = H5Dopen(m_h5_file_id, dslabel.c_str(), H5P_DEFAULT);
 
-    // get file space
-    hid_t fspace = H5Dget_space( dsdata );
+  // get file space
+  hid_t fspace = H5Dget_space(dsdata);
 
-    // fetch rank
-    int n_dims = H5Sget_simple_extent_ndims( fspace );
+  // fetch rank
+  int n_dims = H5Sget_simple_extent_ndims(fspace);
 
-    // dims storage
-    hsize_t *dims = new hsize_t[n_dims];
+  // dims storage
+  hsize_t *dims = new hsize_t[n_dims];
 
-    // output storage
-    vector<int> SizeVect(0);
+  // output storage
+  vector<int> SizeVect(0);
 
-    // fetch dims
-    if ( dims_flag == H5_GETDIMS ||
-         dims_flag == H5_GETMAXDIMS )
-    {
-      if ( dims_flag == H5_GETDIMS )
-        H5Sget_simple_extent_dims( fspace, dims, NULL );
-      else
-        H5Sget_simple_extent_dims( fspace, NULL, dims );
-      SizeVect.resize( n_dims );
-    }
-    else if ( dims_flag == H5_GETCHUNKDIMS )
-    {
-      // rank size
-      int rank_chunk = -1;
-      // fetch chunk size
-      hid_t cparms = H5Dget_create_plist( dsdata );
-      if ( H5D_CHUNKED == H5Pget_layout ( cparms ) )
-      {
-         rank_chunk = H5Pget_chunk ( cparms, n_dims, dims );
-      }
-      if ( rank_chunk > 0 )
-        SizeVect.resize( n_dims );
-    }
+  // fetch dims
+  if (dims_flag == H5_GETDIMS || dims_flag == H5_GETMAXDIMS) {
+    if (dims_flag == H5_GETDIMS)
+      H5Sget_simple_extent_dims(fspace, dims, NULL);
     else
-      CV_Error_(Error::StsInternal, ("Unknown dimension flag: %d", dims_flag));
+      H5Sget_simple_extent_dims(fspace, NULL, dims);
+    SizeVect.resize(n_dims);
+  } else if (dims_flag == H5_GETCHUNKDIMS) {
+    // rank size
+    int rank_chunk = -1;
+    // fetch chunk size
+    hid_t cparms = H5Dget_create_plist(dsdata);
+    if (H5D_CHUNKED == H5Pget_layout(cparms)) {
+      rank_chunk = H5Pget_chunk(cparms, n_dims, dims);
+    }
+    if (rank_chunk > 0)
+      SizeVect.resize(n_dims);
+  } else
+    CV_Error_(Error::StsInternal, ("Unknown dimension flag: %d", dims_flag));
 
-    // fill with size data
-    for ( size_t d = 0; d < SizeVect.size(); d++ )
-      SizeVect[d] = (int) dims[d];
+  // fill with size data
+  for (size_t d = 0; d < SizeVect.size(); d++)
+    SizeVect[d] = (int)dims[d];
 
-    H5Dclose( dsdata );
-    H5Sclose( fspace );
+  H5Dclose(dsdata);
+  H5Sclose(fspace);
 
-    delete [] dims;
+  delete[] dims;
 
-    return SizeVect;
+  return SizeVect;
 }
 
-int HDF5Impl::dsgettype( const String& dslabel ) const
-{
-    hid_t h5type;
+int HDF5Impl::dsgettype(const String &dslabel) const {
+  hid_t h5type;
 
-    // open dataset
-    hid_t dsdata = H5Dopen( m_h5_file_id, dslabel.c_str(), H5P_DEFAULT );
+  // open dataset
+  hid_t dsdata = H5Dopen(m_h5_file_id, dslabel.c_str(), H5P_DEFAULT);
 
-    // get data type
-    hid_t dstype = H5Dget_type( dsdata );
+  // get data type
+  hid_t dstype = H5Dget_type(dsdata);
 
-    int channs = 1;
-    if ( H5Tget_class( dstype ) == H5T_ARRAY )
-    {
-      // fetch channs
-      hsize_t ardims[1];
-      H5Tget_array_dims( dstype, ardims );
-      channs = (int)ardims[0];
-      // fetch depth
-      hid_t tsuper = H5Tget_super( dstype );
-      h5type = H5Tget_native_type( tsuper, H5T_DIR_ASCEND );
-      H5Tclose( tsuper );
-    }
+  int channs = 1;
+  if (H5Tget_class(dstype) == H5T_ARRAY) {
+    // fetch channs
+    hsize_t ardims[1];
+    H5Tget_array_dims(dstype, ardims);
+    channs = (int)ardims[0];
+    // fetch depth
+    hid_t tsuper = H5Tget_super(dstype);
+#if H5_VERSION_GE(1, 14, 4)
+    if (H5Tget_class(tsuper) == H5T_FLOAT && H5Tget_size(tsuper) == 2)
+      h5type = H5Tcopy(tsuper);
     else
-      h5type = H5Tget_native_type( dstype, H5T_DIR_DESCEND );
+#endif
+      h5type = H5Tget_native_type(tsuper, H5T_DIR_ASCEND);
+    H5Tclose(tsuper);
+  } else {
+#if H5_VERSION_GE(1, 14, 4)
+    if (H5Tget_class(dstype) == H5T_FLOAT && H5Tget_size(dstype) == 2)
+      h5type = H5Tcopy(dstype);
+    else
+#endif
+      h5type = H5Tget_native_type(dstype, H5T_DIR_DESCEND);
+  }
 
-    // convert to CVType
-    int cvtype = GetCVtype( h5type );
+  // convert to CVType
+  int cvtype = GetCVtype(h5type);
 
-    H5Tclose( dstype );
-    H5Dclose( dsdata );
+  H5Tclose(dstype);
+  H5Dclose(dsdata);
 
-    return CV_MAKETYPE( cvtype, channs );
+  return CV_MAKETYPE(cvtype, channs);
 }
 
 // overload
-void HDF5Impl::dscreate( const int rows, const int cols, const int type,
-                         const String& dslabel ) const
-{
-    // dataset dims
-    int dsizes[2] = { rows, cols };
+void HDF5Impl::dscreate(const int rows, const int cols, const int type,
+                        const String &dslabel) const {
+  // dataset dims
+  int dsizes[2] = {rows, cols};
 
-    // create the two dim array
-    dscreate( 2, dsizes, type, dslabel, HDF5::H5_NONE, NULL );
+  // create the two dim array
+  dscreate(2, dsizes, type, dslabel, HDF5::H5_NONE, NULL);
 }
 
 // overload
-void HDF5Impl::dscreate( const int rows, const int cols, const int type,
-                         const String& dslabel, const int compresslevel ) const
-{
-    // dataset dims
-    int dsizes[2] = { rows, cols };
+void HDF5Impl::dscreate(const int rows, const int cols, const int type,
+                        const String &dslabel, const int compresslevel) const {
+  // dataset dims
+  int dsizes[2] = {rows, cols};
 
-    // create the two dim array
-    dscreate( 2, dsizes, type, dslabel, compresslevel, NULL );
+  // create the two dim array
+  dscreate(2, dsizes, type, dslabel, compresslevel, NULL);
 }
 
 // overload
-void HDF5Impl::dscreate( const int rows, const int cols, const int type,
-                 const String& dslabel, const int compresslevel,
-                 const vector<int>& dims_chunks ) const
-{
-    CV_Assert( dims_chunks.empty() || dims_chunks.size() == 2 );
-    dscreate( rows, cols, type, dslabel, compresslevel, dims_chunks.empty() ? NULL : &(dims_chunks[0]) );
+void HDF5Impl::dscreate(const int rows, const int cols, const int type,
+                        const String &dslabel, const int compresslevel,
+                        const vector<int> &dims_chunks) const {
+  CV_Assert(dims_chunks.empty() || dims_chunks.size() == 2);
+  dscreate(rows, cols, type, dslabel, compresslevel,
+           dims_chunks.empty() ? NULL : &(dims_chunks[0]));
 }
 
-void HDF5Impl::dscreate( const int rows, const int cols, const int type,
-                 const String& dslabel, const int compresslevel, const int* dims_chunks ) const
-{
-    // dataset dims
-    int dsizes[2] = { rows, cols };
+void HDF5Impl::dscreate(const int rows, const int cols, const int type,
+                        const String &dslabel, const int compresslevel,
+                        const int *dims_chunks) const {
+  // dataset dims
+  int dsizes[2] = {rows, cols};
 
-    // create the two dim array
-    dscreate( 2, dsizes, type, dslabel, compresslevel, dims_chunks );
-}
-
-// overload
-void HDF5Impl::dscreate( const int n_dims, const int* sizes, const int type,
-                 const String& dslabel ) const
-{
-    dscreate( n_dims, sizes, type, dslabel, H5_NONE, NULL );
+  // create the two dim array
+  dscreate(2, dsizes, type, dslabel, compresslevel, dims_chunks);
 }
 
 // overload
-void HDF5Impl::dscreate( const int n_dims, const int* sizes, const int type,
-                 const String& dslabel, const int compresslevel ) const
-{
-    dscreate( n_dims, sizes, type, dslabel, compresslevel, NULL );
+void HDF5Impl::dscreate(const int n_dims, const int *sizes, const int type,
+                        const String &dslabel) const {
+  dscreate(n_dims, sizes, type, dslabel, H5_NONE, NULL);
 }
 
 // overload
-void HDF5Impl::dscreate( const vector<int>& sizes, const int type,
-                 const String& dslabel, const int compresslevel,
-                 const vector<int>& dims_chunks ) const
-{
-    CV_Assert( dims_chunks.empty() || dims_chunks.size() == sizes.size() );
-
-    const int n_dims = (int) sizes.size();
-    dscreate( n_dims, &sizes[0], type, dslabel, compresslevel, dims_chunks.empty() ? NULL : &(dims_chunks[0]) );
-}
-
-void HDF5Impl::dscreate( const int n_dims, const int* sizes, const int type,
-                 const String& dslabel, const int compresslevel, const int* dims_chunks ) const
-{
-    // compress valid H5_NONE, 0-9
-    CV_Assert( compresslevel >= H5_NONE && compresslevel <= 9 );
-
-    if ( hlexists( dslabel ) == true )
-      CV_Error_(Error::StsInternal, ("Requested dataset '%s' already exists.", dslabel.c_str()));
-
-    int channs = CV_MAT_CN( type );
-
-    hsize_t *chunks = new hsize_t[n_dims];
-    hsize_t *dsdims = new hsize_t[n_dims];
-    hsize_t *maxdim = new hsize_t[n_dims];
-
-    // dimension space
-    for ( int d = 0; d < n_dims; d++ )
-    {
-      CV_Assert( sizes[d] >= H5_UNLIMITED );
-
-      // dataset dimension
-      if ( sizes[d] == H5_UNLIMITED )
-      {
-        CV_Assert( dims_chunks != NULL );
-
-        dsdims[d] = 0;
-        maxdim[d] = H5S_UNLIMITED;
-      }
-      else
-      {
-        dsdims[d] = sizes[d];
-        maxdim[d] = sizes[d];
-      }
-      // default chunking
-      if ( dims_chunks == NULL )
-        chunks[d] = sizes[d];
-      else
-        chunks[d] = dims_chunks[d];
-    }
-
-    // create dataset space
-    hid_t dspace = H5Screate_simple( n_dims, dsdims, maxdim );
-
-    // create data property
-    hid_t dsdcpl = H5Pcreate( H5P_DATASET_CREATE );
-
-    // set properties
-    if ( compresslevel >= 0 )
-      H5Pset_deflate( dsdcpl, compresslevel );
-
-    if ( dims_chunks != NULL || compresslevel >= 0 )
-      H5Pset_chunk( dsdcpl, n_dims, chunks );
-
-    // convert to h5 type
-    hid_t dstype = GetH5type( type );
-
-    // expand channs
-    if ( channs > 1 )
-    {
-      hsize_t adims[1] = { (hsize_t)channs };
-      dstype = H5Tarray_create( dstype, 1, adims );
-    }
-
-    // create data
-    hid_t dsdata = H5Dcreate( m_h5_file_id, dslabel.c_str(), dstype,
-               dspace, H5P_DEFAULT, dsdcpl, H5P_DEFAULT );
-
-    if ( channs > 1 )
-      H5Tclose( dstype );
-
-    delete [] chunks;
-    delete [] dsdims;
-    delete [] maxdim;
-
-    H5Pclose( dsdcpl );
-    H5Sclose( dspace );
-    H5Dclose( dsdata );
+void HDF5Impl::dscreate(const int n_dims, const int *sizes, const int type,
+                        const String &dslabel, const int compresslevel) const {
+  dscreate(n_dims, sizes, type, dslabel, compresslevel, NULL);
 }
 
 // overload
-void HDF5Impl::dsread( OutputArray Array, const String& dslabel ) const
-{
-    dsread( Array, dslabel, NULL, NULL );
+void HDF5Impl::dscreate(const vector<int> &sizes, const int type,
+                        const String &dslabel, const int compresslevel,
+                        const vector<int> &dims_chunks) const {
+  CV_Assert(dims_chunks.empty() || dims_chunks.size() == sizes.size());
+
+  const int n_dims = (int)sizes.size();
+  dscreate(n_dims, &sizes[0], type, dslabel, compresslevel,
+           dims_chunks.empty() ? NULL : &(dims_chunks[0]));
+}
+
+void HDF5Impl::dscreate(const int n_dims, const int *sizes, const int type,
+                        const String &dslabel, const int compresslevel,
+                        const int *dims_chunks) const {
+  // compress valid H5_NONE, 0-9
+  CV_Assert(compresslevel >= H5_NONE && compresslevel <= 9);
+
+  if (hlexists(dslabel) == true)
+    CV_Error_(Error::StsInternal,
+              ("Requested dataset '%s' already exists.", dslabel.c_str()));
+
+  int channs = CV_MAT_CN(type);
+
+  hsize_t *chunks = new hsize_t[n_dims];
+  hsize_t *dsdims = new hsize_t[n_dims];
+  hsize_t *maxdim = new hsize_t[n_dims];
+
+  // dimension space
+  for (int d = 0; d < n_dims; d++) {
+    CV_Assert(sizes[d] >= H5_UNLIMITED);
+
+    // dataset dimension
+    if (sizes[d] == H5_UNLIMITED) {
+      CV_Assert(dims_chunks != NULL);
+
+      dsdims[d] = 0;
+      maxdim[d] = H5S_UNLIMITED;
+    } else {
+      dsdims[d] = sizes[d];
+      maxdim[d] = sizes[d];
+    }
+    // default chunking
+    if (dims_chunks == NULL)
+      chunks[d] = sizes[d];
+    else
+      chunks[d] = dims_chunks[d];
+  }
+
+  // create dataset space
+  hid_t dspace = H5Screate_simple(n_dims, dsdims, maxdim);
+
+  // create data property
+  hid_t dsdcpl = H5Pcreate(H5P_DATASET_CREATE);
+
+  // set properties
+  if (compresslevel >= 0)
+    H5Pset_deflate(dsdcpl, compresslevel);
+
+  if (dims_chunks != NULL || compresslevel >= 0)
+    H5Pset_chunk(dsdcpl, n_dims, chunks);
+
+  // convert to h5 type
+  hid_t dstype = GetH5type(type);
+
+  // expand channs
+  if (channs > 1) {
+    hsize_t adims[1] = {(hsize_t)channs};
+    dstype = H5Tarray_create(dstype, 1, adims);
+  }
+
+  // create data
+  hid_t dsdata = H5Dcreate(m_h5_file_id, dslabel.c_str(), dstype, dspace,
+                           H5P_DEFAULT, dsdcpl, H5P_DEFAULT);
+
+  if (channs > 1)
+    H5Tclose(dstype);
+
+  delete[] chunks;
+  delete[] dsdims;
+  delete[] maxdim;
+
+  H5Pclose(dsdcpl);
+  H5Sclose(dspace);
+  H5Dclose(dsdata);
 }
 
 // overload
-void HDF5Impl::dsread( OutputArray Array, const String& dslabel,
-             const int* dims_offset ) const
-{
-    dsread( Array, dslabel, dims_offset, NULL );
+void HDF5Impl::dsread(OutputArray Array, const String &dslabel) const {
+  dsread(Array, dslabel, NULL, NULL);
 }
 
 // overload
-void HDF5Impl::dsread( OutputArray Array, const String& dslabel,
-             const vector<int>& dims_offset,
-             const vector<int>& dims_counts ) const
-{
-    dsread( Array, dslabel, &dims_offset[0], &dims_counts[0] );
-}
-
-void HDF5Impl::dsread( OutputArray Array, const String& dslabel,
-             const int* dims_offset, const int* dims_counts ) const
-{
-    // only Mat support
-    CV_Assert( Array.isMat() );
-
-    hid_t h5type;
-
-    // open the HDF5 dataset
-    hid_t dsdata = H5Dopen( m_h5_file_id, dslabel.c_str(), H5P_DEFAULT );
-
-    // get data type
-    hid_t dstype = H5Dget_type( dsdata );
-
-    int channs = 1;
-    if ( H5Tget_class( dstype ) == H5T_ARRAY )
-    {
-      // fetch channs
-      hsize_t ardims[1];
-      H5Tget_array_dims( dstype, ardims );
-      channs = (int) ardims[0];
-      // fetch depth
-      hid_t tsuper = H5Tget_super( dstype );
-      h5type = H5Tget_native_type( tsuper, H5T_DIR_ASCEND );
-      H5Tclose( tsuper );
-    } else
-      h5type = H5Tget_native_type( dstype, H5T_DIR_ASCEND );
-
-    int dType = GetCVtype( h5type );
-
-    // get file space
-    hid_t fspace = H5Dget_space( dsdata );
-
-    // fetch rank
-    int n_dims = H5Sget_simple_extent_ndims( fspace );
-
-    // fetch dims
-    hsize_t *dsdims = new hsize_t[n_dims];
-    H5Sget_simple_extent_dims( fspace, dsdims, NULL );
-
-    // set amount by custom offset
-    if ( dims_offset != NULL )
-    {
-      for ( int d = 0; d < n_dims; d++ )
-        dsdims[d] -= dims_offset[d];
-    }
-
-    // set custom amount of data
-    if ( dims_counts != NULL )
-    {
-      for ( int d = 0; d < n_dims; d++ )
-        dsdims[d] = dims_counts[d];
-    }
-
-    // get memory write window
-    int *mxdims = new int[n_dims];
-    hsize_t *foffset = new hsize_t[n_dims];
-    for ( int d = 0; d < n_dims; d++ )
-    {
-      foffset[d] = 0;
-      mxdims[d] = (int) dsdims[d];
-    }
-
-    // allocate persistent Mat
-    Array.create( n_dims, mxdims, CV_MAKETYPE(dType, channs) );
-
-    // get blank data space
-    hid_t dspace = H5Screate_simple( n_dims, dsdims, NULL );
-
-    // get matrix write window
-    H5Sselect_hyperslab( dspace, H5S_SELECT_SET,
-                         foffset, NULL, dsdims, NULL );
-
-    // set custom offsets
-    if ( dims_offset != NULL )
-    {
-      for ( int d = 0; d < n_dims; d++ )
-        foffset[d] = dims_offset[d];
-    }
-
-    // get a file read window
-    H5Sselect_hyperslab( fspace, H5S_SELECT_SET,
-                         foffset, NULL, dsdims, NULL );
-
-    // read from DS
-    Mat matrix = Array.getMat();
-    H5Dread( dsdata, dstype, dspace, fspace, H5P_DEFAULT, matrix.data );
-
-    delete [] dsdims;
-    delete [] mxdims;
-    delete [] foffset;
-
-    H5Tclose (h5type );
-    H5Tclose( dstype );
-    H5Sclose( dspace );
-    H5Sclose( fspace );
-    H5Dclose( dsdata );
+void HDF5Impl::dsread(OutputArray Array, const String &dslabel,
+                      const int *dims_offset) const {
+  dsread(Array, dslabel, dims_offset, NULL);
 }
 
 // overload
-void HDF5Impl::dswrite( InputArray Array, const String& dslabel ) const
-{
-    dswrite( Array, dslabel, NULL, NULL );
-}
-// overload
-void HDF5Impl::dswrite( InputArray Array, const String& dslabel,
-             const int* dims_offset ) const
-{
-    dswrite( Array, dslabel, dims_offset, NULL );
-}
-// overload
-void HDF5Impl::dswrite( InputArray Array, const String& dslabel,
-             const vector<int>& dims_offset,
-             const vector<int>& dims_counts ) const
-{
-    dswrite( Array, dslabel, &dims_offset[0], &dims_counts[0] );
+void HDF5Impl::dsread(OutputArray Array, const String &dslabel,
+                      const vector<int> &dims_offset,
+                      const vector<int> &dims_counts) const {
+  dsread(Array, dslabel, &dims_offset[0], &dims_counts[0]);
 }
 
-void HDF5Impl::dswrite( InputArray Array, const String& dslabel,
-             const int* dims_offset, const int* dims_counts ) const
-{
-    // only Mat support
-    CV_Assert( Array.isMat() );
+void HDF5Impl::dsread(OutputArray Array, const String &dslabel,
+                      const int *dims_offset, const int *dims_counts) const {
+  // only Mat support
+  CV_Assert(Array.isMat());
 
-    Mat matrix = Array.getMat();
+  hid_t h5type;
 
-    // memory array should be compact
-    CV_Assert( matrix.isContinuous() );
+  // open the HDF5 dataset
+  hid_t dsdata = H5Dopen(m_h5_file_id, dslabel.c_str(), H5P_DEFAULT);
 
-    int n_dims = matrix.dims;
-    int channs = matrix.channels();
+  // get data type
+  hid_t dstype = H5Dget_type(dsdata);
 
-    int *dsizes = new int[n_dims];
-    hsize_t *dsdims = new hsize_t[n_dims];
-    hsize_t *offset = new hsize_t[n_dims];
-    // replicate Mat dimensions
-    for ( int d = 0; d < n_dims; d++ )
-    {
-      offset[d] = 0;
-      dsizes[d] = matrix.size[d];
-      dsdims[d] = matrix.size[d];
-    }
+  int channs = 1;
+  if (H5Tget_class(dstype) == H5T_ARRAY) {
+    // fetch channs
+    hsize_t ardims[1];
+    H5Tget_array_dims(dstype, ardims);
+    channs = (int)ardims[0];
+    // fetch depth
+    hid_t tsuper = H5Tget_super(dstype);
+#if H5_VERSION_GE(1, 14, 4)
+    if (H5Tget_class(tsuper) == H5T_FLOAT && H5Tget_size(tsuper) == 2)
+      h5type = H5Tcopy(tsuper);
+    else
+#endif
+      h5type = H5Tget_native_type(tsuper, H5T_DIR_ASCEND);
+    H5Tclose(tsuper);
+  } else {
+#if H5_VERSION_GE(1, 14, 4)
+    if (H5Tget_class(dstype) == H5T_FLOAT && H5Tget_size(dstype) == 2)
+      h5type = H5Tcopy(dstype);
+    else
+#endif
+      h5type = H5Tget_native_type(dstype, H5T_DIR_ASCEND);
+  }
 
-    // FixMe: If one of the groups the dataset belongs to does not exist,
-    // FixMe: dscreate() will fail!
-    // FixMe: It should be an error if the specified dataset has not been created instead of trying to create it
-    // pre-create dataset if needed
-    if ( hlexists( dslabel ) == false )
-      dscreate( n_dims, dsizes, matrix.type(), dslabel );
+  int dType = GetCVtype(h5type);
 
-    // set custom amount of data
-    if ( dims_counts != NULL )
-    {
-      for ( int d = 0; d < n_dims; d++ )
-        dsdims[d] = dims_counts[d];
-    }
+  // get file space
+  hid_t fspace = H5Dget_space(dsdata);
 
-    // open dataset
-    hid_t dsdata = H5Dopen( m_h5_file_id, dslabel.c_str(), H5P_DEFAULT );
+  // fetch rank
+  int n_dims = H5Sget_simple_extent_ndims(fspace);
 
-    // create input data space
-    hid_t dspace = H5Screate_simple( n_dims, dsdims, NULL );
+  // fetch dims
+  hsize_t *dsdims = new hsize_t[n_dims];
+  H5Sget_simple_extent_dims(fspace, dsdims, NULL);
 
-    // set custom offsets
-    if ( dims_offset != NULL )
-    {
-      for ( int d = 0; d < n_dims; d++ )
-        offset[d] = dims_offset[d];
-    }
+  // set amount by custom offset
+  if (dims_offset != NULL) {
+    for (int d = 0; d < n_dims; d++)
+      dsdims[d] -= dims_offset[d];
+  }
 
-    // create offset write window space
-    hid_t fspace = H5Dget_space( dsdata );
-    H5Sselect_hyperslab( fspace, H5S_SELECT_SET,
-                         offset, NULL, dsdims, NULL );
+  // set custom amount of data
+  if (dims_counts != NULL) {
+    for (int d = 0; d < n_dims; d++)
+      dsdims[d] = dims_counts[d];
+  }
 
-    // convert type
-    hid_t dstype = GetH5type( matrix.type() );
+  // get memory write window
+  int *mxdims = new int[n_dims];
+  hsize_t *foffset = new hsize_t[n_dims];
+  for (int d = 0; d < n_dims; d++) {
+    foffset[d] = 0;
+    mxdims[d] = (int)dsdims[d];
+  }
 
-    // expand channs
-    if ( matrix.channels() > 1 )
-    {
-      hsize_t adims[1] = { (hsize_t)channs };
-      dstype = H5Tarray_create( dstype, 1, adims );
-    }
+  // allocate persistent Mat
+  Array.create(n_dims, mxdims, CV_MAKETYPE(dType, channs));
 
-    // write into dataset
-    H5Dwrite( dsdata, dstype, dspace, fspace,
-              H5P_DEFAULT, matrix.data );
+  // get blank data space
+  hid_t dspace = H5Screate_simple(n_dims, dsdims, NULL);
 
-    if ( matrix.channels() > 1 )
-      H5Tclose( dstype );
+  // get matrix write window
+  H5Sselect_hyperslab(dspace, H5S_SELECT_SET, foffset, NULL, dsdims, NULL);
 
-    delete [] dsizes;
-    delete [] dsdims;
-    delete [] offset;
+  // set custom offsets
+  if (dims_offset != NULL) {
+    for (int d = 0; d < n_dims; d++)
+      foffset[d] = dims_offset[d];
+  }
 
-    H5Sclose( dspace );
-    H5Sclose( fspace );
-    H5Dclose( dsdata );
-}
+  // get a file read window
+  H5Sselect_hyperslab(fspace, H5S_SELECT_SET, foffset, NULL, dsdims, NULL);
 
-// overload
-void HDF5Impl::dsinsert( InputArray Array, const String& dslabel ) const
-{
-    dsinsert( Array, dslabel, NULL, NULL );
-}
+  // read from DS
+  Mat matrix = Array.getMat();
+  H5Dread(dsdata, dstype, dspace, fspace, H5P_DEFAULT, matrix.data);
 
-// overload
-void HDF5Impl::dsinsert( InputArray Array, const String& dslabel,
-             const int* dims_offset ) const
-{
-    dsinsert( Array, dslabel, dims_offset, NULL );
+  delete[] dsdims;
+  delete[] mxdims;
+  delete[] foffset;
+
+  H5Tclose(h5type);
+  H5Tclose(dstype);
+  H5Sclose(dspace);
+  H5Sclose(fspace);
+  H5Dclose(dsdata);
 }
 
 // overload
-void HDF5Impl::dsinsert( InputArray Array, const String& dslabel,
-             const vector<int>& dims_offset,
-             const vector<int>& dims_counts ) const
-{
-    dsinsert( Array, dslabel, &dims_offset[0], &dims_counts[0] );
+void HDF5Impl::dswrite(InputArray Array, const String &dslabel) const {
+  dswrite(Array, dslabel, NULL, NULL);
+}
+// overload
+void HDF5Impl::dswrite(InputArray Array, const String &dslabel,
+                       const int *dims_offset) const {
+  dswrite(Array, dslabel, dims_offset, NULL);
+}
+// overload
+void HDF5Impl::dswrite(InputArray Array, const String &dslabel,
+                       const vector<int> &dims_offset,
+                       const vector<int> &dims_counts) const {
+  dswrite(Array, dslabel, &dims_offset[0], &dims_counts[0]);
 }
 
-void HDF5Impl::dsinsert( InputArray Array, const String& dslabel,
-             const int* dims_offset, const int* dims_counts ) const
-{
-    // only Mat support
-    CV_Assert( Array.isMat() );
+void HDF5Impl::dswrite(InputArray Array, const String &dslabel,
+                       const int *dims_offset, const int *dims_counts) const {
+  // only Mat support
+  CV_Assert(Array.isMat());
 
-    // check dataset exists
-    if ( hlexists( dslabel ) == false )
-      CV_Error_(Error::StsInternal, ("Dataset '%s' does not exist.", dslabel.c_str()));
+  Mat matrix = Array.getMat();
 
-    Mat matrix = Array.getMat();
+  // memory array should be compact
+  CV_Assert(matrix.isContinuous());
 
-    // memory array should be compact
-    CV_Assert( matrix.isContinuous() );
+  int n_dims = matrix.dims;
+  int channs = matrix.channels();
 
-    int n_dims = matrix.dims;
-    int channs = matrix.channels();
+  int *dsizes = new int[n_dims];
+  hsize_t *dsdims = new hsize_t[n_dims];
+  hsize_t *offset = new hsize_t[n_dims];
+  // replicate Mat dimensions
+  for (int d = 0; d < n_dims; d++) {
+    offset[d] = 0;
+    dsizes[d] = matrix.size[d];
+    dsdims[d] = matrix.size[d];
+  }
 
-    hsize_t *dsdims = new hsize_t[n_dims];
-    hsize_t *offset = new hsize_t[n_dims];
-    // replicate Mat dimensions
-    for ( int d = 0; d < n_dims; d++ )
-    {
-      offset[d] = 0;
-      dsdims[d] = matrix.size[d];
+  // FixMe: If one of the groups the dataset belongs to does not exist,
+  // FixMe: dscreate() will fail!
+  // FixMe: It should be an error if the specified dataset has not been created
+  // instead of trying to create it pre-create dataset if needed
+  if (hlexists(dslabel) == false)
+    dscreate(n_dims, dsizes, matrix.type(), dslabel);
+
+  // set custom amount of data
+  if (dims_counts != NULL) {
+    for (int d = 0; d < n_dims; d++)
+      dsdims[d] = dims_counts[d];
+  }
+
+  // open dataset
+  hid_t dsdata = H5Dopen(m_h5_file_id, dslabel.c_str(), H5P_DEFAULT);
+
+  // create input data space
+  hid_t dspace = H5Screate_simple(n_dims, dsdims, NULL);
+
+  // set custom offsets
+  if (dims_offset != NULL) {
+    for (int d = 0; d < n_dims; d++)
+      offset[d] = dims_offset[d];
+  }
+
+  // create offset write window space
+  hid_t fspace = H5Dget_space(dsdata);
+  H5Sselect_hyperslab(fspace, H5S_SELECT_SET, offset, NULL, dsdims, NULL);
+
+  // convert type
+  hid_t dstype = GetH5type(matrix.type());
+
+  // expand channs
+  if (matrix.channels() > 1) {
+    hsize_t adims[1] = {(hsize_t)channs};
+    dstype = H5Tarray_create(dstype, 1, adims);
+  }
+
+  // write into dataset
+  H5Dwrite(dsdata, dstype, dspace, fspace, H5P_DEFAULT, matrix.data);
+
+  if (matrix.channels() > 1)
+    H5Tclose(dstype);
+
+  delete[] dsizes;
+  delete[] dsdims;
+  delete[] offset;
+
+  H5Sclose(dspace);
+  H5Sclose(fspace);
+  H5Dclose(dsdata);
+}
+
+// overload
+void HDF5Impl::dsinsert(InputArray Array, const String &dslabel) const {
+  dsinsert(Array, dslabel, NULL, NULL);
+}
+
+// overload
+void HDF5Impl::dsinsert(InputArray Array, const String &dslabel,
+                        const int *dims_offset) const {
+  dsinsert(Array, dslabel, dims_offset, NULL);
+}
+
+// overload
+void HDF5Impl::dsinsert(InputArray Array, const String &dslabel,
+                        const vector<int> &dims_offset,
+                        const vector<int> &dims_counts) const {
+  dsinsert(Array, dslabel, &dims_offset[0], &dims_counts[0]);
+}
+
+void HDF5Impl::dsinsert(InputArray Array, const String &dslabel,
+                        const int *dims_offset, const int *dims_counts) const {
+  // only Mat support
+  CV_Assert(Array.isMat());
+
+  // check dataset exists
+  if (hlexists(dslabel) == false)
+    CV_Error_(Error::StsInternal,
+              ("Dataset '%s' does not exist.", dslabel.c_str()));
+
+  Mat matrix = Array.getMat();
+
+  // memory array should be compact
+  CV_Assert(matrix.isContinuous());
+
+  int n_dims = matrix.dims;
+  int channs = matrix.channels();
+
+  hsize_t *dsdims = new hsize_t[n_dims];
+  hsize_t *offset = new hsize_t[n_dims];
+  // replicate Mat dimensions
+  for (int d = 0; d < n_dims; d++) {
+    offset[d] = 0;
+    dsdims[d] = matrix.size[d];
+  }
+
+  // set custom amount of data
+  if (dims_counts != NULL) {
+    for (int d = 0; d < n_dims; d++) {
+      CV_Assert(dims_counts[d] <= matrix.size[d]);
+      dsdims[d] = dims_counts[d];
     }
+  }
 
-    // set custom amount of data
-    if ( dims_counts != NULL )
-    {
-      for ( int d = 0; d < n_dims; d++ )
-      {
-        CV_Assert( dims_counts[d] <= matrix.size[d] );
-        dsdims[d] = dims_counts[d];
-      }
-    }
+  // open dataset
+  hid_t dsdata = H5Dopen(m_h5_file_id, dslabel.c_str(), H5P_DEFAULT);
 
-    // open dataset
-    hid_t dsdata = H5Dopen( m_h5_file_id, dslabel.c_str(), H5P_DEFAULT );
+  // create input data space
+  hid_t dspace = H5Screate_simple(n_dims, dsdims, NULL);
 
-    // create input data space
-    hid_t dspace = H5Screate_simple( n_dims, dsdims, NULL );
+  // set custom offsets
+  if (dims_offset != NULL) {
+    for (int d = 0; d < n_dims; d++)
+      offset[d] = dims_offset[d];
+  }
 
-    // set custom offsets
-    if ( dims_offset != NULL )
-    {
-      for ( int d = 0; d < n_dims; d++ )
-        offset[d] = dims_offset[d];
-    }
+  // get actual file space and dims
+  hid_t fspace = H5Dget_space(dsdata);
+  int f_dims = H5Sget_simple_extent_ndims(fspace);
+  hsize_t *fsdims = new hsize_t[f_dims];
+  H5Sget_simple_extent_dims(fspace, fsdims, NULL);
+  H5Sclose(fspace);
 
-    // get actual file space and dims
-    hid_t fspace = H5Dget_space( dsdata );
-    int f_dims = H5Sget_simple_extent_ndims( fspace );
-    hsize_t *fsdims = new hsize_t[f_dims];
-    H5Sget_simple_extent_dims( fspace, fsdims, NULL );
-    H5Sclose( fspace );
+  CV_Assert(f_dims == n_dims);
 
-    CV_Assert( f_dims == n_dims );
+  // compute new extents
+  hsize_t *nwdims = new hsize_t[n_dims];
+  for (int d = 0; d < n_dims; d++) {
+    // init
+    nwdims[d] = 0;
+    // add offset
+    if (dims_offset != NULL)
+      nwdims[d] += dims_offset[d];
+    // add counts or matrix size
+    if (dims_counts != NULL)
+      nwdims[d] += dims_counts[d];
+    else
+      nwdims[d] += matrix.size[d];
 
-    // compute new extents
-    hsize_t *nwdims = new hsize_t[n_dims];
-    for ( int d = 0; d < n_dims; d++ )
-    {
-      // init
-      nwdims[d] = 0;
-      // add offset
-      if ( dims_offset != NULL )
-        nwdims[d] += dims_offset[d];
-      // add counts or matrix size
-      if ( dims_counts != NULL )
-        nwdims[d] += dims_counts[d];
-      else
-        nwdims[d] += matrix.size[d];
+    // clamp back if smaller
+    if (nwdims[d] < fsdims[d])
+      nwdims[d] = fsdims[d];
+  }
 
-      // clamp back if smaller
-      if ( nwdims[d] < fsdims[d] )
-        nwdims[d] = fsdims[d];
-    }
+  // extend dataset
+  H5Dextend(dsdata, nwdims);
 
-    // extend dataset
-    H5Dextend( dsdata, nwdims );
+  // get the extended data space
+  fspace = H5Dget_space(dsdata);
 
-    // get the extended data space
-    fspace = H5Dget_space( dsdata );
+  H5Sselect_hyperslab(fspace, H5S_SELECT_SET, offset, NULL, dsdims, NULL);
 
-    H5Sselect_hyperslab( fspace, H5S_SELECT_SET,
-                         offset, NULL, dsdims, NULL );
+  // convert type
+  hid_t dstype = GetH5type(matrix.type());
 
-    // convert type
-    hid_t dstype = GetH5type( matrix.type() );
+  // expand channs
+  if (matrix.channels() > 1) {
+    hsize_t adims[1] = {(hsize_t)channs};
+    dstype = H5Tarray_create(dstype, 1, adims);
+  }
 
-    // expand channs
-    if ( matrix.channels() > 1 )
-    {
-      hsize_t adims[1] = { (hsize_t)channs };
-      dstype = H5Tarray_create( dstype, 1, adims );
-    }
+  // write into dataset
+  H5Dwrite(dsdata, dstype, dspace, fspace, H5P_DEFAULT, matrix.data);
 
-    // write into dataset
-    H5Dwrite( dsdata, dstype, dspace, fspace,
-              H5P_DEFAULT, matrix.data );
+  if (matrix.channels() > 1)
+    H5Tclose(dstype);
 
-    if ( matrix.channels() > 1 )
-      H5Tclose( dstype );
+  delete[] dsdims;
+  delete[] offset;
+  delete[] fsdims;
+  delete[] nwdims;
 
-    delete [] dsdims;
-    delete [] offset;
-    delete [] fsdims;
-    delete [] nwdims;
-
-    H5Sclose( dspace );
-    H5Sclose( fspace );
-    H5Dclose( dsdata );
+  H5Sclose(dspace);
+  H5Sclose(fspace);
+  H5Dclose(dsdata);
 }
 
 /*
  *  std::vector<cv::KeyPoint>
  */
 
-int HDF5Impl::kpgetsize( const String& kplabel, int dims_flag ) const
-{
-    vector<int> sizes = dsgetsize( kplabel, dims_flag );
+int HDF5Impl::kpgetsize(const String &kplabel, int dims_flag) const {
+  vector<int> sizes = dsgetsize(kplabel, dims_flag);
 
-    CV_Assert( sizes.size() == 1 );
+  CV_Assert(sizes.size() == 1);
 
-    return sizes[0];
+  return sizes[0];
 }
 
-void HDF5Impl::kpcreate( const int size, const String& kplabel,
-             const int compresslevel, const int chunks ) const
-{
-    // size valid
-    CV_Assert( size >= H5_UNLIMITED );
+void HDF5Impl::kpcreate(const int size, const String &kplabel,
+                        const int compresslevel, const int chunks) const {
+  // size valid
+  CV_Assert(size >= H5_UNLIMITED);
 
-    // valid chunks
-    CV_Assert( chunks == H5_NONE || chunks > 0 );
+  // valid chunks
+  CV_Assert(chunks == H5_NONE || chunks > 0);
 
-    // compress valid -1, 0-9
-    CV_Assert( compresslevel >= H5_NONE && compresslevel <= 9 );
+  // compress valid -1, 0-9
+  CV_Assert(compresslevel >= H5_NONE && compresslevel <= 9);
 
-    if ( hlexists( kplabel ) == true )
-      CV_Error_(Error::StsInternal, ("Requested dataset '%s' already exists.", kplabel.c_str()));
+  if (hlexists(kplabel) == true)
+    CV_Error_(Error::StsInternal,
+              ("Requested dataset '%s' already exists.", kplabel.c_str()));
 
-    hsize_t dchunk[1];
-    hsize_t dsdims[1];
-    hsize_t maxdim[1];
+  hsize_t dchunk[1];
+  hsize_t dsdims[1];
+  hsize_t maxdim[1];
 
-    // dataset dimension
-    if ( size == H5_UNLIMITED )
-    {
-      dsdims[0] = 0;
-      maxdim[0] = H5S_UNLIMITED;
-    }
+  // dataset dimension
+  if (size == H5_UNLIMITED) {
+    dsdims[0] = 0;
+    maxdim[0] = H5S_UNLIMITED;
+  } else {
+    dsdims[0] = size;
+    maxdim[0] = size;
+  }
+
+  // default chunking
+  if (chunks == H5_NONE)
+    if (size == H5_UNLIMITED)
+      dchunk[0] = 1;
     else
-    {
-      dsdims[0] = size;
-      maxdim[0] = size;
-    }
+      dchunk[0] = size;
+  else
+    dchunk[0] = chunks;
 
-    // default chunking
-    if ( chunks == H5_NONE )
-      if ( size == H5_UNLIMITED )
-        dchunk[0] = 1;
-      else
-        dchunk[0] = size;
-    else
-      dchunk[0] = chunks;
+  // dataset compound type
+  hid_t dstype = H5Tcreate(H5T_COMPOUND, sizeof(KeyPoint));
+  H5Tinsert(dstype, "xpos", HOFFSET(KeyPoint, pt.x), H5T_NATIVE_FLOAT);
+  H5Tinsert(dstype, "ypos", HOFFSET(KeyPoint, pt.y), H5T_NATIVE_FLOAT);
+  H5Tinsert(dstype, "size", HOFFSET(KeyPoint, size), H5T_NATIVE_FLOAT);
+  H5Tinsert(dstype, "angle", HOFFSET(KeyPoint, angle), H5T_NATIVE_FLOAT);
+  H5Tinsert(dstype, "response", HOFFSET(KeyPoint, response), H5T_NATIVE_FLOAT);
+  H5Tinsert(dstype, "octave", HOFFSET(KeyPoint, octave), H5T_NATIVE_INT32);
+  H5Tinsert(dstype, "class_id", HOFFSET(KeyPoint, class_id), H5T_NATIVE_INT32);
 
-    // dataset compound type
-    hid_t dstype = H5Tcreate( H5T_COMPOUND, sizeof( KeyPoint ) );
-    H5Tinsert( dstype, "xpos",     HOFFSET( KeyPoint, pt.x     ), H5T_NATIVE_FLOAT );
-    H5Tinsert( dstype, "ypos",     HOFFSET( KeyPoint, pt.y     ), H5T_NATIVE_FLOAT );
-    H5Tinsert( dstype, "size",     HOFFSET( KeyPoint, size     ), H5T_NATIVE_FLOAT );
-    H5Tinsert( dstype, "angle",    HOFFSET( KeyPoint, angle    ), H5T_NATIVE_FLOAT );
-    H5Tinsert( dstype, "response", HOFFSET( KeyPoint, response ), H5T_NATIVE_FLOAT );
-    H5Tinsert( dstype, "octave",   HOFFSET( KeyPoint, octave   ), H5T_NATIVE_INT32 );
-    H5Tinsert( dstype, "class_id", HOFFSET( KeyPoint, class_id ), H5T_NATIVE_INT32 );
+  // create dataset space
+  hid_t dspace = H5Screate_simple(1, dsdims, maxdim);
 
-    // create dataset space
-    hid_t dspace = H5Screate_simple( 1, dsdims, maxdim );
+  // create data property
+  hid_t dsdcpl = H5Pcreate(H5P_DATASET_CREATE);
 
-    // create data property
-    hid_t dsdcpl = H5Pcreate( H5P_DATASET_CREATE );
+  // set properties
+  if (compresslevel >= 0)
+    H5Pset_deflate(dsdcpl, compresslevel);
 
-    // set properties
-    if ( compresslevel >= 0 )
-      H5Pset_deflate( dsdcpl, compresslevel );
+  // if chunking or compression
+  if (dchunk[0] > 0 || compresslevel >= 0)
+    H5Pset_chunk(dsdcpl, 1, dchunk);
 
-    // if chunking or compression
-    if ( dchunk[0] > 0 || compresslevel >= 0 )
-      H5Pset_chunk( dsdcpl, 1, dchunk );
+  // create data
+  H5Dcreate(m_h5_file_id, kplabel.c_str(), dstype, dspace, H5P_DEFAULT, dsdcpl,
+            H5P_DEFAULT);
 
-    // create data
-    H5Dcreate( m_h5_file_id, kplabel.c_str(), dstype,
-               dspace, H5P_DEFAULT, dsdcpl, H5P_DEFAULT );
-
-    H5Tclose( dstype );
-    H5Pclose( dsdcpl );
-    H5Sclose( dspace );
+  H5Tclose(dstype);
+  H5Pclose(dsdcpl);
+  H5Sclose(dspace);
 }
 
-void HDF5Impl::kpwrite( const vector<KeyPoint> keypoints, const String& kplabel,
-             const int offset, const int counts ) const
-{
-    CV_Assert( keypoints.size() > 0 );
+void HDF5Impl::kpwrite(const vector<KeyPoint> keypoints, const String &kplabel,
+                       const int offset, const int counts) const {
+  CV_Assert(keypoints.size() > 0);
 
-    int dskdims[1];
-    hsize_t dsddims[1];
-    hsize_t doffset[1];
+  int dskdims[1];
+  hsize_t dsddims[1];
+  hsize_t doffset[1];
 
-    // replicate vector dimension
-    doffset[0] = 0;
-    dsddims[0] = keypoints.size();
-    dskdims[0] = (int)keypoints.size();
+  // replicate vector dimension
+  doffset[0] = 0;
+  dsddims[0] = keypoints.size();
+  dskdims[0] = (int)keypoints.size();
 
-    // pre-create dataset if needed
-    if ( hlexists( kplabel ) == false )
-      kpcreate( dskdims[0], kplabel );
+  // pre-create dataset if needed
+  if (hlexists(kplabel) == false)
+    kpcreate(dskdims[0], kplabel);
 
-    // set custom amount of data
-    if ( counts != H5_NONE )
-      dsddims[0] = counts;
+  // set custom amount of data
+  if (counts != H5_NONE)
+    dsddims[0] = counts;
 
-    // open dataset
-    hid_t dsdata = H5Dopen( m_h5_file_id, kplabel.c_str(), H5P_DEFAULT );
+  // open dataset
+  hid_t dsdata = H5Dopen(m_h5_file_id, kplabel.c_str(), H5P_DEFAULT);
 
-    // create input data space
-    hid_t dspace = H5Screate_simple( 1, dsddims, NULL );
+  // create input data space
+  hid_t dspace = H5Screate_simple(1, dsddims, NULL);
 
-    // set custom offsets
-    if ( offset != H5_NONE )
-      doffset[0] = offset;
+  // set custom offsets
+  if (offset != H5_NONE)
+    doffset[0] = offset;
 
-    // create offset write window space
-    hid_t fspace = H5Dget_space( dsdata );
-    H5Sselect_hyperslab( fspace, H5S_SELECT_SET,
-                         doffset, NULL, dsddims, NULL );
+  // create offset write window space
+  hid_t fspace = H5Dget_space(dsdata);
+  H5Sselect_hyperslab(fspace, H5S_SELECT_SET, doffset, NULL, dsddims, NULL);
 
-    // memory compound type
-    hid_t mmtype = H5Tcreate( H5T_COMPOUND, sizeof( KeyPoint ) );
-    H5Tinsert( mmtype, "xpos",     HOFFSET( KeyPoint, pt.x     ), H5T_NATIVE_FLOAT );
-    H5Tinsert( mmtype, "ypos",     HOFFSET( KeyPoint, pt.y     ), H5T_NATIVE_FLOAT );
-    H5Tinsert( mmtype, "size",     HOFFSET( KeyPoint, size     ), H5T_NATIVE_FLOAT );
-    H5Tinsert( mmtype, "angle",    HOFFSET( KeyPoint, angle    ), H5T_NATIVE_FLOAT );
-    H5Tinsert( mmtype, "response", HOFFSET( KeyPoint, response ), H5T_NATIVE_FLOAT );
-    H5Tinsert( mmtype, "octave",   HOFFSET( KeyPoint, octave   ), H5T_NATIVE_INT32 );
-    H5Tinsert( mmtype, "class_id", HOFFSET( KeyPoint, class_id ), H5T_NATIVE_INT32 );
+  // memory compound type
+  hid_t mmtype = H5Tcreate(H5T_COMPOUND, sizeof(KeyPoint));
+  H5Tinsert(mmtype, "xpos", HOFFSET(KeyPoint, pt.x), H5T_NATIVE_FLOAT);
+  H5Tinsert(mmtype, "ypos", HOFFSET(KeyPoint, pt.y), H5T_NATIVE_FLOAT);
+  H5Tinsert(mmtype, "size", HOFFSET(KeyPoint, size), H5T_NATIVE_FLOAT);
+  H5Tinsert(mmtype, "angle", HOFFSET(KeyPoint, angle), H5T_NATIVE_FLOAT);
+  H5Tinsert(mmtype, "response", HOFFSET(KeyPoint, response), H5T_NATIVE_FLOAT);
+  H5Tinsert(mmtype, "octave", HOFFSET(KeyPoint, octave), H5T_NATIVE_INT32);
+  H5Tinsert(mmtype, "class_id", HOFFSET(KeyPoint, class_id), H5T_NATIVE_INT32);
 
-    // write into dataset
-    H5Dwrite( dsdata, mmtype, dspace, fspace, H5P_DEFAULT, &keypoints[0] );
+  // write into dataset
+  H5Dwrite(dsdata, mmtype, dspace, fspace, H5P_DEFAULT, &keypoints[0]);
 
-    H5Tclose( mmtype );
-    H5Sclose( dspace );
-    H5Sclose( fspace );
-    H5Dclose( dsdata );
+  H5Tclose(mmtype);
+  H5Sclose(dspace);
+  H5Sclose(fspace);
+  H5Dclose(dsdata);
 }
 
-void HDF5Impl::kpinsert( const vector<KeyPoint> keypoints, const String& kplabel,
-             const int offset, const int counts ) const
-{
-    CV_Assert( keypoints.size() > 0 );
+void HDF5Impl::kpinsert(const vector<KeyPoint> keypoints, const String &kplabel,
+                        const int offset, const int counts) const {
+  CV_Assert(keypoints.size() > 0);
 
-    // check dataset exists
-    if ( hlexists( kplabel ) == false )
-      CV_Error_(Error::StsInternal, ("Dataset '%s' does not exist.", kplabel.c_str()));
+  // check dataset exists
+  if (hlexists(kplabel) == false)
+    CV_Error_(Error::StsInternal,
+              ("Dataset '%s' does not exist.", kplabel.c_str()));
 
-    hsize_t dsddims[1];
-    hsize_t doffset[1];
+  hsize_t dsddims[1];
+  hsize_t doffset[1];
 
-    // replicate vector dimension
-    doffset[0] = 0;
-    dsddims[0] = keypoints.size();
+  // replicate vector dimension
+  doffset[0] = 0;
+  dsddims[0] = keypoints.size();
 
-    // set custom amount of data
-    if ( counts != H5_NONE )
-      dsddims[0] = counts;
+  // set custom amount of data
+  if (counts != H5_NONE)
+    dsddims[0] = counts;
 
-    // open dataset
-    hid_t dsdata = H5Dopen( m_h5_file_id, kplabel.c_str(), H5P_DEFAULT );
+  // open dataset
+  hid_t dsdata = H5Dopen(m_h5_file_id, kplabel.c_str(), H5P_DEFAULT);
 
-    // create input data space
-    hid_t dspace = H5Screate_simple( 1, dsddims, NULL );
+  // create input data space
+  hid_t dspace = H5Screate_simple(1, dsddims, NULL);
 
-    // set custom offsets
-    if ( offset != H5_NONE )
-      doffset[0] = offset;
+  // set custom offsets
+  if (offset != H5_NONE)
+    doffset[0] = offset;
 
-    // get actual file space and dims
-    hid_t fspace = H5Dget_space( dsdata );
-    int f_dims = H5Sget_simple_extent_ndims( fspace );
-    hsize_t *fsdims = new hsize_t[f_dims];
-    H5Sget_simple_extent_dims( fspace, fsdims, NULL );
-    H5Sclose( fspace );
+  // get actual file space and dims
+  hid_t fspace = H5Dget_space(dsdata);
+  int f_dims = H5Sget_simple_extent_ndims(fspace);
+  hsize_t *fsdims = new hsize_t[f_dims];
+  H5Sget_simple_extent_dims(fspace, fsdims, NULL);
+  H5Sclose(fspace);
 
-    CV_Assert( f_dims == 1 );
+  CV_Assert(f_dims == 1);
 
-    // compute new extents
-    hsize_t nwdims[1] = { 0 };
-    // add offset
-    if ( offset != H5_NONE )
-      nwdims[0] += offset;
-    // add counts or matrixsize
-    if ( counts != H5_NONE )
-      nwdims[0] += counts;
-    else
-      nwdims[0] += keypoints.size();
+  // compute new extents
+  hsize_t nwdims[1] = {0};
+  // add offset
+  if (offset != H5_NONE)
+    nwdims[0] += offset;
+  // add counts or matrixsize
+  if (counts != H5_NONE)
+    nwdims[0] += counts;
+  else
+    nwdims[0] += keypoints.size();
 
-    // clamp back if smaller
-    if ( nwdims[0] < fsdims[0] )
-      nwdims[0] = fsdims[0];
+  // clamp back if smaller
+  if (nwdims[0] < fsdims[0])
+    nwdims[0] = fsdims[0];
 
-    // extend dataset
-    H5Dextend( dsdata, nwdims );
+  // extend dataset
+  H5Dextend(dsdata, nwdims);
 
-    // get the extended data space
-    fspace = H5Dget_space( dsdata );
+  // get the extended data space
+  fspace = H5Dget_space(dsdata);
 
-    H5Sselect_hyperslab( fspace, H5S_SELECT_SET,
-                         doffset, NULL, dsddims, NULL );
+  H5Sselect_hyperslab(fspace, H5S_SELECT_SET, doffset, NULL, dsddims, NULL);
 
-    // memory compound type
-    hid_t mmtype = H5Tcreate( H5T_COMPOUND, sizeof( KeyPoint ) );
-    H5Tinsert( mmtype, "xpos",     HOFFSET( KeyPoint, pt.x     ), H5T_NATIVE_FLOAT );
-    H5Tinsert( mmtype, "ypos",     HOFFSET( KeyPoint, pt.y     ), H5T_NATIVE_FLOAT );
-    H5Tinsert( mmtype, "size",     HOFFSET( KeyPoint, size     ), H5T_NATIVE_FLOAT );
-    H5Tinsert( mmtype, "angle",    HOFFSET( KeyPoint, angle    ), H5T_NATIVE_FLOAT );
-    H5Tinsert( mmtype, "response", HOFFSET( KeyPoint, response ), H5T_NATIVE_FLOAT );
-    H5Tinsert( mmtype, "octave",   HOFFSET( KeyPoint, octave   ), H5T_NATIVE_INT32 );
-    H5Tinsert( mmtype, "class_id", HOFFSET( KeyPoint, class_id ), H5T_NATIVE_INT32 );
+  // memory compound type
+  hid_t mmtype = H5Tcreate(H5T_COMPOUND, sizeof(KeyPoint));
+  H5Tinsert(mmtype, "xpos", HOFFSET(KeyPoint, pt.x), H5T_NATIVE_FLOAT);
+  H5Tinsert(mmtype, "ypos", HOFFSET(KeyPoint, pt.y), H5T_NATIVE_FLOAT);
+  H5Tinsert(mmtype, "size", HOFFSET(KeyPoint, size), H5T_NATIVE_FLOAT);
+  H5Tinsert(mmtype, "angle", HOFFSET(KeyPoint, angle), H5T_NATIVE_FLOAT);
+  H5Tinsert(mmtype, "response", HOFFSET(KeyPoint, response), H5T_NATIVE_FLOAT);
+  H5Tinsert(mmtype, "octave", HOFFSET(KeyPoint, octave), H5T_NATIVE_INT32);
+  H5Tinsert(mmtype, "class_id", HOFFSET(KeyPoint, class_id), H5T_NATIVE_INT32);
 
-    // write into dataset
-    H5Dwrite( dsdata, mmtype, dspace, fspace, H5P_DEFAULT, &keypoints[0] );
+  // write into dataset
+  H5Dwrite(dsdata, mmtype, dspace, fspace, H5P_DEFAULT, &keypoints[0]);
 
-    delete [] fsdims;
+  delete[] fsdims;
 
-    H5Tclose( mmtype );
-    H5Sclose( dspace );
-    H5Sclose( fspace );
-    H5Dclose( dsdata );
+  H5Tclose(mmtype);
+  H5Sclose(dspace);
+  H5Sclose(fspace);
+  H5Dclose(dsdata);
 }
 
-void HDF5Impl::kpread( vector<KeyPoint>& keypoints, const String& kplabel,
-             const int offset, const int counts ) const
-{
-    CV_Assert( keypoints.size() == 0 );
+void HDF5Impl::kpread(vector<KeyPoint> &keypoints, const String &kplabel,
+                      const int offset, const int counts) const {
+  CV_Assert(keypoints.size() == 0);
 
-    // open the HDF5 dataset
-    hid_t dsdata = H5Dopen( m_h5_file_id, kplabel.c_str(), H5P_DEFAULT );
+  // open the HDF5 dataset
+  hid_t dsdata = H5Dopen(m_h5_file_id, kplabel.c_str(), H5P_DEFAULT);
 
-    // get data type
-    hid_t dstype = H5Dget_type( dsdata );
+  // get data type
+  hid_t dstype = H5Dget_type(dsdata);
 
-    // get file space
-    hid_t fspace = H5Dget_space( dsdata );
+  // get file space
+  hid_t fspace = H5Dget_space(dsdata);
 
-    // fetch rank
-    int n_dims = H5Sget_simple_extent_ndims( fspace );
+  // fetch rank
+  int n_dims = H5Sget_simple_extent_ndims(fspace);
 
-    CV_Assert( n_dims == 1 );
+  CV_Assert(n_dims == 1);
 
-    // fetch dims
-    hsize_t dsddims[1];
-    H5Sget_simple_extent_dims( fspace, dsddims, NULL );
+  // fetch dims
+  hsize_t dsddims[1];
+  H5Sget_simple_extent_dims(fspace, dsddims, NULL);
 
-    // set amount by custom offset
-    if ( offset != H5_NONE )
-      dsddims[0] -= offset;
+  // set amount by custom offset
+  if (offset != H5_NONE)
+    dsddims[0] -= offset;
 
-    // set custom amount of data
-    if ( counts != H5_NONE )
-      dsddims[0] = counts;
+  // set custom amount of data
+  if (counts != H5_NONE)
+    dsddims[0] = counts;
 
-    // get memory write window
-    hsize_t foffset[1] = { 0 };
+  // get memory write window
+  hsize_t foffset[1] = {0};
 
-    // allocate keypoints vector
-    keypoints.resize( dsddims[0] );
+  // allocate keypoints vector
+  keypoints.resize(dsddims[0]);
 
-    // get blank data space
-    hid_t dspace = H5Screate_simple( 1, dsddims, NULL );
+  // get blank data space
+  hid_t dspace = H5Screate_simple(1, dsddims, NULL);
 
-    // get matrix write window
-    H5Sselect_hyperslab( dspace, H5S_SELECT_SET,
-                         foffset, NULL, dsddims, NULL );
+  // get matrix write window
+  H5Sselect_hyperslab(dspace, H5S_SELECT_SET, foffset, NULL, dsddims, NULL);
 
-    // set custom offsets
-    if ( offset != H5_NONE )
-      foffset[0] = offset;
+  // set custom offsets
+  if (offset != H5_NONE)
+    foffset[0] = offset;
 
-    // get a file read window
-    H5Sselect_hyperslab( fspace, H5S_SELECT_SET,
-                         foffset, NULL, dsddims, NULL );
+  // get a file read window
+  H5Sselect_hyperslab(fspace, H5S_SELECT_SET, foffset, NULL, dsddims, NULL);
 
-    // read from DS
-    H5Dread( dsdata, dstype, dspace, fspace, H5P_DEFAULT, &keypoints[0] );
+  // read from DS
+  H5Dread(dsdata, dstype, dspace, fspace, H5P_DEFAULT, &keypoints[0]);
 
-    H5Tclose( dstype );
-    H5Sclose( dspace );
-    H5Sclose( fspace );
-    H5Dclose( dsdata );
+  H5Tclose(dstype);
+  H5Sclose(dspace);
+  H5Sclose(fspace);
+  H5Dclose(dsdata);
 }
 
-CV_EXPORTS Ptr<HDF5> open( const String& HDF5Filename )
-{
-    return makePtr<HDF5Impl>( HDF5Filename );
+CV_EXPORTS Ptr<HDF5> open(const String &HDF5Filename) {
+  return makePtr<HDF5Impl>(HDF5Filename);
 }
 
 } // end namespace hdf

--- a/modules/hdf/test/test_hdf5.cpp
+++ b/modules/hdf/test/test_hdf5.cpp
@@ -1,6 +1,6 @@
 // This file is part of OpenCV project.
-// It is subject to the license terms in the LICENSE file found in the top-level directory
-// of this distribution and at http://opencv.org/license.html.
+// It is subject to the license terms in the LICENSE file found in the top-level
+// directory of this distribution and at http://opencv.org/license.html.
 
 /**
  * @file test_hdf5.cpp
@@ -8,354 +8,346 @@
  * @date December 2017
  */
 #include "test_precomp.hpp"
+#include <hdf5.h>
 
-namespace opencv_test { namespace {
+namespace opencv_test {
+namespace {
 
-struct HDF5_Test : public testing::Test
-{
-    virtual void SetUp()
-    {
-        m_filename = "test.h5";
+struct HDF5_Test : public testing::Test {
+  virtual void SetUp() {
+    m_filename = "test.h5";
 
-        // 0 1 2
-        // 3 4 5
-        m_single_channel.create(2, 3, CV_32F);
-        for (size_t i = 0; i < m_single_channel.total(); i++)
-        {
-            ((float*)m_single_channel.data)[i] = i;
-        }
-
-        // 0 1 2 3 4  5
-        // 6 7 8 9 10 11
-        m_two_channels.create(2, 3, CV_32SC2);
-        for (size_t i = 0; i < m_two_channels.total()*m_two_channels.channels(); i++)
-        {
-            ((int*)m_two_channels.data)[i] = (int)i;
-        }
+    // 0 1 2
+    // 3 4 5
+    m_single_channel.create(2, 3, CV_32F);
+    for (size_t i = 0; i < m_single_channel.total(); i++) {
+      ((float *)m_single_channel.data)[i] = i;
     }
 
-    //! Remove the hdf5 file
-    void reset()
-    {
-        remove(m_filename.c_str());
+    // 0 1 2 3 4  5
+    // 6 7 8 9 10 11
+    m_two_channels.create(2, 3, CV_32SC2);
+    for (size_t i = 0; i < m_two_channels.total() * m_two_channels.channels();
+         i++) {
+      ((int *)m_two_channels.data)[i] = (int)i;
     }
+  }
 
-    String m_filename; //!< filename for testing
-    Ptr<hdf::HDF5> m_hdf_io; //!< HDF5 file pointer
-    Mat m_single_channel; //!< single channel matrix for test
-    Mat m_two_channels; //!< two-channel matrix for test
+  //! Remove the hdf5 file
+  void reset() { remove(m_filename.c_str()); }
+
+  String m_filename;       //!< filename for testing
+  Ptr<hdf::HDF5> m_hdf_io; //!< HDF5 file pointer
+  Mat m_single_channel;    //!< single channel matrix for test
+  Mat m_two_channels;      //!< two-channel matrix for test
 };
 
-TEST_F(HDF5_Test, create_a_single_group)
-{
-    reset();
+TEST_F(HDF5_Test, create_a_single_group) {
+  reset();
 
-    String group_name = "parent";
-    m_hdf_io = hdf::open(m_filename);
-    m_hdf_io->grcreate(group_name);
+  String group_name = "parent";
+  m_hdf_io = hdf::open(m_filename);
+  m_hdf_io->grcreate(group_name);
 
-    EXPECT_EQ(m_hdf_io->hlexists(group_name), true);
-    EXPECT_EQ(m_hdf_io->hlexists("child"), false);
+  EXPECT_EQ(m_hdf_io->hlexists(group_name), true);
+  EXPECT_EQ(m_hdf_io->hlexists("child"), false);
 
-    // It should fail since it creates a group with an existing name
-    EXPECT_ANY_THROW(m_hdf_io->grcreate(group_name));
+  // It should fail since it creates a group with an existing name
+  EXPECT_ANY_THROW(m_hdf_io->grcreate(group_name));
 
-    m_hdf_io->close();
+  m_hdf_io->close();
 }
 
+TEST_F(HDF5_Test, create_a_child_group) {
+  reset();
 
-TEST_F(HDF5_Test, create_a_child_group)
-{
-    reset();
+  String parent = "parent";
+  String child = parent + "/child";
+  m_hdf_io = hdf::open(m_filename);
+  m_hdf_io->grcreate(parent);
+  m_hdf_io->grcreate(child);
 
-    String parent = "parent";
-    String child = parent + "/child";
-    m_hdf_io = hdf::open(m_filename);
-    m_hdf_io->grcreate(parent);
-    m_hdf_io->grcreate(child);
+  EXPECT_EQ(m_hdf_io->hlexists(parent), true);
+  EXPECT_EQ(m_hdf_io->hlexists(child), true);
 
-    EXPECT_EQ(m_hdf_io->hlexists(parent), true);
-    EXPECT_EQ(m_hdf_io->hlexists(child), true);
-
-    m_hdf_io->close();
+  m_hdf_io->close();
 }
 
-TEST_F(HDF5_Test, create_dataset)
-{
-    reset();
+TEST_F(HDF5_Test, create_dataset) {
+  reset();
 
-    String dataset_single_channel = "/single";
-    String dataset_two_channels = "/dual";
+  String dataset_single_channel = "/single";
+  String dataset_two_channels = "/dual";
 
-    m_hdf_io = hdf::open(m_filename);
+  m_hdf_io = hdf::open(m_filename);
 
-    m_hdf_io->dscreate(m_single_channel.rows,
-                       m_single_channel.cols,
-                       m_single_channel.type(),
-                       dataset_single_channel);
+  m_hdf_io->dscreate(m_single_channel.rows, m_single_channel.cols,
+                     m_single_channel.type(), dataset_single_channel);
 
-    m_hdf_io->dscreate(m_two_channels.rows,
-                       m_two_channels.cols,
-                       m_two_channels.type(),
-                       dataset_two_channels);
+  m_hdf_io->dscreate(m_two_channels.rows, m_two_channels.cols,
+                     m_two_channels.type(), dataset_two_channels);
 
-    EXPECT_EQ(m_hdf_io->hlexists(dataset_single_channel), true);
-    EXPECT_EQ(m_hdf_io->hlexists(dataset_two_channels), true);
+  EXPECT_EQ(m_hdf_io->hlexists(dataset_single_channel), true);
+  EXPECT_EQ(m_hdf_io->hlexists(dataset_two_channels), true);
 
-    std::vector<int> dims;
+  std::vector<int> dims;
 
-    dims = m_hdf_io->dsgetsize(dataset_single_channel, hdf::HDF5::H5_GETDIMS);
-    EXPECT_EQ(dims.size(), (size_t)2);
-    EXPECT_EQ(dims[0], m_single_channel.rows);
-    EXPECT_EQ(dims[1], m_single_channel.cols);
+  dims = m_hdf_io->dsgetsize(dataset_single_channel, hdf::HDF5::H5_GETDIMS);
+  EXPECT_EQ(dims.size(), (size_t)2);
+  EXPECT_EQ(dims[0], m_single_channel.rows);
+  EXPECT_EQ(dims[1], m_single_channel.cols);
 
-    dims = m_hdf_io->dsgetsize(dataset_two_channels, hdf::HDF5::H5_GETDIMS);
-    EXPECT_EQ(dims.size(), (size_t)2);
-    EXPECT_EQ(dims[0], m_two_channels.rows);
-    EXPECT_EQ(dims[1], m_two_channels.cols);
+  dims = m_hdf_io->dsgetsize(dataset_two_channels, hdf::HDF5::H5_GETDIMS);
+  EXPECT_EQ(dims.size(), (size_t)2);
+  EXPECT_EQ(dims[0], m_two_channels.rows);
+  EXPECT_EQ(dims[1], m_two_channels.cols);
 
-    int type;
-    type = m_hdf_io->dsgettype(dataset_single_channel);
-    EXPECT_EQ(type, m_single_channel.type());
+  int type;
+  type = m_hdf_io->dsgettype(dataset_single_channel);
+  EXPECT_EQ(type, m_single_channel.type());
 
-    type = m_hdf_io->dsgettype(dataset_two_channels);
-    EXPECT_EQ(type, m_two_channels.type());
+  type = m_hdf_io->dsgettype(dataset_two_channels);
+  EXPECT_EQ(type, m_two_channels.type());
 
-    m_hdf_io->close();
+  m_hdf_io->close();
 }
 
+TEST_F(HDF5_Test, write_read_dataset_1) {
+  reset();
 
-TEST_F(HDF5_Test, write_read_dataset_1)
-{
-    reset();
+  String dataset_single_channel = "/single";
+  String dataset_two_channels = "/dual";
 
-    String dataset_single_channel = "/single";
-    String dataset_two_channels = "/dual";
+  m_hdf_io = hdf::open(m_filename);
 
-    m_hdf_io = hdf::open(m_filename);
+  // since the dataset is under the root group, it is created by dswrite()
+  // automatically.
+  m_hdf_io->dswrite(m_single_channel, dataset_single_channel);
+  m_hdf_io->dswrite(m_two_channels, dataset_two_channels);
 
-    // since the dataset is under the root group, it is created by dswrite() automatically.
-    m_hdf_io->dswrite(m_single_channel, dataset_single_channel);
-    m_hdf_io->dswrite(m_two_channels, dataset_two_channels);
+  EXPECT_EQ(m_hdf_io->hlexists(dataset_single_channel), true);
+  EXPECT_EQ(m_hdf_io->hlexists(dataset_two_channels), true);
 
-    EXPECT_EQ(m_hdf_io->hlexists(dataset_single_channel), true);
-    EXPECT_EQ(m_hdf_io->hlexists(dataset_two_channels), true);
+  // read single channel matrix
+  Mat single;
+  m_hdf_io->dsread(single, dataset_single_channel);
+  EXPECT_EQ(single.type(), m_single_channel.type());
+  EXPECT_EQ(single.size(), m_single_channel.size());
+  EXPECT_LE(cvtest::norm(single, m_single_channel, NORM_L2), 1e-10);
 
-    // read single channel matrix
-    Mat single;
-    m_hdf_io->dsread(single, dataset_single_channel);
-    EXPECT_EQ(single.type(), m_single_channel.type());
-    EXPECT_EQ(single.size(), m_single_channel.size());
-    EXPECT_LE(cvtest::norm(single, m_single_channel, NORM_L2), 1e-10);
+  // read dual channel matrix
+  Mat dual;
+  m_hdf_io->dsread(dual, dataset_two_channels);
+  EXPECT_EQ(dual.type(), m_two_channels.type());
+  EXPECT_EQ(dual.size(), m_two_channels.size());
+  EXPECT_LE(cvtest::norm(dual, m_two_channels, NORM_L2), 1e-10);
 
-    // read dual channel matrix
-    Mat dual;
-    m_hdf_io->dsread(dual, dataset_two_channels);
-    EXPECT_EQ(dual.type(), m_two_channels.type());
-    EXPECT_EQ(dual.size(), m_two_channels.size());
-    EXPECT_LE(cvtest::norm(dual, m_two_channels, NORM_L2), 1e-10);
-
-    m_hdf_io->close();
+  m_hdf_io->close();
 }
 
-TEST_F(HDF5_Test, write_read_dataset_2)
-{
-    reset();
-    // create the dataset manually if it is not inside
-    // the root group
+TEST_F(HDF5_Test, write_read_dataset_2) {
+  reset();
+  // create the dataset manually if it is not inside
+  // the root group
 
-    String parent = "/parent";
+  String parent = "/parent";
 
-    String dataset_single_channel = parent + "/single";
-    String dataset_two_channels = parent + "/dual";
+  String dataset_single_channel = parent + "/single";
+  String dataset_two_channels = parent + "/dual";
 
-    m_hdf_io = hdf::open(m_filename);
+  m_hdf_io = hdf::open(m_filename);
 
-    m_hdf_io->grcreate(parent);
-    EXPECT_EQ(m_hdf_io->hlexists(parent), true);
+  m_hdf_io->grcreate(parent);
+  EXPECT_EQ(m_hdf_io->hlexists(parent), true);
 
-    m_hdf_io->dscreate(m_single_channel.rows,
-                       m_single_channel.cols,
-                       m_single_channel.type(),
-                       dataset_single_channel);
+  m_hdf_io->dscreate(m_single_channel.rows, m_single_channel.cols,
+                     m_single_channel.type(), dataset_single_channel);
 
-    m_hdf_io->dscreate(m_two_channels.rows,
-                       m_two_channels.cols,
-                       m_two_channels.type(),
-                       dataset_two_channels);
+  m_hdf_io->dscreate(m_two_channels.rows, m_two_channels.cols,
+                     m_two_channels.type(), dataset_two_channels);
 
-    EXPECT_EQ(m_hdf_io->hlexists(dataset_single_channel), true);
-    EXPECT_EQ(m_hdf_io->hlexists(dataset_two_channels), true);
+  EXPECT_EQ(m_hdf_io->hlexists(dataset_single_channel), true);
+  EXPECT_EQ(m_hdf_io->hlexists(dataset_two_channels), true);
 
-    m_hdf_io->dswrite(m_single_channel, dataset_single_channel);
-    m_hdf_io->dswrite(m_two_channels, dataset_two_channels);
+  m_hdf_io->dswrite(m_single_channel, dataset_single_channel);
+  m_hdf_io->dswrite(m_two_channels, dataset_two_channels);
 
-    EXPECT_EQ(m_hdf_io->hlexists(dataset_single_channel), true);
-    EXPECT_EQ(m_hdf_io->hlexists(dataset_two_channels), true);
+  EXPECT_EQ(m_hdf_io->hlexists(dataset_single_channel), true);
+  EXPECT_EQ(m_hdf_io->hlexists(dataset_two_channels), true);
 
-    // read single channel matrix
-    Mat single;
-    m_hdf_io->dsread(single, dataset_single_channel);
-    EXPECT_EQ(single.type(), m_single_channel.type());
-    EXPECT_EQ(single.size(), m_single_channel.size());
-    EXPECT_LE(cvtest::norm(single, m_single_channel, NORM_L2), 1e-10);
+  // read single channel matrix
+  Mat single;
+  m_hdf_io->dsread(single, dataset_single_channel);
+  EXPECT_EQ(single.type(), m_single_channel.type());
+  EXPECT_EQ(single.size(), m_single_channel.size());
+  EXPECT_LE(cvtest::norm(single, m_single_channel, NORM_L2), 1e-10);
 
-    // read dual channel matrix
-    Mat dual;
-    m_hdf_io->dsread(dual, dataset_two_channels);
-    EXPECT_EQ(dual.type(), m_two_channels.type());
-    EXPECT_EQ(dual.size(), m_two_channels.size());
-    EXPECT_LE(cvtest::norm(dual, m_two_channels, NORM_L2), 1e-10);
+  // read dual channel matrix
+  Mat dual;
+  m_hdf_io->dsread(dual, dataset_two_channels);
+  EXPECT_EQ(dual.type(), m_two_channels.type());
+  EXPECT_EQ(dual.size(), m_two_channels.size());
+  EXPECT_LE(cvtest::norm(dual, m_two_channels, NORM_L2), 1e-10);
 
-    m_hdf_io->close();
+  m_hdf_io->close();
 }
 
-TEST_F(HDF5_Test, test_attribute)
-{
-    reset();
+TEST_F(HDF5_Test, test_attribute) {
+  reset();
 
-    String attr_name = "test attribute name";
-    int attr_value = 0x12345678;
+  String attr_name = "test attribute name";
+  int attr_value = 0x12345678;
 
-    m_hdf_io = hdf::open(m_filename);
-    EXPECT_EQ(m_hdf_io->atexists(attr_name), false);
+  m_hdf_io = hdf::open(m_filename);
+  EXPECT_EQ(m_hdf_io->atexists(attr_name), false);
 
-    m_hdf_io->atwrite(attr_value, attr_name);
-    EXPECT_ANY_THROW(m_hdf_io->atwrite(attr_value, attr_name)); // error! it already exists
+  m_hdf_io->atwrite(attr_value, attr_name);
+  EXPECT_ANY_THROW(
+      m_hdf_io->atwrite(attr_value, attr_name)); // error! it already exists
 
-    EXPECT_EQ(m_hdf_io->atexists(attr_name), true);
+  EXPECT_EQ(m_hdf_io->atexists(attr_name), true);
 
-    int expected_attr_value;
-    m_hdf_io->atread(&expected_attr_value, attr_name);
-    EXPECT_EQ(attr_value, expected_attr_value);
+  int expected_attr_value;
+  m_hdf_io->atread(&expected_attr_value, attr_name);
+  EXPECT_EQ(attr_value, expected_attr_value);
 
-    m_hdf_io->atdelete(attr_name);
-    EXPECT_ANY_THROW(m_hdf_io->atdelete(attr_name)); // error! Delete non-existed attribute
+  m_hdf_io->atdelete(attr_name);
+  EXPECT_ANY_THROW(
+      m_hdf_io->atdelete(attr_name)); // error! Delete non-existed attribute
 
-    EXPECT_EQ(m_hdf_io->atexists(attr_name), false);
+  EXPECT_EQ(m_hdf_io->atexists(attr_name), false);
 
-    m_hdf_io->close();
+  m_hdf_io->close();
 }
 
-TEST_F(HDF5_Test, test_attribute_int)
-{
-    reset();
+TEST_F(HDF5_Test, test_attribute_int) {
+  reset();
 
-    String attr_name = "test int";
-    int attr_value = 0x12345678;
+  String attr_name = "test int";
+  int attr_value = 0x12345678;
 
-    m_hdf_io = hdf::open(m_filename);
+  m_hdf_io = hdf::open(m_filename);
 
-    m_hdf_io->atwrite(attr_value, attr_name);
+  m_hdf_io->atwrite(attr_value, attr_name);
 
-    int expected_attr_value;
-    m_hdf_io->atread(&expected_attr_value, attr_name);
-    EXPECT_EQ(attr_value, expected_attr_value);
+  int expected_attr_value;
+  m_hdf_io->atread(&expected_attr_value, attr_name);
+  EXPECT_EQ(attr_value, expected_attr_value);
 
-    m_hdf_io->close();
+  m_hdf_io->close();
 }
 
-TEST_F(HDF5_Test, test_attribute_double)
-{
-    reset();
+TEST_F(HDF5_Test, test_attribute_double) {
+  reset();
 
-    String attr_name = "test double";
-    double attr_value = 123.456789;
+  String attr_name = "test double";
+  double attr_value = 123.456789;
 
-    m_hdf_io = hdf::open(m_filename);
+  m_hdf_io = hdf::open(m_filename);
 
-    m_hdf_io->atwrite(attr_value, attr_name);
+  m_hdf_io->atwrite(attr_value, attr_name);
 
-    double expected_attr_value;
-    m_hdf_io->atread(&expected_attr_value, attr_name);
-    EXPECT_NEAR(attr_value, expected_attr_value, 1e-9);
+  double expected_attr_value;
+  m_hdf_io->atread(&expected_attr_value, attr_name);
+  EXPECT_NEAR(attr_value, expected_attr_value, 1e-9);
 
-    m_hdf_io->close();
+  m_hdf_io->close();
 }
 
-TEST_F(HDF5_Test, test_attribute_String)
-{
-    reset();
+TEST_F(HDF5_Test, test_attribute_String) {
+  reset();
 
-    String attr_name = "test-String";
-    String attr_value = "----_______----Hello HDF5----_______----\n";
+  String attr_name = "test-String";
+  String attr_value = "----_______----Hello HDF5----_______----\n";
 
-    m_hdf_io = hdf::open(m_filename);
+  m_hdf_io = hdf::open(m_filename);
 
-    m_hdf_io->atwrite(attr_value, attr_name);
+  m_hdf_io->atwrite(attr_value, attr_name);
 
-    String got_attr_value;
-    m_hdf_io->atread(&got_attr_value, attr_name);
-    EXPECT_EQ(attr_value, got_attr_value);
+  String got_attr_value;
+  m_hdf_io->atread(&got_attr_value, attr_name);
+  EXPECT_EQ(attr_value, got_attr_value);
 
-    m_hdf_io->close();
+  m_hdf_io->close();
 }
 
-TEST_F(HDF5_Test, test_attribute_String_empty)
-{
-    reset();
+TEST_F(HDF5_Test, test_attribute_String_empty) {
+  reset();
 
-    String attr_name = "test-empty-string";
-    String attr_value;
+  String attr_name = "test-empty-string";
+  String attr_value;
 
-    m_hdf_io = hdf::open(m_filename);
+  m_hdf_io = hdf::open(m_filename);
 
-    m_hdf_io->atwrite(attr_value, attr_name);
+  m_hdf_io->atwrite(attr_value, attr_name);
 
-    String got_attr_value;
-    m_hdf_io->atread(&got_attr_value, attr_name);
-    EXPECT_EQ(attr_value, got_attr_value);
+  String got_attr_value;
+  m_hdf_io->atread(&got_attr_value, attr_name);
+  EXPECT_EQ(attr_value, got_attr_value);
 
-    m_hdf_io->close();
+  m_hdf_io->close();
 }
 
-TEST_F(HDF5_Test, test_attribute_InutArray_OutputArray_2d)
-{
-    reset();
+TEST_F(HDF5_Test, test_attribute_InutArray_OutputArray_2d) {
+  reset();
 
-    String attr_name = "test-InputArray-OutputArray-2d";
-    cv::Mat attr_value;
+  String attr_name = "test-InputArray-OutputArray-2d";
+  cv::Mat attr_value;
 
-    std::vector<int> depth_vec;
-    depth_vec.push_back(CV_8U); depth_vec.push_back(CV_8S);
-    depth_vec.push_back(CV_16U); depth_vec.push_back(CV_16S);
-    depth_vec.push_back(CV_32S); depth_vec.push_back(CV_32F);
-    depth_vec.push_back(CV_64F);
+  std::vector<int> depth_vec;
+  depth_vec.push_back(CV_8U);
+  depth_vec.push_back(CV_8S);
+  depth_vec.push_back(CV_16U);
+  depth_vec.push_back(CV_16S);
+  depth_vec.push_back(CV_32S);
+  depth_vec.push_back(CV_32F);
+  depth_vec.push_back(CV_64F);
+#if H5_VERSION_GE(1, 14, 4)
+  depth_vec.push_back(CV_16F);
+#endif
 
-    std::vector<int> channel_vec;
-    channel_vec.push_back(1); channel_vec.push_back(2);
-    channel_vec.push_back(3); channel_vec.push_back(4);
-    channel_vec.push_back(5); channel_vec.push_back(6);
-    channel_vec.push_back(7); channel_vec.push_back(8);
-    channel_vec.push_back(9); channel_vec.push_back(10);
+  std::vector<int> channel_vec;
+  channel_vec.push_back(1);
+  channel_vec.push_back(2);
+  channel_vec.push_back(3);
+  channel_vec.push_back(4);
+  channel_vec.push_back(5);
+  channel_vec.push_back(6);
+  channel_vec.push_back(7);
+  channel_vec.push_back(8);
+  channel_vec.push_back(9);
+  channel_vec.push_back(10);
 
-    std::vector<std::vector<int> > dim_vec;
-    std::vector<int> dim_2d;
-    dim_2d.push_back(2); dim_2d.push_back(3);
-    dim_vec.push_back(dim_2d);
+  std::vector<std::vector<int>> dim_vec;
+  std::vector<int> dim_2d;
+  dim_2d.push_back(2);
+  dim_2d.push_back(3);
+  dim_vec.push_back(dim_2d);
 
-    std::vector<int> dim_3d;
-    dim_3d.push_back(2);
-    dim_3d.push_back(3);
-    dim_3d.push_back(4);
-    dim_vec.push_back(dim_3d);
+  std::vector<int> dim_3d;
+  dim_3d.push_back(2);
+  dim_3d.push_back(3);
+  dim_3d.push_back(4);
+  dim_vec.push_back(dim_3d);
 
-    std::vector<int> dim_4d;
-    dim_4d.push_back(2); dim_4d.push_back(3);
-    dim_4d.push_back(4); dim_4d.push_back(5);
-    dim_vec.push_back(dim_4d);
+  std::vector<int> dim_4d;
+  dim_4d.push_back(2);
+  dim_4d.push_back(3);
+  dim_4d.push_back(4);
+  dim_4d.push_back(5);
+  dim_vec.push_back(dim_4d);
 
-    Mat expected_attr_value;
+  Mat expected_attr_value;
 
-    m_hdf_io = hdf::open(m_filename);
-    for (size_t i = 0; i < depth_vec.size(); i++)
+  m_hdf_io = hdf::open(m_filename);
+  for (size_t i = 0; i < depth_vec.size(); i++)
     for (size_t j = 0; j < channel_vec.size(); j++)
-    for (size_t k = 0; k < dim_vec.size(); k++)
-    {
+      for (size_t k = 0; k < dim_vec.size(); k++) {
         if (m_hdf_io->atexists(attr_name))
-            m_hdf_io->atdelete(attr_name);
+          m_hdf_io->atdelete(attr_name);
 
-        attr_value.create(dim_vec[k], CV_MAKETYPE(depth_vec[i], channel_vec[j]));
+        attr_value.create(dim_vec[k],
+                          CV_MAKETYPE(depth_vec[i], channel_vec[j]));
         randu(attr_value, 0, 255);
 
         m_hdf_io->atwrite(attr_value, attr_name);
@@ -366,9 +358,82 @@ TEST_F(HDF5_Test, test_attribute_InutArray_OutputArray_2d)
 
         EXPECT_EQ(attr_value.size, expected_attr_value.size);
         EXPECT_EQ(attr_value.type(), expected_attr_value.type());
-    }
+      }
 
-    m_hdf_io->close();
+  m_hdf_io->close();
 }
 
-}} // namespace
+}
+}
+
+#if H5_VERSION_GE(1, 14, 4)
+TEST_F(HDF5_Test, write_read_dataset_float16) {
+  reset();
+
+  String dataset_name = "/float16";
+
+  // create a CV_16F matrix with known values
+  Mat float32_src(3, 4, CV_32F);
+  for (size_t i = 0; i < float32_src.total(); i++)
+    ((float *)float32_src.data)[i] = (float)i * 0.5f;
+
+  Mat src;
+  float32_src.convertTo(src, CV_16F);
+
+  m_hdf_io = hdf::open(m_filename);
+
+  // write float16 dataset
+  m_hdf_io->dswrite(src, dataset_name);
+  EXPECT_EQ(m_hdf_io->hlexists(dataset_name), true);
+
+  // verify stored type
+  int type = m_hdf_io->dsgettype(dataset_name);
+  EXPECT_EQ(type, CV_16F);
+
+  // read back
+  Mat dst;
+  m_hdf_io->dsread(dst, dataset_name);
+  EXPECT_EQ(dst.type(), src.type());
+  EXPECT_EQ(dst.size(), src.size());
+
+  // compare values via float32 conversion to use norm
+  Mat src_f32, dst_f32;
+  src.convertTo(src_f32, CV_32F);
+  dst.convertTo(dst_f32, CV_32F);
+  EXPECT_LE(cvtest::norm(src_f32, dst_f32, NORM_L2), 1e-3);
+
+  m_hdf_io->close();
+}
+
+TEST_F(HDF5_Test, write_read_attribute_float16) {
+  reset();
+
+  String attr_name = "test-float16-attr";
+
+  // create a CV_16F matrix
+  Mat float32_src(2, 3, CV_32F);
+  for (size_t i = 0; i < float32_src.total(); i++)
+    ((float *)float32_src.data)[i] = (float)i * 0.25f;
+
+  Mat src;
+  float32_src.convertTo(src, CV_16F);
+
+  m_hdf_io = hdf::open(m_filename);
+
+  m_hdf_io->atwrite(src, attr_name);
+
+  Mat dst;
+  m_hdf_io->atread(dst, attr_name);
+  EXPECT_EQ(dst.type(), src.type());
+  EXPECT_EQ(dst.size(), src.size());
+
+  Mat src_f32, dst_f32;
+  src.convertTo(src_f32, CV_32F);
+  dst.convertTo(dst_f32, CV_32F);
+  EXPECT_LE(cvtest::norm(src_f32, dst_f32, NORM_L2), 1e-3);
+
+  m_hdf_io->close();
+}
+#endif
+}
+} // namespace


### PR DESCRIPTION
HDF5 >= 1.14.4 introduced IEEE float16 predefined datatypes. This change adds the ability to directly save/load CV_16F matrices in HDF5 without casting to CV_16S.

- Add CV_16F case to GetH5type() using H5T_IEEE_F16LE
- Add float16 detection to GetCVtype() via H5T_FLOAT class + 2-byte size
- Add float16 detection to dsgettype(), dsread(), atread() to prevent H5Tget_native_type from promoting float16 to float32
- Handle both single-channel and multi-channel (H5T_ARRAY) cases
- All changes guarded with #if H5_VERSION_GE(1,14,4)
- Add CV_16F to existing attribute depth tests
- Add dedicated float16 dataset and attribute write/read tests

Fixes #4075

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
