### PR TITLE
Replace blocking waitForCompletion() calls with waitEvent() calls in …

### DIFF
--- a/modules/cudastereo/src/cuda/stereosgm.cu
+++ b/modules/cudastereo/src/cuda/stereosgm.cu
@@ -1338,7 +1338,11 @@ void PathAggregation::operator() (const GpuMat& left, const GpuMat& right, GpuMa
 
     const int num_paths = mode == StereoSGBM::MODE_HH4 ? 4 : 8;
 
-    stream.waitForCompletion();
+    fork.record(stream);
+    for (int i = 0; i < num_paths; ++i)
+    {
+        streams[i].waitEvent(fork);
+    }
 
     const Size size = left.size();
     const int buffer_step = size.width * size.height * static_cast<int>(MAX_DISPARITY);
@@ -1367,7 +1371,6 @@ void PathAggregation::operator() (const GpuMat& left, const GpuMat& right, GpuMa
     {
         events[i].record(streams[i]);
         stream.waitEvent(events[i]);
-        streams[i].waitForCompletion();
     }
 }
 

--- a/modules/cudastereo/src/cuda/stereosgm.hpp
+++ b/modules/cudastereo/src/cuda/stereosgm.hpp
@@ -28,6 +28,7 @@ private:
     std::array<Stream, MAX_NUM_PATHS> streams;
     std::array<Event, MAX_NUM_PATHS> events;
     std::array<GpuMat, MAX_NUM_PATHS> subs;
+    Event fork{Event::CreateFlags::DISABLE_TIMING};
 public:
     template <size_t MAX_DISPARITY>
     void operator() (const GpuMat& left, const GpuMat& right, GpuMat& dest, int mode, int p1, int p2, int min_disp, Stream& stream);

--- a/modules/cudastereo/src/stereosgm.cpp
+++ b/modules/cudastereo/src/stereosgm.cpp
@@ -87,7 +87,9 @@ StereoSGMImpl::StereoSGMImpl(int minDisparity, int numDisparities, int P1, int P
 
 void StereoSGMImpl::compute(InputArray left, InputArray right, OutputArray disparity)
 {
-    compute(left, right, disparity, Stream::Null());
+    Stream& s = Stream::Null();
+    compute(left, right, disparity, s);
+    s.waitForCompletion();
 }
 
 void StereoSGMImpl::compute(InputArray _left, InputArray _right, OutputArray _disparity, Stream& _stream)

--- a/modules/cudastereo/test/test_stereo.cpp
+++ b/modules/cudastereo/test/test_stereo.cpp
@@ -1043,5 +1043,57 @@ protected:
 
 TEST(CudaStereo_StereoSGM, regression) { CV_Cuda_StereoSGMTest test; test.safe_run(); }
 
+
+struct StereoSGM : testing::TestWithParam<cv::cuda::DeviceInfo>
+{
+    cv::cuda::DeviceInfo devInfo;
+
+    virtual void SetUp()
+    {
+        devInfo = GetParam();
+        cv::cuda::setDevice(devInfo.deviceID());
+    }
+};
+
+CUDA_TEST_P(StereoSGM, StreamForkJoinSynchronization)
+{
+    // Tests that calling cv::cuda::StereoSGM::compute with a
+    // cv::cuda::Stream does not block the CPU.
+
+    cv::cuda::Stream main_stream;
+    cv::cuda::Event done_adding_to_stream;
+    cv::Mat left_image  = readImage("stereobm/aloe-L.png", cv::IMREAD_GRAYSCALE);
+    cv::Mat right_image = readImage("stereobm/aloe-R.png", cv::IMREAD_GRAYSCALE);
+
+    ASSERT_FALSE(left_image.empty());
+    ASSERT_FALSE(right_image.empty());
+
+    Ptr<cv::cuda::StereoSGM> sgm = cv::cuda::createStereoSGM(0, 128, 10, 120, 5, cv::cuda::StereoSGM::MODE_HH);
+
+    cv::cuda::GpuMat d_leftImg, d_rightImg, d_disp;
+    d_leftImg.upload(left_image, main_stream);
+    d_rightImg.upload(right_image, main_stream);
+
+    // Enqueue some work so we can detect any hidden stream synchronization inside compute().
+    cv::cuda::GpuMat busy(4096, 4096, CV_8UC1);
+    for (int i = 0; i < 32; ++i)
+        busy.setTo(cv::Scalar::all(i), main_stream);
+
+    cv::cuda::Event busy_done;
+    busy_done.record(main_stream);
+    ASSERT_FALSE(busy_done.queryIfComplete());
+
+    sgm->compute(d_leftImg, d_rightImg, d_disp, main_stream);
+
+    // compute() should not synchronize the provided stream.
+    EXPECT_FALSE(busy_done.queryIfComplete());
+    cv::Mat disp_result;
+    d_disp.download(disp_result, main_stream);
+
+    main_stream.waitForCompletion();
+}
+
+INSTANTIATE_TEST_CASE_P(CUDA_Stereo, StereoSGM, ALL_DEVICES);
+
 }} // namespace
 #endif // HAVE_CUDA


### PR DESCRIPTION
…stereosgm.cu to allow for async CUDA calls

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

Fixes  #4145
