### PR TITLE
sfm: Fix declarations to make Python bindings work

### DIFF
--- a/modules/sfm/include/opencv2/sfm/reconstruct.hpp
+++ b/modules/sfm/include/opencv2/sfm/reconstruct.hpp
@@ -82,7 +82,7 @@ reconstruct(InputArrayOfArrays points2d, OutputArray Ps, OutputArray points3d, I
   @param K Input/Output camera matrix \f$K = \vecthreethree{f_x}{0}{c_x}{0}{f_y}{c_y}{0}{0}{1}\f$. Input parameters used as initial guess.
   @param is_projective if true, the cameras are supposed to be projective.
 
-  Internally calls libmv simple pipeline routine with some default parameters by instatiating SFMLibmvEuclideanReconstruction class.
+  Internally calls libmv simple pipeline routine with some default parameters by instatiating SFMLibmvEuclideanRecons class.
 
   @note
     - Tracks must be as precise as possible. It does not handle outliers and is very sensible to them.
@@ -119,7 +119,7 @@ reconstruct(const std::vector<String> images, OutputArray Ps, OutputArray points
   @param K Input/Output camera matrix \f$K = \vecthreethree{f_x}{0}{c_x}{0}{f_y}{c_y}{0}{0}{1}\f$. Input parameters used as initial guess.
   @param is_projective if true, the cameras are supposed to be projective.
 
-  Internally calls libmv simple pipeline routine with some default parameters by instatiating SFMLibmvEuclideanReconstruction class.
+  Internally calls libmv simple pipeline routine with some default parameters by instatiating SFMLibmvEuclideanRecons class.
 
    @note
     - The images must be ordered as they were an image sequence. Additionally, each frame should be as close as posible to the previous and posterior.

--- a/modules/sfm/include/opencv2/sfm/simple_pipeline.hpp
+++ b/modules/sfm/include/opencv2/sfm/simple_pipeline.hpp
@@ -167,17 +167,17 @@ public:
   virtual void run(InputArrayOfArrays points2d) = 0;
 
   CV_WRAP
-  virtual void run(InputArrayOfArrays points2d, InputOutputArray K, OutputArray Rs,
-                   OutputArray Ts, OutputArray points3d) = 0;
+  virtual void run(InputArrayOfArrays points2d, CV_IN_OUT InputOutputArray K, CV_OUT OutputArrayOfArrays Rs,
+                   OutputArrayOfArrays Ts, OutputArrayOfArrays points3d) = 0;
 
   virtual void run(const std::vector<String> &images) = 0;
-  virtual void run(const std::vector<String> &images, InputOutputArray K, OutputArray Rs,
-                   OutputArray Ts, OutputArray points3d) = 0;
+  virtual void run(const std::vector<String> &images, CV_IN_OUT InputOutputArray K, CV_OUT OutputArrayOfArrays Rs,
+                   OutputArrayOfArrays Ts, OutputArrayOfArrays points3d) = 0;
 
   CV_WRAP virtual double getError() const = 0;
-  CV_WRAP virtual void getPoints(OutputArray points3d) = 0;
+  CV_WRAP virtual void getPoints(CV_OUT OutputArrayOfArrays points3d) = 0;
   CV_WRAP virtual cv::Mat getIntrinsics() const = 0;
-  CV_WRAP virtual void getCameras(OutputArray Rs, OutputArray Ts) = 0;
+  CV_WRAP virtual void getCameras(CV_OUT OutputArrayOfArrays Rs, OutputArrayOfArrays Ts) = 0;
 
   CV_WRAP
   virtual void
@@ -188,9 +188,9 @@ public:
   setCameraIntrinsicOptions(const libmv_CameraIntrinsicsOptions &libmv_camera_intrinsics_options) = 0;
 };
 
-/** @brief SFMLibmvEuclideanReconstruction class provides an interface with the Libmv Structure From Motion pipeline.
+/** @brief SFMLibmvEuclideanRecons class provides an interface with the Libmv Structure From Motion pipeline.
  */
-class CV_EXPORTS_W SFMLibmvEuclideanReconstruction : public BaseSFM
+class CV_EXPORTS_W SFMLibmvEuclideanRecons : public BaseSFM
 {
 public:
   /** @brief Calls the pipeline in order to perform Eclidean reconstruction.
@@ -213,8 +213,8 @@ public:
       - Tracks must be as precise as possible. It does not handle outliers and is very sensible to them.
   */
   CV_WRAP
-  virtual void run(InputArrayOfArrays points2d, InputOutputArray K, OutputArray Rs,
-                   OutputArray Ts, OutputArray points3d) CV_OVERRIDE = 0;
+  virtual void run(InputArrayOfArrays points2d, CV_IN_OUT InputOutputArray K, CV_OUT OutputArrayOfArrays Rs,
+                   OutputArrayOfArrays Ts, OutputArrayOfArrays points3d) CV_OVERRIDE = 0;
 
   /** @brief Calls the pipeline in order to perform Eclidean reconstruction.
     @param images a vector of string with the images paths.
@@ -236,8 +236,8 @@ public:
       - The images must be ordered as they were an image sequence. Additionally, each frame should be as close as posible to the previous and posterior.
       - For now DAISY features are used in order to compute the 2d points tracks and it only works for 3-4 images.
   */
-  virtual void run(const std::vector<String> &images, InputOutputArray K, OutputArray Rs,
-                   OutputArray Ts, OutputArray points3d) CV_OVERRIDE = 0;
+  virtual void run(const std::vector<String> &images, CV_IN_OUT InputOutputArray K, CV_OUT OutputArrayOfArrays Rs,
+                   OutputArrayOfArrays Ts, OutputArrayOfArrays points3d) CV_OVERRIDE = 0;
 
   /** @brief Returns the computed reprojection error.
   */
@@ -248,7 +248,7 @@ public:
     @param points3d Output array with estimated 3d points.
   */
   CV_WRAP
-  virtual void getPoints(OutputArray points3d) CV_OVERRIDE = 0;
+  virtual void getPoints(CV_OUT OutputArrayOfArrays points3d) CV_OVERRIDE = 0;
 
   /** @brief Returns the refined camera calibration matrix.
   */
@@ -260,7 +260,7 @@ public:
     @param Ts Output vector of 3x1 translations of the camera.
   */
   CV_WRAP
-  virtual void getCameras(OutputArray Rs, OutputArray Ts) CV_OVERRIDE = 0;
+  virtual void getCameras(CV_OUT OutputArrayOfArrays Rs, OutputArrayOfArrays Ts) CV_OVERRIDE = 0;
 
   /** @brief Setter method for reconstruction options.
     @param libmv_reconstruction_options struct with reconstruction options such as initial keyframes,
@@ -278,8 +278,9 @@ public:
   virtual void
   setCameraIntrinsicOptions(const libmv_CameraIntrinsicsOptions &libmv_camera_intrinsics_options) CV_OVERRIDE = 0;
 
-  /** @brief Creates an instance of the SFMLibmvEuclideanReconstruction class. Initializes Libmv. */
-  static Ptr<SFMLibmvEuclideanReconstruction>
+  /** @brief Creates an instance of the SFMLibmvEuclideanRecons class. Initializes Libmv. */
+  CV_WRAP
+  static Ptr<SFMLibmvEuclideanRecons>
     create(const libmv_CameraIntrinsicsOptions &camera_instrinsic_options=libmv_CameraIntrinsicsOptions(),
            const libmv_ReconstructionOptions &reconstruction_options=libmv_ReconstructionOptions());
   };

--- a/modules/sfm/src/reconstruct.cpp
+++ b/modules/sfm/src/reconstruct.cpp
@@ -56,7 +56,7 @@ namespace sfm
 
   template<class T>
   void
-  reconstruct_(const T &input, OutputArray Rs, OutputArray Ts, InputOutputArray K, OutputArray points3d, const bool refinement=true)
+  reconstruct_(const T &input, OutputArrayOfArrays Rs, OutputArrayOfArrays Ts, InputOutputArray K, OutputArrayOfArrays points3d, const bool refinement=true)
   {
     // Initial reconstruction
     const int keyframe1 = 1, keyframe2 = 2;
@@ -84,7 +84,7 @@ namespace sfm
 
     //-- Instantiate reconstruction pipeline
     Ptr<BaseSFM> reconstruction =
-      SFMLibmvEuclideanReconstruction::create(camera_instrinsic_options, reconstruction_options);
+      SFMLibmvEuclideanRecons::create(camera_instrinsic_options, reconstruction_options);
 
     //-- Run reconstruction pipeline
     reconstruction->run(input, K, Rs, Ts, points3d);
@@ -94,7 +94,7 @@ namespace sfm
 
   //  Reconstruction function for API
   void
-  reconstruct(InputArrayOfArrays points2d, OutputArray Ps, OutputArray points3d, InputOutputArray K,
+  reconstruct(InputArrayOfArrays points2d, OutputArrayOfArrays Ps, OutputArrayOfArrays points3d, InputOutputArray K,
               bool is_projective)
   {
     const int nviews = points2d.total();
@@ -161,8 +161,8 @@ namespace sfm
 
 
   void
-  reconstruct(InputArrayOfArrays points2d, OutputArray Rs, OutputArray Ts, InputOutputArray K,
-              OutputArray points3d, bool is_projective)
+  reconstruct(InputArrayOfArrays points2d, OutputArrayOfArrays Rs, OutputArrayOfArrays Ts, InputOutputArray K,
+              OutputArrayOfArrays points3d, bool is_projective)
   {
     const int nviews = points2d.total();
     CV_Assert( nviews >= 2 );
@@ -190,7 +190,7 @@ namespace sfm
 
 
   void
-  reconstruct(const std::vector<cv::String> images, OutputArray Ps, OutputArray points3d,
+  reconstruct(const std::vector<cv::String> images, OutputArrayOfArrays Ps, OutputArrayOfArrays points3d,
               InputOutputArray K, bool is_projective)
   {
     const int nviews = static_cast<int>(images.size());
@@ -234,8 +234,8 @@ namespace sfm
 
 
   void
-  reconstruct(const std::vector<cv::String> images, OutputArray Rs, OutputArray Ts,
-              InputOutputArray K, OutputArray points3d, bool is_projective)
+  reconstruct(const std::vector<cv::String> images, OutputArrayOfArrays Rs, OutputArrayOfArrays Ts,
+              InputOutputArray K, OutputArrayOfArrays points3d, bool is_projective)
   {
     const int nviews = static_cast<int>(images.size());
     CV_Assert( nviews >= 2 );

--- a/modules/sfm/src/simple_pipeline.cpp
+++ b/modules/sfm/src/simple_pipeline.cpp
@@ -189,8 +189,8 @@ public:
     CV_Assert(libmv_reconstruction_);
   }
 
-  virtual void run(InputArrayOfArrays points2d, InputOutputArray K, OutputArray Rs,
-                   OutputArray Ts, OutputArray points3d)
+  virtual void run(InputArrayOfArrays points2d, InputOutputArray K, OutputArrayOfArrays Rs,
+                   OutputArrayOfArrays Ts, OutputArrayOfArrays points3d)
   {
     // Run the pipeline
     run(points2d);
@@ -225,8 +225,8 @@ public:
   }
 
 
-  virtual void run(const std::vector <String> &images, InputOutputArray K, OutputArray Rs,
-                   OutputArray Ts, OutputArray points3d)
+  virtual void run(const std::vector <String> &images, InputOutputArray K, OutputArrayOfArrays Rs,
+                   OutputArrayOfArrays Ts, OutputArrayOfArrays points3d)
   {
     // Run the pipeline
     run(images);
@@ -238,7 +238,7 @@ public:
   virtual double getError() const { return libmv_reconstruction_->error; }
 
   virtual void
-  getPoints(OutputArray points3d) {
+  getPoints(OutputArrayOfArrays points3d) {
     const size_t n_points =
       libmv_reconstruction_->reconstruction.AllPoints().size();
 
@@ -262,7 +262,7 @@ public:
   }
 
   virtual void
-  getCameras(OutputArray Rs, OutputArray Ts) {
+  getCameras(OutputArrayOfArrays Rs, OutputArrayOfArrays Ts) {
     const size_t n_views =
       libmv_reconstruction_->reconstruction.AllCameras().size();
 
@@ -294,9 +294,9 @@ private:
 
   void
   extractLibmvReconstructionData(InputOutputArray K,
-                                 OutputArray Rs,
-                                 OutputArray Ts,
-                                 OutputArray points3d)
+                                 OutputArrayOfArrays Rs,
+                                 OutputArrayOfArrays Ts,
+                                 OutputArrayOfArrays points3d)
   {
     getCameras(Rs, Ts);
     getPoints(points3d);
@@ -310,11 +310,11 @@ private:
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
 
-Ptr<SFMLibmvEuclideanReconstruction>
-SFMLibmvEuclideanReconstruction::create(const libmv_CameraIntrinsicsOptions &camera_instrinsic_options,
+Ptr<SFMLibmvEuclideanRecons>
+SFMLibmvEuclideanRecons::create(const libmv_CameraIntrinsicsOptions &camera_instrinsic_options,
                                         const libmv_ReconstructionOptions &reconstruction_options)
 {
-  return makePtr<SFMLibmvReconstructionImpl<SFMLibmvEuclideanReconstruction> >(camera_instrinsic_options,reconstruction_options);
+  return makePtr<SFMLibmvReconstructionImpl<SFMLibmvEuclideanRecons> >(camera_instrinsic_options,reconstruction_options);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////

--- a/modules/sfm/test/test_simple_pipeline.cpp
+++ b/modules/sfm/test/test_simple_pipeline.cpp
@@ -70,8 +70,8 @@ TEST(Sfm_simple_pipeline, backyard)
                                     k1, k2, k3);
     libmv_ReconstructionOptions reconstruction_options(keyframe1, keyframe2, refine_intrinsics, select_keyframes, verbosity_level);
 
-    Ptr<SFMLibmvEuclideanReconstruction> euclidean_reconstruction =
-        SFMLibmvEuclideanReconstruction::create(camera_instrinsic_options, reconstruction_options);
+    Ptr<SFMLibmvEuclideanRecons> euclidean_reconstruction =
+        SFMLibmvEuclideanRecons::create(camera_instrinsic_options, reconstruction_options);
 
     // Run reconstruction pipeline
     euclidean_reconstruction->run(points2d);


### PR DESCRIPTION
See issue https://github.com/opencv/opencv_contrib/issues/636

I ran into the same issue and would like to discuss/propose the remedy in this PR which allowed me to use the SFM module from Python.

Note 1: I had to add a CV_WRAP for SFMLibmvEuclideanReconstruction::create, just running the constructor produced a NULL _self_ in pyopencv_generated_types_content.h when ->run() was called.

Note 2: Most of the other problems were solved by replacing OutputArray to OutputArrayOfArrays (distinction doesn't matter to the C++ type system but does matter to the Python bindings generator) to prevent GetMatRef(i) from throwing an assert on the OutputArray not being of a STD_VECTOR_MAT kind in all routines returning Ts and points3d.

I don't know if using a vector<Mat> is the best choice for Ts and points3d output, I'd say a regular Mat with 3 columns would produce nicer Numpy arrays and something that serializes nicer to cv::FileStorage. But I didn't want to change any semantics.

Note 3: I also had to shorten SFMLibmvEuclideanReconstruction to SFMLibmvEuclideanRecons in order to avoid the Python bindings generator shortening/garbling it to SFMLibmvEuclideanReruction in pyopencv_generated_types_content.h (could also be that something overenthousiastically strips 'const' in the wrong way, I'm no expert on the bindings generators).

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
