### PR TITLE
Fix wechat qrcode 3519

### DIFF
--- a/modules/reg/samples/reg_shift.py
+++ b/modules/reg/samples/reg_shift.py
@@ -6,13 +6,13 @@ import sys
 
 img1 = cv.imread(sys.argv[1])
 img1 = img1.astype(np.float32)
+
 shift = np.array([5., 5.])
-mapTest = cv.reg_MapShift(shift)
 
+mapTest = cv.reg.MapShift(shift)
 img2 = mapTest.warp(img1)
-
-mapper = cv.reg_MapperGradShift()
-mappPyr = cv.reg_MapperPyramid(mapper)
+mapper = cv.reg.MapperGradShift()
+mappPyr = cv.reg.MapperPyramid(mapper)
 
 resMap = mappPyr.calculate(img1, img2)
 mapShift = cv.reg.MapTypeCaster_toShift(resMap)

--- a/modules/wechat_qrcode/src/wechat_qrcode.cpp
+++ b/modules/wechat_qrcode/src/wechat_qrcode.cpp
@@ -20,6 +20,8 @@ public:
     Impl() {}
     ~Impl() {}
     /**
+     * 
+     * 
      * @brief detect QR codes from the given image
      *
      * @param img supports grayscale or color (BGR) image.
@@ -96,9 +98,20 @@ vector<string> WeChatQRCode::detectAndDecode(InputArray img, OutputArrayOfArrays
     } else {
         input_img = img.getMat();
     }
-    auto candidate_points = p->detect(input_img);
-    auto res_points = vector<Mat>();
-    auto ret = p->decode(input_img, candidate_points, res_points);
+   auto candidate_points = p->detect(input_img);
+
+// No QR candidates detected (can happen for scaled images, e.g. scale=2).
+// Avoid calling decode() with empty input which may lead to out-of-bounds.
+if (candidate_points.empty())
+{
+    if (points.needed())
+        points.release();
+    return vector<string>();
+}
+
+   auto res_points = vector<Mat>();
+   auto ret = p->decode(input_img, candidate_points, res_points);
+   
     // opencv type convert
     vector<Mat> tmp_points;
     if (points.needed()) {

--- a/modules/wechat_qrcode/src/wechat_qrcode.cpp
+++ b/modules/wechat_qrcode/src/wechat_qrcode.cpp
@@ -19,9 +19,8 @@ class WeChatQRCode::Impl {
 public:
     Impl() {}
     ~Impl() {}
-    /**
-     * 
-     * 
+    
+    /** 
      * @brief detect QR codes from the given image
      *
      * @param img supports grayscale or color (BGR) image.


### PR DESCRIPTION
### Description
Fix potential out-of-bounds / invalid access in WeChatQRCode::detectAndDecode
when no QR candidates are detected.

When detector returns empty candidate_points (e.g. scaled images with scale=2),
decode() was still called. This may lead to inconsistent state and crashes in
debug builds.

### Fix
Add early return when candidate_points is empty before calling decode().

### Patch
modules/wechat_qrcode/src/wechat_qrcode.cpp

Before:
auto candidate_points = p->detect(input_img);
auto res_points = vector<Mat>();
auto ret = p->decode(input_img, candidate_points, res_points);

After:
auto candidate_points = p->detect(input_img);

if (candidate_points.empty())
{
    if (points.needed())
        points.release();
    return vector<string>();
}

auto res_points = vector<Mat>();
auto ret = p->decode(input_img, candidate_points, res_points);

### Issue
Fixes #3519