### PR TITLE
line_descriptor: enable __popcnt intrinsic for knn_match function

### DIFF
--- a/modules/line_descriptor/src/bitops.hpp
+++ b/modules/line_descriptor/src/bitops.hpp
@@ -49,9 +49,13 @@
 #if defined(_M_ARM) || defined(_M_ARM64)
 static inline UINT32 popcnt(UINT32 v)
 {
+#if CV_NEON
+  return __popcnt(v);
+#else
     v = v - ((v >> 1) & 0x55555555);
     v = (v & 0x33333333) + ((v >> 2) & 0x33333333);
     return ((v + (v >> 4) & 0xF0F0F0F) * 0x1010101) >> 24;
+#endif
 }
 #else
 # include <intrin.h>


### PR DESCRIPTION
- This PR optimizes the popcnt implementation used by the line_descriptor module.
- Currently, ARM64 uses scalar implementation and this change enables the use of the hardware __popcnt intrinsic, while preserving the existing scalar implementation as a fallback.
- The optimization improves the performance of the knn_match function and also benefits several other functions in the line_descriptor module that rely on the same popcnt implementation.

**Performance Benchmarks:**
<img width="523" height="165" alt="image" src="https://github.com/user-attachments/assets/e1d60b52-6289-4f4c-aa04-7c1028a9862d" />

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch