### PR TITLE
julia: fix bindings build with mirrored types and current CxxWrap

### DIFF
--- a/modules/julia/CMakeLists.txt
+++ b/modules/julia/CMakeLists.txt
@@ -81,12 +81,32 @@ endforeach(m)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/gen/ DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/gen)
 file(COPY ${HDR_PARSER_PATH} DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/gen)
 
+include("${OpenCV_SOURCE_DIR}/cmake/OpenCVBindingsPreprocessorDefinitions.cmake")
+ocv_bindings_generator_populate_preprocessor_definitions(
+  OPENCV_MODULES_BUILD
+  opencv_preprocessor_defs
+)
+
+set(JULIA_GENERATOR_CONFIG "${CMAKE_CURRENT_BINARY_DIR}/gen_julia_config.json")
+set(__config_str
+"{
+  \"preprocessor_definitions\": {
+${opencv_preprocessor_defs}
+  }
+}")
+file(WRITE "${JULIA_GENERATOR_CONFIG}" "${__config_str}")
+unset(__config_str)
+
 message(STATUS "Generating Julia Binding Files")
 
 execute_process(
                 WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/gen"
-                COMMAND ${PYTHON_DEFAULT_EXECUTABLE} "${CMAKE_CURRENT_BINARY_DIR}/gen/gen_all.py" ${CMAKE_SOURCE_DIR}/modules ${OPENCV_MODULES_BUILD}
+                COMMAND ${PYTHON_DEFAULT_EXECUTABLE} "${CMAKE_CURRENT_BINARY_DIR}/gen/gen_all.py" ${CMAKE_SOURCE_DIR}/modules ${OPENCV_MODULES_BUILD} --config "${JULIA_GENERATOR_CONFIG}"
+                RESULT_VARIABLE JULIA_GENERATOR_RESULT
                 )
+if(NOT JULIA_GENERATOR_RESULT EQUAL 0)
+    message(FATAL_ERROR "Julia bindings generator failed")
+endif()
 
 file(COPY ${CMAKE_CURRENT_BINARY_DIR}/gen/cpp_files/ DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/gen/autogen_cpp)
 file(COPY ${CMAKE_CURRENT_BINARY_DIR}/gen/jl_cxx_files/ DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/gen/autogen_jl)

--- a/modules/julia/gen/binding_templates_cpp/cv_core.cpp
+++ b/modules/julia/gen/binding_templates_cpp/cv_core.cpp
@@ -25,7 +25,11 @@ struct IsSmartPointerType<cv::Ptr<T>> : std::true_type
 template <typename T>
 struct ConstructorPointerType<cv::Ptr<T>>
 {
+#if (JLCXX_VERSION_MAJOR > 0) || (JLCXX_VERSION_MAJOR == 0 && JLCXX_VERSION_MINOR >= 14)
+    typedef cv::Ptr<T> type;
+#else
     typedef T *type;
+#endif
 };
 
 template<typename T, int Val>

--- a/modules/julia/gen/cpp_files/jlcv.hpp
+++ b/modules/julia/gen/cpp_files/jlcv.hpp
@@ -74,11 +74,16 @@ typedef flann::SearchParams flann_SearchParams;
 typedef cv::dnn::DictValue LayerId;
 typedef cv::dnn::Backend dnn_Backend;
 typedef cv::dnn::Target dnn_Target;
+#if CV_VERSION_MAJOR > 4 || (CV_VERSION_MAJOR == 4 && CV_VERSION_MINOR >= 11)
+typedef cv::dnn::DataLayout dnn_DataLayout;
+typedef cv::dnn::ImagePaddingMode dnn_ImagePaddingMode;
+#endif
 #endif
 
 #ifdef HAVE_OPENCV_CALIB3D
 
 #include <opencv2/calib3d.hpp>
+typedef CirclesGridFinderParameters::GridType GridType;
 #endif
 
 template <typename C>
