### PR TITLE
ximgproc: move EMD (Earth Mover's Distance) from imgproc

### DIFF
--- a/modules/ximgproc/include/opencv2/ximgproc.hpp
+++ b/modules/ximgproc/include/opencv2/ximgproc.hpp
@@ -63,6 +63,7 @@
 #include "ximgproc/color_match.hpp"
 #include "ximgproc/radon_transform.hpp"
 #include "ximgproc/find_ellipses.hpp"
+#include "ximgproc/emd.hpp"
 
 
 /**

--- a/modules/ximgproc/include/opencv2/ximgproc/emd.hpp
+++ b/modules/ximgproc/include/opencv2/ximgproc/emd.hpp
@@ -1,0 +1,62 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#ifndef __OPENCV_XIMGPROC_EMD_HPP__
+#define __OPENCV_XIMGPROC_EMD_HPP__
+
+#include "opencv2/core.hpp"
+#include "opencv2/imgproc.hpp"
+
+namespace cv { namespace ximgproc {
+
+//! @addtogroup ximgproc
+//! @{
+
+/** @brief Computes the "minimal work" distance between two weighted point configurations.
+
+The function computes the earth mover distance and/or a lower boundary of the distance between the
+two weighted point configurations. One of the applications described in @cite RubnerSept98,
+@cite Rubner2000 is multi-dimensional histogram comparison for image retrieval. EMD is a transportation
+problem that is solved using some modification of a simplex algorithm, thus the complexity is
+exponential in the worst case, though, on average it is much faster. In the case of a real metric
+the lower boundary can be calculated even faster (using linear-time algorithm) and it can be used
+to determine roughly whether the two signatures are far enough so that they cannot relate to the
+same object.
+
+@param signature1 First signature, a \f$\texttt{size1}\times \texttt{dims}+1\f$ floating-point matrix.
+Each row stores the point weight followed by the point coordinates. The matrix is allowed to have
+a single column (weights only) if the user-defined cost matrix is used. The weights must be
+non-negative and have at least one non-zero value.
+@param signature2 Second signature of the same format as signature1 , though the number of rows
+may be different. The total weights may be different. In this case an extra "dummy" point is added
+to either signature1 or signature2. The weights must be non-negative and have at least one non-zero
+value.
+@param distType Used metric. See #DistanceTypes.
+@param cost User-defined \f$\texttt{size1}\times \texttt{size2}\f$ cost matrix. Also, if a cost matrix
+is used, lower boundary lowerBound cannot be calculated because it needs a metric function.
+@param lowerBound Optional input/output parameter: lower boundary of a distance between the two
+signatures that is a distance between mass centers. The lower boundary may not be calculated if
+the user-defined cost matrix is used, the total weights of point configurations are not equal, or
+if the signatures consist of weights only (the signature matrices have a single column). You
+**must** initialize \*lowerBound . If the calculated distance between mass centers is greater or
+equal to \*lowerBound (it means that the signatures are far enough), the function does not
+calculate EMD. In any case \*lowerBound is set to the calculated distance between mass centers on
+return. Thus, if you want to calculate both distance between mass centers and EMD, \*lowerBound
+should be set to 0.
+@param flow Resultant \f$\texttt{size1} \times \texttt{size2}\f$ flow matrix: \f$\texttt{flow}_{i,j}\f$ is
+a flow from \f$i\f$ -th point of signature1 to \f$j\f$ -th point of signature2 .
+ */
+CV_EXPORTS float EMD( InputArray signature1, InputArray signature2,
+                      int distType, InputArray cost=noArray(),
+                      float* lowerBound = 0, OutputArray flow = noArray() );
+
+CV_EXPORTS_AS(EMD) float wrapperEMD( InputArray signature1, InputArray signature2,
+                      int distType, InputArray cost=noArray(),
+                      CV_IN_OUT Ptr<float> lowerBound = Ptr<float>(), OutputArray flow = noArray() );
+
+//! @}
+
+}} // namespace cv::ximgproc
+
+#endif // __OPENCV_XIMGPROC_EMD_HPP__

