### PR TITLE
Migrated chessboard and circles grid detectors to objdetect

### DIFF
--- a/modules/ccalib/CMakeLists.txt
+++ b/modules/ccalib/CMakeLists.txt
@@ -1,2 +1,2 @@
 set(the_description "Custom Calibration Pattern")
-ocv_define_module(ccalib opencv_core opencv_imgproc opencv_3d opencv_calib opencv_features opencv_xfeatures2d opencv_highgui opencv_imgcodecs WRAP python)
+ocv_define_module(ccalib opencv_core opencv_imgproc opencv_3d opencv_calib opencv_objdetect opencv_features opencv_xfeatures2d opencv_highgui opencv_imgcodecs WRAP python)

--- a/modules/ccalib/samples/omni_calibration.cpp
+++ b/modules/ccalib/samples/omni_calibration.cpp
@@ -3,6 +3,7 @@
 #include "opencv2/imgproc.hpp"
 #include "opencv2/3d.hpp"
 #include "opencv2/calib.hpp"
+#include "opencv2/objdetect.hpp"
 #include "opencv2/highgui.hpp"
 #include <vector>
 #include <iostream>

--- a/modules/ccalib/samples/omni_stereo_calibration.cpp
+++ b/modules/ccalib/samples/omni_stereo_calibration.cpp
@@ -3,6 +3,7 @@
 #include "opencv2/imgproc.hpp"
 #include "opencv2/highgui.hpp"
 #include "opencv2/3d.hpp"
+#include "opencv2/objdetect.hpp"
 #include "opencv2/calib.hpp"
 #include <vector>
 #include <iostream>

--- a/modules/structured_light/samples/projectorcalibration.cpp
+++ b/modules/structured_light/samples/projectorcalibration.cpp
@@ -48,6 +48,7 @@
 #include <opencv2/core/utility.hpp>
 #include <opencv2/imgproc.hpp>
 #include <opencv2/3d.hpp>
+#include <opencv2/objdetect.hpp>
 #include <opencv2/calib.hpp>
 
 using namespace std;


### PR DESCRIPTION
OpenCV: https://github.com/opencv/opencv/pull/28804

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