@@ -115,6 +120,7 @@ struct force_enum_int{
 
 typedef vector<Mat> vector_Mat;
 typedef vector<UMat> vector_UMat;
+typedef vector<int> vector_int;
 
 typedef char* c_string;
 

--- a/modules/julia/gen/cpp_files/jlcv.hpp
+++ b/modules/julia/gen/cpp_files/jlcv.hpp
@@ -74,10 +74,8 @@ typedef flann::SearchParams flann_SearchParams;
 typedef cv::dnn::DictValue LayerId;
 typedef cv::dnn::Backend dnn_Backend;
 typedef cv::dnn::Target dnn_Target;
-#if CV_VERSION_MAJOR > 4 || (CV_VERSION_MAJOR == 4 && CV_VERSION_MINOR >= 11)
 typedef cv::dnn::DataLayout dnn_DataLayout;
 typedef cv::dnn::ImagePaddingMode dnn_ImagePaddingMode;
-#endif
 #endif
 
 #ifdef HAVE_OPENCV_CALIB3D

--- a/modules/julia/gen/cpp_files/jlcv_types.hpp
+++ b/modules/julia/gen/cpp_files/jlcv_types.hpp
@@ -64,6 +64,25 @@ struct CxxComplex
 
 namespace jlcxx
 {
+  namespace opencv_julia_detail
+  {
+    template<typename T>
+    inline jl_value_t* julia_base_type_value()
+    {
+#if (JLCXX_VERSION_MAJOR > 0) || (JLCXX_VERSION_MAJOR == 0 && JLCXX_VERSION_MINOR >= 14)
+      return static_cast<jl_value_t*>(julia_base_type<T>());
+#else
+      return reinterpret_cast<jl_value_t*>(julia_base_type<T>());
+#endif
+    }
+
+    template<typename T>
+    inline jl_svec_t* julia_base_type_tuple()
+    {
+      return jl_svec1(julia_base_type_value<T>());
+    }
+  }
+
   template <> struct IsMirroredType<cv::Range> : std::true_type {};
   template <> struct IsMirroredType<cv::RotatedRect> : std::true_type {};
   template <> struct IsMirroredType<cv::TermCriteria> : std::true_type {};
@@ -77,7 +96,7 @@ namespace jlcxx
   {
     static inline jl_datatype_t* julia_type()
     {
-      return (jl_datatype_t*)apply_type((jl_value_t*)jlcxx::julia_type("Point"), jl_svec1(julia_base_type<T>()));
+      return (jl_datatype_t*)apply_type((jl_value_t*)jlcxx::julia_type("Point"), opencv_julia_detail::julia_base_type_tuple<T>());
     }
   };
 
@@ -109,7 +128,7 @@ namespace jlcxx
   {
     static inline jl_datatype_t* julia_type()
     {
-      return (jl_datatype_t*)apply_type((jl_value_t*)jlcxx::julia_type("Size"), jl_svec1(julia_base_type<T>()));
+      return (jl_datatype_t*)apply_type((jl_value_t*)jlcxx::julia_type("Size"), opencv_julia_detail::julia_base_type_tuple<T>());
     }
   };
 
@@ -142,7 +161,7 @@ namespace jlcxx
   {
     static inline jl_datatype_t* julia_type()
     {
-      return (jl_datatype_t*)apply_type((jl_value_t*)jlcxx::julia_type("Point3"), jl_svec1(julia_base_type<T>()));
+      return (jl_datatype_t*)apply_type((jl_value_t*)jlcxx::julia_type("Point3"), opencv_julia_detail::julia_base_type_tuple<T>());
     }
   };
 
@@ -172,7 +191,7 @@ namespace jlcxx
   {
     static inline jl_datatype_t* julia_type()
     {
-      return (jl_datatype_t*)apply_type((jl_value_t*)jlcxx::julia_type("Rect"), jl_svec1(julia_base_type<T>()));
+      return (jl_datatype_t*)apply_type((jl_value_t*)jlcxx::julia_type("Rect"), opencv_julia_detail::julia_base_type_tuple<T>());
     }
   };
 
@@ -203,7 +222,7 @@ namespace jlcxx
   {
     static inline jl_datatype_t* julia_type()
     {
-      return (jl_datatype_t*)apply_type((jl_value_t*)jlcxx::julia_type("cvComplex"), jl_svec1(julia_base_type<T>()));
+      return (jl_datatype_t*)apply_type((jl_value_t*)jlcxx::julia_type("cvComplex"), opencv_julia_detail::julia_base_type_tuple<T>());
     }
   };
 

--- a/modules/julia/gen/cpp_files/jlcxx/array.hpp
+++ b/modules/julia/gen/cpp_files/jlcxx/array.hpp
@@ -26,6 +26,19 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace jlcxx
 {
 
+namespace opencv_julia_detail
+{
+template <typename T>
+inline T* array_data(jl_array_t* arr)
+{
+#if (JULIA_VERSION_MAJOR * 100 + JULIA_VERSION_MINOR) >= 111
+  return jl_array_data(arr, T);
+#else
+  return static_cast<T*>(jl_array_data(arr));
+#endif
+}
+}
+
 template<typename PointedT, typename CppT>
 struct ValueExtractor
 {
@@ -189,22 +202,22 @@ public:
 
   iterator begin()
   {
-    return iterator(static_cast<julia_t*>(jl_array_data(wrapped())));
+    return iterator(opencv_julia_detail::array_data<julia_t>(wrapped()));
   }
 
   const_iterator begin() const
   {
-    return const_iterator(static_cast<julia_t*>(jl_array_data(wrapped())));
+    return const_iterator(opencv_julia_detail::array_data<julia_t>(wrapped()));
   }
 
   iterator end()
   {
-    return iterator(static_cast<julia_t*>(jl_array_data(wrapped())) + jl_array_len(wrapped()));
+    return iterator(opencv_julia_detail::array_data<julia_t>(wrapped()) + jl_array_len(wrapped()));
   }
 
   const_iterator end() const
   {
-    return const_iterator(static_cast<julia_t*>(jl_array_data(wrapped())) + jl_array_len(wrapped()));
+    return const_iterator(opencv_julia_detail::array_data<julia_t>(wrapped()) + jl_array_len(wrapped()));
   }
 
   void push_back(const ValueT& val)
@@ -221,12 +234,12 @@ public:
 
   const julia_t* data() const
   {
-    return (julia_t*)jl_array_data(wrapped());
+    return opencv_julia_detail::array_data<julia_t>(wrapped());
   }
 
   julia_t* data()
   {
-    return (julia_t*)jl_array_data(wrapped());
+    return opencv_julia_detail::array_data<julia_t>(wrapped());
   }
 
   std::size_t size() const
@@ -293,7 +306,11 @@ struct PackedArrayType<T*, WrappedPtrTrait>
 {
   static jl_datatype_t* type()
   {
+#if (JLCXX_VERSION_MAJOR > 0) || (JLCXX_VERSION_MAJOR == 0 && JLCXX_VERSION_MINOR >= 14)
+    return apply_type(jlcxx::julia_type("Ptr"), julia_base_type<T>());
+#else
     return (jl_datatype_t*)apply_type((jl_value_t*)jlcxx::julia_type("Ptr"), jl_svec1(julia_base_type<T>()));
+#endif
   }
 };
 

--- a/modules/julia/gen/gen3_cpp.py
+++ b/modules/julia/gen/gen3_cpp.py
@@ -72,6 +72,8 @@ registered_types = ["int", "Size.*", "Rect.*", "Scalar", "RotatedRect", "Point.*
 
 class ClassInfo(ClassInfo):
     def get_cpp_code_header(self):
+        if is_manual_mapped_type(self.name):
+            return ''
         if self.ismap:
             return 'mod.map_type<%s>("%s");\n'%(self.name, self.mapped_name)
         if not self.base:
@@ -80,6 +82,8 @@ class ClassInfo(ClassInfo):
             return 'mod.add_type<%s>("%s", jlcxx::julia_base_type<%s>());\n' % (self.name, self.mapped_name, self.base)
 
     def get_cpp_code_body(self):
+        if is_manual_mapped_type(self.name):
+            return ''
         if self.ismap:
             return ''
         cpp_code = StringIO()
@@ -268,6 +272,8 @@ def gen(srcfiles, preprocessor_definitions=None):
         sorted_cls = sort_classes(ns.classes.items())
         for name, cl in sorted_cls:
             cl.__class__ = ClassInfo
+            if is_manual_mapped_type(cl.name):
+                continue
             cpp_code.write(cl.get_cpp_code_header())
             if cl.base:
                 include_code.write("""
@@ -294,6 +300,8 @@ struct SuperType<%s>
         nsname = name.replace("::", "_")
         for name, cl in ns.classes.items():
             cl.__class__ = ClassInfo
+            if is_manual_mapped_type(cl.name):
+                continue
             cpp_code.write(cl.get_cpp_code_body())
             for mname, fs in cl.methods.items():
                 for f in fs:

--- a/modules/julia/gen/gen3_cpp.py
+++ b/modules/julia/gen/gen3_cpp.py
@@ -226,8 +226,8 @@ class FuncVariant(FuncVariant):
 
 
 
-def gen(srcfiles):
-    namespaces, default_values = gen_tree(srcfiles)
+def gen(srcfiles, preprocessor_definitions=None):
+    namespaces, default_values = gen_tree(srcfiles, preprocessor_definitions)
     cpp_code = StringIO()
     include_code = StringIO()
     nsi = sorted(namespaces.items(), key =lambda x: x[0])
@@ -324,9 +324,5 @@ struct SuperType<%s>
 
 
 
-srcfiles = hdr_parser.opencv_hdr_list
-if len(sys.argv) > 1:
-    srcfiles = [l.strip() for l in sys.argv[1].split(';')]
-
-
-gen(srcfiles)
+srcfiles, preprocessor_definitions = parse_generator_args(sys.argv[1:])
+gen(srcfiles, preprocessor_definitions)

--- a/modules/julia/gen/gen3_julia.py
+++ b/modules/julia/gen/gen3_julia.py
@@ -50,6 +50,8 @@ def gen(srcfiles, preprocessor_definitions=None):
         if name != 'cv':
             for cname, cl in ns.classes.items():
                 cl.__class__ = ClassInfo
+                if is_manual_mapped_type(cl.name):
+                    continue
                 for mname, fs in cl.methods.items():
                     for f in fs:
                         f.__class__ = FuncVariant

--- a/modules/julia/gen/gen3_julia.py
+++ b/modules/julia/gen/gen3_julia.py
@@ -36,8 +36,8 @@ class FuncVariant(FuncVariant):
         return 'const %s = OpenCV.%s_%s' %(self.mapped_name, ns, self.mapped_name)
 
 
-def gen(srcfiles):
-    namespaces, _ = gen_tree(srcfiles)
+def gen(srcfiles, preprocessor_definitions=None):
+    namespaces, _ = gen_tree(srcfiles, preprocessor_definitions)
 
     jl_code = StringIO()
     for name, ns in namespaces.items():
@@ -91,9 +91,5 @@ def gen(srcfiles):
 
 
 
-srcfiles = hdr_parser.opencv_hdr_list
-if len(sys.argv) > 1:
-    srcfiles = [l.strip() for l in sys.argv[1].split(';')]
-
-
-gen(srcfiles)
+srcfiles, preprocessor_definitions = parse_generator_args(sys.argv[1:])
+gen(srcfiles, preprocessor_definitions)

--- a/modules/julia/gen/gen3_julia_cxx.py
+++ b/modules/julia/gen/gen3_julia_cxx.py
@@ -72,6 +72,8 @@ class ClassInfo(ClassInfo):
 
     def get_jl_code(self):
 
+        if is_manual_mapped_type(self.name):
+            return ''
         if self.ismap:
             return ''
         return self.overload_get()+self.overload_set()
@@ -183,6 +185,8 @@ def gen(srcfiles, preprocessor_definitions=None):
         function_signatures = []
         for cname, cl in ns.classes.items():
             cl.__class__ = ClassInfo
+            if is_manual_mapped_type(cl.name):
+                continue
             jl_code.write(cl.get_jl_code())
             for mname, fs in cl.methods.items():
                 for f in fs:

--- a/modules/julia/gen/gen3_julia_cxx.py
+++ b/modules/julia/gen/gen3_julia_cxx.py
@@ -167,8 +167,8 @@ class FuncVariant(FuncVariant):
 
 
 
-def gen(srcfiles):
-    namespaces, _ = gen_tree(srcfiles)
+def gen(srcfiles, preprocessor_definitions=None):
+    namespaces, _ = gen_tree(srcfiles, preprocessor_definitions)
 
     jl_code = StringIO()
     for name, ns in namespaces.items():
@@ -237,8 +237,5 @@ def gen(srcfiles):
 
 
 
-srcfiles = hdr_parser.opencv_hdr_list
-if len(sys.argv) > 1:
-    srcfiles = [l.strip() for l in sys.argv[1].split(';')]
-
-gen(srcfiles)
+srcfiles, preprocessor_definitions = parse_generator_args(sys.argv[1:])
+gen(srcfiles, preprocessor_definitions)

--- a/modules/julia/gen/gen_all.py
+++ b/modules/julia/gen/gen_all.py
@@ -10,6 +10,16 @@ import subprocess
 import os
 
 mod_path = sys.argv[1]
+modules = []
+config_path = None
+i = 2
+while i < len(sys.argv):
+    if sys.argv[i] == "--config":
+        i += 1
+        config_path = sys.argv[i]
+    else:
+        modules.append(sys.argv[i])
+    i += 1
 
 
 hdr_list = [
@@ -21,7 +31,7 @@ mod_path+"/core/include/opencv2/core/persistence.hpp",
 mod_path+"/core/include/opencv2/core/types.hpp",
 mod_path+"/core/include/opencv2/core/utility.hpp"]
 
-for module in sys.argv[2:]:
+for module in modules:
     if module=='opencv_imgproc':
         hdr_list.append(mod_path+"/imgproc/include/opencv2/imgproc.hpp")
     elif module =='opencv_dnn':
@@ -39,6 +49,10 @@ if not os.path.exists('autogen_cpp'):
     os.makedirs('autogen_cpp')
     os.makedirs('autogen_jl')
 
-subprocess.call([sys.executable, 'gen3_cpp.py', str(';'.join(hdr_list))])
-subprocess.call([sys.executable, 'gen3_julia_cxx.py', str(';'.join(hdr_list))])
-subprocess.call([sys.executable, 'gen3_julia.py', str(';'.join(hdr_list))])
+generator_args = [str(';'.join(hdr_list))]
+if config_path:
+    generator_args.extend(["--config", config_path])
+
+subprocess.check_call([sys.executable, 'gen3_cpp.py'] + generator_args)
+subprocess.check_call([sys.executable, 'gen3_julia_cxx.py'] + generator_args)
+subprocess.check_call([sys.executable, 'gen3_julia.py'] + generator_args)

--- a/modules/julia/gen/parse_tree.py
+++ b/modules/julia/gen/parse_tree.py
@@ -105,6 +105,12 @@ functions = {}
 registered_types = ["int", "Size.*", "Rect.*", "Scalar", "RotatedRect", "Point.*", "explicit", "string", "bool", "uchar",
                     "Vec.*", "float", "double", "char", "Mat", "size_t", "RNG", "DescriptorExtractor", "FeatureDetector", "TermCriteria"]
 
+manual_mapped_types = set(["cv::Range", "cv::RotatedRect", "cv::TermCriteria"])
+
+def is_manual_mapped_type(name):
+    normalized = normalize_name(name)
+    return normalized in manual_mapped_types or ("cv::" + normalized) in manual_mapped_types
+
 def read_preprocessor_definitions(config_path):
     if not config_path:
         return None

--- a/modules/julia/gen/parse_tree.py
+++ b/modules/julia/gen/parse_tree.py
@@ -105,6 +105,28 @@ functions = {}
 registered_types = ["int", "Size.*", "Rect.*", "Scalar", "RotatedRect", "Point.*", "explicit", "string", "bool", "uchar",
                     "Vec.*", "float", "double", "char", "Mat", "size_t", "RNG", "DescriptorExtractor", "FeatureDetector", "TermCriteria"]
 
+def read_preprocessor_definitions(config_path):
+    if not config_path:
+        return None
+    with open(config_path, "r") as f:
+        config = json.load(f)
+    return config.get("preprocessor_definitions", None)
+
+def parse_generator_args(args):
+    srcfiles = hdr_parser.opencv_hdr_list
+    config_path = None
+    i = 0
+    while i < len(args):
+        if args[i] == "--config":
+            i += 1
+            config_path = args[i]
+        elif args[i].startswith("--"):
+            raise ValueError("unknown argument: %s" % args[i])
+        else:
+            srcfiles = [l.strip() for l in args[i].split(';') if l.strip()]
+        i += 1
+    return srcfiles, read_preprocessor_definitions(config_path)
+
 class ClassProp(object):
     """
     Helper class to store field information(type, name and flags) of classes and structs
@@ -429,8 +451,9 @@ def add_enum(name, decl):
 
 
 
-def gen_tree(srcfiles):
-    parser = hdr_parser.CppHeaderParser(generate_umat_decls=False, generate_gpumat_decls=False)
+def gen_tree(srcfiles, preprocessor_definitions=None):
+    parser = hdr_parser.CppHeaderParser(generate_umat_decls=False, generate_gpumat_decls=False,
+                                        preprocessor_definitions=preprocessor_definitions)
 
     allowed_func_list = []
 


### PR DESCRIPTION
## Summary

This PR fixes the Julia bindings build against current OpenCV `4.x` and recent Julia/CxxWrap releases.

The main issues addressed are:

- The Julia generator can emit wrappers for OpenCV value types that are already mapped manually as CxxWrap mirrored types.
- The Julia generator was not receiving the same OpenCV preprocessor definitions used by other binding generators, so generated wrappers could reference unavailable or version-gated symbols.
- Recent Julia and CxxWrap releases changed APIs used by the Julia module's C++ support code.

## Related issues

Fixes #4142.

Also addresses the mirrored-type failure reported in #3531.

Related to #3915, which reports current Julia/CxxWrap build failures including `jl_array_data`, `vector_int`, mirrored-type, and `cv::Ptr` errors.

## Fix approach

The fix keeps manually mirrored OpenCV value types on the manual CxxWrap path and prevents the generator from also emitting regular class wrappers for them. This avoids the invalid `map_type` plus `add_type` combination for types such as `cv::RotatedRect`.

The Julia generator now receives OpenCV binding preprocessor definitions through a small generated JSON config, and the generator entry points pass those definitions to `hdr_parser`. This makes generated Julia wrappers respect the same module and version guards as the rest of the binding infrastructure.

The C++ support code uses version-gated compatibility paths for Julia and CxxWrap API changes:

- Julia `jl_array_data` one-argument versus typed two-argument form.
- CxxWrap pointer type construction changes.
- CxxWrap `julia_base_type` return type handling.

The PR also adds aliases needed by the generated wrappers for current OpenCV headers, including `vector_int`, `CirclesGridFinderParameters::GridType`, and newer DNN enum aliases.

## Verification

Tested with:

- Official `ubuntu:latest` container image
- OpenCV core `4.x`
- This opencv_contrib branch: `fix-julia-module-build`
- Julia `1.12.6`
- CxxWrap `0.17.5`
- Target: `opencv_julia`

At the time of verification, `opencv/opencv:4.x` resolved to `ab1aaa75`, and this branch resolved to `72df737a`.

Reproducer:

```bash
docker run --rm ubuntu:latest bash -lc '
set -euo pipefail
export DEBIAN_FRONTEND=noninteractive
export JULIA_VERSION=1.12.6
export WORKDIR=/work

apt-get update >/dev/null
apt-get install -y --no-install-recommends \
  ca-certificates curl git build-essential cmake ninja-build python3 pkg-config tar xz-utils >/dev/null

case "$(uname -m)" in
  x86_64|amd64) JULIA_ARCH=x64; JULIA_PLATFORM=linux-x86_64 ;;
  aarch64|arm64) JULIA_ARCH=aarch64; JULIA_PLATFORM=linux-aarch64 ;;
  *) echo "unsupported architecture: $(uname -m)" >&2; exit 2 ;;
esac

JULIA_MINOR="${JULIA_VERSION%.*}"
JULIA_URL="https://julialang-s3.julialang.org/bin/linux/${JULIA_ARCH}/${JULIA_MINOR}/julia-${JULIA_VERSION}-${JULIA_PLATFORM}.tar.gz"
mkdir -p /opt/julia "${WORKDIR}"
curl -fsSL --retry 3 --retry-delay 2 "${JULIA_URL}" -o /tmp/julia.tar.gz
tar -xzf /tmp/julia.tar.gz -C /opt/julia --strip-components=1
export PATH=/opt/julia/bin:${PATH}
export JULIA_DEPOT_PATH=${WORKDIR}/julia-depot

julia --startup-file=no --version
julia --startup-file=no -e "using Pkg; Pkg.add(\"CxxWrap\"); Pkg.precompile()"
JLCXX_PREFIX="$(julia --startup-file=no -e "using CxxWrap; print(CxxWrap.CxxWrapCore.prefix_path())")"
JLCXX_DIR="$(dirname "$(find "${JLCXX_PREFIX}" -name JlCxxConfig.cmake -print -quit)")"
test -n "${JLCXX_DIR}"
julia --startup-file=no -e "using Pkg; deps=Pkg.dependencies(); foreach(d -> d.second.name == \"CxxWrap\" && println(\"CxxWrap \" * string(d.second.version)), deps)"
echo "JlCxx_DIR=${JLCXX_DIR}"

git clone --depth=1 --branch 4.x https://github.com/opencv/opencv.git "${WORKDIR}/opencv"
git clone --depth=1 --branch fix-julia-module-build https://github.com/tae0x/opencv_contrib.git "${WORKDIR}/opencv_contrib"

cmake -S "${WORKDIR}/opencv" -B "${WORKDIR}/build" -G Ninja \
  -DCMAKE_BUILD_TYPE=Release \
  -DOPENCV_EXTRA_MODULES_PATH="${WORKDIR}/opencv_contrib/modules" \
  -DWITH_JULIA=ON \
  -DJulia_EXECUTABLE="$(command -v julia)" \
  -DJlCxx_DIR="${JLCXX_DIR}" \
  -DPYTHON_DEFAULT_EXECUTABLE="$(command -v python3)" \
  -DBUILD_LIST=core,imgproc,imgcodecs,highgui,videoio,dnn,features2d,objdetect,calib3d,julia \
  -DBUILD_TESTS=OFF \
  -DBUILD_PERF_TESTS=OFF \
  -DBUILD_EXAMPLES=OFF \
  -DBUILD_DOCS=OFF \
  -DBUILD_JAVA=OFF \
  -DBUILD_opencv_apps=OFF \
  -DBUILD_opencv_python2=OFF \
  -DBUILD_opencv_python3=OFF \
  -DWITH_FFMPEG=OFF \
  -DWITH_GSTREAMER=OFF \
  -DWITH_GTK=OFF \
  -DWITH_IPP=OFF \
  -DWITH_OPENCL=OFF \
  -DWITH_QT=OFF \
  -DWITH_TBB=OFF \
  -DWITH_V4L=OFF

cmake --build "${WORKDIR}/build" --target opencv_julia --parallel "$(nproc)"
'
```

This command completes by building and linking `libopencv_julia.so`.