--- a/modules/ximgproc/include/opencv2/ximgproc/emd.hpp
+++ b/modules/ximgproc/include/opencv2/ximgproc/emd.hpp
@@ -49,7 +49,7 @@ a flow from \f$i\f$ -th point of signature1 to \f$j\f$ -th point of signature2 .
  */
 CV_EXPORTS float EMD( InputArray signature1, InputArray signature2,
                       int distType, InputArray cost=noArray(),
-                      float* lowerBound = 0, OutputArray flow = noArray() );
+                      float* lowerBound = nullptr, OutputArray flow = noArray() );
 
 CV_EXPORTS_AS(EMD) float wrapperEMD( InputArray signature1, InputArray signature2,
                       int distType, InputArray cost=noArray(),

--- a/modules/ximgproc/src/emd.cpp
+++ b/modules/ximgproc/src/emd.cpp
@@ -1,0 +1,1012 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
+
+/*
+    Partially based on Yossi Rubner code:
+    =========================================================================
+    emd.c
+
+    Last update: 3/14/98
+
+    An implementation of the Earth Movers Distance.
+    Based of the solution for the Transportation problem as described in
+    "Introduction to Mathematical Programming" by F. S. Hillier and
+    G. J. Lieberman, McGraw-Hill, 1990.
+
+    Copyright (C) 1998 Yossi Rubner
+    Computer Science Department, Stanford University
+    E-Mail: rubner@cs.stanford.edu   URL: http://vision.stanford.edu/~rubner
+    ==========================================================================
+*/
+
+#include "precomp.hpp"
+#include "opencv2/core/utils/buffer_area.private.hpp"
+
+using namespace cv;
+
+namespace {
+
+
+//==============================================================================
+// Distance functions
+
+typedef float (*DistFunc)(const float* a, const float* b, int dims);
+
+static float distL1(const float* x, const float* y, int dims)
+{
+    double s = 0;
+    for (int i = 0; i < dims; i++)
+    {
+        const double t = x[i] - y[i];
+        s += fabs(t);
+    }
+    return (float)s;
+}
+
+static float distL2(const float* x, const float* y, int dims)
+{
+    double s = 0;
+    for (int i = 0; i < dims; i++)
+    {
+        const double t = x[i] - y[i];
+        s += t * t;
+    }
+    return sqrt((float)s);
+}
+
+static float distC(const float* x, const float* y, int dims)
+{
+    double s = 0;
+    for (int i = 0; i < dims; i++)
+    {
+        const double t = fabs(x[i] - y[i]);
+        if (s < t)
+            s = t;
+    }
+    return (float)s;
+}
+
+
+//==============================================================================
+// Data structures
+
+/* Node1D is used for lists, representing 1D sparse array */
+struct Node1D
+{
+    float val;
+    Node1D* next;
+};
+
+/* Node2D is used for lists, representing 2D sparse matrix */
+struct Node2D
+{
+    float val;
+    int i, j;
+    Node2D* next[2]; /* next row & next column */
+};
+
+
+//==============================================================================
+// Main class
+
+struct EMDSolver
+{
+    static constexpr int MAX_ITERATIONS = 500;
+    static constexpr float CV_EMD_INF = 1e20f;
+    static constexpr float CV_EMD_EPS = 1e-5f;
+
+    int ssize, dsize;
+
+    float* cost_buf;
+    AutoBuffer<Node2D, 0> data_x;
+    Node2D* end_x;
+    Node2D* enter_x;
+    char* is_x;
+
+    Node2D** rows_x;
+    Node2D** cols_x;
+
+    Node1D* u;
+    Node1D* v;
+
+    int* idx1;
+    int* idx2;
+
+    /* find_loop buffers */
+    Node2D** loop;
+    char* is_used;
+
+    /* russel buffers */
+    float* s;
+    float* d;
+    float* delta;
+
+    float weight, max_cost;
+
+    utils::BufferArea area, area2;
+
+public:
+    float getWeight() const
+    {
+        return weight;
+    }
+
+    float& getCost(int i, int j)
+    {
+        return *(this->cost_buf + i * dsize + j);
+    }
+    const float& getCost(int i, int j) const
+    {
+        return *(this->cost_buf + i * dsize + j);
+    }
+    char& getIsX(int i, int j)
+    {
+        return *(this->is_x + i * dsize + j);
+    }
+    const char& getIsX(int i, int j) const
+    {
+        return *(this->is_x + i * dsize + j);
+    }
+
+    EMDSolver() :
+        ssize(0), dsize(0), cost_buf(0), end_x(0), enter_x(0), is_x(0), rows_x(0),
+        cols_x(0), u(0), v(0), idx1(0), idx2(0), loop(0), is_used(0), s(0), d(0), delta(0),
+        weight(0), max_cost(0)
+    {
+    }
+
+public:
+    bool init(const Mat& sign1,
+              const Mat& sign2,
+              int dims,
+              DistFunc dfunc,
+              const Mat& cost,
+              float* lowerBound);
+    bool checkLowerBound(const Mat& sign1,
+                         const Mat& sign2,
+                         int dims,
+                         DistFunc dfunc,
+                         float& lowerBound);
+    bool calcSums(const Mat& sign1, const Mat& sign2);
+    float calcCost(const Mat& sign1, const Mat& sign2, int dims, DistFunc dfunc, const Mat& cost);
+    void solve();
+    double calcFlow(Mat* flow_) const;
+    int findBasicVars() const;
+    float checkOptimal() const;
+    void callRussel();
+    bool checkNewSolution();
+    int findLoop() const;
+    void addBasicVar(int min_i,
+                     int min_j,
+                     Node1D* prev_u_min_i,
+                     Node1D* prev_v_min_j,
+                     Node1D* u_head);
+};
+
+
+//==============================================================================
+// Implementations
+
+bool EMDSolver::init(const Mat& sign1,
+                     const Mat& sign2,
+                     int dims,
+                     DistFunc dfunc,
+                     const Mat& cost,
+                     float* lowerBound)
+{
+    const int size1 = sign1.size().height;
+    const int size2 = sign2.size().height;
+
+    area.allocate(this->idx1, size1 + 1);
+    area.allocate(this->idx2, size2 + 1);
+    area.allocate(this->s, size1 + 1);
+    area.allocate(this->d, size2 + 1);
+    area.commit();
+    area.zeroFill();
+
+    const bool areSumsEqual = calcSums(sign1, sign2);
+    if (areSumsEqual && lowerBound)
+    {
+        if (checkLowerBound(sign1, sign2, dims, dfunc, *lowerBound))
+            return false;
+    }
+
+    area2.allocate(this->u, ssize, 64);
+    area2.allocate(this->v, dsize, 64);
+    area2.allocate(this->is_used, ssize + dsize);
+    area2.allocate(this->delta, ssize * dsize);
+    area2.allocate(this->cost_buf, ssize * dsize);
+    area2.allocate(this->is_x, ssize * dsize);
+    area2.allocate(this->rows_x, ssize, 64);
+    area2.allocate(this->cols_x, dsize, 64);
+    area2.allocate(this->loop, ssize + dsize + 1, 64);
+    area2.commit();
+    area2.zeroFill();
+
+    this->data_x.allocate(ssize + dsize);
+
+    this->end_x = this->data_x.data();
+    this->max_cost = calcCost(sign1, sign2, dims, dfunc, cost);
+    callRussel();
+    this->enter_x = (this->end_x)++;
+    return true;
+}
+
+
+bool EMDSolver::checkLowerBound(const Mat& sign1,
+                                const Mat& sign2,
+                                int dims,
+                                DistFunc dfunc,
+                                float& lowerBound)
+{
+    AutoBuffer<float> buf;
+    buf.allocate(dims * 2);
+    memset(buf.data(), 0, dims * 2 * sizeof(float));
+
+    float* xs = buf.data();
+    float* xd = buf.data() + dims;
+
+    for (int j = 0; j < sign1.rows; ++j)
+    {
+        const float weight_ = sign1.at<float>(j, 0);
+        for (int i = 0; i < dims; i++)
+            xs[i] += sign1.at<float>(j, i + 1) * weight_;
+    }
+
+    for (int j = 0; j < sign2.rows; ++j)
+    {
+        const float weight_ = sign2.at<float>(j, 0);
+        for (int i = 0; i < dims; i++)
+            xd[i] += sign2.at<float>(j, i + 1) * weight_;
+    }
+
+    const float lb = dfunc(xs, xd, dims) / this->weight;
+    const bool result = (lowerBound <= lb);
+    lowerBound = lb;
+    return result;
+}
+
+
+// return true if total sums of signatures are equal, false otherwise
+bool EMDSolver::calcSums(const Mat& sign1, const Mat& sign2)
+{
+    bool result = true;
+    /* sum up the supply and demand */
+    int ssize_ = 0, dsize_ = 0;
+    float s_sum = 0, d_sum = 0, diff;
+    for (int i = 0; i < sign1.size().height; i++)
+    {
+        const float weight_ = sign1.at<float>(i, 0);
+
+        if (weight_ > 0)
+        {
+            s_sum += weight_;
+            this->s[ssize_] = weight_;
+            this->idx1[ssize_++] = i;
+        }
+        else if (weight_ < 0)
+            CV_Error(cv::Error::StsBadArg, "sign1 must not contain negative weights");
+    }
+
+    for (int i = 0; i < sign2.size().height; i++)
+    {
+        const float weight_ = sign2.at<float>(i, 0);
+
+        if (weight_ > 0)
+        {
+            d_sum += weight_;
+            this->d[dsize_] = weight_;
+            this->idx2[dsize_++] = i;
+        }
+        else if (weight_ < 0)
+            CV_Error(cv::Error::StsBadArg, "sign2 must not contain negative weights");
+    }
+
+    if (ssize_ == 0)
+        CV_Error(cv::Error::StsBadArg, "sign1 must contain at least one non-zero value");
+    if (dsize_ == 0)
+        CV_Error(cv::Error::StsBadArg, "sign2 must contain at least one non-zero value");
+
+    /* if supply different than the demand, add a zero-cost dummy cluster */
+    diff = s_sum - d_sum;
+    if (fabs(diff) >= CV_EMD_EPS * s_sum)
+    {
+        result = false;
+        if (diff < 0)
+        {
+            this->s[ssize_] = -diff;
+            this->idx1[ssize_++] = -1;
+        }
+        else
+        {
+            this->d[dsize_] = diff;
+            this->idx2[dsize_++] = -1;
+        }
+    }
+
+    this->ssize = ssize_;
+    this->dsize = dsize_;
+    this->weight = s_sum > d_sum ? s_sum : d_sum;
+    return result;
+}
+
+
+// returns maximum cost over all possible s->d combinations
+float EMDSolver::calcCost(const Mat& sign1,
+                          const Mat& sign2,
+                          int dims,
+                          DistFunc dfunc,
+                          const Mat& cost)
+{
+    if (!dfunc)
+    {
+        CV_Assert(!cost.empty());
+    }
+    float result = 0;
+
+    /* compute the distance matrix */
+    for (int i = 0; i < ssize; i++)
+    {
+        const int ci = this->idx1[i];
+        if (ci >= 0)
+        {
+            for (int j = 0; j < dsize; j++)
+            {
+                const int cj = this->idx2[j];
+                if (cj < 0)
+                    getCost(i, j) = 0;
+                else
+                {
+                    float val;
+                    if (dfunc)
+                    {
+                        val = dfunc(sign1.ptr<float>(ci, 1), sign2.ptr<float>(cj, 1), dims);
+                    }
+                    else
+                    {
+                        val = cost.at<float>(ci, cj);
+                    }
+                    getCost(i, j) = val;
+                    if (result < val)
+                        result = val;
+                }
+            }
+        }
+        else
+        {
+            for (int j = 0; j < dsize; j++)
+                getCost(i, j) = 0;
+        }
+    }
+    return result;
+}
+
+
+// runs solver iterations
+void EMDSolver::solve()
+{
+    if (ssize > 1 && dsize > 1)
+    {
+        const float eps = CV_EMD_EPS * max_cost;
+        for (int itr = 1; itr < MAX_ITERATIONS; itr++)
+        {
+            /* find basic variables */
+            if (findBasicVars() < 0)
+                break;
+
+            /* check for optimality */
+            const float min_delta = checkOptimal();
+
+            if (min_delta == CV_EMD_INF)
+                CV_Error(cv::Error::StsNoConv, "");
+
+            /* if no negative deltamin, we found the optimal solution */
+            if (min_delta >= -eps)
+                break;
+
+            /* improve solution */
+            if (!checkNewSolution())
+                CV_Error(cv::Error::StsNoConv, "");
+        }
+    }
+}
+
+double EMDSolver::calcFlow(Mat* flow_) const
+{
+    double result = 0.;
+    const Node2D* xp = 0;
+    for (xp = data_x.data(); xp < end_x; xp++)
+    {
+        float val = xp->val;
+        const int i = xp->i;
+        const int j = xp->j;
+
+        if (xp == enter_x)
+            continue;
+
+        const int ci = idx1[i];
+        const int cj = idx2[j];
+
+        if (ci >= 0 && cj >= 0)
+        {
+            result += (double)val * getCost(i, j);
+            if (flow_)
+            {
+                flow_->at<float>(ci, cj) = val;
+            }
+        }
+    }
+    return result;
+}
+
+
+int EMDSolver::findBasicVars() const
+{
+    int i, j;
+    int u_cfound, v_cfound;
+    Node1D u0_head, u1_head, *cur_u, *prev_u;
+    Node1D v0_head, v1_head, *cur_v, *prev_v;
+    bool found;
+
+    CV_Assert(u != 0 && v != 0);
+
+    /* initialize the rows list (u) and the columns list (v) */
+    u0_head.next = u;
+    for (i = 0; i < ssize; i++)
+    {
+        u[i].next = u + i + 1;
+    }
+    u[ssize - 1].next = 0;
+    u1_head.next = 0;
+
+    v0_head.next = ssize > 1 ? v + 1 : 0;
+    for (i = 1; i < dsize; i++)
+    {
+        v[i].next = v + i + 1;
+    }
+    v[dsize - 1].next = 0;
+    v1_head.next = 0;
+
+    /* there are ssize+dsize variables but only ssize+dsize-1 independent equations,
+       so set v[0]=0 */
+    v[0].val = 0;
+    v1_head.next = v;
+    v1_head.next->next = 0;
+
+    /* loop until all variables are found */
+    u_cfound = v_cfound = 0;
+    while (u_cfound < ssize || v_cfound < dsize)
+    {
+        found = false;
+        if (v_cfound < dsize)
+        {
+            /* loop over all marked columns */
+            prev_v = &v1_head;
+            cur_v = v1_head.next;
+            found = found || (cur_v != 0);
+            for (; cur_v != 0; cur_v = cur_v->next)
+            {
+                float cur_v_val = cur_v->val;
+
+                j = (int)(cur_v - v);
+                /* find the variables in column j */
+                prev_u = &u0_head;
+                for (cur_u = u0_head.next; cur_u != 0;)
+                {
+                    i = (int)(cur_u - u);
+                    if (getIsX(i, j))
+                    {
+                        /* compute u[i] */
+                        cur_u->val = getCost(i, j) - cur_v_val;
+                        /* ...and add it to the marked list */
+                        prev_u->next = cur_u->next;
+                        cur_u->next = u1_head.next;
+                        u1_head.next = cur_u;
+                        cur_u = prev_u->next;
+                    }
+                    else
+                    {
+                        prev_u = cur_u;
+                        cur_u = cur_u->next;
+                    }
+                }
+                prev_v->next = cur_v->next;
+                v_cfound++;
+            }
+        }
+
+        if (u_cfound < ssize)
+        {
+            /* loop over all marked rows */
+            prev_u = &u1_head;
+            cur_u = u1_head.next;
+            found = found || (cur_u != 0);
+            for (; cur_u != 0; cur_u = cur_u->next)
+            {
+                float cur_u_val = cur_u->val;
+                i = (int)(cur_u - u);
+                /* find the variables in rows i */
+                prev_v = &v0_head;
+                for (cur_v = v0_head.next; cur_v != 0;)
+                {
+                    j = (int)(cur_v - v);
+                    if (getIsX(i, j))
+                    {
+                        /* compute v[j] */
+                        cur_v->val = getCost(i, j) - cur_u_val;
+                        /* ...and add it to the marked list */
+                        prev_v->next = cur_v->next;
+                        cur_v->next = v1_head.next;
+                        v1_head.next = cur_v;
+                        cur_v = prev_v->next;
+                    }
+                    else
+                    {
+                        prev_v = cur_v;
+                        cur_v = cur_v->next;
+                    }
+                }
+                prev_u->next = cur_u->next;
+                u_cfound++;
+            }
+        }
+
+        if (!found)
+            return -1;
+    }
+
+    return 0;
+}
+
+float EMDSolver::checkOptimal() const
+{
+    int i, j, min_i = 0, min_j = 0;
+
+    float min_delta = CV_EMD_INF;
+    /* find the minimal cij-ui-vj over all i,j */
+    for (i = 0; i < ssize; i++)
+    {
+        float u_val = u[i].val;
+        for (j = 0; j < dsize; j++)
+        {
+            if (!getIsX(i, j))
+            {
+                const float delta_ = getCost(i, j) - u_val - v[j].val;
+                if (min_delta > delta_)
+                {
+                    min_delta = delta_;
+                    min_i = i;
+                    min_j = j;
+                }
+            }
+        }
+    }
+
+    enter_x->i = min_i;
+    enter_x->j = min_j;
+
+    return min_delta;
+}
+
+bool EMDSolver::checkNewSolution()
+{
+    int i, j;
+    float min_val = CV_EMD_INF;
+    int steps;
+    Node2D head {0, 0, 0, {0, 0}}, *cur_x, *next_x, *leave_x = 0;
+    Node2D* enter_x_ = this->enter_x;
+    Node2D** loop_ = this->loop;
+
+    /* enter the new basic variable */
+    i = enter_x_->i;
+    j = enter_x_->j;
+    getIsX(i, j) = 1;
+    enter_x_->next[0] = this->rows_x[i];
+    enter_x->next[1] = this->cols_x[j];
+    enter_x_->val = 0;
+    this->rows_x[i] = enter_x_;
+    this->cols_x[j] = enter_x_;
+
+    /* find a chain reaction */
+    steps = findLoop();
+
+    if (steps == 0)
+        return false;
+
+    /* find the largest value in the loop */
+    for (i = 1; i < steps; i += 2)
+    {
+        float temp = loop_[i]->val;
+
+        if (min_val > temp)
+        {
+            leave_x = loop_[i];
+            min_val = temp;
+        }
+    }
+
+    /* update the loop */
+    for (i = 0; i < steps; i += 2)
+    {
+        float temp0 = loop_[i]->val + min_val;
+        float temp1 = loop_[i + 1]->val - min_val;
+
+        loop_[i]->val = temp0;
+        loop_[i + 1]->val = temp1;
+    }
+
+    /* remove the leaving basic variable */
+    CV_Assert(leave_x != NULL);
+    i = leave_x->i;
+    j = leave_x->j;
+    getIsX(i, j) = 0;
+
+    head.next[0] = this->rows_x[i];
+    cur_x = &head;
+    while ((next_x = cur_x->next[0]) != leave_x)
+    {
+        cur_x = next_x;
+        CV_Assert(cur_x);
+    }
+    cur_x->next[0] = next_x->next[0];
+    this->rows_x[i] = head.next[0];
+
+    head.next[1] = this->cols_x[j];
+    cur_x = &head;
+    while ((next_x = cur_x->next[1]) != leave_x)
+    {
+        cur_x = next_x;
+        CV_Assert(cur_x);
+    }
+    cur_x->next[1] = next_x->next[1];
+    this->cols_x[j] = head.next[1];
+
+    /* set enter_x to be the new empty slot */
+    this->enter_x = leave_x;
+
+    return true;
+}
+
+int EMDSolver::findLoop() const
+{
+    int i;
+
+    memset(is_used, 0, this->ssize + this->dsize);
+
+    Node2D* new_x = loop[0] = enter_x;
+    is_used[enter_x - data_x.data()] = 1;
+    int steps = 1;
+
+    do
+    {
+        if ((steps & 1) == 1)
+        {
+            /* find an unused x in the row */
+            new_x = this->rows_x[new_x->i];
+            while (new_x != 0 && is_used[new_x - data_x.data()])
+                new_x = new_x->next[0];
+        }
+        else
+        {
+            /* find an unused x in the column, or the entering x */
+            new_x = this->cols_x[new_x->j];
+            while (new_x != 0 && is_used[new_x - data_x.data()] && new_x != enter_x)
+                new_x = new_x->next[1];
+            if (new_x == enter_x)
+                break;
+        }
+
+        if (new_x != 0) /* found the next x */
+        {
+            /* add x to the loop */
+            loop[steps++] = new_x;
+            is_used[new_x - data_x.data()] = 1;
+        }
+        else /* didn't find the next x */
+        {
+            /* backtrack */
+            do
+            {
+                i = steps & 1;
+                new_x = loop[steps - 1];
+                do
+                {
+                    new_x = new_x->next[i];
+                }
+                while (new_x != 0 && is_used[new_x - data_x.data()]);
+
+                if (new_x == 0)
+                {
+                    is_used[loop[--steps] - data_x.data()] = 0;
+                }
+            }
+            while (new_x == 0 && steps > 0);
+
+            is_used[loop[steps - 1] - data_x.data()] = 0;
+            loop[steps - 1] = new_x;
+            is_used[new_x - data_x.data()] = 1;
+        }
+    }
+    while (steps > 0);
+
+    return steps;
+}
+
+void EMDSolver::callRussel()
+{
+    int i, j, min_i = -1, min_j = -1;
+    float min_delta, diff;
+    Node1D u_head, *cur_u, *prev_u;
+    Node1D v_head, *cur_v, *prev_v;
+    Node1D *prev_u_min_i = 0, *prev_v_min_j = 0, *remember;
+    float eps = CV_EMD_EPS * this->max_cost;
+
+    /* initialize the rows list (ur), and the columns list (vr) */
+    u_head.next = u;
+    for (i = 0; i < ssize; i++)
+    {
+        u[i].next = u + i + 1;
+    }
+    u[ssize - 1].next = 0;
+
+    v_head.next = v;
+    for (i = 0; i < dsize; i++)
+    {
+        v[i].val = -CV_EMD_INF;
+        v[i].next = v + i + 1;
+    }
+    v[dsize - 1].next = 0;
+
+    /* find the maximum row and column values (ur[i] and vr[j]) */
+    for (i = 0; i < ssize; i++)
+    {
+        float u_val = -CV_EMD_INF;
+        for (j = 0; j < dsize; j++)
+        {
+            float temp = getCost(i, j);
+
+            if (u_val < temp)
+                u_val = temp;
+            if (v[j].val < temp)
+                v[j].val = temp;
+        }
+        u[i].val = u_val;
+    }
+
+    /* compute the delta matrix */
+    for (i = 0; i < ssize; i++)
+    {
+        float u_val = u[i].val;
+        float* delta_row = delta + i * dsize;
+        for (j = 0; j < dsize; j++)
+        {
+            delta_row[j] = getCost(i, j) - u_val - v[j].val;
+        }
+    }
+
+    /* find the basic variables */
+    do
+    {
+        /* find the smallest delta[i][j] */
+        min_i = -1;
+        min_delta = CV_EMD_INF;
+        prev_u = &u_head;
+        for (cur_u = u_head.next; cur_u != 0; cur_u = cur_u->next)
+        {
+            i = (int)(cur_u - u);
+            float* delta_row = delta + i * dsize;
+
+            prev_v = &v_head;
+            for (cur_v = v_head.next; cur_v != 0; cur_v = cur_v->next)
+            {
+                j = (int)(cur_v - v);
+                if (min_delta > delta_row[j])
+                {
+                    min_delta = delta_row[j];
+                    min_i = i;
+                    min_j = j;
+                    prev_u_min_i = prev_u;
+                    prev_v_min_j = prev_v;
+                }
+                prev_v = cur_v;
+            }
+            prev_u = cur_u;
+        }
+
+        if (min_i < 0)
+            break;
+
+        /* add x[min_i][min_j] to the basis, and adjust supplies and cost */
+        remember = prev_u_min_i->next;
+        addBasicVar(min_i, min_j, prev_u_min_i, prev_v_min_j, &u_head);
+
+        /* update the necessary delta[][] */
+        if (remember == prev_u_min_i->next) /* line min_i was deleted */
+        {
+            for (cur_v = v_head.next; cur_v != 0; cur_v = cur_v->next)
+            {
+                j = (int)(cur_v - v);
+                if (cur_v->val == getCost(min_i, j)) /* column j needs updating */
+                {
+                    float max_val = -CV_EMD_INF;
+
+                    /* find the new maximum value in the column */
+                    for (cur_u = u_head.next; cur_u != 0; cur_u = cur_u->next)
+                    {
+                        float temp = getCost((int)(cur_u - u), j);
+
+                        if (max_val < temp)
+                            max_val = temp;
+                    }
+
+                    /* if needed, adjust the relevant delta[*][j] */
+                    diff = max_val - cur_v->val;
+                    cur_v->val = max_val;
+                    if (fabs(diff) < eps)
+                    {
+                        for (cur_u = u_head.next; cur_u != 0; cur_u = cur_u->next)
+                            *(delta + (cur_u - u) * dsize + j) += diff;
+                    }
+                }
+            }
+        }
+        else /* column min_j was deleted */
+        {
+            for (cur_u = u_head.next; cur_u != 0; cur_u = cur_u->next)
+            {
+                i = (int)(cur_u - u);
+                if (cur_u->val == getCost(i, min_j)) /* row i needs updating */
+                {
+                    float max_val = -CV_EMD_INF;
+
+                    /* find the new maximum value in the row */
+                    for (cur_v = v_head.next; cur_v != 0; cur_v = cur_v->next)
+                    {
+                        float temp = getCost(i, (int)(cur_v - v));
+
+                        if (max_val < temp)
+                            max_val = temp;
+                    }
+
+                    /* if needed, adjust the relevant delta[i][*] */
+                    diff = max_val - cur_u->val;
+                    cur_u->val = max_val;
+
+                    if (fabs(diff) < eps)
+                    {
+                        for (cur_v = v_head.next; cur_v != 0; cur_v = cur_v->next)
+                            *(delta + i * dsize + (cur_v - v)) += diff;
+                    }
+                }
+            }
+        }
+    }
+    while (u_head.next != 0 || v_head.next != 0);
+}
+
+void EMDSolver::addBasicVar(int min_i,
+                            int min_j,
+                            Node1D* prev_u_min_i,
+                            Node1D* prev_v_min_j,
+                            Node1D* u_head)
+{
+    float temp;
+
+    if (this->s[min_i] < this->d[min_j] + this->weight * CV_EMD_EPS)
+    { /* supply exhausted */
+        temp = this->s[min_i];
+        this->s[min_i] = 0;
+        this->d[min_j] -= temp;
+    }
+    else /* demand exhausted */
+    {
+        temp = this->d[min_j];
+        this->d[min_j] = 0;
+        this->s[min_i] -= temp;
+    }
+
+    /* x(min_i,min_j) is a basic variable */
+    getIsX(min_i, min_j) = 1;
+
+    end_x->val = temp;
+    end_x->i = min_i;
+    end_x->j = min_j;
+    end_x->next[0] = this->rows_x[min_i];
+    end_x->next[1] = this->cols_x[min_j];
+    this->rows_x[min_i] = end_x;
+    this->cols_x[min_j] = end_x;
+    this->end_x = end_x + 1;
+
+    /* delete supply row only if the empty, and if not last row */
+    if (this->s[min_i] == 0 && u_head->next->next != 0)
+        prev_u_min_i->next = prev_u_min_i->next->next; /* remove row from list */
+    else
+        prev_v_min_j->next = prev_v_min_j->next->next; /* remove column from list */
+}
+
+}  // namespace
+
+
+//==============================================================================
+// External interface
+
+float cv::ximgproc::EMD(InputArray _sign1,
+              InputArray _sign2,
+              int distType,
+              InputArray _cost,
+              float* lowerBound,
+              OutputArray _flow)
+{
+    CV_INSTRUMENT_REGION();
+
+    Mat sign1 = _sign1.getMat();
+    Mat sign2 = _sign2.getMat();
+    Mat cost = _cost.getMat();
+
+    CV_CheckEQ(sign1.cols, sign2.cols, "Signatures must have equal number of columns");
+    CV_CheckEQ(sign1.type(), CV_32FC1, "The sign1 must be 32FC1");
+    CV_CheckEQ(sign2.type(), CV_32FC1, "The sign2 must be 32FC1");
+
+    const int dims = sign1.cols - 1;
+    const int size1 = sign1.rows;
+    const int size2 = sign2.rows;
+
+    Mat flow;
+    if (_flow.needed())
+    {
+        _flow.create(sign1.rows, sign2.rows, CV_32F);
+        flow = _flow.getMat();
+        flow = Scalar::all(0);
+        CV_CheckEQ(flow.type(), CV_32FC1, "Flow matrix must have type 32FC1");
+        CV_CheckTrue(flow.rows == size1 && flow.cols == size2,
+                     "Flow matrix size does not match signatures");
+    }
+
+    DistFunc dfunc = 0;
+    if (distType == DIST_USER)
+    {
+        if (!cost.empty())
+        {
+            CV_CheckEQ(cost.type(), CV_32FC1, "Cost matrix must have type 32FC1");
+            CV_CheckTrue(cost.rows == size1 && cost.cols == size2,
+                         "Cost matrix size does not match signatures");
+            CV_CheckTrue(lowerBound == NULL,
+                         "Lower boundary can not be calculated if the cost matrix is used");
+        }
+        else
+        {
+            CV_CheckTrue(dfunc == NULL, "Dist function must be set if cost matrix is empty");
+        }
+    }
+    else
+    {
+        CV_CheckNE(dims, 0, "Number of dimensions can be 0 only if a user-defined metric is used");
+        switch (distType)
+        {
+            case cv::DIST_L1: dfunc = distL1; break;
+            case cv::DIST_L2: dfunc = distL2; break;
+            case cv::DIST_C: dfunc = distC; break;
+            default: CV_Error(cv::Error::StsBadFlag, "Bad or unsupported metric type");
+        }
+    }
+
+    EMDSolver state;
+    const bool result = state.init(sign1, sign2, dims, dfunc, cost, lowerBound);
+    if (!result && lowerBound)
+    {
+        return *lowerBound;
+    }
+    state.solve();
+    return (float)(state.calcFlow(_flow.needed() ? &flow : 0) / state.getWeight());
+}
+
+float cv::ximgproc::wrapperEMD(InputArray _sign1,
+                     InputArray _sign2,
+                     int distType,
+                     InputArray _cost,
+                     Ptr<float> lowerBound,
+                     OutputArray _flow)
+{
+    return cv::ximgproc::EMD(_sign1, _sign2, distType, _cost, lowerBound.get(), _flow);
+}

--- a/modules/ximgproc/src/emd.cpp
+++ b/modules/ximgproc/src/emd.cpp
@@ -23,6 +23,9 @@
 #include "precomp.hpp"
 #include "opencv2/core/utils/buffer_area.private.hpp"
 
+#include <cmath>
+#include <cstring>
+
 using namespace cv;
 
 namespace {
@@ -31,7 +34,7 @@ namespace {
 //==============================================================================
 // Distance functions
 
-typedef float (*DistFunc)(const float* a, const float* b, int dims);
+using DistFunc = float (*)(const float* a, const float* b, int dims);
 
 static float distL1(const float* x, const float* y, int dims)
 {
@@ -39,9 +42,9 @@ static float distL1(const float* x, const float* y, int dims)
     for (int i = 0; i < dims; i++)
     {
         const double t = x[i] - y[i];
-        s += fabs(t);
+        s += std::abs(t);
     }
-    return (float)s;
+    return static_cast<float>(s);
 }
 
 static float distL2(const float* x, const float* y, int dims)
@@ -52,7 +55,7 @@ static float distL2(const float* x, const float* y, int dims)
         const double t = x[i] - y[i];
         s += t * t;
     }
-    return sqrt((float)s);
+    return std::sqrt(static_cast<float>(s));
 }
 
 static float distC(const float* x, const float* y, int dims)
@@ -60,11 +63,11 @@ static float distC(const float* x, const float* y, int dims)
     double s = 0;
     for (int i = 0; i < dims; i++)
     {
-        const double t = fabs(x[i] - y[i]);
+        const double t = std::abs(x[i] - y[i]);
         if (s < t)
             s = t;
     }
-    return (float)s;
+    return static_cast<float>(s);
 }
 
 
