### PR TITLE
reg: fix broken Python sample - use dot notation and fix segfault

### DIFF
--- a/modules/reg/samples/reg_shift.py
+++ b/modules/reg/samples/reg_shift.py
@@ -6,13 +6,13 @@ import sys
 
 img1 = cv.imread(sys.argv[1])
 img1 = img1.astype(np.float32)
+
 shift = np.array([5., 5.])
-mapTest = cv.reg_MapShift(shift)
 
+mapTest = cv.reg.MapShift(shift)
 img2 = mapTest.warp(img1)
-
-mapper = cv.reg_MapperGradShift()
-mappPyr = cv.reg_MapperPyramid(mapper)
+mapper = cv.reg.MapperGradShift()
+mappPyr = cv.reg.MapperPyramid(mapper)
 
 resMap = mappPyr.calculate(img1, img2)
 mapShift = cv.reg.MapTypeCaster_toShift(resMap)


### PR DESCRIPTION
Fixes #1935

Changes made:
- Replaced underscore-style API calls (cv.reg_MapShift) with correct 
  dot notation (cv.reg.MapShift)
- Replaced cv.reg_MapperGradShift with cv.reg.MapperGradShift  
- Replaced cv.reg_MapperPyramid with cv.reg.MapperPyramid
- Stored mapper in a separate variable before passing to MapperPyramid 
  to prevent segfault

Tested on: OpenCV 3.4.4 / Python