### PR TITLE
Fixed CUDA build after geometry module refactoring.

### DIFF
--- a/modules/cudaimgproc/CMakeLists.txt
+++ b/modules/cudaimgproc/CMakeLists.txt
@@ -6,7 +6,7 @@ set(the_description "CUDA-accelerated Image Processing")
 
 ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4127 /wd4100 /wd4324 /wd4512 /wd4515 -Wundef -Wmissing-declarations -Wshadow -Wunused-parameter)
 
-ocv_define_module(cudaimgproc opencv_imgproc OPTIONAL opencv_cudev opencv_cudaarithm opencv_cudafilters WRAP python)
+ocv_define_module(cudaimgproc opencv_imgproc OPTIONAL opencv_cudev opencv_cudaarithm opencv_cudafilters opencv_geometry WRAP python)
 
 if(ENABLE_CUDA_FIRST_CLASS_LANGUAGE)
   ocv_target_link_libraries(${the_module} PRIVATE CUDA::cudart${CUDA_LIB_EXT} CUDA::nppial${CUDA_LIB_EXT} CUDA::nppist${CUDA_LIB_EXT} CUDA::nppicc${CUDA_LIB_EXT} CUDA::nppidei${CUDA_LIB_EXT})

--- a/modules/cudaimgproc/perf/perf_precomp.hpp
+++ b/modules/cudaimgproc/perf/perf_precomp.hpp
@@ -44,8 +44,8 @@
 
 #include "opencv2/ts.hpp"
 #include "opencv2/ts/cuda_perf.hpp"
-
 #include "opencv2/cudaimgproc.hpp"
+#include "opencv2/geometry.hpp"
 
 namespace opencv_test {
 using namespace perf;

--- a/modules/cudaimgproc/test/test_precomp.hpp
+++ b/modules/cudaimgproc/test/test_precomp.hpp
@@ -44,8 +44,8 @@
 
 #include "opencv2/ts.hpp"
 #include "opencv2/ts/cuda_test.hpp"
-
 #include "opencv2/cudaimgproc.hpp"
+#include "opencv2/geometry.hpp"
 
 #include "cvconfig.h"
 

--- a/modules/cudalegacy/CMakeLists.txt
+++ b/modules/cudalegacy/CMakeLists.txt
@@ -6,7 +6,7 @@ set(the_description "CUDA-accelerated Computer Vision (legacy)")
 
 ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4127 /wd4130 /wd4324 /wd4512 /wd4310 -Wundef -Wmissing-declarations -Wuninitialized -Wshadow -Wdeprecated-declarations -Wstrict-aliasing -Wtautological-compare)
 
-ocv_add_module(cudalegacy opencv_core opencv_video OPTIONAL opencv_objdetect opencv_xobjdetect opencv_imgproc opencv_geometry opencv_stereo opencv_calib opencv_cudaarithm opencv_cudafilters opencv_cudaimgproc)
+ocv_add_module(cudalegacy opencv_core opencv_geometry opencv_video OPTIONAL opencv_objdetect opencv_xobjdetect opencv_imgproc opencv_geometry opencv_stereo opencv_calib opencv_cudaarithm opencv_cudafilters opencv_cudaimgproc)
 
 ocv_module_include_directories()
 ocv_glob_module_sources()

--- a/modules/cudalegacy/src/precomp.hpp
+++ b/modules/cudalegacy/src/precomp.hpp
@@ -54,6 +54,7 @@
 #pragma GCC diagnostic ignored "-Wsuggest-override"
 #endif
 
+#include "opencv2/geometry.hpp"
 #include "opencv2/cudalegacy.hpp"
 #include "opencv2/core/utility.hpp"
 

--- a/modules/cudawarping/CMakeLists.txt
+++ b/modules/cudawarping/CMakeLists.txt
@@ -11,7 +11,7 @@ if(ENABLE_CUDA_FIRST_CLASS_LANGUAGE)
   list(APPEND build_libs CUDA::cudart${CUDA_LIB_EXT} CUDA::nppial${CUDA_LIB_EXT} CUDA::nppig${CUDA_LIB_EXT})
 endif()
 
-ocv_add_module(cudawarping opencv_core opencv_imgproc OPTIONAL opencv_cudev WRAP python)
+ocv_add_module(cudawarping opencv_core opencv_imgproc opencv_geometry OPTIONAL opencv_cudev WRAP python)
 
 ocv_module_include_directories()
 ocv_glob_module_sources()

--- a/modules/cudawarping/src/precomp.hpp
+++ b/modules/cudawarping/src/precomp.hpp
@@ -43,6 +43,7 @@
 #ifndef __OPENCV_PRECOMP_H__
 #define __OPENCV_PRECOMP_H__
 
+#include "opencv2/geometry.hpp"
 #include "opencv2/cudawarping.hpp"
 
 #include "opencv2/core/private.cuda.hpp"

--- a/modules/cudawarping/test/test_precomp.hpp
+++ b/modules/cudawarping/test/test_precomp.hpp
@@ -48,6 +48,7 @@
 #include "opencv2/ts/cuda_test.hpp"
 
 #include "opencv2/cudawarping.hpp"
+#include "opencv2/geometry.hpp"
 
 #include "cvconfig.h"
 


### PR DESCRIPTION
The regression was introduced in https://github.com/opencv/opencv/pull/29230.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