@@ -96,33 +99,33 @@ struct EMDSolver
     static constexpr float CV_EMD_INF = 1e20f;
     static constexpr float CV_EMD_EPS = 1e-5f;
 
-    int ssize, dsize;
+    int ssize = 0, dsize = 0;
 
-    float* cost_buf;
+    float* cost_buf = nullptr;
     AutoBuffer<Node2D, 0> data_x;
-    Node2D* end_x;
-    Node2D* enter_x;
-    char* is_x;
+    Node2D* end_x = nullptr;
+    Node2D* enter_x = nullptr;
+    char* is_x = nullptr;
 
-    Node2D** rows_x;
-    Node2D** cols_x;
+    Node2D** rows_x = nullptr;
+    Node2D** cols_x = nullptr;
 
-    Node1D* u;
-    Node1D* v;
+    Node1D* u = nullptr;
+    Node1D* v = nullptr;
 
-    int* idx1;
-    int* idx2;
+    int* idx1 = nullptr;
+    int* idx2 = nullptr;
 
     /* find_loop buffers */
-    Node2D** loop;
-    char* is_used;
+    Node2D** loop = nullptr;
+    char* is_used = nullptr;
 
     /* russel buffers */
-    float* s;
-    float* d;
-    float* delta;
+    float* s = nullptr;
+    float* d = nullptr;
+    float* delta = nullptr;
 
