### PR TITLE
ximgproc: fix angle difference normalization in FastLineDetector merging

### DIFF
--- a/modules/ximgproc/src/fast_line_detector.cpp
+++ b/modules/ximgproc/src/fast_line_detector.cpp
@@ -266,6 +266,8 @@ bool FastLineDetectorImpl::mergeSegments(const SEGMENT& seg1, const SEGMENT& seg
     float seg2len = sqrt((seg2.x1 - seg2.x2)*(seg2.x1 - seg2.x2)+(seg2.y1 - seg2.y2)*(seg2.y1 - seg2.y2));
     float middist = sqrt((seg1mid.x - seg2mid.x)*(seg1mid.x - seg2mid.x) + (seg1mid.y - seg2mid.y)*(seg1mid.y - seg2mid.y));
     float angdiff = fabs(seg1.angle - seg2.angle);
+    while (angdiff >= (float)CV_PI) angdiff -= (float)CV_PI;
+    angdiff = std::min(angdiff, (float)CV_PI - angdiff);;
 
     float dist = (float)distPointLine(ori, l1);
 

--- a/modules/ximgproc/src/fast_line_detector.cpp
+++ b/modules/ximgproc/src/fast_line_detector.cpp
@@ -267,7 +267,7 @@ bool FastLineDetectorImpl::mergeSegments(const SEGMENT& seg1, const SEGMENT& seg
     float middist = sqrt((seg1mid.x - seg2mid.x)*(seg1mid.x - seg2mid.x) + (seg1mid.y - seg2mid.y)*(seg1mid.y - seg2mid.y));
     float angdiff = fabs(seg1.angle - seg2.angle);
     while (angdiff >= (float)CV_PI) angdiff -= (float)CV_PI;
-    angdiff = std::min(angdiff, (float)CV_PI - angdiff);;
+    angdiff = std::min(angdiff, (float)CV_PI - angdiff);
 
     float dist = (float)distPointLine(ori, l1);
 

--- a/modules/ximgproc/test/test_fld.cpp
+++ b/modules/ximgproc/test/test_fld.cpp
@@ -199,6 +199,64 @@ TEST_F(ximgproc_FLD, mergeLines)
     ASSERT_EQ(EPOCHS, passedtests);
 }
 
+TEST_F(ximgproc_FLD, mergeOppositeDirections)
+{
+    std::vector<std::pair<cv::Vec4f, cv::Vec4f>> touchingParallelPairs;
+
+    RNG rng(12345);
+    std::vector<cv::Point2f> dirs;
+    for (int i = 0; i < 10; i++)
+    {
+        float x = rng.uniform(1.f, 99.f);
+        float y = 100.f - x;
+        dirs.emplace_back(x, y);
+    }
+    
+    // --- Add the four fixed vectors ---
+    dirs.emplace_back(100.f,   0.f);
+    dirs.emplace_back(  0.f, 100.f);
+    dirs.emplace_back(-100.f,  0.f);
+    dirs.emplace_back(  0.f, -100.f);
+    // --- Construct segment pairs ---
+    const cv::Point2f base(150.f, 150.f);
+
+    for (const auto& v : dirs)
+    {
+        cv::Point2f p1 = base;
+        cv::Point2f p2 = base + v;
+        cv::Point2f mid = 0.5f * (p1 + p2);
+        // Pair A: same direction, touching
+        {
+            cv::Vec4f seg1(p1.x, p1.y, p2.x, p2.y);
+            cv::Vec4f seg2(mid.x, mid.y, p2.x, p2.y);
+            touchingParallelPairs.emplace_back(seg1, seg2);
+        }
+        // Pair B: opposite direction, touching
+        {
+            cv::Vec4f seg1(p1.x, p1.y, p2.x, p2.y);
+            cv::Vec4f seg2(mid.x, mid.y, p1.x, p1.y);
+            touchingParallelPairs.emplace_back(seg1, seg2);
+        }
+    }
+
+    for (const auto& pair : touchingParallelPairs)
+    {
+        lines.clear();
+        test_image = Mat(img_size, CV_8UC1, Scalar::all(0));
+        
+        cv::Vec4f seg1 = pair.first;
+        cv::Vec4f seg2 = pair.second;
+        
+        line(test_image, Point2f(seg1[0], seg1[1]), Point2f(seg1[2], seg1[3]), Scalar(255), 2);
+        line(test_image, Point2f(seg2[0], seg2[1]), Point2f(seg2[2], seg2[3]), Scalar(255), 2);
+        
+        Ptr<FastLineDetector> detector = createFastLineDetector(10, 1.414213562f, 50, 50, 0, true);
+        detector->detect(test_image, lines);
+        
+        EXPECT_EQ(1u, lines.size());
+    }
+}
+
 TEST_F(ximgproc_FLD, rotatedRect)
 {
     for (int i = 0; i < EPOCHS; ++i)


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv_contrib/issues/3956
Fix angle difference computation in FastLineDetector::mergeSegments.

Previously the angular difference was computed using a direct absolute
difference between segment angles. As a result, collinear segments with
opposite directions (~pi radians apart) could fail to merge.

The angle difference is now normalized so that segments differing by pi
radians are treated as equivalent.

A regression test (mergeOppositeDirections) was added to verify that
touching parallel segments are merged correctly for both same and
opposite directions.

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
