### PR TITLE
videostab: Add missing include to fix build failure

### DIFF
--- a/modules/videostab/src/cuda/global_motion.cu
+++ b/modules/videostab/src/cuda/global_motion.cu
@@ -45,6 +45,7 @@
 #include <thrust/device_ptr.h>
 #include <thrust/remove.h>
 #include <thrust/functional.h>
+#include <thrust/tuple.h>
 #include "opencv2/core/cuda/common.hpp"
 
 namespace cv { namespace cuda { namespace device { namespace globmotion {


### PR DESCRIPTION
When building the OpenCV package on Arch Linux with CUDA 13.2.1 the
following build failure arises:

    [ 82%] Built target example_cudaoptflow_nvidia_optical_flow
    /build/opencv/src/opencv_contrib/modules/videostab/src/cuda/global_motion.cu(66): error: namespace "thrust" has no member "make_tuple"
    /build/opencv/src/opencv_contrib/modules/videostab/src/cuda/global_motion.cu(67): error: namespace "thrust" has no member "make_tuple"
    /build/opencv/src/opencv_contrib/modules/videostab/src/cuda/global_motion.cu(69): error: identifier "make_tuple" is undefined
    3 errors detected in the compilation of "/build/opencv/src/opencv_contrib/modules/videostab/src/cuda/global_motion.cu".

This is due to the currently undeclared dependency on the tuple header
from the thrust library and fixed in this changeset by adding the
missing include.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