-    float weight, max_cost;
+    float weight = 0.f, max_cost = 0.f;
 
     utils::BufferArea area, area2;
 
@@ -149,12 +152,7 @@ public:
         return *(this->is_x + i * dsize + j);
     }
 
-    EMDSolver() :
-        ssize(0), dsize(0), cost_buf(0), end_x(0), enter_x(0), is_x(0), rows_x(0),
-        cols_x(0), u(0), v(0), idx1(0), idx2(0), loop(0), is_used(0), s(0), d(0), delta(0),
-        weight(0), max_cost(0)
-    {
-    }
+    EMDSolver() = default;
 
 public:
     bool init(const Mat& sign1,
@@ -242,7 +240,7 @@ bool EMDSolver::checkLowerBound(const Mat& sign1,
 {
     AutoBuffer<float> buf;
     buf.allocate(dims * 2);
-    memset(buf.data(), 0, dims * 2 * sizeof(float));
+    std::memset(buf.data(), 0, dims * 2 * sizeof(float));
 
     float* xs = buf.data();
     float* xd = buf.data() + dims;
@@ -274,7 +272,7 @@ bool EMDSolver::calcSums(const Mat& sign1, const Mat& sign2)
     bool result = true;
     /* sum up the supply and demand */
     int ssize_ = 0, dsize_ = 0;
-    float s_sum = 0, d_sum = 0, diff;
+    float s_sum = 0, d_sum = 0;
     for (int i = 0; i < sign1.size().height; i++)
     {
         const float weight_ = sign1.at<float>(i, 0);
@@ -309,8 +307,8 @@ bool EMDSolver::calcSums(const Mat& sign1, const Mat& sign2)
         CV_Error(cv::Error::StsBadArg, "sign2 must contain at least one non-zero value");
 
     /* if supply different than the demand, add a zero-cost dummy cluster */
-    diff = s_sum - d_sum;
-    if (fabs(diff) >= CV_EMD_EPS * s_sum)
+    const float diff = s_sum - d_sum;
+    if (std::abs(diff) >= CV_EMD_EPS * s_sum)
     {
         result = false;
         if (diff < 0)
@@ -415,8 +413,7 @@ void EMDSolver::solve()
 double EMDSolver::calcFlow(Mat* flow_) const
 {
     double result = 0.;
-    const Node2D* xp = 0;
-    for (xp = data_x.data(); xp < end_x; xp++)
+    for (const Node2D* xp = data_x.data(); xp < end_x; xp++)
     {
         float val = xp->val;
         const int i = xp->i;
@@ -430,7 +427,7 @@ double EMDSolver::calcFlow(Mat* flow_) const
 
         if (ci >= 0 && cj >= 0)
         {
-            result += (double)val * getCost(i, j);
+            result += static_cast<double>(val) * getCost(i, j);
             if (flow_)
             {
                 flow_->at<float>(ci, cj) = val;
@@ -449,7 +446,7 @@ int EMDSolver::findBasicVars() const
     Node1D v0_head, v1_head, *cur_v, *prev_v;
     bool found;
 
-    CV_Assert(u != 0 && v != 0);
+    CV_Assert(u != nullptr && v != nullptr);
 
     /* initialize the rows list (u) and the columns list (v) */
     u0_head.next = u;
@@ -457,22 +454,22 @@ int EMDSolver::findBasicVars() const
     {
         u[i].next = u + i + 1;
     }
-    u[ssize - 1].next = 0;
-    u1_head.next = 0;
+    u[ssize - 1].next = nullptr;
+    u1_head.next = nullptr;
 
-    v0_head.next = ssize > 1 ? v + 1 : 0;
+    v0_head.next = ssize > 1 ? v + 1 : nullptr;
     for (i = 1; i < dsize; i++)
     {
         v[i].next = v + i + 1;
     }
-    v[dsize - 1].next = 0;
-    v1_head.next = 0;
+    v[dsize - 1].next = nullptr;
+    v1_head.next = nullptr;
 
     /* there are ssize+dsize variables but only ssize+dsize-1 independent equations,
        so set v[0]=0 */
     v[0].val = 0;
     v1_head.next = v;
-    v1_head.next->next = 0;
+    v1_head.next->next = nullptr;
 
     /* loop until all variables are found */
     u_cfound = v_cfound = 0;
@@ -484,17 +481,17 @@ int EMDSolver::findBasicVars() const
             /* loop over all marked columns */
             prev_v = &v1_head;
             cur_v = v1_head.next;
-            found = found || (cur_v != 0);
-            for (; cur_v != 0; cur_v = cur_v->next)
+            found = found || (cur_v != nullptr);
+            for (; cur_v != nullptr; cur_v = cur_v->next)
             {
                 float cur_v_val = cur_v->val;
 
-                j = (int)(cur_v - v);
+                j = static_cast<int>(cur_v - v);
                 /* find the variables in column j */
                 prev_u = &u0_head;
-                for (cur_u = u0_head.next; cur_u != 0;)
+                for (cur_u = u0_head.next; cur_u != nullptr;)
                 {
-                    i = (int)(cur_u - u);
+                    i = static_cast<int>(cur_u - u);
                     if (getIsX(i, j))
                     {
                         /* compute u[i] */
@@ -521,16 +518,16 @@ int EMDSolver::findBasicVars() const
             /* loop over all marked rows */
             prev_u = &u1_head;
             cur_u = u1_head.next;
-            found = found || (cur_u != 0);
-            for (; cur_u != 0; cur_u = cur_u->next)
+            found = found || (cur_u != nullptr);
+            for (; cur_u != nullptr; cur_u = cur_u->next)
             {
                 float cur_u_val = cur_u->val;
-                i = (int)(cur_u - u);
+                i = static_cast<int>(cur_u - u);
                 /* find the variables in rows i */
                 prev_v = &v0_head;
-                for (cur_v = v0_head.next; cur_v != 0;)
+                for (cur_v = v0_head.next; cur_v != nullptr;)
                 {
-                    j = (int)(cur_v - v);
+                    j = static_cast<int>(cur_v - v);
                     if (getIsX(i, j))
                     {
                         /* compute v[j] */
@@ -594,7 +591,7 @@ bool EMDSolver::checkNewSolution()
     int i, j;
     float min_val = CV_EMD_INF;
     int steps;
-    Node2D head {0, 0, 0, {0, 0}}, *cur_x, *next_x, *leave_x = 0;
+    Node2D head{}, *cur_x, *next_x, *leave_x = nullptr;
     Node2D* enter_x_ = this->enter_x;
     Node2D** loop_ = this->loop;
 
@@ -637,7 +634,7 @@ bool EMDSolver::checkNewSolution()
     }
 
     /* remove the leaving basic variable */
-    CV_Assert(leave_x != NULL);
+    CV_Assert(leave_x != nullptr);
     i = leave_x->i;
     j = leave_x->j;
     getIsX(i, j) = 0;
@@ -670,9 +667,7 @@ bool EMDSolver::checkNewSolution()
 
 int EMDSolver::findLoop() const
 {
-    int i;
-
-    memset(is_used, 0, this->ssize + this->dsize);
+    std::memset(is_used, 0, this->ssize + this->dsize);
 
     Node2D* new_x = loop[0] = enter_x;
     is_used[enter_x - data_x.data()] = 1;
@@ -684,20 +679,20 @@ int EMDSolver::findLoop() const
         {
             /* find an unused x in the row */
             new_x = this->rows_x[new_x->i];
-            while (new_x != 0 && is_used[new_x - data_x.data()])
+            while (new_x != nullptr && is_used[new_x - data_x.data()])
                 new_x = new_x->next[0];
         }
         else
         {
             /* find an unused x in the column, or the entering x */
             new_x = this->cols_x[new_x->j];
-            while (new_x != 0 && is_used[new_x - data_x.data()] && new_x != enter_x)
+            while (new_x != nullptr && is_used[new_x - data_x.data()] && new_x != enter_x)
                 new_x = new_x->next[1];
             if (new_x == enter_x)
                 break;
         }
 
-        if (new_x != 0) /* found the next x */
+        if (new_x != nullptr) /* found the next x */
         {
             /* add x to the loop */
             loop[steps++] = new_x;
@@ -708,20 +703,20 @@ int EMDSolver::findLoop() const
             /* backtrack */
             do
             {
-                i = steps & 1;
+                const int i = steps & 1;
                 new_x = loop[steps - 1];
                 do
                 {
                     new_x = new_x->next[i];
                 }
-                while (new_x != 0 && is_used[new_x - data_x.data()]);
+                while (new_x != nullptr && is_used[new_x - data_x.data()]);
 
-                if (new_x == 0)
+                if (new_x == nullptr)
                 {
                     is_used[loop[--steps] - data_x.data()] = 0;
                 }
             }
-            while (new_x == 0 && steps > 0);
+            while (new_x == nullptr && steps > 0);
 
             is_used[loop[steps - 1] - data_x.data()] = 0;
             loop[steps - 1] = new_x;
@@ -736,11 +731,11 @@ int EMDSolver::findLoop() const
 void EMDSolver::callRussel()
 {
     int i, j, min_i = -1, min_j = -1;
-    float min_delta, diff;
+    float min_delta;
     Node1D u_head, *cur_u, *prev_u;
     Node1D v_head, *cur_v, *prev_v;
-    Node1D *prev_u_min_i = 0, *prev_v_min_j = 0, *remember;
-    float eps = CV_EMD_EPS * this->max_cost;
+    Node1D *prev_u_min_i = nullptr, *prev_v_min_j = nullptr, *remember;
+    const float eps = CV_EMD_EPS * this->max_cost;
 
     /* initialize the rows list (ur), and the columns list (vr) */
     u_head.next = u;
@@ -748,7 +743,7 @@ void EMDSolver::callRussel()
     {
         u[i].next = u + i + 1;
     }
-    u[ssize - 1].next = 0;
+    u[ssize - 1].next = nullptr;
 
     v_head.next = v;
     for (i = 0; i < dsize; i++)
@@ -756,7 +751,7 @@ void EMDSolver::callRussel()
         v[i].val = -CV_EMD_INF;
         v[i].next = v + i + 1;
     }
-    v[dsize - 1].next = 0;
+    v[dsize - 1].next = nullptr;
 
     /* find the maximum row and column values (ur[i] and vr[j]) */
     for (i = 0; i < ssize; i++)
@@ -792,15 +787,15 @@ void EMDSolver::callRussel()
         min_i = -1;
         min_delta = CV_EMD_INF;
         prev_u = &u_head;
-        for (cur_u = u_head.next; cur_u != 0; cur_u = cur_u->next)
+        for (cur_u = u_head.next; cur_u != nullptr; cur_u = cur_u->next)
         {
-            i = (int)(cur_u - u);
+            i = static_cast<int>(cur_u - u);
             float* delta_row = delta + i * dsize;
 
             prev_v = &v_head;
-            for (cur_v = v_head.next; cur_v != 0; cur_v = cur_v->next)
+            for (cur_v = v_head.next; cur_v != nullptr; cur_v = cur_v->next)
             {
-                j = (int)(cur_v - v);
+                j = static_cast<int>(cur_v - v);
                 if (min_delta > delta_row[j])
                 {
                     min_delta = delta_row[j];
@@ -824,28 +819,28 @@ void EMDSolver::callRussel()
         /* update the necessary delta[][] */
         if (remember == prev_u_min_i->next) /* line min_i was deleted */
         {
-            for (cur_v = v_head.next; cur_v != 0; cur_v = cur_v->next)
+            for (cur_v = v_head.next; cur_v != nullptr; cur_v = cur_v->next)
             {
-                j = (int)(cur_v - v);
+                j = static_cast<int>(cur_v - v);
                 if (cur_v->val == getCost(min_i, j)) /* column j needs updating */
                 {
                     float max_val = -CV_EMD_INF;
 
                     /* find the new maximum value in the column */
-                    for (cur_u = u_head.next; cur_u != 0; cur_u = cur_u->next)
+                    for (cur_u = u_head.next; cur_u != nullptr; cur_u = cur_u->next)
                     {
-                        float temp = getCost((int)(cur_u - u), j);
+                        float temp = getCost(static_cast<int>(cur_u - u), j);
 
                         if (max_val < temp)
                             max_val = temp;
                     }
 
                     /* if needed, adjust the relevant delta[*][j] */
-                    diff = max_val - cur_v->val;
+                    const float diff = max_val - cur_v->val;
                     cur_v->val = max_val;
-                    if (fabs(diff) < eps)
+                    if (std::abs(diff) < eps)
                     {
-                        for (cur_u = u_head.next; cur_u != 0; cur_u = cur_u->next)
+                        for (cur_u = u_head.next; cur_u != nullptr; cur_u = cur_u->next)
                             *(delta + (cur_u - u) * dsize + j) += diff;
                     }
                 }
@@ -853,36 +848,36 @@ void EMDSolver::callRussel()
         }
         else /* column min_j was deleted */
         {
-            for (cur_u = u_head.next; cur_u != 0; cur_u = cur_u->next)
+            for (cur_u = u_head.next; cur_u != nullptr; cur_u = cur_u->next)
             {
-                i = (int)(cur_u - u);
+                i = static_cast<int>(cur_u - u);
                 if (cur_u->val == getCost(i, min_j)) /* row i needs updating */
                 {
                     float max_val = -CV_EMD_INF;
 
                     /* find the new maximum value in the row */
-                    for (cur_v = v_head.next; cur_v != 0; cur_v = cur_v->next)
+                    for (cur_v = v_head.next; cur_v != nullptr; cur_v = cur_v->next)
                     {
-                        float temp = getCost(i, (int)(cur_v - v));
+                        float temp = getCost(i, static_cast<int>(cur_v - v));
 
                         if (max_val < temp)
                             max_val = temp;
                     }
 
                     /* if needed, adjust the relevant delta[i][*] */
-                    diff = max_val - cur_u->val;
+                    const float diff = max_val - cur_u->val;
                     cur_u->val = max_val;
 
-                    if (fabs(diff) < eps)
+                    if (std::abs(diff) < eps)
                     {
-                        for (cur_v = v_head.next; cur_v != 0; cur_v = cur_v->next)
+                        for (cur_v = v_head.next; cur_v != nullptr; cur_v = cur_v->next)
                             *(delta + i * dsize + (cur_v - v)) += diff;
                     }
                 }
             }
         }
     }
-    while (u_head.next != 0 || v_head.next != 0);
+    while (u_head.next != nullptr || v_head.next != nullptr);
 }
 
 void EMDSolver::addBasicVar(int min_i,
@@ -919,7 +914,7 @@ void EMDSolver::addBasicVar(int min_i,
     this->end_x = end_x + 1;
 
     /* delete supply row only if the empty, and if not last row */
-    if (this->s[min_i] == 0 && u_head->next->next != 0)
+    if (this->s[min_i] == 0 && u_head->next->next != nullptr)
         prev_u_min_i->next = prev_u_min_i->next->next; /* remove row from list */
     else
         prev_v_min_j->next = prev_v_min_j->next->next; /* remove column from list */
@@ -963,7 +958,7 @@ float cv::ximgproc::EMD(InputArray _sign1,
                      "Flow matrix size does not match signatures");
     }
 
-    DistFunc dfunc = 0;
+    DistFunc dfunc = nullptr;
     if (distType == DIST_USER)
     {
         if (!cost.empty())
@@ -971,12 +966,12 @@ float cv::ximgproc::EMD(InputArray _sign1,
             CV_CheckEQ(cost.type(), CV_32FC1, "Cost matrix must have type 32FC1");
             CV_CheckTrue(cost.rows == size1 && cost.cols == size2,
                          "Cost matrix size does not match signatures");
-            CV_CheckTrue(lowerBound == NULL,
+            CV_CheckTrue(lowerBound == nullptr,
                          "Lower boundary can not be calculated if the cost matrix is used");
         }
         else
         {
-            CV_CheckTrue(dfunc == NULL, "Dist function must be set if cost matrix is empty");
+            CV_CheckTrue(dfunc == nullptr, "Dist function must be set if cost matrix is empty");
         }
     }
     else
@@ -998,7 +993,7 @@ float cv::ximgproc::EMD(InputArray _sign1,
         return *lowerBound;
     }
     state.solve();
-    return (float)(state.calcFlow(_flow.needed() ? &flow : 0) / state.getWeight());
+    return static_cast<float>(state.calcFlow(_flow.needed() ? &flow : nullptr) / state.getWeight());
 }
 
 float cv::ximgproc::wrapperEMD(InputArray _sign1,

--- a/modules/ximgproc/test/test_emd.cpp
+++ b/modules/ximgproc/test/test_emd.cpp
@@ -1,0 +1,330 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
+
+#include "test_precomp.hpp"
+
+using namespace cv;
+using namespace std;
+
+namespace opencv_test { namespace {
+
+//==============================================================================
+// Utility
+
+template <typename T>
+inline T sqr(T val)
+{
+    return val * val;
+}
+
+inline static float calcEMD(Mat w1, Mat w2, Mat& flow, int dist, int dims)
+{
+    float mass1 = 0.f, mass2 = 0.f, work = 0.f;
+    for (int i = 0; i < flow.rows; ++i)
+    {
+        mass1 += w1.at<float>(i, 0);
+        for (int j = 0; j < flow.cols; ++j)
+        {
+            if (i == 0)
+                mass2 += w2.at<float>(j, 0);
+            float dist_ = 0.f;
+            switch (dist)
+            {
+                case DIST_L1:
+                {
+                    for (int k = 1; k <= dims; ++k)
+                    {
+                        dist_ += abs(w1.at<float>(i, k) - w2.at<float>(j, k));
+                    }
+                    break;
+                }
+                case DIST_L2:
+                {
+                    for (int k = 1; k <= dims; ++k)
+                    {
+                        dist_ += sqr(w1.at<float>(i, k) - w2.at<float>(j, k));
+                    }
+                    dist_ = sqrt(dist_);
+                    break;
+                }
+                case DIST_C:
+                {
+                    for (int k = 1; k <= dims; ++k)
+                    {
+                        const float val = abs(w1.at<float>(i, k) - w2.at<float>(j, k));
+                        if (val > dist_)
+                            dist_ = val;
+                    }
+                    break;
+                }
+            }
+            const float weight = flow.at<float>(i, j);
+            work += dist_ * weight;
+        }
+    }
+    return work / max(mass1, mass2);
+}
+
+// Independent reference for the lower bound: the distance between the weighted
+// mass centers of the two signatures, normalized by the larger total weight.
+// Mirrors EMDSolver::checkLowerBound so it can pin that code path.
+inline static float massCenterLowerBound(Mat s1, Mat s2, int dist, int dims)
+{
+    vector<float> xs(dims, 0.f), xd(dims, 0.f);
+    float sum1 = 0.f, sum2 = 0.f;
+    for (int j = 0; j < s1.rows; ++j)
+    {
+        const float w = s1.at<float>(j, 0);
+        sum1 += w;
+        for (int k = 0; k < dims; ++k)
+            xs[k] += s1.at<float>(j, k + 1) * w;
+    }
+    for (int j = 0; j < s2.rows; ++j)
+    {
+        const float w = s2.at<float>(j, 0);
+        sum2 += w;
+        for (int k = 0; k < dims; ++k)
+            xd[k] += s2.at<float>(j, k + 1) * w;
+    }
+    float d = 0.f;
+    switch (dist)
+    {
+        case DIST_L1:
+            for (int k = 0; k < dims; ++k)
+                d += abs(xs[k] - xd[k]);
+            break;
+        case DIST_L2:
+            for (int k = 0; k < dims; ++k)
+                d += sqr(xs[k] - xd[k]);
+            d = sqrt(d);
+            break;
+        case DIST_C:
+            for (int k = 0; k < dims; ++k)
+                d = max(d, abs(xs[k] - xd[k]));
+            break;
+    }
+    return d / max(sum1, sum2);
+}
+
+//==============================================================================
+
+TEST(Ximgproc_EMD, regression)
+{
+    // input data
+    const float M = 10000;
+    Matx<float, 4, 1> w1 {50, 60, 50, 50};
+    Matx<float, 5, 1> w2 {30, 20, 70, 30, 60};
+    Matx<float, 4, 5> cost {16, 16, 13, 22, 17, 14, 14, 13, 19, 15,
+                            19, 19, 20, 23, M,  M,  0,  M,  0,  0};
+
+    // expected results
+    const double emd0 = 2460. / 210;
+    Matx<float, 4, 5> flow0 {0, 0, 50, 0, 0, 0, 0, 20, 0, 40, 30, 20, 0, 0, 0, 0, 0, 0, 30, 20};
+
+    // basic call with cost
+    {
+        float emd = 0.f;
+        ASSERT_NO_THROW(emd = cv::ximgproc::EMD(w1, w2, DIST_USER, cost));
+        EXPECT_NEAR(emd, emd0, 1e-6 * emd0);
+    }
+
+    // basic call with cost and flow output
+    {
+        Mat flow;
+        float emd = 0.f;
+        ASSERT_NO_THROW(emd = cv::ximgproc::EMD(w1, w2, DIST_USER, cost, nullptr, flow));
+        EXPECT_NEAR(emd, emd0, 1e-6 * emd0);
+        EXPECT_LE(cvtest::norm(Mat(flow0), flow, NORM_INF), 1e-6);
+    }
+    // no cost and DIST_USER - error
+    {
+        Mat flow;
+        EXPECT_THROW(cv::ximgproc::EMD(w1, w2, DIST_USER, noArray(), nullptr, flow), cv::Exception);
+        EXPECT_THROW(cv::ximgproc::EMD(w1, w2, DIST_USER), cv::Exception);
+    }
+}
+
+TEST(Ximgproc_EMD, distance_types)
+{
+    // 1D (sum = 210)
+    Matx<float, 4, 2> w1 {50, 1, 60, 2, 50, 3, 50, 4};
+    Matx<float, 5, 2> w2 {30, 1, 20, 2, 70, 3, 30, 4, 60, 5};
+
+    // 2D (sum = 210)
+    Matx<float, 4, 3> w3 {50, 0, 0, 60, 0, 1, 50, 1, 0, 50, 1, 1};
+    Matx<float, 5, 3> w4 {20, 0, 1, 70, 1, 0, 30, 1, 1, 60, 2, 2, 30, 3, 3};
+
+    // basic call with all distance types
+    {
+        const vector<DistanceTypes> good_types {DIST_L1, DIST_L2, DIST_C};
+        for (const auto& dt : good_types)
+        {
+            SCOPED_TRACE(cv::format("dt=%d", dt));
+            float emd = 0.f;
+            Mat flow;
+            // 1D
+            {
+                ASSERT_NO_THROW(emd = cv::ximgproc::EMD(w1, w2, dt, noArray(), nullptr, flow));
+                const float emd0 = calcEMD(Mat(w1), Mat(w2), flow, dt, 1);
+                EXPECT_NEAR(emd0, emd, 1e-6);
+            }
+            // 2D
+            {
+                ASSERT_NO_THROW(emd = cv::ximgproc::EMD(w3, w4, dt, noArray(), nullptr, flow));
+                const float emd0 = calcEMD(Mat(w3), Mat(w4), flow, dt, 2);
+                EXPECT_NEAR(emd0, emd, 1e-6);
+            }
+        }
+    }
+}
+
+TEST(Ximgproc_EMD, lower_bound)
+{
+    // Equal total weights (210 each) so the lower-bound path is active
+    // (checkLowerBound is only reached when the signature sums match).
+    Matx<float, 4, 2> w1 {50, 1, 60, 2, 50, 3, 50, 4};
+    Matx<float, 5, 2> w2 {30, 1, 20, 2, 70, 3, 30, 4, 60, 5};
+    const int dims = 1;
+
+    const vector<DistanceTypes> good_types {DIST_L1, DIST_L2, DIST_C};
+    for (const auto& dt : good_types)
+    {
+        SCOPED_TRACE(cv::format("dt=%d", dt));
+        const float lb0 = massCenterLowerBound(Mat(w1), Mat(w2), dt, dims);
+        const float tol = 1e-4f * max(lb0, 1.f);
+
+        // Small initial bound: the mass-center distance already meets it, so the
+        // signatures are "far enough", the solver is skipped, and the lower
+        // bound is returned. bound is updated to the mass-center distance.
+        {
+            Mat flow;
+            float bound = 0.f, emd = 0.f;
+            ASSERT_NO_THROW(emd = cv::ximgproc::EMD(w1, w2, dt, noArray(), &bound, flow));
+            EXPECT_NEAR(bound, lb0, tol);
+            EXPECT_NEAR(emd, lb0, tol);
+        }
+
+        // Large initial bound: not far enough, so the full EMD is computed.
+        // bound is still updated to the mass-center distance on return.
+        {
+            Mat flow;
+            float bound = 1e9f, emd = 0.f;
+            ASSERT_NO_THROW(emd = cv::ximgproc::EMD(w1, w2, dt, noArray(), &bound, flow));
+            const float emd0 = calcEMD(Mat(w1), Mat(w2), flow, dt, dims);
+            EXPECT_NEAR(emd, emd0, 1e-4f * max(emd0, 1.f));
+            EXPECT_NEAR(bound, lb0, tol);
+            EXPECT_LE(lb0, emd + tol);  // a lower bound never exceeds the EMD
+        }
+    }
+}
+
+typedef testing::TestWithParam<int> Ximgproc_EMD_dist;
+
+TEST_P(Ximgproc_EMD_dist, random_flow_verify)
+{
+    const int dist = GetParam();
+    for (size_t iter = 0; iter < 100; ++iter)
+    {
+        SCOPED_TRACE(cv::format("iter=%zu", iter));
+        RNG& rng = TS::ptr()->get_rng();
+        const int dims = rng.uniform(1, 10);
+        Mat w1(rng.uniform(1, 10), dims + 1, CV_32FC1);
+        Mat w2(rng.uniform(1, 10), dims + 1, CV_32FC1);
+
+        // weights > 0
+        {
+            Mat w1_weights = w1.col(0);
+            Mat w2_weights = w2.col(0);
+            cvtest::randUni(rng, w1_weights, 0, 100);
+            cvtest::randUni(rng, w2_weights, 0, 100);
+        }
+
+        // coord
+        {
+            Mat w1_coord = w1.colRange(1, dims + 1);
+            Mat w2_coord = w2.colRange(1, dims + 1);
+            cvtest::randUni(rng, w1_coord, -10, +10);
+            cvtest::randUni(rng, w2_coord, -10, +10);
+        }
+
+        float emd1 = 0.f, emd2 = 0.f;
+        const float eps = 1e-5f;
+        Mat flow;
+        {
+            ASSERT_NO_THROW(emd1 = cv::ximgproc::EMD(w1, w2, dist, noArray(), nullptr, flow));
+            const float emd0 = calcEMD(w1, w2, flow, dist, dims);
+            EXPECT_NEAR(emd0, emd1, eps);
+        }
+        {
+            ASSERT_NO_THROW(emd2 = cv::ximgproc::EMD(w2, w1, dist, noArray(), nullptr, flow));
+            const float emd0 = calcEMD(w2, w1, flow, dist, dims);
+            EXPECT_NEAR(emd0, emd2, eps);
+        }
+        EXPECT_NEAR(emd1, emd2, eps);
+    }
+}
+
+INSTANTIATE_TEST_CASE_P(, Ximgproc_EMD_dist, testing::Values(DIST_L1, DIST_L2, DIST_C));
+
+
+TEST(Ximgproc_EMD, invalid)
+{
+    Matx<float, 4, 2> w1 {50, 1, 60, 2, 50, 3, 50, 4};
+    Matx<float, 5, 2> w2 {30, 1, 20, 2, 70, 3, 30, 4, 60, 5};
+
+    // empty signature
+    {
+        Mat empty;
+        EXPECT_THROW(cv::ximgproc::EMD(empty, w2, DIST_USER), cv::Exception);
+        EXPECT_THROW(cv::ximgproc::EMD(w1, empty, DIST_USER), cv::Exception);
+    }
+
+    // zero total weight, negative weight
+    {
+        Matx<float, 3, 1> wz {0, 0, 0};
+        Matx<float, 3, 2> wz1 {0, 1, 0, 2, 0, 3};
+        Matx<float, 3, 1> wn {0, 3, -2};
+        Matx<float, 3, 2> wn1 {0, 1, 3, 2, -2, 3};
+        EXPECT_THROW(cv::ximgproc::EMD(wz, w2, DIST_USER), cv::Exception);
+        EXPECT_THROW(cv::ximgproc::EMD(wz1, w2, DIST_USER), cv::Exception);
+        EXPECT_THROW(cv::ximgproc::EMD(wn, w2, DIST_USER), cv::Exception);
+        EXPECT_THROW(cv::ximgproc::EMD(wn1, w2, DIST_USER), cv::Exception);
+    }
+
+    // user distance type, but no cost matrix provided or is wrong
+    {
+        Mat cost(3, 3, CV_32FC1, Scalar::all(0)), cost8u(4, 5, CV_8UC1, Scalar::all(0)), empty;
+        EXPECT_THROW(cv::ximgproc::EMD(w1, w2, DIST_USER, noArray()), cv::Exception);
+        EXPECT_THROW(cv::ximgproc::EMD(w1, w2, DIST_USER, empty), cv::Exception);
+        EXPECT_THROW(cv::ximgproc::EMD(w1, w2, DIST_USER, cost8u), cv::Exception);
+        EXPECT_THROW(cv::ximgproc::EMD(w1, w2, DIST_USER, cost), cv::Exception);
+    }
+
+    // lower_bound is set together with cost
+    {
+        Mat cost(4, 5, CV_32FC1, Scalar::all(0));
+        float bound = 0.f;
+        EXPECT_THROW(cv::ximgproc::EMD(w1, w2, DIST_USER, cost, &bound), cv::Exception);
+    }
+
+    // zero dimensions with non-user distance type
+    const vector<DistanceTypes> good_types {DIST_L1, DIST_L2, DIST_C};
+    for (const auto& dt : good_types)
+    {
+        SCOPED_TRACE(cv::format("dt=%d", dt));
+        Matx<float, 4, 1> w01 {20, 30, 40, 50};
+        Matx<float, 5, 1> w02 {20, 30, 40, 50, 10};
+        EXPECT_THROW(cv::ximgproc::EMD(w01, w02, dt), cv::Exception);
+    }
+
+    // wrong distance type
+    const vector<DistanceTypes> bad_types {DIST_L12, DIST_FAIR, DIST_WELSCH, DIST_HUBER};
+    for (const auto& dt : bad_types)
+    {
+        SCOPED_TRACE(cv::format("dt=%d", dt));
+        EXPECT_THROW(cv::ximgproc::EMD(w1, w2, dt), cv::Exception);
+    }
+}
+
+}}  // namespace opencv_test


### PR DESCRIPTION
As part of the imgproc cleanup in opencv/opencv#25001, this moves the Earth
Mover's Distance function (`EMD`) from imgproc into ximgproc. EMD is an old,
rarely used function with no callers elsewhere in the library, so the extended
module is a more natural home for it.

This is the opencv_contrib side of the change. The companion pull request on the main repository removes EMD from imgproc
(opencv/opencv#29302), and the two are meant to be merged together. The public interface is unchanged apart from the namespace, so callers
reach the function through `cv::ximgproc` now.

The change is split into two commits so each can be reviewed on its own:

- The first moves the implementation, the `EMD` / `wrapperEMD` declarations, and
  the accuracy test across unchanged apart from the `cv::ximgproc` namespace, so
  it reads as a straight move.
- The second is a behavior-preserving C++17 cleanup of the moved code: C-style
  casts become `static_cast`, null pointer literals become `nullptr`, the
  constructor initializer list moves to in-class member initializers, and the
  math and `memset` calls are `std::`-qualified. No logic or numerics change.

The accuracy test moved with the function and still passes. It also gains a case
covering the lower-bound path, which the previous test did not exercise.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
- [x] The feature is well documented and sample code can be built with the project CMake
