### PR TITLE
Deprecate CUDA's convertFp16() in favor of convertTo() with CV_16F

### DIFF
--- a/modules/cudev/test/test_cvt.cu
+++ b/modules/cudev/test/test_cvt.cu
@@ -101,10 +101,11 @@ public:
         GpuMat g_dst;
 
         // Fp32 -> Fp16
-        cv::cuda::convertFp16(g_src, g_dst);
+        g_src.convertTo(g_dst, CV_16F);
         src.convertTo(dst, CV_16F);
         // Fp16 -> Fp32
-        cv::cuda::convertFp16(g_dst.clone(), g_dst);
+        GpuMat g_tmp = g_dst.clone();
+        g_tmp.convertTo(g_dst, CV_32F);
         dst.convertTo(ref, CV_32F);
 
         g_dst.download(dst);
@@ -127,7 +128,7 @@ public:
         GpuMat g_dst;
 
         // Fp32 -> Fp16
-        cv::cuda::convertFp16(g_src, g_dst);
+        g_src.convertTo(g_dst, CV_16F);
         src.convertTo(ref, CV_16F);
 
         g_dst.download(dst);


### PR DESCRIPTION
### Pull Request Readiness Checklist

Resolves https://github.com/opencv/opencv/issues/24909

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
