### PR TITLE
ximgproc: move accumulate functions from imgproc

### DIFF
--- a/modules/ximgproc/CMakeLists.txt
+++ b/modules/ximgproc/CMakeLists.txt
@@ -1,2 +1,5 @@
 set(the_description "Extended image processing module. It includes edge-aware filters and etc.")
+
+ocv_add_dispatched_file(accum SSE4_1 AVX AVX2)
+
 ocv_define_module(ximgproc opencv_core opencv_imgproc opencv_geometry opencv_stereo opencv_imgcodecs opencv_video WRAP python java objc js)

--- a/modules/ximgproc/include/opencv2/ximgproc.hpp
+++ b/modules/ximgproc/include/opencv2/ximgproc.hpp
@@ -63,6 +63,7 @@
 #include "ximgproc/color_match.hpp"
 #include "ximgproc/radon_transform.hpp"
 #include "ximgproc/find_ellipses.hpp"
+#include "ximgproc/accumulate.hpp"
 
 
 /**

--- a/modules/ximgproc/include/opencv2/ximgproc/accumulate.hpp
+++ b/modules/ximgproc/include/opencv2/ximgproc/accumulate.hpp
@@ -1,0 +1,100 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#ifndef __OPENCV_XIMGPROC_ACCUMULATE_HPP__
+#define __OPENCV_XIMGPROC_ACCUMULATE_HPP__
+
+#include "opencv2/core.hpp"
+#include "opencv2/imgproc.hpp"
+
+namespace cv {
+namespace ximgproc {
+
+//! @addtogroup ximgproc
+//! @{
+
+/** @brief Adds an image to the accumulator image.
+
+The function adds src or some of its elements to dst :
+
+\f[\texttt{dst} (x,y)  \leftarrow \texttt{dst} (x,y) +  \texttt{src} (x,y)  \quad \text{if} \quad \texttt{mask} (x,y)  \ne 0\f]
+
+The function supports multi-channel images. Each channel is processed independently.
+
+The function cv::ximgproc::accumulate can be used, for example, to collect statistics of a scene
+background viewed by a still camera and for the further foreground-background segmentation.
+
+@param src Input image of type CV_8UC(n), CV_16UC(n), CV_32FC(n) or CV_64FC(n), where n is a positive integer.
+@param dst %Accumulator image with the same number of channels as input image, and a depth of CV_32F or CV_64F.
+@param mask Optional operation mask.
+
+@sa  accumulateSquare, accumulateProduct, accumulateWeighted
+ */
+CV_EXPORTS_W void accumulate( InputArray src, InputOutputArray dst,
+                              InputArray mask = noArray() );
+
+/** @brief Adds the square of a source image to the accumulator image.
+
+The function adds the input image src or its selected region, raised to a power of 2, to the
+accumulator dst :
+
+\f[\texttt{dst} (x,y)  \leftarrow \texttt{dst} (x,y) +  \texttt{src} (x,y)^2  \quad \text{if} \quad \texttt{mask} (x,y)  \ne 0\f]
+
+The function supports multi-channel images. Each channel is processed independently.
+
+@param src Input image as 1- or 3-channel, 8-bit or 32-bit floating point.
+@param dst %Accumulator image with the same number of channels as input image, 32-bit or 64-bit
+floating-point.
+@param mask Optional operation mask.
+
+@sa  accumulate, accumulateProduct, accumulateWeighted
+ */
+CV_EXPORTS_W void accumulateSquare( InputArray src, InputOutputArray dst,
+                                    InputArray mask = noArray() );
+
+/** @brief Adds the per-element product of two input images to the accumulator image.
+
+The function adds the product of two images or their selected regions to the accumulator dst :
+
+\f[\texttt{dst} (x,y)  \leftarrow \texttt{dst} (x,y) +  \texttt{src1} (x,y)  \cdot \texttt{src2} (x,y)  \quad \text{if} \quad \texttt{mask} (x,y)  \ne 0\f]
+
+The function supports multi-channel images. Each channel is processed independently.
+
+@param src1 First input image, 1- or 3-channel, 8-bit or 32-bit floating point.
+@param src2 Second input image of the same type and the same size as src1 .
+@param dst %Accumulator image with the same number of channels as input images, 32-bit or 64-bit
+floating-point.
+@param mask Optional operation mask.
+
+@sa  accumulate, accumulateSquare, accumulateWeighted
+ */
+CV_EXPORTS_W void accumulateProduct( InputArray src1, InputArray src2,
+                                     InputOutputArray dst, InputArray mask=noArray() );
+
+/** @brief Updates a running average.
+
+The function calculates the weighted sum of the input image src and the accumulator dst so that dst
+becomes a running average of a frame sequence:
+
+\f[\texttt{dst} (x,y)  \leftarrow (1- \texttt{alpha} )  \cdot \texttt{dst} (x,y) +  \texttt{alpha} \cdot \texttt{src} (x,y)  \quad \text{if} \quad \texttt{mask} (x,y)  \ne 0\f]
+
+That is, alpha regulates the update speed (how fast the accumulator "forgets" about earlier images).
+The function supports multi-channel images. Each channel is processed independently.
+
+@param src Input image as 1- or 3-channel, 8-bit or 32-bit floating point.
+@param dst %Accumulator image with the same number of channels as input image, 32-bit or 64-bit
+floating-point.
+@param alpha Weight of the input image.
+@param mask Optional operation mask.
+
+@sa  accumulate, accumulateSquare, accumulateProduct
+ */
+CV_EXPORTS_W void accumulateWeighted( InputArray src, InputOutputArray dst,
+                                      double alpha, InputArray mask = noArray() );
+
+//! @}
+
+}} // namespace cv::ximgproc
+
+#endif // __OPENCV_XIMGPROC_ACCUMULATE_HPP__

--- a/modules/ximgproc/perf/perf_accumulate.cpp
+++ b/modules/ximgproc/perf/perf_accumulate.cpp
@@ -1,0 +1,200 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+#include "perf_precomp.hpp"
+#include "opencv2/ts/ocl_perf.hpp"
+
+namespace opencv_test {
+
+typedef Size_MatType Accumulate;
+
+#define MAT_TYPES_ACCUMLATE CV_8UC1, CV_16UC1, CV_32FC1
+#define MAT_TYPES_ACCUMLATE_C MAT_TYPES_ACCUMLATE, CV_8UC3, CV_16UC3, CV_32FC3
+#define MAT_TYPES_ACCUMLATE_D MAT_TYPES_ACCUMLATE, CV_64FC1
+#define MAT_TYPES_ACCUMLATE_D_C MAT_TYPES_ACCUMLATE_C, CV_64FC1, CV_64FC1
+
+#define PERF_ACCUMULATE_INIT(_FLTC)                    \
+    const Size srcSize = get<0>(GetParam());           \
+    const int srcType = get<1>(GetParam());            \
+    const int dstType = _FLTC(CV_MAT_CN(srcType));     \
+    Mat src1(srcSize, srcType), dst(srcSize, dstType); \
+    declare.in(src1, dst, WARMUP_RNG).out(dst);
+
+#define PERF_ACCUMULATE_MASK_INIT(_FLTC) \
+    PERF_ACCUMULATE_INIT(_FLTC)          \
+    Mat mask(srcSize, CV_8UC1);          \
+    declare.in(mask, WARMUP_RNG);
+
+#define PERF_TEST_P_ACCUMULATE(_NAME, _TYPES, _INIT, _FUN)           \
+    PERF_TEST_P(Accumulate, _NAME,                                   \
+        testing::Combine(                                            \
+            testing::Values(sz1080p, sz720p, szVGA, szQVGA, szODD),  \
+            testing::Values(_TYPES)                                  \
+        )                                                            \
+    )                                                                \
+    {                                                                \
+        _INIT                                                        \
+        TEST_CYCLE() _FUN;                                           \
+        SANITY_CHECK_NOTHING();                                      \
+    }
+
+/////////////////////////////////// Accumulate ///////////////////////////////////
+
+PERF_TEST_P_ACCUMULATE(Accumulate, MAT_TYPES_ACCUMLATE,
+        PERF_ACCUMULATE_INIT(CV_32FC), cv::ximgproc::accumulate(src1, dst))
+
+PERF_TEST_P_ACCUMULATE(AccumulateMask, MAT_TYPES_ACCUMLATE_C,
+    PERF_ACCUMULATE_MASK_INIT(CV_32FC), cv::ximgproc::accumulate(src1, dst, mask))
+
+PERF_TEST_P_ACCUMULATE(AccumulateMask32FC4, CV_32FC4,
+    PERF_ACCUMULATE_MASK_INIT(CV_32FC), cv::ximgproc::accumulate(src1, dst, mask))
+
+PERF_TEST_P_ACCUMULATE(AccumulateMask8UC4To32FC4, CV_8UC4,
+    PERF_ACCUMULATE_MASK_INIT(CV_32FC), cv::ximgproc::accumulate(src1, dst, mask))
+
+PERF_TEST_P_ACCUMULATE(AccumulateDouble, MAT_TYPES_ACCUMLATE_D,
+    PERF_ACCUMULATE_INIT(CV_64FC), cv::ximgproc::accumulate(src1, dst))
+
+PERF_TEST_P_ACCUMULATE(AccumulateDoubleMask, MAT_TYPES_ACCUMLATE_D_C,
+    PERF_ACCUMULATE_MASK_INIT(CV_64FC), cv::ximgproc::accumulate(src1, dst, mask))
+
+///////////////////////////// AccumulateSquare ///////////////////////////////////
+
+PERF_TEST_P_ACCUMULATE(Square, MAT_TYPES_ACCUMLATE,
+    PERF_ACCUMULATE_INIT(CV_32FC), cv::ximgproc::accumulateSquare(src1, dst))
+
+PERF_TEST_P_ACCUMULATE(SquareMask, MAT_TYPES_ACCUMLATE_C,
+    PERF_ACCUMULATE_MASK_INIT(CV_32FC), cv::ximgproc::accumulateSquare(src1, dst, mask))
+
+PERF_TEST_P_ACCUMULATE(SquareDouble, MAT_TYPES_ACCUMLATE_D,
+    PERF_ACCUMULATE_INIT(CV_64FC), cv::ximgproc::accumulateSquare(src1, dst))
+
+PERF_TEST_P_ACCUMULATE(SquareDoubleMask, MAT_TYPES_ACCUMLATE_D_C,
+    PERF_ACCUMULATE_MASK_INIT(CV_64FC), cv::ximgproc::accumulateSquare(src1, dst, mask))
+
+///////////////////////////// AccumulateProduct ///////////////////////////////////
+
+#define PERF_ACCUMULATE_INIT_2(_FLTC) \
+    PERF_ACCUMULATE_INIT(_FLTC)       \
+    Mat src2(srcSize, srcType);       \
+    declare.in(src2);
+
+#define PERF_ACCUMULATE_MASK_INIT_2(_FLTC) \
+    PERF_ACCUMULATE_MASK_INIT(_FLTC)       \
+    Mat src2(srcSize, srcType);            \
+    declare.in(src2);
+
+PERF_TEST_P_ACCUMULATE(Product, MAT_TYPES_ACCUMLATE,
+    PERF_ACCUMULATE_INIT_2(CV_32FC), cv::ximgproc::accumulateProduct(src1, src2, dst))
+
+PERF_TEST_P_ACCUMULATE(ProductMask, MAT_TYPES_ACCUMLATE_C,
+    PERF_ACCUMULATE_MASK_INIT_2(CV_32FC), cv::ximgproc::accumulateProduct(src1, src2, dst, mask))
+
+PERF_TEST_P_ACCUMULATE(ProductDouble, MAT_TYPES_ACCUMLATE_D,
+    PERF_ACCUMULATE_INIT_2(CV_64FC), cv::ximgproc::accumulateProduct(src1, src2, dst))
+
+PERF_TEST_P_ACCUMULATE(ProductDoubleMask, MAT_TYPES_ACCUMLATE_D_C,
+    PERF_ACCUMULATE_MASK_INIT_2(CV_64FC), cv::ximgproc::accumulateProduct(src1, src2, dst, mask))
+
+///////////////////////////// AccumulateWeighted ///////////////////////////////////
+
+PERF_TEST_P_ACCUMULATE(Weighted, MAT_TYPES_ACCUMLATE,
+    PERF_ACCUMULATE_INIT(CV_32FC), cv::ximgproc::accumulateWeighted(src1, dst, 0.123))
+
+PERF_TEST_P_ACCUMULATE(WeightedMask, MAT_TYPES_ACCUMLATE_C,
+    PERF_ACCUMULATE_MASK_INIT(CV_32FC), cv::ximgproc::accumulateWeighted(src1, dst, 0.123, mask))
+
+PERF_TEST_P_ACCUMULATE(WeightedDouble, MAT_TYPES_ACCUMLATE_D,
+    PERF_ACCUMULATE_INIT(CV_64FC), cv::ximgproc::accumulateWeighted(src1, dst, 0.123456))
+
+PERF_TEST_P_ACCUMULATE(WeightedDoubleMask, MAT_TYPES_ACCUMLATE_D_C,
+    PERF_ACCUMULATE_MASK_INIT(CV_64FC), cv::ximgproc::accumulateWeighted(src1, dst, 0.123456, mask))
+
+} // namespace
+
+//////////////////////////////// OpenCL perf //////////////////////////////////
+
+#ifdef HAVE_OPENCL
+
+namespace opencv_test {
+namespace ocl {
+
+typedef Size_MatType AccumulateFixture;
+
+OCL_PERF_TEST_P(AccumulateFixture, Accumulate,
+                ::testing::Combine(OCL_TEST_SIZES, OCL_TEST_TYPES))
+{
+    Size_MatType_t params = GetParam();
+    const Size srcSize = get<0>(params);
+    const int srcType = get<1>(params), cn = CV_MAT_CN(srcType), dstType = CV_32FC(cn);
+
+    checkDeviceMaxMemoryAllocSize(srcSize, dstType);
+
+    UMat src(srcSize, srcType), dst(srcSize, dstType);
+    declare.in(src, dst, WARMUP_RNG).out(dst);
+
+    OCL_TEST_CYCLE() cv::ximgproc::accumulate(src, dst);
+
+    SANITY_CHECK_NOTHING();
+}
+
+typedef Size_MatType AccumulateSquareFixture;
+
+OCL_PERF_TEST_P(AccumulateSquareFixture, AccumulateSquare,
+                ::testing::Combine(OCL_TEST_SIZES, OCL_TEST_TYPES))
+{
+    Size_MatType_t params = GetParam();
+    const Size srcSize = get<0>(params);
+    const int srcType = get<1>(params), cn = CV_MAT_CN(srcType), dstType = CV_32FC(cn);
+
+    checkDeviceMaxMemoryAllocSize(srcSize, dstType);
+
+    UMat src(srcSize, srcType), dst(srcSize, dstType);
+    declare.in(src, dst, WARMUP_RNG);
+
+    OCL_TEST_CYCLE() cv::ximgproc::accumulateSquare(src, dst);
+
+    SANITY_CHECK_NOTHING();
+}
+
+typedef Size_MatType AccumulateProductFixture;
+
+OCL_PERF_TEST_P(AccumulateProductFixture, AccumulateProduct,
+                ::testing::Combine(OCL_TEST_SIZES, OCL_TEST_TYPES))
+{
+    Size_MatType_t params = GetParam();
+    const Size srcSize = get<0>(params);
+    const int srcType = get<1>(params), cn = CV_MAT_CN(srcType), dstType = CV_32FC(cn);
+
+    checkDeviceMaxMemoryAllocSize(srcSize, dstType);
+
+    UMat src1(srcSize, srcType), src2(srcSize, srcType), dst(srcSize, dstType);
+    declare.in(src1, src2, dst, WARMUP_RNG);
+
+    OCL_TEST_CYCLE() cv::ximgproc::accumulateProduct(src1, src2, dst);
+
+    SANITY_CHECK_NOTHING();
+}
+
+typedef Size_MatType AccumulateWeightedFixture;
+
+OCL_PERF_TEST_P(AccumulateWeightedFixture, AccumulateWeighted,
+                ::testing::Combine(OCL_TEST_SIZES, OCL_TEST_TYPES))
+{
+    Size_MatType_t params = GetParam();
+    const Size srcSize = get<0>(params);
+    const int srcType = get<1>(params), cn = CV_MAT_CN(srcType), dstType = CV_32FC(cn);
+
+    checkDeviceMaxMemoryAllocSize(srcSize, dstType);
+
+    UMat src(srcSize, srcType), dst(srcSize, dstType);
+    declare.in(src, dst, WARMUP_RNG);
+
+    OCL_TEST_CYCLE() cv::ximgproc::accumulateWeighted(src, dst, 2.0);
+
+    SANITY_CHECK_NOTHING();
+}
+
+} } // namespace opencv_test::ocl
+
+#endif // HAVE_OPENCL

--- a/modules/ximgproc/src/accum.cpp
+++ b/modules/ximgproc/src/accum.cpp
@@ -1,0 +1,564 @@
+/*M///////////////////////////////////////////////////////////////////////////////////////
+//
+//  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
+//
+//  By downloading, copying, installing or using the software you agree to this license.
+//  If you do not agree to this license, do not download, install,
+//  copy or use the software.
+//
+//
+//                           License Agreement
+//                For Open Source Computer Vision Library
+//
+// Copyright (C) 2000-2008, Intel Corporation, all rights reserved.
+// Copyright (C) 2009, Willow Garage Inc., all rights reserved.
+// Copyright (C) 2014, Itseez Inc., all rights reserved.
+// Third party copyrights are property of their respective owners.
+/
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//   * Redistribution's of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//   * Redistribution's in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//   * The name of the copyright holders may not be used to endorse or promote products
+//     derived from this software without specific prior written permission.
+//
+// This software is provided by the copyright holders and contributors "as is" and
+// any express or implied warranties, including, but not limited to, the implied
+// warranties of merchantability and fitness for a particular purpose are disclaimed.
+// In no event shall the Intel Corporation or contributors be liable for any direct,
+// indirect, incidental, special, exemplary, or consequential damages
+// (including, but not limited to, procurement of substitute goods or services;
+// loss of use, data, or profits; or business interruption) however caused
+// and on any theory of liability, whether in contract, strict liability,
+// or tort (including negligence or otherwise) arising in any way out of
+// the use of this software, even if advised of the possibility of such damage.
+//
+//M*/
+
+#include "precomp.hpp"
+#include "opencl_kernels_ximgproc.hpp"
+#include "opencv2/core/hal/intrin.hpp"
+#define CV_CPU_OPTIMIZATION_DECLARATIONS_ONLY
+#include "accum.simd.hpp"
+#include "accum.simd_declarations.hpp"
+
+namespace cv
+{
+
+typedef void(*AccFunc)(const uchar*, uchar*, const uchar*, int, int);
+typedef void(*AccProdFunc)(const uchar*, const uchar*, uchar*, const uchar*, int, int);
+typedef void(*AccWFunc)(const uchar*, uchar*, const uchar*, int, int, double);
+
+static AccFunc accTab[CV_DEPTH_MAX] =
+{
+    (AccFunc)acc_8u32f, (AccFunc)acc_8u64f,
+    (AccFunc)acc_16u32f, (AccFunc)acc_16u64f,
+    (AccFunc)acc_32f, (AccFunc)acc_32f64f,
+    (AccFunc)acc_64f
+};
+
+static AccFunc accSqrTab[CV_DEPTH_MAX] =
+{
+    (AccFunc)accSqr_8u32f, (AccFunc)accSqr_8u64f,
+    (AccFunc)accSqr_16u32f, (AccFunc)accSqr_16u64f,
+    (AccFunc)accSqr_32f, (AccFunc)accSqr_32f64f,
+    (AccFunc)accSqr_64f
+};
+
+static AccProdFunc accProdTab[CV_DEPTH_MAX] =
+{
+    (AccProdFunc)accProd_8u32f, (AccProdFunc)accProd_8u64f,
+    (AccProdFunc)accProd_16u32f, (AccProdFunc)accProd_16u64f,
+    (AccProdFunc)accProd_32f, (AccProdFunc)accProd_32f64f,
+    (AccProdFunc)accProd_64f
+};
+
+static AccWFunc accWTab[CV_DEPTH_MAX] =
+{
+    (AccWFunc)accW_8u32f, (AccWFunc)accW_8u64f,
+    (AccWFunc)accW_16u32f, (AccWFunc)accW_16u64f,
+    (AccWFunc)accW_32f, (AccWFunc)accW_32f64f,
+    (AccWFunc)accW_64f
+};
+
+inline int getAccTabIdx(int sdepth, int ddepth)
+{
+    return sdepth == CV_8U && ddepth == CV_32F ? 0 :
+           sdepth == CV_8U && ddepth == CV_64F ? 1 :
+           sdepth == CV_16U && ddepth == CV_32F ? 2 :
+           sdepth == CV_16U && ddepth == CV_64F ? 3 :
+           sdepth == CV_32F && ddepth == CV_32F ? 4 :
+           sdepth == CV_32F && ddepth == CV_64F ? 5 :
+           sdepth == CV_64F && ddepth == CV_64F ? 6 : -1;
+}
+
+#ifdef HAVE_OPENCL
+
+enum
+{
+    ACCUMULATE = 0,
+    ACCUMULATE_SQUARE = 1,
+    ACCUMULATE_PRODUCT = 2,
+    ACCUMULATE_WEIGHTED = 3
+};
+
+static bool ocl_accumulate( InputArray _src, InputArray _src2, InputOutputArray _dst, double alpha,
+                            InputArray _mask, int op_type )
+{
+    CV_Assert(op_type == ACCUMULATE || op_type == ACCUMULATE_SQUARE ||
+              op_type == ACCUMULATE_PRODUCT || op_type == ACCUMULATE_WEIGHTED);
+
+    const ocl::Device & dev = ocl::Device::getDefault();
+    bool haveMask = !_mask.empty(), doubleSupport = dev.doubleFPConfig() > 0;
+    int stype = _src.type(), sdepth = CV_MAT_DEPTH(stype), cn = CV_MAT_CN(stype), ddepth = _dst.depth();
+    int kercn = haveMask ? cn : ocl::predictOptimalVectorWidthMax(_src, _src2, _dst), rowsPerWI = dev.isIntel() ? 4 : 1;
+
+    if (!doubleSupport && (sdepth == CV_64F || ddepth == CV_64F))
+        return false;
+
+    const char * const opMap[4] = { "ACCUMULATE", "ACCUMULATE_SQUARE", "ACCUMULATE_PRODUCT",
+                                   "ACCUMULATE_WEIGHTED" };
+
+    char cvt[50];
+    ocl::Kernel k("accumulate", ocl::ximgproc::accumulate_oclsrc,
+                  format("-D %s%s -D srcT1=%s -D cn=%d -D dstT1=%s%s -D rowsPerWI=%d -D convertToDT=%s",
+                         opMap[op_type], haveMask ? " -D HAVE_MASK" : "",
+                         ocl::typeToStr(sdepth), kercn, ocl::typeToStr(ddepth),
+                         doubleSupport ? " -D DOUBLE_SUPPORT" : "", rowsPerWI,
+                         ocl::convertTypeStr(sdepth, ddepth, 1, cvt, sizeof(cvt))));
+    if (k.empty())
+        return false;
+
+    UMat src = _src.getUMat(), src2 = _src2.getUMat(), dst = _dst.getUMat(), mask = _mask.getUMat();
+
+    ocl::KernelArg srcarg = ocl::KernelArg::ReadOnlyNoSize(src),
+            src2arg = ocl::KernelArg::ReadOnlyNoSize(src2),
+            dstarg = ocl::KernelArg::ReadWrite(dst, cn, kercn),
+            maskarg = ocl::KernelArg::ReadOnlyNoSize(mask);
+
+    int argidx = k.set(0, srcarg);
+    if (op_type == ACCUMULATE_PRODUCT)
+        argidx = k.set(argidx, src2arg);
+    argidx = k.set(argidx, dstarg);
+    if (op_type == ACCUMULATE_WEIGHTED)
+    {
+        if (ddepth == CV_32F)
+            argidx = k.set(argidx, (float)alpha);
+        else
+            argidx = k.set(argidx, alpha);
+    }
+    if (haveMask)
+        k.set(argidx, maskarg);
+
+    size_t globalsize[2] = { (size_t)src.cols * cn / kercn, ((size_t)src.rows + rowsPerWI - 1) / rowsPerWI };
+    return k.run(2, globalsize, NULL, false);
+}
+
+#endif
+
+}
+
+#if defined(HAVE_IPP)
+namespace cv
+{
+static bool ipp_accumulate(InputArray _src, InputOutputArray _dst, InputArray _mask)
+{
+    CV_INSTRUMENT_REGION_IPP();
+
+    int stype = _src.type(), sdepth = CV_MAT_DEPTH(stype), scn = CV_MAT_CN(stype);
+    int dtype = _dst.type(), ddepth = CV_MAT_DEPTH(dtype);
+
+    Mat src = _src.getMat(), dst = _dst.getMat(), mask = _mask.getMat();
+
+    if (src.dims <= 2 || (src.isContinuous() && dst.isContinuous() && (mask.empty() || mask.isContinuous())))
+    {
+        typedef IppStatus (CV_STDCALL * IppiAdd)(const void * pSrc, int srcStep, Ipp32f * pSrcDst, int srcdstStep, IppiSize roiSize);
+        typedef IppStatus (CV_STDCALL * IppiAddMask)(const void * pSrc, int srcStep, const Ipp8u * pMask, int maskStep, Ipp32f * pSrcDst,
+                                                    int srcDstStep, IppiSize roiSize);
+        IppiAdd ippiAdd_I = 0;
+        IppiAddMask ippiAdd_IM = 0;
+
+        if (mask.empty())
+        {
+            CV_SUPPRESS_DEPRECATED_START
+            ippiAdd_I = sdepth == CV_8U && ddepth == CV_32F ? (IppiAdd)ippiAdd_8u32f_C1IR :
+                sdepth == CV_16U && ddepth == CV_32F ? (IppiAdd)ippiAdd_16u32f_C1IR :
+                sdepth == CV_32F && ddepth == CV_32F ? (IppiAdd)ippiAdd_32f_C1IR : 0;
+            CV_SUPPRESS_DEPRECATED_END
+        }
+        else if (scn == 1)
+        {
+            ippiAdd_IM = sdepth == CV_8U && ddepth == CV_32F ? (IppiAddMask)ippiAdd_8u32f_C1IMR :
+                sdepth == CV_16U && ddepth == CV_32F ? (IppiAddMask)ippiAdd_16u32f_C1IMR :
+                sdepth == CV_32F && ddepth == CV_32F ? (IppiAddMask)ippiAdd_32f_C1IMR : 0;
+        }
+
+        if (ippiAdd_I || ippiAdd_IM)
+        {
+            IppStatus status = ippStsErr;
+
+            Size size = src.size();
+            int srcstep = (int)src.step, dststep = (int)dst.step, maskstep = (int)mask.step;
+            if (src.isContinuous() && dst.isContinuous() && mask.isContinuous())
+            {
+                srcstep = static_cast<int>(src.total() * src.elemSize());
+                dststep = static_cast<int>(dst.total() * dst.elemSize());
+                maskstep = static_cast<int>(mask.total() * mask.elemSize());
+                size.width = static_cast<int>(src.total());
+                size.height = 1;
+            }
+            size.width *= scn;
+
+            if (ippiAdd_I)
+                status = CV_INSTRUMENT_FUN_IPP(ippiAdd_I, src.ptr(), srcstep, dst.ptr<Ipp32f>(), dststep, ippiSize(size.width, size.height));
+            else if (ippiAdd_IM)
+                status = CV_INSTRUMENT_FUN_IPP(ippiAdd_IM, src.ptr(), srcstep, mask.ptr<Ipp8u>(), maskstep,
+                    dst.ptr<Ipp32f>(), dststep, ippiSize(size.width, size.height));
+
+            if (status >= 0)
+                return true;
+        }
+    }
+    return false;
+}
+}
+#endif
+
+void cv::ximgproc::accumulate( InputArray _src, InputOutputArray _dst, InputArray _mask )
+{
+    CV_INSTRUMENT_REGION();
+
+    int stype = _src.type(), sdepth = CV_MAT_DEPTH(stype), scn = CV_MAT_CN(stype);
+    int dtype = _dst.type(), ddepth = CV_MAT_DEPTH(dtype), dcn = CV_MAT_CN(dtype);
+
+    CV_Assert( _src.sameSize(_dst) && dcn == scn );
+    CV_Assert( _mask.empty() || (_src.sameSize(_mask) && (_mask.type() == CV_8U || _mask.type() == CV_Bool)) );
+
+    CV_OCL_RUN(_src.dims() <= 2 && _dst.isUMat(),
+               ocl_accumulate(_src, noArray(), _dst, 0.0, _mask, ACCUMULATE))
+
+    CV_IPP_RUN((_src.dims() <= 2 || (_src.isContinuous() && _dst.isContinuous() && (_mask.empty() || _mask.isContinuous()))),
+        ipp_accumulate(_src, _dst, _mask));
+
+    Mat src = _src.getMat(), dst = _dst.getMat(), mask = _mask.getMat();
+
+
+    int fidx = getAccTabIdx(sdepth, ddepth);
+    AccFunc func = fidx >= 0 ? accTab[fidx] : 0;
+    CV_Assert( func != 0 );
+
+    const Mat* arrays[] = {&src, &dst, &mask, 0};
+    uchar* ptrs[3] = {};
+    NAryMatIterator it(arrays, ptrs);
+    int len = (int)it.size;
+
+    for( size_t i = 0; i < it.nplanes; i++, ++it )
+        func(ptrs[0], ptrs[1], ptrs[2], len, scn);
+}
+
+#if defined(HAVE_IPP)
+namespace cv
+{
+static bool ipp_accumulate_square(InputArray _src, InputOutputArray _dst, InputArray _mask)
+{
+    CV_INSTRUMENT_REGION_IPP();
+
+    int stype = _src.type(), sdepth = CV_MAT_DEPTH(stype), scn = CV_MAT_CN(stype);
+    int dtype = _dst.type(), ddepth = CV_MAT_DEPTH(dtype);
+
+    Mat src = _src.getMat(), dst = _dst.getMat(), mask = _mask.getMat();
+
+    if (src.dims <= 2 || (src.isContinuous() && dst.isContinuous() && (mask.empty() || mask.isContinuous())))
+    {
+        typedef IppStatus (CV_STDCALL * ippiAddSquare)(const void * pSrc, int srcStep, Ipp32f * pSrcDst, int srcdstStep, IppiSize roiSize);
+        typedef IppStatus (CV_STDCALL * ippiAddSquareMask)(const void * pSrc, int srcStep, const Ipp8u * pMask, int maskStep, Ipp32f * pSrcDst,
+                                                            int srcDstStep, IppiSize roiSize);
+        ippiAddSquare ippiAddSquare_I = 0;
+        ippiAddSquareMask ippiAddSquare_IM = 0;
+
+        if (mask.empty())
+        {
+            ippiAddSquare_I = sdepth == CV_8U && ddepth == CV_32F ? (ippiAddSquare)ippiAddSquare_8u32f_C1IR :
+                sdepth == CV_16U && ddepth == CV_32F ? (ippiAddSquare)ippiAddSquare_16u32f_C1IR :
+                sdepth == CV_32F && ddepth == CV_32F ? (ippiAddSquare)ippiAddSquare_32f_C1IR : 0;
+        }
+        else if (scn == 1)
+        {
+            ippiAddSquare_IM = sdepth == CV_8U && ddepth == CV_32F ? (ippiAddSquareMask)ippiAddSquare_8u32f_C1IMR :
+                sdepth == CV_16U && ddepth == CV_32F ? (ippiAddSquareMask)ippiAddSquare_16u32f_C1IMR :
+                sdepth == CV_32F && ddepth == CV_32F ? (ippiAddSquareMask)ippiAddSquare_32f_C1IMR : 0;
+        }
+
+        if (ippiAddSquare_I || ippiAddSquare_IM)
+        {
+            IppStatus status = ippStsErr;
+
+            Size size = src.size();
+            int srcstep = (int)src.step, dststep = (int)dst.step, maskstep = (int)mask.step;
+            if (src.isContinuous() && dst.isContinuous() && mask.isContinuous())
+            {
+                srcstep = static_cast<int>(src.total() * src.elemSize());
+                dststep = static_cast<int>(dst.total() * dst.elemSize());
+                maskstep = static_cast<int>(mask.total() * mask.elemSize());
+                size.width = static_cast<int>(src.total());
+                size.height = 1;
+            }
+            size.width *= scn;
+
+            if (ippiAddSquare_I)
+                status = CV_INSTRUMENT_FUN_IPP(ippiAddSquare_I, src.ptr(), srcstep, dst.ptr<Ipp32f>(), dststep, ippiSize(size.width, size.height));
+            else if (ippiAddSquare_IM)
+                status = CV_INSTRUMENT_FUN_IPP(ippiAddSquare_IM, src.ptr(), srcstep, mask.ptr<Ipp8u>(), maskstep,
+                    dst.ptr<Ipp32f>(), dststep, ippiSize(size.width, size.height));
+
+            if (status >= 0)
+                return true;
+        }
+    }
+    return false;
+}
+}
+#endif
+
+void cv::ximgproc::accumulateSquare( InputArray _src, InputOutputArray _dst, InputArray _mask )
+{
+    CV_INSTRUMENT_REGION();
+
+    int stype = _src.type(), sdepth = CV_MAT_DEPTH(stype), scn = CV_MAT_CN(stype);
+    int dtype = _dst.type(), ddepth = CV_MAT_DEPTH(dtype), dcn = CV_MAT_CN(dtype);
+
+    CV_Assert( _src.sameSize(_dst) && dcn == scn );
+    CV_Assert( _mask.empty() || (_src.sameSize(_mask) && (_mask.type() == CV_8U || _mask.type() == CV_Bool)) );
+
+    CV_OCL_RUN(_src.dims() <= 2 && _dst.isUMat(),
+               ocl_accumulate(_src, noArray(), _dst, 0.0, _mask, ACCUMULATE_SQUARE))
+
+    CV_IPP_RUN((_src.dims() <= 2 || (_src.isContinuous() && _dst.isContinuous() && (_mask.empty() || _mask.isContinuous()))),
+        ipp_accumulate_square(_src, _dst, _mask));
+
+    Mat src = _src.getMat(), dst = _dst.getMat(), mask = _mask.getMat();
+
+    int fidx = getAccTabIdx(sdepth, ddepth);
+    AccFunc func = fidx >= 0 ? accSqrTab[fidx] : 0;
+    CV_Assert( func != 0 );
+
+    const Mat* arrays[] = {&src, &dst, &mask, 0};
+    uchar* ptrs[3] = {};
+    NAryMatIterator it(arrays, ptrs);
+    int len = (int)it.size;
+
+    for( size_t i = 0; i < it.nplanes; i++, ++it )
+        func(ptrs[0], ptrs[1], ptrs[2], len, scn);
+}
+
+#if defined(HAVE_IPP)
+namespace cv
+{
+static bool ipp_accumulate_product(InputArray _src1, InputArray _src2,
+                            InputOutputArray _dst, InputArray _mask)
+{
+    CV_INSTRUMENT_REGION_IPP();
+
+    int stype = _src1.type(), sdepth = CV_MAT_DEPTH(stype), scn = CV_MAT_CN(stype);
+    int dtype = _dst.type(), ddepth = CV_MAT_DEPTH(dtype);
+
+    Mat src1 = _src1.getMat(), src2 = _src2.getMat(), dst = _dst.getMat(), mask = _mask.getMat();
+
+    if (src1.dims <= 2 || (src1.isContinuous() && src2.isContinuous() && dst.isContinuous()))
+    {
+        typedef IppStatus (CV_STDCALL * ippiAddProduct)(const void * pSrc1, int src1Step, const void * pSrc2,
+                                                        int src2Step, Ipp32f * pSrcDst, int srcDstStep, IppiSize roiSize);
+        typedef IppStatus (CV_STDCALL * ippiAddProductMask)(const void * pSrc1, int src1Step, const void * pSrc2, int src2Step,
+                                                            const Ipp8u * pMask, int maskStep, Ipp32f * pSrcDst, int srcDstStep, IppiSize roiSize);
+        ippiAddProduct ippiAddProduct_I = 0;
+        ippiAddProductMask ippiAddProduct_IM = 0;
+
+        if (mask.empty())
+        {
+            ippiAddProduct_I = sdepth == CV_8U && ddepth == CV_32F ? (ippiAddProduct)ippiAddProduct_8u32f_C1IR :
+                sdepth == CV_16U && ddepth == CV_32F ? (ippiAddProduct)ippiAddProduct_16u32f_C1IR :
+                sdepth == CV_32F && ddepth == CV_32F ? (ippiAddProduct)ippiAddProduct_32f_C1IR : 0;
+        }
+        else if (scn == 1)
+        {
+            ippiAddProduct_IM = sdepth == CV_8U && ddepth == CV_32F ? (ippiAddProductMask)ippiAddProduct_8u32f_C1IMR :
+                sdepth == CV_16U && ddepth == CV_32F ? (ippiAddProductMask)ippiAddProduct_16u32f_C1IMR :
+                sdepth == CV_32F && ddepth == CV_32F ? (ippiAddProductMask)ippiAddProduct_32f_C1IMR : 0;
+        }
+
+        if (ippiAddProduct_I || ippiAddProduct_IM)
+        {
+            IppStatus status = ippStsErr;
+
+            Size size = src1.size();
+            int src1step = (int)src1.step, src2step = (int)src2.step, dststep = (int)dst.step, maskstep = (int)mask.step;
+            if (src1.isContinuous() && src2.isContinuous() && dst.isContinuous() && mask.isContinuous())
+            {
+                src1step = static_cast<int>(src1.total() * src1.elemSize());
+                src2step = static_cast<int>(src2.total() * src2.elemSize());
+                dststep = static_cast<int>(dst.total() * dst.elemSize());
+                maskstep = static_cast<int>(mask.total() * mask.elemSize());
+                size.width = static_cast<int>(src1.total());
+                size.height = 1;
+            }
+            size.width *= scn;
+
+            if (ippiAddProduct_I)
+                status = CV_INSTRUMENT_FUN_IPP(ippiAddProduct_I, src1.ptr(), src1step, src2.ptr(), src2step, dst.ptr<Ipp32f>(),
+                    dststep, ippiSize(size.width, size.height));
+            else if (ippiAddProduct_IM)
+                status = CV_INSTRUMENT_FUN_IPP(ippiAddProduct_IM, src1.ptr(), src1step, src2.ptr(), src2step, mask.ptr<Ipp8u>(), maskstep,
+                    dst.ptr<Ipp32f>(), dststep, ippiSize(size.width, size.height));
+
+            if (status >= 0)
+                return true;
+        }
+    }
+    return false;
+}
+}
+#endif
+
+
+
+void cv::ximgproc::accumulateProduct( InputArray _src1, InputArray _src2,
+                            InputOutputArray _dst, InputArray _mask )
+{
+    CV_INSTRUMENT_REGION();
+
+    int stype = _src1.type(), sdepth = CV_MAT_DEPTH(stype), scn = CV_MAT_CN(stype);
+    int dtype = _dst.type(), ddepth = CV_MAT_DEPTH(dtype), dcn = CV_MAT_CN(dtype);
+
+    CV_Assert( _src1.sameSize(_src2) && stype == _src2.type() );
+    CV_Assert( _src1.sameSize(_dst) && dcn == scn );
+    CV_Assert( _mask.empty() || (_src1.sameSize(_mask) && (_mask.type() == CV_8U || _mask.type() == CV_Bool)) );
+
+    CV_OCL_RUN(_src1.dims() <= 2 && _dst.isUMat(),
+               ocl_accumulate(_src1, _src2, _dst, 0.0, _mask, ACCUMULATE_PRODUCT))
+
+    CV_IPP_RUN( (_src1.dims() <= 2 || (_src1.isContinuous() && _src2.isContinuous() && _dst.isContinuous())),
+        ipp_accumulate_product(_src1, _src2, _dst, _mask));
+
+    Mat src1 = _src1.getMat(), src2 = _src2.getMat(), dst = _dst.getMat(), mask = _mask.getMat();
+
+    int fidx = getAccTabIdx(sdepth, ddepth);
+    AccProdFunc func = fidx >= 0 ? accProdTab[fidx] : 0;
+    CV_Assert( func != 0 );
+
+    const Mat* arrays[] = {&src1, &src2, &dst, &mask, 0};
+    uchar* ptrs[4] = {};
+    NAryMatIterator it(arrays, ptrs);
+    int len = (int)it.size;
+
+    for( size_t i = 0; i < it.nplanes; i++, ++it )
+        func(ptrs[0], ptrs[1], ptrs[2], ptrs[3], len, scn);
+}
+
+#if defined(HAVE_IPP)
+namespace cv
+{
+static bool ipp_accumulate_weighted( InputArray _src, InputOutputArray _dst,
+                             double alpha, InputArray _mask )
+{
+    CV_INSTRUMENT_REGION_IPP();
+
+    int stype = _src.type(), sdepth = CV_MAT_DEPTH(stype), scn = CV_MAT_CN(stype);
+    int dtype = _dst.type(), ddepth = CV_MAT_DEPTH(dtype);
+
+    Mat src = _src.getMat(), dst = _dst.getMat(), mask = _mask.getMat();
+
+    if (src.dims <= 2 || (src.isContinuous() && dst.isContinuous() && mask.isContinuous()))
+    {
+        typedef IppStatus (CV_STDCALL * ippiAddWeighted)(const void * pSrc, int srcStep, Ipp32f * pSrcDst, int srcdstStep,
+                                                            IppiSize roiSize, Ipp32f alpha);
+        typedef IppStatus (CV_STDCALL * ippiAddWeightedMask)(const void * pSrc, int srcStep, const Ipp8u * pMask,
+                                                                int maskStep, Ipp32f * pSrcDst,
+                                                                int srcDstStep, IppiSize roiSize, Ipp32f alpha);
+        ippiAddWeighted ippiAddWeighted_I = 0;
+        ippiAddWeightedMask ippiAddWeighted_IM = 0;
+
+        if (mask.empty())
+        {
+            ippiAddWeighted_I = sdepth == CV_8U && ddepth == CV_32F ? (ippiAddWeighted)ippiAddWeighted_8u32f_C1IR :
+                sdepth == CV_16U && ddepth == CV_32F ? (ippiAddWeighted)ippiAddWeighted_16u32f_C1IR :
+                sdepth == CV_32F && ddepth == CV_32F ? (ippiAddWeighted)ippiAddWeighted_32f_C1IR : 0;
+        }
+        else if (scn == 1)
+        {
+            ippiAddWeighted_IM = sdepth == CV_8U && ddepth == CV_32F ? (ippiAddWeightedMask)ippiAddWeighted_8u32f_C1IMR :
+                sdepth == CV_16U && ddepth == CV_32F ? (ippiAddWeightedMask)ippiAddWeighted_16u32f_C1IMR :
+                sdepth == CV_32F && ddepth == CV_32F ? (ippiAddWeightedMask)ippiAddWeighted_32f_C1IMR : 0;
+        }
+
+        if (ippiAddWeighted_I || ippiAddWeighted_IM)
+        {
+            IppStatus status = ippStsErr;
+
+            Size size = src.size();
+            int srcstep = (int)src.step, dststep = (int)dst.step, maskstep = (int)mask.step;
+            if (src.isContinuous() && dst.isContinuous() && mask.isContinuous())
+            {
+                srcstep = static_cast<int>(src.total() * src.elemSize());
+                dststep = static_cast<int>(dst.total() * dst.elemSize());
+                maskstep = static_cast<int>(mask.total() * mask.elemSize());
+                size.width = static_cast<int>((int)src.total());
+                size.height = 1;
+            }
+            size.width *= scn;
+
+            if (ippiAddWeighted_I)
+                status = CV_INSTRUMENT_FUN_IPP(ippiAddWeighted_I, src.ptr(), srcstep, dst.ptr<Ipp32f>(), dststep, ippiSize(size.width, size.height), (Ipp32f)alpha);
+            else if (ippiAddWeighted_IM)
+                status = CV_INSTRUMENT_FUN_IPP(ippiAddWeighted_IM, src.ptr(), srcstep, mask.ptr<Ipp8u>(), maskstep,
+                    dst.ptr<Ipp32f>(), dststep, ippiSize(size.width, size.height), (Ipp32f)alpha);
+
+            if (status >= 0)
+                return true;
+        }
+    }
+    return false;
+}
+}
+#endif
+
+void cv::ximgproc::accumulateWeighted( InputArray _src, InputOutputArray _dst,
+                             double alpha, InputArray _mask )
+{
+    CV_INSTRUMENT_REGION();
+
+    int stype = _src.type(), sdepth = CV_MAT_DEPTH(stype), scn = CV_MAT_CN(stype);
+    int dtype = _dst.type(), ddepth = CV_MAT_DEPTH(dtype), dcn = CV_MAT_CN(dtype);
+
+    CV_Assert( _src.sameSize(_dst) && dcn == scn );
+    CV_Assert( _mask.empty() || (_src.sameSize(_mask) && (_mask.type() == CV_8U || _mask.type() == CV_Bool)) );
+
+    CV_OCL_RUN(_src.dims() <= 2 && _dst.isUMat(),
+               ocl_accumulate(_src, noArray(), _dst, alpha, _mask, ACCUMULATE_WEIGHTED))
+
+    CV_IPP_RUN((_src.dims() <= 2 || (_src.isContinuous() && _dst.isContinuous() && _mask.isContinuous())), ipp_accumulate_weighted(_src, _dst, alpha, _mask));
+
+    Mat src = _src.getMat(), dst = _dst.getMat(), mask = _mask.getMat();
+
+
+    int fidx = getAccTabIdx(sdepth, ddepth);
+    AccWFunc func = fidx >= 0 ? accWTab[fidx] : 0;
+    CV_Assert( func != 0 );
+
+    const Mat* arrays[] = {&src, &dst, &mask, 0};
+    uchar* ptrs[3] = {};
+    NAryMatIterator it(arrays, ptrs);
+    int len = (int)it.size;
+
+    for( size_t i = 0; i < it.nplanes; i++, ++it )
+        func(ptrs[0], ptrs[1], ptrs[2], len, scn, alpha);
+}
+
+
+
+/* End of file. */

--- a/modules/ximgproc/src/accum.cpp
+++ b/modules/ximgproc/src/accum.cpp
@@ -51,40 +51,40 @@
 namespace cv
 {
 
-typedef void(*AccFunc)(const uchar*, uchar*, const uchar*, int, int);
-typedef void(*AccProdFunc)(const uchar*, const uchar*, uchar*, const uchar*, int, int);
-typedef void(*AccWFunc)(const uchar*, uchar*, const uchar*, int, int, double);
+using AccFunc = void(*)(const uchar*, uchar*, const uchar*, int, int);
+using AccProdFunc = void(*)(const uchar*, const uchar*, uchar*, const uchar*, int, int);
+using AccWFunc = void(*)(const uchar*, uchar*, const uchar*, int, int, double);
 
 static AccFunc accTab[CV_DEPTH_MAX] =
 {
-    (AccFunc)acc_8u32f, (AccFunc)acc_8u64f,
-    (AccFunc)acc_16u32f, (AccFunc)acc_16u64f,
-    (AccFunc)acc_32f, (AccFunc)acc_32f64f,
-    (AccFunc)acc_64f
+    reinterpret_cast<AccFunc>(acc_8u32f), reinterpret_cast<AccFunc>(acc_8u64f),
+    reinterpret_cast<AccFunc>(acc_16u32f), reinterpret_cast<AccFunc>(acc_16u64f),
+    reinterpret_cast<AccFunc>(acc_32f), reinterpret_cast<AccFunc>(acc_32f64f),
+    reinterpret_cast<AccFunc>(acc_64f)
 };
 
 static AccFunc accSqrTab[CV_DEPTH_MAX] =
 {
-    (AccFunc)accSqr_8u32f, (AccFunc)accSqr_8u64f,
-    (AccFunc)accSqr_16u32f, (AccFunc)accSqr_16u64f,
-    (AccFunc)accSqr_32f, (AccFunc)accSqr_32f64f,
-    (AccFunc)accSqr_64f
+    reinterpret_cast<AccFunc>(accSqr_8u32f), reinterpret_cast<AccFunc>(accSqr_8u64f),
+    reinterpret_cast<AccFunc>(accSqr_16u32f), reinterpret_cast<AccFunc>(accSqr_16u64f),
+    reinterpret_cast<AccFunc>(accSqr_32f), reinterpret_cast<AccFunc>(accSqr_32f64f),
+    reinterpret_cast<AccFunc>(accSqr_64f)
 };
 
 static AccProdFunc accProdTab[CV_DEPTH_MAX] =
 {
-    (AccProdFunc)accProd_8u32f, (AccProdFunc)accProd_8u64f,
-    (AccProdFunc)accProd_16u32f, (AccProdFunc)accProd_16u64f,
-    (AccProdFunc)accProd_32f, (AccProdFunc)accProd_32f64f,
-    (AccProdFunc)accProd_64f
+    reinterpret_cast<AccProdFunc>(accProd_8u32f), reinterpret_cast<AccProdFunc>(accProd_8u64f),
+    reinterpret_cast<AccProdFunc>(accProd_16u32f), reinterpret_cast<AccProdFunc>(accProd_16u64f),
+    reinterpret_cast<AccProdFunc>(accProd_32f), reinterpret_cast<AccProdFunc>(accProd_32f64f),
+    reinterpret_cast<AccProdFunc>(accProd_64f)
 };
 
 static AccWFunc accWTab[CV_DEPTH_MAX] =
 {
-    (AccWFunc)accW_8u32f, (AccWFunc)accW_8u64f,
-    (AccWFunc)accW_16u32f, (AccWFunc)accW_16u64f,
-    (AccWFunc)accW_32f, (AccWFunc)accW_32f64f,
-    (AccWFunc)accW_64f
+    reinterpret_cast<AccWFunc>(accW_8u32f), reinterpret_cast<AccWFunc>(accW_8u64f),
+    reinterpret_cast<AccWFunc>(accW_16u32f), reinterpret_cast<AccWFunc>(accW_16u64f),
+    reinterpret_cast<AccWFunc>(accW_32f), reinterpret_cast<AccWFunc>(accW_32f64f),
+    reinterpret_cast<AccWFunc>(accW_64f)
 };
 
 inline int getAccTabIdx(int sdepth, int ddepth)
@@ -157,7 +157,7 @@ static bool ocl_accumulate( InputArray _src, InputArray _src2, InputOutputArray 
         k.set(argidx, maskarg);
 
     size_t globalsize[2] = { (size_t)src.cols * cn / kercn, ((size_t)src.rows + rowsPerWI - 1) / rowsPerWI };
-    return k.run(2, globalsize, NULL, false);
+    return k.run(2, globalsize, nullptr, false);
 }
 
 #endif
@@ -250,8 +250,8 @@ void cv::ximgproc::accumulate( InputArray _src, InputOutputArray _dst, InputArra
 
 
     int fidx = getAccTabIdx(sdepth, ddepth);
-    AccFunc func = fidx >= 0 ? accTab[fidx] : 0;
-    CV_Assert( func != 0 );
+    AccFunc func = fidx >= 0 ? accTab[fidx] : nullptr;
+    CV_Assert( func != nullptr );
 
     const Mat* arrays[] = {&src, &dst, &mask, 0};
     uchar* ptrs[3] = {};
@@ -345,8 +345,8 @@ void cv::ximgproc::accumulateSquare( InputArray _src, InputOutputArray _dst, Inp
     Mat src = _src.getMat(), dst = _dst.getMat(), mask = _mask.getMat();
 
     int fidx = getAccTabIdx(sdepth, ddepth);
-    AccFunc func = fidx >= 0 ? accSqrTab[fidx] : 0;
-    CV_Assert( func != 0 );
+    AccFunc func = fidx >= 0 ? accSqrTab[fidx] : nullptr;
+    CV_Assert( func != nullptr );
 
     const Mat* arrays[] = {&src, &dst, &mask, 0};
     uchar* ptrs[3] = {};
@@ -448,8 +448,8 @@ void cv::ximgproc::accumulateProduct( InputArray _src1, InputArray _src2,
     Mat src1 = _src1.getMat(), src2 = _src2.getMat(), dst = _dst.getMat(), mask = _mask.getMat();
 
     int fidx = getAccTabIdx(sdepth, ddepth);
-    AccProdFunc func = fidx >= 0 ? accProdTab[fidx] : 0;
-    CV_Assert( func != 0 );
+    AccProdFunc func = fidx >= 0 ? accProdTab[fidx] : nullptr;
+    CV_Assert( func != nullptr );
 
     const Mat* arrays[] = {&src1, &src2, &dst, &mask, 0};
     uchar* ptrs[4] = {};
@@ -547,8 +547,8 @@ void cv::ximgproc::accumulateWeighted( InputArray _src, InputOutputArray _dst,
 
 
     int fidx = getAccTabIdx(sdepth, ddepth);
-    AccWFunc func = fidx >= 0 ? accWTab[fidx] : 0;
-    CV_Assert( func != 0 );
+    AccWFunc func = fidx >= 0 ? accWTab[fidx] : nullptr;
+    CV_Assert( func != nullptr );
 
     const Mat* arrays[] = {&src, &dst, &mask, 0};
     uchar* ptrs[3] = {};

--- a/modules/ximgproc/src/accum.dispatch.cpp
+++ b/modules/ximgproc/src/accum.dispatch.cpp
@@ -1,0 +1,20 @@
+ // This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "precomp.hpp"
+
+#include "accum.simd.hpp"
+#include "accum.simd_declarations.hpp" // defines CV_CPU_DISPATCH_MODES_ALL=AVX2,...,BASELINE based on CMakeLists.txt content
+
+namespace cv {
+
+DEF_ACC_INT_FUNCS(8u32f, uchar, float)
+DEF_ACC_INT_FUNCS(8u64f, uchar, double)
+DEF_ACC_INT_FUNCS(16u32f, ushort, float)
+DEF_ACC_INT_FUNCS(16u64f, ushort, double)
+DEF_ACC_FLT_FUNCS(32f, float, float)
+DEF_ACC_FLT_FUNCS(32f64f, float, double)
+DEF_ACC_FLT_FUNCS(64f, double, double)
+
+} //cv::hal

--- a/modules/ximgproc/src/accum.dispatch.cpp
+++ b/modules/ximgproc/src/accum.dispatch.cpp
@@ -17,4 +17,4 @@ DEF_ACC_FLT_FUNCS(32f, float, float)
 DEF_ACC_FLT_FUNCS(32f64f, float, double)
 DEF_ACC_FLT_FUNCS(64f, double, double)
 
-} //cv::hal
+} // namespace cv

--- a/modules/ximgproc/src/accum.simd.hpp
+++ b/modules/ximgproc/src/accum.simd.hpp
@@ -1,0 +1,3273 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "opencv2/core/hal/intrin.hpp"
+
+#define DEF_ACC_INT_FUNCS(suffix, type, acctype) \
+void acc_##suffix(const type* src, acctype* dst, \
+                         const uchar* mask, int len, int cn) \
+{ \
+    CV_CPU_DISPATCH(acc_simd_, (src, dst, mask, len, cn),  CV_CPU_DISPATCH_MODES_ALL); \
+} \
+void accSqr_##suffix(const type* src, acctype* dst, \
+                            const uchar* mask, int len, int cn) \
+{ \
+    CV_CPU_DISPATCH(accSqr_simd_, (src, dst, mask, len, cn),  CV_CPU_DISPATCH_MODES_ALL); \
+} \
+void accProd_##suffix(const type* src1, const type* src2, \
+                             acctype* dst, const uchar* mask, int len, int cn) \
+{ \
+    CV_CPU_DISPATCH(accProd_simd_, (src1, src2, dst, mask, len, cn),  CV_CPU_DISPATCH_MODES_ALL); \
+} \
+void accW_##suffix(const type* src, acctype* dst, \
+                          const uchar* mask, int len, int cn, double alpha) \
+{ \
+    CV_CPU_DISPATCH(accW_simd_, (src, dst, mask, len, cn, alpha),  CV_CPU_DISPATCH_MODES_ALL); \
+}
+#define DEF_ACC_FLT_FUNCS(suffix, type, acctype) \
+void acc_##suffix(const type* src, acctype* dst, \
+                         const uchar* mask, int len, int cn) \
+{ \
+    CV_CPU_DISPATCH(acc_simd_, (src, dst, mask, len, cn),  CV_CPU_DISPATCH_MODES_ALL); \
+} \
+void accSqr_##suffix(const type* src, acctype* dst, \
+                            const uchar* mask, int len, int cn) \
+{ \
+    CV_CPU_DISPATCH(accSqr_simd_, (src, dst, mask, len, cn),  CV_CPU_DISPATCH_MODES_ALL); \
+} \
+void accProd_##suffix(const type* src1, const type* src2, \
+                             acctype* dst, const uchar* mask, int len, int cn) \
+{ \
+    CV_CPU_DISPATCH(accProd_simd_, (src1, src2, dst, mask, len, cn),  CV_CPU_DISPATCH_MODES_ALL); \
+} \
+void accW_##suffix(const type* src, acctype* dst, \
+                          const uchar* mask, int len, int cn, double alpha) \
+{ \
+    CV_CPU_DISPATCH(accW_simd_, (src, dst, mask, len, cn, alpha),  CV_CPU_DISPATCH_MODES_ALL); \
+}
+#define DECLARATE_ACC_FUNCS(suffix, type, acctype) \
+void acc_##suffix(const type* src, acctype* dst, const uchar* mask, int len, int cn); \
+void accSqr_##suffix(const type* src, acctype* dst, const uchar* mask, int len, int cn); \
+void accProd_##suffix(const type* src1, const type* src2, acctype* dst, const uchar* mask, int len, int cn); \
+void accW_##suffix(const type* src, acctype* dst, const uchar* mask, int len, int cn, double alpha);
+
+
+namespace cv {
+
+DECLARATE_ACC_FUNCS(8u32f, uchar, float)
+DECLARATE_ACC_FUNCS(8u64f, uchar, double)
+DECLARATE_ACC_FUNCS(16u32f, ushort, float)
+DECLARATE_ACC_FUNCS(16u64f, ushort, double)
+DECLARATE_ACC_FUNCS(32f, float, float)
+DECLARATE_ACC_FUNCS(32f64f, float, double)
+DECLARATE_ACC_FUNCS(64f, double, double)
+
+CV_CPU_OPTIMIZATION_NAMESPACE_BEGIN
+
+void acc_simd_(const uchar* src, float* dst, const uchar* mask, int len, int cn);
+void acc_simd_(const ushort* src, float* dst, const uchar* mask, int len, int cn);
+void acc_simd_(const uchar* src, double* dst, const uchar* mask, int len, int cn);
+void acc_simd_(const ushort* src, double* dst, const uchar* mask, int len, int cn);
+void acc_simd_(const float* src, float* dst, const uchar* mask, int len, int cn);
+void acc_simd_(const float* src, double* dst, const uchar* mask, int len, int cn);
+void acc_simd_(const double* src, double* dst, const uchar* mask, int len, int cn);
+void accSqr_simd_(const uchar* src, float* dst, const uchar* mask, int len, int cn);
+void accSqr_simd_(const ushort* src, float* dst, const uchar* mask, int len, int cn);
+void accSqr_simd_(const uchar* src, double* dst, const uchar* mask, int len, int cn);
+void accSqr_simd_(const ushort* src, double* dst, const uchar* mask, int len, int cn);
+void accSqr_simd_(const float* src, float* dst, const uchar* mask, int len, int cn);
+void accSqr_simd_(const float* src, double* dst, const uchar* mask, int len, int cn);
+void accSqr_simd_(const double* src, double* dst, const uchar* mask, int len, int cn);
+void accProd_simd_(const uchar* src1, const uchar* src2, float* dst, const uchar* mask, int len, int cn);
+void accProd_simd_(const ushort* src1, const ushort* src2, float* dst, const uchar* mask, int len, int cn);
+void accProd_simd_(const uchar* src1, const uchar* src2, double* dst, const uchar* mask, int len, int cn);
+void accProd_simd_(const ushort* src1, const ushort* src2, double* dst, const uchar* mask, int len, int cn);
+void accProd_simd_(const float* src1, const float* src2, float* dst, const uchar* mask, int len, int cn);
+void accProd_simd_(const float* src1, const float* src2, double* dst, const uchar* mask, int len, int cn);
+void accProd_simd_(const double* src1, const double* src2, double* dst, const uchar* mask, int len, int cn);
+void accW_simd_(const uchar* src, float* dst, const uchar* mask, int len, int cn, double alpha);
+void accW_simd_(const ushort* src, float* dst, const uchar* mask, int len, int cn, double alpha);
+void accW_simd_(const uchar* src, double* dst, const uchar* mask, int len, int cn, double alpha);
+void accW_simd_(const ushort* src, double* dst, const uchar* mask, int len, int cn, double alpha);
+void accW_simd_(const float* src, float* dst, const uchar* mask, int len, int cn, double alpha);
+void accW_simd_(const float* src, double* dst, const uchar* mask, int len, int cn, double alpha);
+void accW_simd_(const double* src, double* dst, const uchar* mask, int len, int cn, double alpha);
+
+#ifndef CV_CPU_OPTIMIZATION_DECLARATIONS_ONLY
+// todo: remove AVX branch after support it by universal intrinsics
+template <typename T, typename AT>
+void acc_general_(const T* src, AT* dst, const uchar* mask, int len, int cn, int start = 0 )
+{
+    int i = start;
+
+    if( !mask )
+    {
+        len *= cn;
+        #if CV_ENABLE_UNROLLED
+        for( ; i <= len - 4; i += 4 )
+        {
+            AT t0, t1;
+            t0 = src[i] + dst[i];
+            t1 = src[i+1] + dst[i+1];
+            dst[i] = t0; dst[i+1] = t1;
+
+            t0 = src[i+2] + dst[i+2];
+            t1 = src[i+3] + dst[i+3];
+            dst[i+2] = t0; dst[i+3] = t1;
+        }
+        #endif
+        for( ; i < len; i++ )
+        {
+            dst[i] += src[i];
+        }
+    }
+    else
+    {
+        src += (i * cn);
+        dst += (i * cn);
+        for( ; i < len; i++, src += cn, dst += cn )
+        {
+            if( mask[i] )
+            {
+                for( int k = 0; k < cn; k++ )
+                {
+                    dst[k] += src[k];
+                }
+            }
+        }
+    }
+#if CV_AVX && !CV_AVX2
+    _mm256_zeroupper();
+#elif (CV_SIMD || CV_SIMD_SCALABLE)
+    vx_cleanup();
+#endif
+}
+
+template<typename T, typename AT> void
+accSqr_general_( const T* src, AT* dst, const uchar* mask, int len, int cn, int start = 0 )
+{
+    int i = start;
+
+    if( !mask )
+    {
+        len *= cn;
+        #if CV_ENABLE_UNROLLED
+        for( ; i <= len - 4; i += 4 )
+        {
+            AT t0, t1;
+            t0 = (AT)src[i]*src[i] + dst[i];
+            t1 = (AT)src[i+1]*src[i+1] + dst[i+1];
+            dst[i] = t0; dst[i+1] = t1;
+
+            t0 = (AT)src[i+2]*src[i+2] + dst[i+2];
+            t1 = (AT)src[i+3]*src[i+3] + dst[i+3];
+            dst[i+2] = t0; dst[i+3] = t1;
+        }
+        #endif
+        for( ; i < len; i++ )
+        {
+            dst[i] += (AT)src[i]*src[i];
+        }
+    }
+    else
+    {
+        src += (i * cn);
+        dst += (i * cn);
+        for( ; i < len; i++, src += cn, dst += cn )
+        {
+            if( mask[i] )
+            {
+                for( int k = 0; k < cn; k++ )
+                {
+                    dst[k] += (AT)src[k]*src[k];
+                }
+            }
+        }
+    }
+#if CV_AVX && !CV_AVX2
+    _mm256_zeroupper();
+#elif (CV_SIMD || CV_SIMD_SCALABLE)
+    vx_cleanup();
+#endif
+}
+
+template<typename T, typename AT> void
+accProd_general_( const T* src1, const T* src2, AT* dst, const uchar* mask, int len, int cn, int start = 0 )
+{
+    int i = start;
+
+    if( !mask )
+    {
+        len *= cn;
+        #if CV_ENABLE_UNROLLED
+        for( ; i <= len - 4; i += 4 )
+        {
+            AT t0, t1;
+            t0 = (AT)src1[i]*src2[i] + dst[i];
+            t1 = (AT)src1[i+1]*src2[i+1] + dst[i+1];
+            dst[i] = t0; dst[i+1] = t1;
+
+            t0 = (AT)src1[i+2]*src2[i+2] + dst[i+2];
+            t1 = (AT)src1[i+3]*src2[i+3] + dst[i+3];
+            dst[i+2] = t0; dst[i+3] = t1;
+        }
+        #endif
+        for( ; i < len; i++ )
+        {
+            dst[i] += (AT)src1[i]*src2[i];
+        }
+    }
+    else
+    {
+        src1 += (i * cn);
+        src2 += (i * cn);
+        dst += (i * cn);
+        for( ; i < len; i++, src1 += cn, src2 += cn, dst += cn )
+        {
+            if( mask[i] )
+            {
+                for( int k = 0; k < cn; k++ )
+                {
+                    dst[k] += (AT)src1[k]*src2[k];
+                }
+            }
+        }
+    }
+#if CV_AVX && !CV_AVX2
+    _mm256_zeroupper();
+#elif (CV_SIMD || CV_SIMD_SCALABLE)
+    vx_cleanup();
+#endif
+}
+
+template<typename T, typename AT> void
+accW_general_( const T* src, AT* dst, const uchar* mask, int len, int cn, double alpha, int start = 0 )
+{
+    AT a = (AT)alpha, b = 1 - a;
+    int i = start;
+
+    if( !mask )
+    {
+        len *= cn;
+        #if CV_ENABLE_UNROLLED
+        for( ; i <= len - 4; i += 4 )
+        {
+            AT t0, t1;
+            t0 = src[i]*a + dst[i]*b;
+            t1 = src[i+1]*a + dst[i+1]*b;
+            dst[i] = t0; dst[i+1] = t1;
+
+            t0 = src[i+2]*a + dst[i+2]*b;
+            t1 = src[i+3]*a + dst[i+3]*b;
+            dst[i+2] = t0; dst[i+3] = t1;
+        }
+        #endif
+        for( ; i < len; i++ )
+        {
+            dst[i] = src[i]*a + dst[i]*b;
+        }
+    }
+    else
+    {
+        src += (i * cn);
+        dst += (i * cn);
+        for( ; i < len; i++, src += cn, dst += cn )
+        {
+            if( mask[i] )
+            {
+                for( int k = 0; k < cn; k++ )
+                {
+                    dst[k] = src[k]*a + dst[k]*b;
+                }
+            }
+        }
+    }
+#if CV_AVX && !CV_AVX2
+    _mm256_zeroupper();
+#elif (CV_SIMD || CV_SIMD_SCALABLE)
+    vx_cleanup();
+#endif
+}
+void acc_simd_(const uchar* src, float* dst, const uchar* mask, int len, int cn)
+{
+    int x = 0;
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+    const int cVectorWidth = VTraits<v_uint8>::vlanes();
+    const int step = VTraits<v_float32>::vlanes();
+
+    if (!mask)
+    {
+        int size = len * cn;
+        for (; x <= size - cVectorWidth; x += cVectorWidth)
+        {
+            v_uint8 v_src  = vx_load(src + x);
+            v_uint16 v_src0, v_src1;
+            v_expand(v_src, v_src0, v_src1);
+
+            v_uint32 v_src00, v_src01, v_src10, v_src11;
+            v_expand(v_src0, v_src00, v_src01);
+            v_expand(v_src1, v_src10, v_src11);
+
+            v_store(dst + x, v_add(vx_load(dst + x), v_cvt_f32(v_reinterpret_as_s32(v_src00))));
+            v_store(dst + x + step, v_add(vx_load(dst + x + step), v_cvt_f32(v_reinterpret_as_s32(v_src01))));
+            v_store(dst + x + step * 2, v_add(vx_load(dst + x + step * 2), v_cvt_f32(v_reinterpret_as_s32(v_src10))));
+            v_store(dst + x + step * 3, v_add(vx_load(dst + x + step * 3), v_cvt_f32(v_reinterpret_as_s32(v_src11))));
+        }
+    }
+    else
+    {
+        if (x <= len - cVectorWidth)
+        {
+            v_uint8 v_0 = vx_setall_u8(0);
+            if (cn == 1)
+            {
+                for ( ; x <= len - cVectorWidth; x += cVectorWidth)
+                {
+                    v_uint8 v_mask = vx_load(mask + x);
+                    v_mask = v_ne(v_0, v_mask);
+                    v_uint8 v_src = vx_load(src + x);
+                    v_src = v_and(v_src, v_mask);
+                    v_uint16 v_src0, v_src1;
+                    v_expand(v_src, v_src0, v_src1);
+
+                    v_uint32 v_src00, v_src01, v_src10, v_src11;
+                    v_expand(v_src0, v_src00, v_src01);
+                    v_expand(v_src1, v_src10, v_src11);
+
+                    v_store(dst + x, v_add(vx_load(dst + x), v_cvt_f32(v_reinterpret_as_s32(v_src00))));
+                    v_store(dst + x + step, v_add(vx_load(dst + x + step), v_cvt_f32(v_reinterpret_as_s32(v_src01))));
+                    v_store(dst + x + step * 2, v_add(vx_load(dst + x + step * 2), v_cvt_f32(v_reinterpret_as_s32(v_src10))));
+                    v_store(dst + x + step * 3, v_add(vx_load(dst + x + step * 3), v_cvt_f32(v_reinterpret_as_s32(v_src11))));
+                }
+            }
+            else if (cn == 3)
+            {
+                for ( ; x <= len - cVectorWidth; x += cVectorWidth)
+                {
+                    v_uint8 v_mask = vx_load(mask + x);
+                    v_mask = v_ne(v_0, v_mask);
+                    v_uint8 v_src0, v_src1, v_src2;
+                    v_load_deinterleave(src + (x * cn), v_src0, v_src1, v_src2);
+                    v_src0 = v_and(v_src0, v_mask);
+                    v_src1 = v_and(v_src1, v_mask);
+                    v_src2 = v_and(v_src2, v_mask);
+                    v_uint16 v_src00, v_src01, v_src10, v_src11, v_src20, v_src21;
+                    v_expand(v_src0, v_src00, v_src01);
+                    v_expand(v_src1, v_src10, v_src11);
+                    v_expand(v_src2, v_src20, v_src21);
+
+                    v_uint32 v_src000, v_src001, v_src010, v_src011;
+                    v_uint32 v_src100, v_src101, v_src110, v_src111;
+                    v_uint32 v_src200, v_src201, v_src210, v_src211;
+                    v_expand(v_src00, v_src000, v_src001);
+                    v_expand(v_src01, v_src010, v_src011);
+                    v_expand(v_src10, v_src100, v_src101);
+                    v_expand(v_src11, v_src110, v_src111);
+                    v_expand(v_src20, v_src200, v_src201);
+                    v_expand(v_src21, v_src210, v_src211);
+
+                    v_float32 v_dst000, v_dst001, v_dst010, v_dst011;
+                    v_float32 v_dst100, v_dst101, v_dst110, v_dst111;
+                    v_float32 v_dst200, v_dst201, v_dst210, v_dst211;
+                    v_load_deinterleave(dst + (x * cn), v_dst000, v_dst100, v_dst200);
+                    v_load_deinterleave(dst + ((x + step) * cn), v_dst001, v_dst101, v_dst201);
+                    v_load_deinterleave(dst + ((x + step * 2) * cn), v_dst010, v_dst110, v_dst210);
+                    v_load_deinterleave(dst + ((x + step * 3) * cn), v_dst011, v_dst111, v_dst211);
+
+                    v_dst000 = v_add(v_dst000, v_cvt_f32(v_reinterpret_as_s32(v_src000)));
+                    v_dst100 = v_add(v_dst100, v_cvt_f32(v_reinterpret_as_s32(v_src100)));
+                    v_dst200 = v_add(v_dst200, v_cvt_f32(v_reinterpret_as_s32(v_src200)));
+                    v_dst001 = v_add(v_dst001, v_cvt_f32(v_reinterpret_as_s32(v_src001)));
+                    v_dst101 = v_add(v_dst101, v_cvt_f32(v_reinterpret_as_s32(v_src101)));
+                    v_dst201 = v_add(v_dst201, v_cvt_f32(v_reinterpret_as_s32(v_src201)));
+                    v_dst010 = v_add(v_dst010, v_cvt_f32(v_reinterpret_as_s32(v_src010)));
+                    v_dst110 = v_add(v_dst110, v_cvt_f32(v_reinterpret_as_s32(v_src110)));
+                    v_dst210 = v_add(v_dst210, v_cvt_f32(v_reinterpret_as_s32(v_src210)));
+                    v_dst011 = v_add(v_dst011, v_cvt_f32(v_reinterpret_as_s32(v_src011)));
+                    v_dst111 = v_add(v_dst111, v_cvt_f32(v_reinterpret_as_s32(v_src111)));
+                    v_dst211 = v_add(v_dst211, v_cvt_f32(v_reinterpret_as_s32(v_src211)));
+
+                    v_store_interleave(dst + (x * cn), v_dst000, v_dst100, v_dst200);
+                    v_store_interleave(dst + ((x + step) * cn), v_dst001, v_dst101, v_dst201);
+                    v_store_interleave(dst + ((x + step * 2) * cn), v_dst010, v_dst110, v_dst210);
+                    v_store_interleave(dst + ((x + step * 3) * cn), v_dst011, v_dst111, v_dst211);
+                }
+            }
+            else if (cn == 4)
+            {
+                v_uint8 v_zero = vx_setzero_u8();
+
+                for (; x <= len - cVectorWidth; x += cVectorWidth)
+                {
+                    v_uint8 v_mask = vx_load(mask + x);
+                    v_mask = v_ne(v_mask, v_zero);
+
+                    v_uint8 v_src0, v_src1, v_src2, v_src3;
+
+                    v_load_deinterleave(src + x * cn,
+                                        v_src0, v_src1, v_src2, v_src3);
+
+                    v_src0 = v_and(v_src0, v_mask);
+                    v_src1 = v_and(v_src1, v_mask);
+                    v_src2 = v_and(v_src2, v_mask);
+                    v_src3 = v_and(v_src3, v_mask);
+
+                    v_uint16 v_src0_u16_0, v_src0_u16_1;
+                    v_uint16 v_src1_u16_0, v_src1_u16_1;
+                    v_uint16 v_src2_u16_0, v_src2_u16_1;
+                    v_uint16 v_src3_u16_0, v_src3_u16_1;
+
+                    v_expand(v_src0, v_src0_u16_0, v_src0_u16_1);
+                    v_expand(v_src1, v_src1_u16_0, v_src1_u16_1);
+                    v_expand(v_src2, v_src2_u16_0, v_src2_u16_1);
+                    v_expand(v_src3, v_src3_u16_0, v_src3_u16_1);
+
+                    v_uint32 v_src0_u32_0, v_src0_u32_1, v_src0_u32_2, v_src0_u32_3;
+                    v_uint32 v_src1_u32_0, v_src1_u32_1, v_src1_u32_2, v_src1_u32_3;
+                    v_uint32 v_src2_u32_0, v_src2_u32_1, v_src2_u32_2, v_src2_u32_3;
+                    v_uint32 v_src3_u32_0, v_src3_u32_1, v_src3_u32_2, v_src3_u32_3;
+
+                    v_expand(v_src0_u16_0, v_src0_u32_0, v_src0_u32_1);
+                    v_expand(v_src0_u16_1, v_src0_u32_2, v_src0_u32_3);
+
+                    v_expand(v_src1_u16_0, v_src1_u32_0, v_src1_u32_1);
+                    v_expand(v_src1_u16_1, v_src1_u32_2, v_src1_u32_3);
+
+                    v_expand(v_src2_u16_0, v_src2_u32_0, v_src2_u32_1);
+                    v_expand(v_src2_u16_1, v_src2_u32_2, v_src2_u32_3);
+
+                    v_expand(v_src3_u16_0, v_src3_u32_0, v_src3_u32_1);
+                    v_expand(v_src3_u16_1, v_src3_u32_2, v_src3_u32_3);
+
+                    v_float32 v_src0_f0 = v_cvt_f32(v_reinterpret_as_s32(v_src0_u32_0));
+                    v_float32 v_src0_f1 = v_cvt_f32(v_reinterpret_as_s32(v_src0_u32_1));
+                    v_float32 v_src0_f2 = v_cvt_f32(v_reinterpret_as_s32(v_src0_u32_2));
+                    v_float32 v_src0_f3 = v_cvt_f32(v_reinterpret_as_s32(v_src0_u32_3));
+
+                    v_float32 v_src1_f0 = v_cvt_f32(v_reinterpret_as_s32(v_src1_u32_0));
+                    v_float32 v_src1_f1 = v_cvt_f32(v_reinterpret_as_s32(v_src1_u32_1));
+                    v_float32 v_src1_f2 = v_cvt_f32(v_reinterpret_as_s32(v_src1_u32_2));
+                    v_float32 v_src1_f3 = v_cvt_f32(v_reinterpret_as_s32(v_src1_u32_3));
+
+                    v_float32 v_src2_f0 = v_cvt_f32(v_reinterpret_as_s32(v_src2_u32_0));
+                    v_float32 v_src2_f1 = v_cvt_f32(v_reinterpret_as_s32(v_src2_u32_1));
+                    v_float32 v_src2_f2 = v_cvt_f32(v_reinterpret_as_s32(v_src2_u32_2));
+                    v_float32 v_src2_f3 = v_cvt_f32(v_reinterpret_as_s32(v_src2_u32_3));
+
+                    v_float32 v_src3_f0 = v_cvt_f32(v_reinterpret_as_s32(v_src3_u32_0));
+                    v_float32 v_src3_f1 = v_cvt_f32(v_reinterpret_as_s32(v_src3_u32_1));
+                    v_float32 v_src3_f2 = v_cvt_f32(v_reinterpret_as_s32(v_src3_u32_2));
+                    v_float32 v_src3_f3 = v_cvt_f32(v_reinterpret_as_s32(v_src3_u32_3));
+
+                    v_float32 v_dst0, v_dst1, v_dst2, v_dst3;
+
+                    v_load_deinterleave(dst + x * cn, v_dst0, v_dst1, v_dst2, v_dst3);
+
+                    v_store_interleave(dst + x * cn,
+                                        v_add(v_dst0, v_src0_f0),
+                                        v_add(v_dst1, v_src1_f0),
+                                        v_add(v_dst2, v_src2_f0),
+                                        v_add(v_dst3, v_src3_f0));
+
+                    v_load_deinterleave(dst + (x + step) * cn, v_dst0, v_dst1, v_dst2, v_dst3);
+
+                    v_store_interleave(dst + (x + step) * cn,
+                                        v_add(v_dst0, v_src0_f1),
+                                        v_add(v_dst1, v_src1_f1),
+                                        v_add(v_dst2, v_src2_f1),
+                                        v_add(v_dst3, v_src3_f1));
+
+                    v_load_deinterleave(dst + (x + 2 * step) * cn, v_dst0, v_dst1, v_dst2, v_dst3);
+
+                    v_store_interleave(dst + (x + 2 * step) * cn,
+                                        v_add(v_dst0, v_src0_f2),
+                                        v_add(v_dst1, v_src1_f2),
+                                        v_add(v_dst2, v_src2_f2),
+                                        v_add(v_dst3, v_src3_f2));
+
+                    v_load_deinterleave(dst + (x + 3 * step) * cn, v_dst0, v_dst1, v_dst2, v_dst3);
+
+                    v_store_interleave(dst + (x + 3 * step) * cn,
+                                        v_add(v_dst0, v_src0_f3),
+                                        v_add(v_dst1, v_src1_f3),
+                                        v_add(v_dst2, v_src2_f3),
+                                        v_add(v_dst3, v_src3_f3));
+                }
+            }
+        }
+    }
+#endif // CV_SIMD
+    acc_general_(src, dst, mask, len, cn, x);
+}
+
+void acc_simd_(const ushort* src, float* dst, const uchar* mask, int len, int cn)
+{
+    int x = 0;
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+    const int cVectorWidth = VTraits<v_uint16>::vlanes();
+    const int step = VTraits<v_float32>::vlanes();
+
+    if (!mask)
+    {
+        int size = len * cn;
+        for (; x <= size - cVectorWidth; x += cVectorWidth)
+        {
+            v_uint16 v_src = vx_load(src + x);
+            v_uint32 v_src0, v_src1;
+            v_expand(v_src, v_src0, v_src1);
+
+            v_store(dst + x, v_add(vx_load(dst + x), v_cvt_f32(v_reinterpret_as_s32(v_src0))));
+            v_store(dst + x + step, v_add(vx_load(dst + x + step), v_cvt_f32(v_reinterpret_as_s32(v_src1))));
+        }
+    }
+    else
+    {
+        if (cn == 1)
+        {
+            v_uint16 v_0 = vx_setall_u16(0);
+            for ( ; x <= len - cVectorWidth; x += cVectorWidth)
+            {
+                v_uint16 v_mask = vx_load_expand(mask + x);
+                v_mask = v_not(v_eq(v_mask, v_0));
+                v_uint16 v_src = vx_load(src + x);
+                v_src = v_and(v_src, v_mask);
+                v_uint32 v_src0, v_src1;
+                v_expand(v_src, v_src0, v_src1);
+
+                v_store(dst + x, v_add(vx_load(dst + x), v_cvt_f32(v_reinterpret_as_s32(v_src0))));
+                v_store(dst + x + step, v_add(vx_load(dst + x + step), v_cvt_f32(v_reinterpret_as_s32(v_src1))));
+            }
+        }
+        else if (cn == 3)
+        {
+            v_uint16 v_0 = vx_setall_u16(0);
+            for ( ; x <= len - cVectorWidth; x += cVectorWidth)
+            {
+                v_uint16 v_mask = vx_load_expand(mask + x);
+                v_mask = v_not(v_eq(v_mask, v_0));
+                v_uint16 v_src0, v_src1, v_src2;
+                v_load_deinterleave(src + x * cn, v_src0, v_src1, v_src2);
+                v_src0 = v_and(v_src0, v_mask);
+                v_src1 = v_and(v_src1, v_mask);
+                v_src2 = v_and(v_src2, v_mask);
+                v_uint32 v_src00, v_src01, v_src10, v_src11, v_src20, v_src21;
+                v_expand(v_src0, v_src00, v_src01);
+                v_expand(v_src1, v_src10, v_src11);
+                v_expand(v_src2, v_src20, v_src21);
+
+                v_float32 v_dst00, v_dst01, v_dst10, v_dst11, v_dst20, v_dst21;
+                v_load_deinterleave(dst + x * cn, v_dst00, v_dst10, v_dst20);
+                v_load_deinterleave(dst + (x + step) * cn, v_dst01, v_dst11, v_dst21);
+
+                v_dst00 = v_add(v_dst00, v_cvt_f32(v_reinterpret_as_s32(v_src00)));
+                v_dst01 = v_add(v_dst01, v_cvt_f32(v_reinterpret_as_s32(v_src01)));
+                v_dst10 = v_add(v_dst10, v_cvt_f32(v_reinterpret_as_s32(v_src10)));
+                v_dst11 = v_add(v_dst11, v_cvt_f32(v_reinterpret_as_s32(v_src11)));
+                v_dst20 = v_add(v_dst20, v_cvt_f32(v_reinterpret_as_s32(v_src20)));
+                v_dst21 = v_add(v_dst21, v_cvt_f32(v_reinterpret_as_s32(v_src21)));
+
+                v_store_interleave(dst + x * cn, v_dst00, v_dst10, v_dst20);
+                v_store_interleave(dst + (x + step) * cn, v_dst01, v_dst11, v_dst21);
+            }
+        }
+    }
+#endif // CV_SIMD
+    acc_general_(src, dst, mask, len, cn, x);
+}
+// todo: remove AVX branch after support it by universal intrinsics
+void acc_simd_(const float* src, float* dst, const uchar* mask, int len, int cn)
+{
+    int x = 0;
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+    const int cVectorWidth = VTraits<v_uint16>::vlanes();
+    const int step = VTraits<v_float32>::vlanes();
+
+    if (!mask)
+    {
+        int size = len * cn;
+        #if CV_AVX && !CV_AVX2
+        for (; x <= size - 8 ; x += 8)
+        {
+            __m256 v_src = _mm256_loadu_ps(src + x);
+            __m256 v_dst = _mm256_loadu_ps(dst + x);
+            v_dst = _mm256_add_ps(v_src, v_dst);
+            _mm256_storeu_ps(dst + x, v_dst);
+        }
+        #else
+        for (; x <= size - cVectorWidth; x += cVectorWidth)
+        {
+            v_store(dst + x, v_add(vx_load(dst + x), vx_load(src + x)));
+            v_store(dst + x + step, v_add(vx_load(dst + x + step), vx_load(src + x + step)));
+        }
+        #endif // CV_AVX && !CV_AVX2
+    }
+    else
+    {
+        if (x <= len - cVectorWidth)
+        {
+            v_float32 v_0 = vx_setzero_f32();
+            if (cn == 1)
+            {
+                for ( ; x <= len - cVectorWidth ; x += cVectorWidth)
+                {
+                    v_uint16 v_masku16 = vx_load_expand(mask + x);
+                    v_uint32 v_masku320, v_masku321;
+                    v_expand(v_masku16, v_masku320, v_masku321);
+                    v_float32 v_mask0 = v_reinterpret_as_f32(v_not(v_eq(v_masku320, v_reinterpret_as_u32(v_0))));
+                    v_float32 v_mask1 = v_reinterpret_as_f32(v_not(v_eq(v_masku321, v_reinterpret_as_u32(v_0))));
+
+                    v_store(dst + x, v_add(vx_load(dst + x), v_and(vx_load(src + x), v_mask0)));
+                    v_store(dst + x + step, v_add(vx_load(dst + x + step), v_and(vx_load(src + x + step), v_mask1)));
+                }
+            }
+            else if (cn == 3)
+            {
+                for ( ; x <= len - cVectorWidth ; x += cVectorWidth)
+                {
+                    v_uint16 v_masku16 = vx_load_expand(mask + x);
+                    v_uint32 v_masku320, v_masku321;
+                    v_expand(v_masku16, v_masku320, v_masku321);
+                    v_float32 v_mask0 = v_reinterpret_as_f32(v_not(v_eq(v_masku320, v_reinterpret_as_u32(v_0))));
+                    v_float32 v_mask1 = v_reinterpret_as_f32(v_not(v_eq(v_masku321, v_reinterpret_as_u32(v_0))));
+
+                    v_float32 v_src00, v_src01, v_src10, v_src11, v_src20, v_src21;
+                    v_load_deinterleave(src + x * cn, v_src00, v_src10, v_src20);
+                    v_load_deinterleave(src + (x + step) * cn, v_src01, v_src11, v_src21);
+                    v_src00 = v_and(v_src00, v_mask0);
+                    v_src01 = v_and(v_src01, v_mask1);
+                    v_src10 = v_and(v_src10, v_mask0);
+                    v_src11 = v_and(v_src11, v_mask1);
+                    v_src20 = v_and(v_src20, v_mask0);
+                    v_src21 = v_and(v_src21, v_mask1);
+
+                    v_float32 v_dst00, v_dst01, v_dst10, v_dst11, v_dst20, v_dst21;
+                    v_load_deinterleave(dst + x * cn, v_dst00, v_dst10, v_dst20);
+                    v_load_deinterleave(dst + (x + step) * cn, v_dst01, v_dst11, v_dst21);
+
+                    v_store_interleave(dst + x * cn, v_add(v_dst00, v_src00), v_add(v_dst10, v_src10), v_add(v_dst20, v_src20));
+                    v_store_interleave(dst + (x + step) * cn, v_add(v_dst01, v_src01), v_add(v_dst11, v_src11), v_add(v_dst21, v_src21));
+                }
+            }
+            else if (cn == 4)
+            {
+                    for (; x <= len - cVectorWidth; x += cVectorWidth)
+                    {
+                        v_uint16 v_masku16 = vx_load_expand(mask + x);
+
+                        v_uint32 v_masku320, v_masku321;
+                        v_expand(v_masku16, v_masku320, v_masku321);
+
+                        v_float32 v_mask0 = v_reinterpret_as_f32(v_ne(v_masku320, v_reinterpret_as_u32(v_0)));
+
+                        v_float32 v_mask1 = v_reinterpret_as_f32(v_ne(v_masku321, v_reinterpret_as_u32(v_0)));
+
+                        v_float32 v_src00, v_src01;
+                        v_float32 v_src10, v_src11;
+                        v_float32 v_src20, v_src21;
+                        v_float32 v_src30, v_src31;
+
+                        v_load_deinterleave(src + x * cn,
+                                            v_src00, v_src10, v_src20, v_src30);
+
+                        v_load_deinterleave(src + (x + step) * cn,
+                                            v_src01, v_src11, v_src21, v_src31);
+
+                        v_src00 = v_and(v_src00, v_mask0);
+                        v_src10 = v_and(v_src10, v_mask0);
+                        v_src20 = v_and(v_src20, v_mask0);
+                        v_src30 = v_and(v_src30, v_mask0);
+
+                        v_src01 = v_and(v_src01, v_mask1);
+                        v_src11 = v_and(v_src11, v_mask1);
+                        v_src21 = v_and(v_src21, v_mask1);
+                        v_src31 = v_and(v_src31, v_mask1);
+
+                        v_float32 v_dst00, v_dst01;
+                        v_float32 v_dst10, v_dst11;
+                        v_float32 v_dst20, v_dst21;
+                        v_float32 v_dst30, v_dst31;
+
+                        v_load_deinterleave(dst + x * cn, v_dst00, v_dst10, v_dst20, v_dst30);
+
+                        v_load_deinterleave(dst + (x + step) * cn, v_dst01, v_dst11, v_dst21, v_dst31);
+
+                        v_store_interleave(dst + x * cn,
+                                            v_add(v_dst00, v_src00),
+                                            v_add(v_dst10, v_src10),
+                                            v_add(v_dst20, v_src20),
+                                            v_add(v_dst30, v_src30));
+
+                        v_store_interleave(dst + (x + step) * cn,
+                                            v_add(v_dst01, v_src01),
+                                            v_add(v_dst11, v_src11),
+                                            v_add(v_dst21, v_src21),
+                                            v_add(v_dst31, v_src31));
+                    }
+            }
+        }
+
+    }
+#endif // CV_SIMD
+    acc_general_(src, dst, mask, len, cn, x);
+}
+
+void acc_simd_(const uchar* src, double* dst, const uchar* mask, int len, int cn)
+{
+    int x = 0;
+#if (CV_SIMD_64F || CV_SIMD_SCALABLE_64F)
+    const int cVectorWidth = VTraits<v_uint8>::vlanes();
+    const int step = VTraits<v_float64>::vlanes();
+
+    if (!mask)
+    {
+        int size = len * cn;
+        for (; x <= size - cVectorWidth; x += cVectorWidth)
+        {
+            v_uint8 v_src  = vx_load(src + x);
+            v_uint16 v_int0, v_int1;
+            v_expand(v_src, v_int0, v_int1);
+
+            v_uint32 v_int00, v_int01, v_int10, v_int11;
+            v_expand(v_int0, v_int00, v_int01);
+            v_expand(v_int1, v_int10, v_int11);
+
+            v_float64 v_src0 = v_cvt_f64(v_reinterpret_as_s32(v_int00));
+            v_float64 v_src1 = v_cvt_f64_high(v_reinterpret_as_s32(v_int00));
+            v_float64 v_src2 = v_cvt_f64(v_reinterpret_as_s32(v_int01));
+            v_float64 v_src3 = v_cvt_f64_high(v_reinterpret_as_s32(v_int01));
+            v_float64 v_src4 = v_cvt_f64(v_reinterpret_as_s32(v_int10));
+            v_float64 v_src5 = v_cvt_f64_high(v_reinterpret_as_s32(v_int10));
+            v_float64 v_src6 = v_cvt_f64(v_reinterpret_as_s32(v_int11));
+            v_float64 v_src7 = v_cvt_f64_high(v_reinterpret_as_s32(v_int11));
+
+            v_float64 v_dst0 = vx_load(dst + x);
+            v_float64 v_dst1 = vx_load(dst + x + step);
+            v_float64 v_dst2 = vx_load(dst + x + step * 2);
+            v_float64 v_dst3 = vx_load(dst + x + step * 3);
+            v_float64 v_dst4 = vx_load(dst + x + step * 4);
+            v_float64 v_dst5 = vx_load(dst + x + step * 5);
+            v_float64 v_dst6 = vx_load(dst + x + step * 6);
+            v_float64 v_dst7 = vx_load(dst + x + step * 7);
+
+            v_dst0 = v_add(v_dst0, v_src0);
+            v_dst1 = v_add(v_dst1, v_src1);
+            v_dst2 = v_add(v_dst2, v_src2);
+            v_dst3 = v_add(v_dst3, v_src3);
+            v_dst4 = v_add(v_dst4, v_src4);
+            v_dst5 = v_add(v_dst5, v_src5);
+            v_dst6 = v_add(v_dst6, v_src6);
+            v_dst7 = v_add(v_dst7, v_src7);
+
+            v_store(dst + x, v_dst0);
+            v_store(dst + x + step, v_dst1);
+            v_store(dst + x + step * 2, v_dst2);
+            v_store(dst + x + step * 3, v_dst3);
+            v_store(dst + x + step * 4, v_dst4);
+            v_store(dst + x + step * 5, v_dst5);
+            v_store(dst + x + step * 6, v_dst6);
+            v_store(dst + x + step * 7, v_dst7);
+        }
+    }
+    else
+    {
+        v_uint8 v_0 = vx_setall_u8(0);
+        if (cn == 1)
+        {
+            for ( ; x <= len - cVectorWidth; x += cVectorWidth)
+            {
+                v_uint8 v_mask = vx_load(mask + x);
+                v_mask = v_not(v_eq(v_mask, v_0));
+                v_uint8 v_src  = vx_load(src + x);
+                v_src = v_and(v_src, v_mask);
+                v_uint16 v_int0, v_int1;
+                v_expand(v_src, v_int0, v_int1);
+
+                v_uint32 v_int00, v_int01, v_int10, v_int11;
+                v_expand(v_int0, v_int00, v_int01);
+                v_expand(v_int1, v_int10, v_int11);
+
+                v_float64 v_src0 = v_cvt_f64(v_reinterpret_as_s32(v_int00));
+                v_float64 v_src1 = v_cvt_f64_high(v_reinterpret_as_s32(v_int00));
+                v_float64 v_src2 = v_cvt_f64(v_reinterpret_as_s32(v_int01));
+                v_float64 v_src3 = v_cvt_f64_high(v_reinterpret_as_s32(v_int01));
+                v_float64 v_src4 = v_cvt_f64(v_reinterpret_as_s32(v_int10));
+                v_float64 v_src5 = v_cvt_f64_high(v_reinterpret_as_s32(v_int10));
+                v_float64 v_src6 = v_cvt_f64(v_reinterpret_as_s32(v_int11));
+                v_float64 v_src7 = v_cvt_f64_high(v_reinterpret_as_s32(v_int11));
+
+                v_float64 v_dst0 = vx_load(dst + x);
+                v_float64 v_dst1 = vx_load(dst + x + step);
+                v_float64 v_dst2 = vx_load(dst + x + step * 2);
+                v_float64 v_dst3 = vx_load(dst + x + step * 3);
+                v_float64 v_dst4 = vx_load(dst + x + step * 4);
+                v_float64 v_dst5 = vx_load(dst + x + step * 5);
+                v_float64 v_dst6 = vx_load(dst + x + step * 6);
+                v_float64 v_dst7 = vx_load(dst + x + step * 7);
+
+                v_dst0 = v_add(v_dst0, v_src0);
+                v_dst1 = v_add(v_dst1, v_src1);
+                v_dst2 = v_add(v_dst2, v_src2);
+                v_dst3 = v_add(v_dst3, v_src3);
+                v_dst4 = v_add(v_dst4, v_src4);
+                v_dst5 = v_add(v_dst5, v_src5);
+                v_dst6 = v_add(v_dst6, v_src6);
+                v_dst7 = v_add(v_dst7, v_src7);
+
+                v_store(dst + x, v_dst0);
+                v_store(dst + x + step, v_dst1);
+                v_store(dst + x + step * 2, v_dst2);
+                v_store(dst + x + step * 3, v_dst3);
+                v_store(dst + x + step * 4, v_dst4);
+                v_store(dst + x + step * 5, v_dst5);
+                v_store(dst + x + step * 6, v_dst6);
+                v_store(dst + x + step * 7, v_dst7);
+            }
+        }
+        else if (cn == 3)
+        {
+            for ( ; x <= len - cVectorWidth; x += cVectorWidth)
+            {
+                v_uint8 v_mask = vx_load(mask + x);
+                v_mask = v_not(v_eq(v_0, v_mask));
+                v_uint8 v_src0, v_src1, v_src2;
+                v_load_deinterleave(src + (x * cn), v_src0, v_src1, v_src2);
+                v_src0 = v_and(v_src0, v_mask);
+                v_src1 = v_and(v_src1, v_mask);
+                v_src2 = v_and(v_src2, v_mask);
+                v_uint16 v_src00, v_src01, v_src10, v_src11, v_src20, v_src21;
+                v_expand(v_src0, v_src00, v_src01);
+                v_expand(v_src1, v_src10, v_src11);
+                v_expand(v_src2, v_src20, v_src21);
+
+                v_uint32 v_src000, v_src001, v_src010, v_src011;
+                v_uint32 v_src100, v_src101, v_src110, v_src111;
+                v_uint32 v_src200, v_src201, v_src210, v_src211;
+                v_expand(v_src00, v_src000, v_src001);
+                v_expand(v_src01, v_src010, v_src011);
+                v_expand(v_src10, v_src100, v_src101);
+                v_expand(v_src11, v_src110, v_src111);
+                v_expand(v_src20, v_src200, v_src201);
+                v_expand(v_src21, v_src210, v_src211);
+
+                v_float64 v_src0000, v_src0001, v_src0010, v_src0011, v_src0100, v_src0101, v_src0110, v_src0111;
+                v_float64 v_src1000, v_src1001, v_src1010, v_src1011, v_src1100, v_src1101, v_src1110, v_src1111;
+                v_float64 v_src2000, v_src2001, v_src2010, v_src2011, v_src2100, v_src2101, v_src2110, v_src2111;
+                v_src0000 = v_cvt_f64(v_cvt_f32(v_reinterpret_as_s32(v_src000)));
+                v_src0001 = v_cvt_f64_high(v_cvt_f32(v_reinterpret_as_s32(v_src000)));
+                v_src0010 = v_cvt_f64(v_cvt_f32(v_reinterpret_as_s32(v_src001)));
+                v_src0011 = v_cvt_f64_high(v_cvt_f32(v_reinterpret_as_s32(v_src001)));
+                v_src0100 = v_cvt_f64(v_cvt_f32(v_reinterpret_as_s32(v_src010)));
+                v_src0101 = v_cvt_f64_high(v_cvt_f32(v_reinterpret_as_s32(v_src010)));
+                v_src0110 = v_cvt_f64(v_cvt_f32(v_reinterpret_as_s32(v_src011)));
+                v_src0111 = v_cvt_f64_high(v_cvt_f32(v_reinterpret_as_s32(v_src011)));
+                v_src1000 = v_cvt_f64(v_cvt_f32(v_reinterpret_as_s32(v_src100)));
+                v_src1001 = v_cvt_f64_high(v_cvt_f32(v_reinterpret_as_s32(v_src100)));
+                v_src1010 = v_cvt_f64(v_cvt_f32(v_reinterpret_as_s32(v_src101)));
+                v_src1011 = v_cvt_f64_high(v_cvt_f32(v_reinterpret_as_s32(v_src101)));
+                v_src1100 = v_cvt_f64(v_cvt_f32(v_reinterpret_as_s32(v_src110)));
+                v_src1101 = v_cvt_f64_high(v_cvt_f32(v_reinterpret_as_s32(v_src110)));
+                v_src1110 = v_cvt_f64(v_cvt_f32(v_reinterpret_as_s32(v_src111)));
+                v_src1111 = v_cvt_f64_high(v_cvt_f32(v_reinterpret_as_s32(v_src111)));
+                v_src2000 = v_cvt_f64(v_cvt_f32(v_reinterpret_as_s32(v_src200)));
+                v_src2001 = v_cvt_f64_high(v_cvt_f32(v_reinterpret_as_s32(v_src200)));
+                v_src2010 = v_cvt_f64(v_cvt_f32(v_reinterpret_as_s32(v_src201)));
+                v_src2011 = v_cvt_f64_high(v_cvt_f32(v_reinterpret_as_s32(v_src201)));
+                v_src2100 = v_cvt_f64(v_cvt_f32(v_reinterpret_as_s32(v_src210)));
+                v_src2101 = v_cvt_f64_high(v_cvt_f32(v_reinterpret_as_s32(v_src210)));
+                v_src2110 = v_cvt_f64(v_cvt_f32(v_reinterpret_as_s32(v_src211)));
+                v_src2111 = v_cvt_f64_high(v_cvt_f32(v_reinterpret_as_s32(v_src211)));
+
+                v_float64 v_dst0000, v_dst0001, v_dst0010, v_dst0011, v_dst0100, v_dst0101, v_dst0110, v_dst0111;
+                v_float64 v_dst1000, v_dst1001, v_dst1010, v_dst1011, v_dst1100, v_dst1101, v_dst1110, v_dst1111;
+                v_float64 v_dst2000, v_dst2001, v_dst2010, v_dst2011, v_dst2100, v_dst2101, v_dst2110, v_dst2111;
+                v_load_deinterleave(dst + (x * cn), v_dst0000, v_dst1000, v_dst2000);
+                v_load_deinterleave(dst + ((x + step) * cn), v_dst0001, v_dst1001, v_dst2001);
+                v_load_deinterleave(dst + ((x + step * 2) * cn), v_dst0010, v_dst1010, v_dst2010);
+                v_load_deinterleave(dst + ((x + step * 3) * cn), v_dst0011, v_dst1011, v_dst2011);
+                v_load_deinterleave(dst + ((x + step * 4) * cn), v_dst0100, v_dst1100, v_dst2100);
+                v_load_deinterleave(dst + ((x + step * 5) * cn), v_dst0101, v_dst1101, v_dst2101);
+                v_load_deinterleave(dst + ((x + step * 6) * cn), v_dst0110, v_dst1110, v_dst2110);
+                v_load_deinterleave(dst + ((x + step * 7) * cn), v_dst0111, v_dst1111, v_dst2111);
+
+                v_store_interleave(dst + (x * cn), v_add(v_dst0000, v_src0000), v_add(v_dst1000, v_src1000), v_add(v_dst2000, v_src2000));
+                v_store_interleave(dst + ((x + step) * cn), v_add(v_dst0001, v_src0001), v_add(v_dst1001, v_src1001), v_add(v_dst2001, v_src2001));
+                v_store_interleave(dst + ((x + step * 2) * cn), v_add(v_dst0010, v_src0010), v_add(v_dst1010, v_src1010), v_add(v_dst2010, v_src2010));
+                v_store_interleave(dst + ((x + step * 3) * cn), v_add(v_dst0011, v_src0011), v_add(v_dst1011, v_src1011), v_add(v_dst2011, v_src2011));
+                v_store_interleave(dst + ((x + step * 4) * cn), v_add(v_dst0100, v_src0100), v_add(v_dst1100, v_src1100), v_add(v_dst2100, v_src2100));
+                v_store_interleave(dst + ((x + step * 5) * cn), v_add(v_dst0101, v_src0101), v_add(v_dst1101, v_src1101), v_add(v_dst2101, v_src2101));
+                v_store_interleave(dst + ((x + step * 6) * cn), v_add(v_dst0110, v_src0110), v_add(v_dst1110, v_src1110), v_add(v_dst2110, v_src2110));
+                v_store_interleave(dst + ((x + step * 7) * cn), v_add(v_dst0111, v_src0111), v_add(v_dst1111, v_src1111), v_add(v_dst2111, v_src2111));
+            }
+        }
+    }
+#endif // CV_SIMD_64F
+    acc_general_(src, dst, mask, len, cn, x);
+}
+
+void acc_simd_(const ushort* src, double* dst, const uchar* mask, int len, int cn)
+{
+    int x = 0;
+#if (CV_SIMD_64F || CV_SIMD_SCALABLE_64F)
+    const int cVectorWidth = VTraits<v_uint16>::vlanes();
+    const int step = VTraits<v_float64>::vlanes();
+
+    if (!mask)
+    {
+        int size = len * cn;
+        for (; x <= size - cVectorWidth; x += cVectorWidth)
+        {
+            v_uint16 v_src  = vx_load(src + x);
+            v_uint32 v_int0, v_int1;
+            v_expand(v_src, v_int0, v_int1);
+
+            v_float64 v_src0 = v_cvt_f64(v_reinterpret_as_s32(v_int0));
+            v_float64 v_src1 = v_cvt_f64_high(v_reinterpret_as_s32(v_int0));
+            v_float64 v_src2 = v_cvt_f64(v_reinterpret_as_s32(v_int1));
+            v_float64 v_src3 = v_cvt_f64_high(v_reinterpret_as_s32(v_int1));
+
+            v_float64 v_dst0 = vx_load(dst + x);
+            v_float64 v_dst1 = vx_load(dst + x + step);
+            v_float64 v_dst2 = vx_load(dst + x + step * 2);
+            v_float64 v_dst3 = vx_load(dst + x + step * 3);
+
+            v_dst0 = v_add(v_dst0, v_src0);
+            v_dst1 = v_add(v_dst1, v_src1);
+            v_dst2 = v_add(v_dst2, v_src2);
+            v_dst3 = v_add(v_dst3, v_src3);
+
+            v_store(dst + x, v_dst0);
+            v_store(dst + x + step, v_dst1);
+            v_store(dst + x + step * 2, v_dst2);
+            v_store(dst + x + step * 3, v_dst3);
+        }
+    }
+    else
+    {
+        v_uint16 v_0 = vx_setzero_u16();
+        if (cn == 1)
+        {
+            for ( ; x <= len - cVectorWidth; x += cVectorWidth)
+            {
+                v_uint16 v_mask = vx_load_expand(mask + x);
+                v_mask = v_not(v_eq(v_mask, v_0));
+                v_uint16 v_src  = vx_load(src + x);
+                v_src = v_and(v_src, v_mask);
+                v_uint32 v_int0, v_int1;
+                v_expand(v_src, v_int0, v_int1);
+
+                v_float64 v_src0 = v_cvt_f64(v_reinterpret_as_s32(v_int0));
+                v_float64 v_src1 = v_cvt_f64_high(v_reinterpret_as_s32(v_int0));
+                v_float64 v_src2 = v_cvt_f64(v_reinterpret_as_s32(v_int1));
+                v_float64 v_src3 = v_cvt_f64_high(v_reinterpret_as_s32(v_int1));
+
+                v_float64 v_dst0 = vx_load(dst + x);
+                v_float64 v_dst1 = vx_load(dst + x + step);
+                v_float64 v_dst2 = vx_load(dst + x + step * 2);
+                v_float64 v_dst3 = vx_load(dst + x + step * 3);
+
+                v_dst0 = v_add(v_dst0, v_src0);
+                v_dst1 = v_add(v_dst1, v_src1);
+                v_dst2 = v_add(v_dst2, v_src2);
+                v_dst3 = v_add(v_dst3, v_src3);
+
+                v_store(dst + x, v_dst0);
+                v_store(dst + x + step, v_dst1);
+                v_store(dst + x + step * 2, v_dst2);
+                v_store(dst + x + step * 3, v_dst3);
+            }
+        }
+        if (cn == 3)
+        {
+            for ( ; x <= len - cVectorWidth; x += cVectorWidth)
+            {
+                v_uint16 v_mask = vx_load_expand(mask + x);
+                v_mask = v_not(v_eq(v_mask, v_0));
+                v_uint16 v_src0, v_src1, v_src2;
+                v_load_deinterleave(src + x * cn, v_src0, v_src1, v_src2);
+                v_src0 = v_and(v_src0, v_mask);
+                v_src1 = v_and(v_src1, v_mask);
+                v_src2 = v_and(v_src2, v_mask);
+                v_uint32 v_int00, v_int01, v_int10, v_int11, v_int20, v_int21;
+                v_expand(v_src0, v_int00, v_int01);
+                v_expand(v_src1, v_int10, v_int11);
+                v_expand(v_src2, v_int20, v_int21);
+
+                v_float64 v_src00 = v_cvt_f64(v_reinterpret_as_s32(v_int00));
+                v_float64 v_src01 = v_cvt_f64_high(v_reinterpret_as_s32(v_int00));
+                v_float64 v_src02 = v_cvt_f64(v_reinterpret_as_s32(v_int01));
+                v_float64 v_src03 = v_cvt_f64_high(v_reinterpret_as_s32(v_int01));
+                v_float64 v_src10 = v_cvt_f64(v_reinterpret_as_s32(v_int10));
+                v_float64 v_src11 = v_cvt_f64_high(v_reinterpret_as_s32(v_int10));
+                v_float64 v_src12 = v_cvt_f64(v_reinterpret_as_s32(v_int11));
+                v_float64 v_src13 = v_cvt_f64_high(v_reinterpret_as_s32(v_int11));
+                v_float64 v_src20 = v_cvt_f64(v_reinterpret_as_s32(v_int20));
+                v_float64 v_src21 = v_cvt_f64_high(v_reinterpret_as_s32(v_int20));
+                v_float64 v_src22 = v_cvt_f64(v_reinterpret_as_s32(v_int21));
+                v_float64 v_src23 = v_cvt_f64_high(v_reinterpret_as_s32(v_int21));
+
+                v_float64 v_dst00, v_dst01, v_dst02, v_dst03, v_dst10, v_dst11, v_dst12, v_dst13, v_dst20, v_dst21, v_dst22, v_dst23;
+                v_load_deinterleave(dst + x * cn, v_dst00, v_dst10, v_dst20);
+                v_load_deinterleave(dst + (x + step) * cn, v_dst01, v_dst11, v_dst21);
+                v_load_deinterleave(dst + (x + step * 2) * cn, v_dst02, v_dst12, v_dst22);
+                v_load_deinterleave(dst + (x + step * 3) * cn, v_dst03, v_dst13, v_dst23);
+
+                v_store_interleave(dst + x * cn, v_add(v_dst00, v_src00), v_add(v_dst10, v_src10), v_add(v_dst20, v_src20));
+                v_store_interleave(dst + (x + step) * cn, v_add(v_dst01, v_src01), v_add(v_dst11, v_src11), v_add(v_dst21, v_src21));
+                v_store_interleave(dst + (x + step * 2) * cn, v_add(v_dst02, v_src02), v_add(v_dst12, v_src12), v_add(v_dst22, v_src22));
+                v_store_interleave(dst + (x + step * 3) * cn, v_add(v_dst03, v_src03), v_add(v_dst13, v_src13), v_add(v_dst23, v_src23));
+            }
+        }
+    }
+#endif // CV_SIMD_64F
+    acc_general_(src, dst, mask, len, cn, x);
+}
+
+void acc_simd_(const float* src, double* dst, const uchar* mask, int len, int cn)
+{
+    int x = 0;
+#if (CV_SIMD_64F || CV_SIMD_SCALABLE_64F)
+    const int cVectorWidth = VTraits<v_float32>::vlanes();
+    const int step = VTraits<v_float64>::vlanes();
+
+    if (!mask)
+    {
+        int size = len * cn;
+        #if CV_AVX && !CV_AVX2
+        for (; x <= size - 8 ; x += 8)
+        {
+            __m256 v_src = _mm256_loadu_ps(src + x);
+            __m256d v_src0 = _mm256_cvtps_pd(_mm256_extractf128_ps(v_src, 0));
+            __m256d v_src1 = _mm256_cvtps_pd(_mm256_extractf128_ps(v_src, 1));
+            __m256d v_dst0 = _mm256_loadu_pd(dst + x);
+            __m256d v_dst1 = _mm256_loadu_pd(dst + x + 4);
+            v_dst0 = _mm256_add_pd(v_src0, v_dst0);
+            v_dst1 = _mm256_add_pd(v_src1, v_dst1);
+            _mm256_storeu_pd(dst + x, v_dst0);
+            _mm256_storeu_pd(dst + x + 4, v_dst1);
+        }
+        #else
+        for (; x <= size - cVectorWidth; x += cVectorWidth)
+        {
+            v_float32 v_src = vx_load(src + x);
+            v_float64 v_src0 = v_cvt_f64(v_src);
+            v_float64 v_src1 = v_cvt_f64_high(v_src);
+
+            v_store(dst + x, v_add(vx_load(dst + x), v_src0));
+            v_store(dst + x + step, v_add(vx_load(dst + x + step), v_src1));
+        }
+        #endif // CV_AVX && !CV_AVX2
+    }
+    else
+    {
+        v_uint64 v_0 = vx_setzero_u64();
+        if (cn == 1)
+        {
+            for ( ; x <= len - cVectorWidth ; x += cVectorWidth)
+            {
+                v_uint32 v_masku32 = vx_load_expand_q(mask + x);
+                v_uint64 v_masku640, v_masku641;
+                v_expand(v_masku32, v_masku640, v_masku641);
+                v_float64 v_mask0 = v_reinterpret_as_f64(v_not(v_eq(v_masku640, v_0)));
+                v_float64 v_mask1 = v_reinterpret_as_f64(v_not(v_eq(v_masku641, v_0)));
+
+                v_float32 v_src = vx_load(src + x);
+                v_float64 v_src0 = v_and(v_cvt_f64(v_src), v_mask0);
+                v_float64 v_src1 = v_and(v_cvt_f64_high(v_src), v_mask1);
+
+                v_store(dst + x, v_add(vx_load(dst + x), v_src0));
+                v_store(dst + x + step, v_add(vx_load(dst + x + step), v_src1));
+            }
+        }
+        else if (cn == 3)
+        {
+            for ( ; x <= len - cVectorWidth ; x += cVectorWidth)
+            {
+                v_uint32 v_masku32 = vx_load_expand_q(mask + x);
+                v_uint64 v_masku640, v_masku641;
+                v_expand(v_masku32, v_masku640, v_masku641);
+                v_float64 v_mask0 = v_reinterpret_as_f64(v_not(v_eq(v_masku640, v_0)));
+                v_float64 v_mask1 = v_reinterpret_as_f64(v_not(v_eq(v_masku641, v_0)));
+
+                v_float32 v_src0, v_src1, v_src2;
+                v_load_deinterleave(src + x * cn, v_src0, v_src1, v_src2);
+                v_float64 v_src00 = v_and(v_cvt_f64(v_src0), v_mask0);
+                v_float64 v_src01 = v_and(v_cvt_f64_high(v_src0), v_mask1);
+                v_float64 v_src10 = v_and(v_cvt_f64(v_src1), v_mask0);
+                v_float64 v_src11 = v_and(v_cvt_f64_high(v_src1), v_mask1);
+                v_float64 v_src20 = v_and(v_cvt_f64(v_src2), v_mask0);
+                v_float64 v_src21 = v_and(v_cvt_f64_high(v_src2), v_mask1);
+
+                v_float64 v_dst00, v_dst01, v_dst10, v_dst11, v_dst20, v_dst21;
+                v_load_deinterleave(dst + x * cn, v_dst00, v_dst10, v_dst20);
+                v_load_deinterleave(dst + (x + step) * cn, v_dst01, v_dst11, v_dst21);
+
+                v_store_interleave(dst + x * cn, v_add(v_dst00, v_src00), v_add(v_dst10, v_src10), v_add(v_dst20, v_src20));
+                v_store_interleave(dst + (x + step) * cn, v_add(v_dst01, v_src01), v_add(v_dst11, v_src11), v_add(v_dst21, v_src21));
+            }
+        }
+    }
+#endif // CV_SIMD_64F
+    acc_general_(src, dst, mask, len, cn, x);
+}
+
+void acc_simd_(const double* src, double* dst, const uchar* mask, int len, int cn)
+{
+    int x = 0;
+#if (CV_SIMD_64F || CV_SIMD_SCALABLE_64F)
+    const int cVectorWidth = VTraits<v_float64>::vlanes() * 2;
+    const int step = VTraits<v_float64>::vlanes();
+
+    if (!mask)
+    {
+        int size = len * cn;
+        #if CV_AVX && !CV_AVX2
+        for ( ; x <= size - 4 ; x += 4)
+        {
+            __m256d v_src = _mm256_loadu_pd(src + x);
+            __m256d v_dst = _mm256_loadu_pd(dst + x);
+            v_dst = _mm256_add_pd(v_dst, v_src);
+            _mm256_storeu_pd(dst + x, v_dst);
+        }
+        #else
+        for (; x <= size - cVectorWidth; x += cVectorWidth)
+        {
+            v_float64 v_src0 = vx_load(src + x);
+            v_float64 v_src1 = vx_load(src + x + step);
+
+            v_store(dst + x, v_add(vx_load(dst + x), v_src0));
+            v_store(dst + x + step, v_add(vx_load(dst + x + step), v_src1));
+        }
+        #endif // CV_AVX && !CV_AVX2
+    }
+    else
+    {
+        v_uint64 v_0 = vx_setzero_u64();
+        if (cn == 1)
+        {
+            for ( ; x <= len - cVectorWidth ; x += cVectorWidth)
+            {
+                v_uint32 v_masku32 = vx_load_expand_q(mask + x);
+                v_uint64 v_masku640, v_masku641;
+                v_expand(v_masku32, v_masku640, v_masku641);
+                v_float64 v_mask0 = v_reinterpret_as_f64(v_not(v_eq(v_masku640, v_0)));
+                v_float64 v_mask1 = v_reinterpret_as_f64(v_not(v_eq(v_masku641, v_0)));
+
+                v_float64 v_src0 = vx_load(src + x);
+                v_float64 v_src1 = vx_load(src + x + step);
+
+                v_store(dst + x, v_add(vx_load(dst + x), v_and(v_src0, v_mask0)));
+                v_store(dst + x + step, v_add(vx_load(dst + x + step), v_and(v_src1, v_mask1)));
+            }
+        }
+        else if (cn == 3)
+        {
+            for ( ; x <= len - cVectorWidth ; x += cVectorWidth)
+            {
+                v_uint32 v_masku32 = vx_load_expand_q(mask + x);
+                v_uint64 v_masku640, v_masku641;
+                v_expand(v_masku32, v_masku640, v_masku641);
+                v_float64 v_mask0 = v_reinterpret_as_f64(v_not(v_eq(v_masku640, v_0)));
+                v_float64 v_mask1 = v_reinterpret_as_f64(v_not(v_eq(v_masku641, v_0)));
+
+                v_float64 v_src00, v_src10, v_src20, v_src01, v_src11, v_src21;
+                v_load_deinterleave(src + x * cn, v_src00, v_src10, v_src20);
+                v_load_deinterleave(src + (x + step) * cn, v_src01, v_src11, v_src21);
+                v_src00 = v_and(v_src00, v_mask0);
+                v_src01 = v_and(v_src01, v_mask1);
+                v_src10 = v_and(v_src10, v_mask0);
+                v_src11 = v_and(v_src11, v_mask1);
+                v_src20 = v_and(v_src20, v_mask0);
+                v_src21 = v_and(v_src21, v_mask1);
+
+                v_float64 v_dst00, v_dst10, v_dst20, v_dst01, v_dst11, v_dst21;
+                v_load_deinterleave(dst + x * cn, v_dst00, v_dst10, v_dst20);
+                v_load_deinterleave(dst + (x + step) * cn, v_dst01, v_dst11, v_dst21);
+
+                v_store_interleave(dst + x * cn, v_add(v_dst00, v_src00), v_add(v_dst10, v_src10), v_add(v_dst20, v_src20));
+                v_store_interleave(dst + (x + step) * cn, v_add(v_dst01, v_src01), v_add(v_dst11, v_src11), v_add(v_dst21, v_src21));
+            }
+        }
+    }
+#endif // CV_SIMD_64F
+    acc_general_(src, dst, mask, len, cn, x);
+}
+
+// square accumulate optimized by universal intrinsic
+void accSqr_simd_(const uchar* src, float* dst, const uchar* mask, int len, int cn)
+{
+    int x = 0;
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+    const int cVectorWidth = VTraits<v_uint8>::vlanes();
+    const int step = VTraits<v_float32>::vlanes();
+
+    if (!mask)
+    {
+        int size = len * cn;
+        for (; x <= size - cVectorWidth; x += cVectorWidth)
+        {
+            v_uint8 v_src  = vx_load(src + x);
+            v_uint16 v_src0, v_src1;
+            v_expand(v_src, v_src0, v_src1);
+            v_src0 = v_mul_wrap(v_src0, v_src0);
+            v_src1 = v_mul_wrap(v_src1, v_src1);
+
+            v_uint32 v_src00, v_src01, v_src10, v_src11;
+            v_expand(v_src0, v_src00, v_src01);
+            v_expand(v_src1, v_src10, v_src11);
+
+            v_store(dst + x, v_add(vx_load(dst + x), v_cvt_f32(v_reinterpret_as_s32(v_src00))));
+            v_store(dst + x + step, v_add(vx_load(dst + x + step), v_cvt_f32(v_reinterpret_as_s32(v_src01))));
+            v_store(dst + x + step * 2, v_add(vx_load(dst + x + step * 2), v_cvt_f32(v_reinterpret_as_s32(v_src10))));
+            v_store(dst + x + step * 3, v_add(vx_load(dst + x + step * 3), v_cvt_f32(v_reinterpret_as_s32(v_src11))));
+        }
+    }
+    else
+    {
+        v_uint8 v_0 = vx_setall_u8(0);
+        if (cn == 1)
+        {
+            for ( ; x <= len - cVectorWidth ; x += cVectorWidth)
+            {
+                v_uint8 v_mask = vx_load(mask + x);
+                v_mask = v_not(v_eq(v_0, v_mask));
+                v_uint8 v_src = vx_load(src + x);
+                v_src = v_and(v_src, v_mask);
+                v_uint16 v_src0, v_src1;
+                v_expand(v_src, v_src0, v_src1);
+                v_src0 = v_mul_wrap(v_src0, v_src0);
+                v_src1 = v_mul_wrap(v_src1, v_src1);
+
+                v_uint32 v_src00, v_src01, v_src10, v_src11;
+                v_expand(v_src0, v_src00, v_src01);
+                v_expand(v_src1, v_src10, v_src11);
+
+                v_store(dst + x, v_add(vx_load(dst + x), v_cvt_f32(v_reinterpret_as_s32(v_src00))));
+                v_store(dst + x + step, v_add(vx_load(dst + x + step), v_cvt_f32(v_reinterpret_as_s32(v_src01))));
+                v_store(dst + x + step * 2, v_add(vx_load(dst + x + step * 2), v_cvt_f32(v_reinterpret_as_s32(v_src10))));
+                v_store(dst + x + step * 3, v_add(vx_load(dst + x + step * 3), v_cvt_f32(v_reinterpret_as_s32(v_src11))));
+            }
+        }
+        else if (cn == 3)
+        {
+            for ( ; x <= len - cVectorWidth ; x += cVectorWidth)
+            {
+                v_uint8 v_mask = vx_load(mask + x);
+                v_mask = v_not(v_eq(v_0, v_mask));
+
+                v_uint8 v_src0, v_src1, v_src2;
+                v_load_deinterleave(src + x * cn, v_src0, v_src1, v_src2);
+                v_src0 = v_and(v_src0, v_mask);
+                v_src1 = v_and(v_src1, v_mask);
+                v_src2 = v_and(v_src2, v_mask);
+
+                v_uint16 v_src00, v_src01, v_src10, v_src11, v_src20, v_src21;
+                v_expand(v_src0, v_src00, v_src01);
+                v_expand(v_src1, v_src10, v_src11);
+                v_expand(v_src2, v_src20, v_src21);
+                v_src00 = v_mul_wrap(v_src00, v_src00);
+                v_src01 = v_mul_wrap(v_src01, v_src01);
+                v_src10 = v_mul_wrap(v_src10, v_src10);
+                v_src11 = v_mul_wrap(v_src11, v_src11);
+                v_src20 = v_mul_wrap(v_src20, v_src20);
+                v_src21 = v_mul_wrap(v_src21, v_src21);
+
+                v_uint32 v_src000, v_src001, v_src010, v_src011;
+                v_uint32 v_src100, v_src101, v_src110, v_src111;
+                v_uint32 v_src200, v_src201, v_src210, v_src211;
+                v_expand(v_src00, v_src000, v_src001);
+                v_expand(v_src01, v_src010, v_src011);
+                v_expand(v_src10, v_src100, v_src101);
+                v_expand(v_src11, v_src110, v_src111);
+                v_expand(v_src20, v_src200, v_src201);
+                v_expand(v_src21, v_src210, v_src211);
+
+                v_float32 v_dst000, v_dst001, v_dst010, v_dst011;
+                v_float32 v_dst100, v_dst101, v_dst110, v_dst111;
+                v_float32 v_dst200, v_dst201, v_dst210, v_dst211;
+                v_load_deinterleave(dst + x * cn, v_dst000, v_dst100, v_dst200);
+                v_load_deinterleave(dst + (x + step) * cn, v_dst001, v_dst101, v_dst201);
+                v_load_deinterleave(dst + (x + step * 2) * cn, v_dst010, v_dst110, v_dst210);
+                v_load_deinterleave(dst + (x + step * 3) * cn, v_dst011, v_dst111, v_dst211);
+
+                v_dst000 = v_add(v_dst000, v_cvt_f32(v_reinterpret_as_s32(v_src000)));
+                v_dst001 = v_add(v_dst001, v_cvt_f32(v_reinterpret_as_s32(v_src001)));
+                v_dst010 = v_add(v_dst010, v_cvt_f32(v_reinterpret_as_s32(v_src010)));
+                v_dst011 = v_add(v_dst011, v_cvt_f32(v_reinterpret_as_s32(v_src011)));
+
+                v_dst100 = v_add(v_dst100, v_cvt_f32(v_reinterpret_as_s32(v_src100)));
+                v_dst101 = v_add(v_dst101, v_cvt_f32(v_reinterpret_as_s32(v_src101)));
+                v_dst110 = v_add(v_dst110, v_cvt_f32(v_reinterpret_as_s32(v_src110)));
+                v_dst111 = v_add(v_dst111, v_cvt_f32(v_reinterpret_as_s32(v_src111)));
+
+                v_dst200 = v_add(v_dst200, v_cvt_f32(v_reinterpret_as_s32(v_src200)));
+                v_dst201 = v_add(v_dst201, v_cvt_f32(v_reinterpret_as_s32(v_src201)));
+                v_dst210 = v_add(v_dst210, v_cvt_f32(v_reinterpret_as_s32(v_src210)));
+                v_dst211 = v_add(v_dst211, v_cvt_f32(v_reinterpret_as_s32(v_src211)));
+
+                v_store_interleave(dst + x * cn, v_dst000, v_dst100, v_dst200);
+                v_store_interleave(dst + (x + step) * cn, v_dst001, v_dst101, v_dst201);
+                v_store_interleave(dst + (x + step * 2) * cn, v_dst010, v_dst110, v_dst210);
+                v_store_interleave(dst + (x + step * 3) * cn, v_dst011, v_dst111, v_dst211);
+            }
+        }
+    }
+#endif // CV_SIMD
+    accSqr_general_(src, dst, mask, len, cn, x);
+}
+
+void accSqr_simd_(const ushort* src, float* dst, const uchar* mask, int len, int cn)
+{
+    int x = 0;
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+    const int cVectorWidth = VTraits<v_uint16>::vlanes();
+    const int step = VTraits<v_float32>::vlanes();
+
+    if (!mask)
+    {
+        int size = len * cn;
+        for (; x <= size - cVectorWidth; x += cVectorWidth)
+        {
+            v_uint16 v_src = vx_load(src + x);
+            v_uint32 v_src0, v_src1;
+            v_expand(v_src, v_src0, v_src1);
+
+            v_float32 v_float0, v_float1;
+            v_float0 = v_cvt_f32(v_reinterpret_as_s32(v_src0));
+            v_float1 = v_cvt_f32(v_reinterpret_as_s32(v_src1));
+
+            v_store(dst + x, v_fma(v_float0, v_float0, vx_load(dst + x)));
+            v_store(dst + x + step, v_fma(v_float1, v_float1, vx_load(dst + x + step)));
+        }
+    }
+    else
+    {
+        v_uint32 v_0 = vx_setzero_u32();
+        if (cn == 1)
+        {
+            for ( ; x <= len - cVectorWidth ; x += cVectorWidth)
+            {
+                v_uint16 v_mask16 = vx_load_expand(mask + x);
+                v_uint32 v_mask0, v_mask1;
+                v_expand(v_mask16, v_mask0, v_mask1);
+                v_mask0 = v_not(v_eq(v_mask0, v_0));
+                v_mask1 = v_not(v_eq(v_mask1, v_0));
+                v_uint16 v_src = vx_load(src + x);
+                v_uint32 v_src0, v_src1;
+                v_expand(v_src, v_src0, v_src1);
+                v_src0 = v_and(v_src0, v_mask0);
+                v_src1 = v_and(v_src1, v_mask1);
+
+                v_float32 v_float0, v_float1;
+                v_float0 = v_cvt_f32(v_reinterpret_as_s32(v_src0));
+                v_float1 = v_cvt_f32(v_reinterpret_as_s32(v_src1));
+
+                v_store(dst + x, v_fma(v_float0, v_float0, vx_load(dst + x)));
+                v_store(dst + x + step, v_fma(v_float1, v_float1, vx_load(dst + x + step)));
+            }
+        }
+        else if (cn == 3)
+        {
+            for ( ; x <= len - cVectorWidth ; x += cVectorWidth)
+            {
+                v_uint16 v_mask16 = vx_load_expand(mask + x);
+                v_uint32 v_mask0, v_mask1;
+                v_expand(v_mask16, v_mask0, v_mask1);
+                v_mask0 = v_not(v_eq(v_mask0, v_0));
+                v_mask1 = v_not(v_eq(v_mask1, v_0));
+
+                v_uint16 v_src0, v_src1, v_src2;
+                v_load_deinterleave(src + x * cn, v_src0, v_src1, v_src2);
+                v_uint32 v_int00, v_int01, v_int10, v_int11, v_int20, v_int21;
+                v_expand(v_src0, v_int00, v_int01);
+                v_expand(v_src1, v_int10, v_int11);
+                v_expand(v_src2, v_int20, v_int21);
+                v_int00 = v_and(v_int00, v_mask0);
+                v_int01 = v_and(v_int01, v_mask1);
+                v_int10 = v_and(v_int10, v_mask0);
+                v_int11 = v_and(v_int11, v_mask1);
+                v_int20 = v_and(v_int20, v_mask0);
+                v_int21 = v_and(v_int21, v_mask1);
+
+                v_float32 v_src00, v_src01, v_src10, v_src11, v_src20, v_src21;
+                v_src00 = v_cvt_f32(v_reinterpret_as_s32(v_int00));
+                v_src01 = v_cvt_f32(v_reinterpret_as_s32(v_int01));
+                v_src10 = v_cvt_f32(v_reinterpret_as_s32(v_int10));
+                v_src11 = v_cvt_f32(v_reinterpret_as_s32(v_int11));
+                v_src20 = v_cvt_f32(v_reinterpret_as_s32(v_int20));
+                v_src21 = v_cvt_f32(v_reinterpret_as_s32(v_int21));
+
+                v_float32 v_dst00, v_dst01, v_dst10, v_dst11, v_dst20, v_dst21;
+                v_load_deinterleave(dst + x * cn, v_dst00, v_dst10, v_dst20);
+                v_load_deinterleave(dst + (x + step) * cn, v_dst01, v_dst11, v_dst21);
+
+                v_dst00 = v_fma(v_src00, v_src00, v_dst00);
+                v_dst01 = v_fma(v_src01, v_src01, v_dst01);
+                v_dst10 = v_fma(v_src10, v_src10, v_dst10);
+                v_dst11 = v_fma(v_src11, v_src11, v_dst11);
+                v_dst20 = v_fma(v_src20, v_src20, v_dst20);
+                v_dst21 = v_fma(v_src21, v_src21, v_dst21);
+
+                v_store_interleave(dst + x * cn, v_dst00, v_dst10, v_dst20);
+                v_store_interleave(dst + (x + step) * cn, v_dst01, v_dst11, v_dst21);
+            }
+        }
+    }
+#endif // CV_SIMD
+    accSqr_general_(src, dst, mask, len, cn, x);
+}
+
+void accSqr_simd_(const float* src, float* dst, const uchar* mask, int len, int cn)
+{
+    int x = 0;
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+    const int cVectorWidth = VTraits<v_uint16>::vlanes();
+    const int step = VTraits<v_float32>::vlanes();
+
+    if (!mask)
+    {
+        int size = len * cn;
+        #if CV_AVX && !CV_AVX2
+        for ( ; x <= size - 8 ; x += 8)
+        {
+            __m256 v_src = _mm256_loadu_ps(src + x);
+            __m256 v_dst = _mm256_loadu_ps(dst + x);
+            v_src = _mm256_mul_ps(v_src, v_src);
+            v_dst = _mm256_add_ps(v_src, v_dst);
+            _mm256_storeu_ps(dst + x, v_dst);
+        }
+        #else
+        for (; x <= size - cVectorWidth; x += cVectorWidth)
+        {
+            v_float32 v_src0 = vx_load(src + x);
+            v_float32 v_src1 = vx_load(src + x + step);
+
+            v_store(dst + x, v_fma(v_src0, v_src0, vx_load(dst + x)));
+            v_store(dst + x + step, v_fma(v_src1, v_src1, vx_load(dst + x + step)));
+        }
+        #endif // CV_AVX && !CV_AVX2
+    }
+    else
+    {
+        v_uint32 v_0 = vx_setzero_u32();
+        if (cn == 1)
+        {
+            for (; x <= len - cVectorWidth; x += cVectorWidth)
+            {
+                v_uint16 v_mask16 = vx_load_expand(mask + x);
+                v_uint32 v_mask_0, v_mask_1;
+                v_expand(v_mask16, v_mask_0, v_mask_1);
+                v_float32 v_mask0 = v_reinterpret_as_f32(v_not(v_eq(v_mask_0, v_0)));
+                v_float32 v_mask1 = v_reinterpret_as_f32(v_not(v_eq(v_mask_1, v_0)));
+                v_float32 v_src0 = vx_load(src + x);
+                v_float32 v_src1 = vx_load(src + x + step);
+                v_src0 = v_and(v_src0, v_mask0);
+                v_src1 = v_and(v_src1, v_mask1);
+
+                v_store(dst + x, v_fma(v_src0, v_src0, vx_load(dst + x)));
+                v_store(dst + x + step, v_fma(v_src1, v_src1, vx_load(dst + x + step)));
+            }
+        }
+        else if (cn == 3)
+        {
+            for (; x <= len - cVectorWidth; x += cVectorWidth)
+            {
+                v_uint16 v_mask16 = vx_load_expand(mask + x);
+                v_uint32 v_mask_0, v_mask_1;
+                v_expand(v_mask16, v_mask_0, v_mask_1);
+                v_float32 v_mask0 = v_reinterpret_as_f32(v_not(v_eq(v_mask_0, v_0)));
+                v_float32 v_mask1 = v_reinterpret_as_f32(v_not(v_eq(v_mask_1, v_0)));
+
+                v_float32 v_src00, v_src10, v_src20, v_src01, v_src11, v_src21;
+                v_load_deinterleave(src + x * cn, v_src00, v_src10, v_src20);
+                v_load_deinterleave(src + (x + step) * cn, v_src01, v_src11, v_src21);
+                v_src00 = v_and(v_src00, v_mask0);
+                v_src01 = v_and(v_src01, v_mask1);
+                v_src10 = v_and(v_src10, v_mask0);
+                v_src11 = v_and(v_src11, v_mask1);
+                v_src20 = v_and(v_src20, v_mask0);
+                v_src21 = v_and(v_src21, v_mask1);
+
+                v_float32 v_dst00, v_dst10, v_dst20, v_dst01, v_dst11, v_dst21;
+                v_load_deinterleave(dst + x * cn, v_dst00, v_dst10, v_dst20);
+                v_load_deinterleave(dst + (x + step) * cn, v_dst01, v_dst11, v_dst21);
+
+                v_dst00 = v_fma(v_src00, v_src00, v_dst00);
+                v_dst01 = v_fma(v_src01, v_src01, v_dst01);
+                v_dst10 = v_fma(v_src10, v_src10, v_dst10);
+                v_dst11 = v_fma(v_src11, v_src11, v_dst11);
+                v_dst20 = v_fma(v_src20, v_src20, v_dst20);
+                v_dst21 = v_fma(v_src21, v_src21, v_dst21);
+
+                v_store_interleave(dst + x * cn, v_dst00, v_dst10, v_dst20);
+                v_store_interleave(dst + (x + step) * cn, v_dst01, v_dst11, v_dst21);
+            }
+        }
+    }
+#endif // CV_SIMD
+    accSqr_general_(src, dst, mask, len, cn, x);
+}
+
+void accSqr_simd_(const uchar* src, double* dst, const uchar* mask, int len, int cn)
+{
+    int x = 0;
+#if (CV_SIMD_64F || CV_SIMD_SCALABLE_64F)
+    const int cVectorWidth = VTraits<v_uint16>::vlanes();
+    const int step = VTraits<v_float64>::vlanes();
+
+    if (!mask)
+    {
+        int size = len * cn;
+        for (; x <= size - cVectorWidth; x += cVectorWidth)
+        {
+            v_uint16 v_int = vx_load_expand(src + x);
+
+            v_uint32 v_int0, v_int1;
+            v_expand(v_int, v_int0, v_int1);
+
+            v_float64 v_src0 = v_cvt_f64(v_reinterpret_as_s32(v_int0));
+            v_float64 v_src1 = v_cvt_f64_high(v_reinterpret_as_s32(v_int0));
+            v_float64 v_src2 = v_cvt_f64(v_reinterpret_as_s32(v_int1));
+            v_float64 v_src3 = v_cvt_f64_high(v_reinterpret_as_s32(v_int1));
+
+            v_float64 v_dst0 = vx_load(dst + x);
+            v_float64 v_dst1 = vx_load(dst + x + step);
+            v_float64 v_dst2 = vx_load(dst + x + step * 2);
+            v_float64 v_dst3 = vx_load(dst + x + step * 3);
+
+            v_dst0 = v_fma(v_src0, v_src0, v_dst0);
+            v_dst1 = v_fma(v_src1, v_src1, v_dst1);
+            v_dst2 = v_fma(v_src2, v_src2, v_dst2);
+            v_dst3 = v_fma(v_src3, v_src3, v_dst3);
+
+            v_store(dst + x, v_dst0);
+            v_store(dst + x + step, v_dst1);
+            v_store(dst + x + step * 2, v_dst2);
+            v_store(dst + x + step * 3, v_dst3);
+        }
+    }
+    else
+    {
+        v_uint16 v_0 = vx_setzero_u16();
+        if (cn == 1)
+        {
+            for (; x <= len - cVectorWidth; x += cVectorWidth)
+            {
+                v_uint16 v_mask = vx_load_expand(mask + x);
+                v_mask = v_not(v_eq(v_mask, v_0));
+                v_uint16 v_src = vx_load_expand(src + x);
+                v_uint16 v_int = v_and(v_src, v_mask);
+
+                v_uint32 v_int0, v_int1;
+                v_expand(v_int, v_int0, v_int1);
+
+                v_float64 v_src0 = v_cvt_f64(v_reinterpret_as_s32(v_int0));
+                v_float64 v_src1 = v_cvt_f64_high(v_reinterpret_as_s32(v_int0));
+                v_float64 v_src2 = v_cvt_f64(v_reinterpret_as_s32(v_int1));
+                v_float64 v_src3 = v_cvt_f64_high(v_reinterpret_as_s32(v_int1));
+
+                v_float64 v_dst0 = vx_load(dst + x);
+                v_float64 v_dst1 = vx_load(dst + x + step);
+                v_float64 v_dst2 = vx_load(dst + x + step * 2);
+                v_float64 v_dst3 = vx_load(dst + x + step * 3);
+
+                v_dst0 = v_fma(v_src0, v_src0, v_dst0);
+                v_dst1 = v_fma(v_src1, v_src1, v_dst1);
+                v_dst2 = v_fma(v_src2, v_src2, v_dst2);
+                v_dst3 = v_fma(v_src3, v_src3, v_dst3);
+
+                v_store(dst + x, v_dst0);
+                v_store(dst + x + step, v_dst1);
+                v_store(dst + x + step * 2, v_dst2);
+                v_store(dst + x + step * 3, v_dst3);
+            }
+        }
+        else if (cn == 3)
+        {
+            for (; x <= len - cVectorWidth * 2; x += cVectorWidth)
+            {
+                v_uint8 v_src0, v_src1, v_src2;
+                v_load_deinterleave(src + x * cn, v_src0, v_src1, v_src2);
+
+                v_uint16 v_int0 = v_expand_low(v_src0);
+                v_uint16 v_int1 = v_expand_low(v_src1);
+                v_uint16 v_int2 = v_expand_low(v_src2);
+
+                v_uint16 v_mask = vx_load_expand(mask + x);
+                v_mask = v_not(v_eq(v_mask, v_0));
+                v_int0 = v_and(v_int0, v_mask);
+                v_int1 = v_and(v_int1, v_mask);
+                v_int2 = v_and(v_int2, v_mask);
+
+                v_uint32 v_int00, v_int01, v_int10, v_int11, v_int20, v_int21;
+                v_expand(v_int0, v_int00, v_int01);
+                v_expand(v_int1, v_int10, v_int11);
+                v_expand(v_int2, v_int20, v_int21);
+
+                v_float64 v_src00 = v_cvt_f64(v_reinterpret_as_s32(v_int00));
+                v_float64 v_src01 = v_cvt_f64_high(v_reinterpret_as_s32(v_int00));
+                v_float64 v_src02 = v_cvt_f64(v_reinterpret_as_s32(v_int01));
+                v_float64 v_src03 = v_cvt_f64_high(v_reinterpret_as_s32(v_int01));
+                v_float64 v_src10 = v_cvt_f64(v_reinterpret_as_s32(v_int10));
+                v_float64 v_src11 = v_cvt_f64_high(v_reinterpret_as_s32(v_int10));
+                v_float64 v_src12 = v_cvt_f64(v_reinterpret_as_s32(v_int11));
+                v_float64 v_src13 = v_cvt_f64_high(v_reinterpret_as_s32(v_int11));
+                v_float64 v_src20 = v_cvt_f64(v_reinterpret_as_s32(v_int20));
+                v_float64 v_src21 = v_cvt_f64_high(v_reinterpret_as_s32(v_int20));
+                v_float64 v_src22 = v_cvt_f64(v_reinterpret_as_s32(v_int21));
+                v_float64 v_src23 = v_cvt_f64_high(v_reinterpret_as_s32(v_int21));
+
+                v_float64 v_dst00, v_dst01, v_dst02, v_dst03, v_dst10, v_dst11, v_dst12, v_dst13, v_dst20, v_dst21, v_dst22, v_dst23;
+                v_load_deinterleave(dst + x * cn, v_dst00, v_dst10, v_dst20);
+                v_load_deinterleave(dst + (x + step) * cn, v_dst01, v_dst11, v_dst21);
+                v_load_deinterleave(dst + (x + step * 2) * cn, v_dst02, v_dst12, v_dst22);
+                v_load_deinterleave(dst + (x + step * 3) * cn, v_dst03, v_dst13, v_dst23);
+
+                v_dst00 = v_fma(v_src00, v_src00, v_dst00);
+                v_dst01 = v_fma(v_src01, v_src01, v_dst01);
+                v_dst02 = v_fma(v_src02, v_src02, v_dst02);
+                v_dst03 = v_fma(v_src03, v_src03, v_dst03);
+                v_dst10 = v_fma(v_src10, v_src10, v_dst10);
+                v_dst11 = v_fma(v_src11, v_src11, v_dst11);
+                v_dst12 = v_fma(v_src12, v_src12, v_dst12);
+                v_dst13 = v_fma(v_src13, v_src13, v_dst13);
+                v_dst20 = v_fma(v_src20, v_src20, v_dst20);
+                v_dst21 = v_fma(v_src21, v_src21, v_dst21);
+                v_dst22 = v_fma(v_src22, v_src22, v_dst22);
+                v_dst23 = v_fma(v_src23, v_src23, v_dst23);
+
+                v_store_interleave(dst + x * cn, v_dst00, v_dst10, v_dst20);
+                v_store_interleave(dst + (x + step) * cn, v_dst01, v_dst11, v_dst21);
+                v_store_interleave(dst + (x + step * 2) * cn, v_dst02, v_dst12, v_dst22);
+                v_store_interleave(dst + (x + step * 3) * cn, v_dst03, v_dst13, v_dst23);
+            }
+        }
+    }
+#endif // CV_SIMD_64F
+    accSqr_general_(src, dst, mask, len, cn, x);
+}
+
+void accSqr_simd_(const ushort* src, double* dst, const uchar* mask, int len, int cn)
+{
+    int x = 0;
+#if (CV_SIMD_64F || CV_SIMD_SCALABLE_64F)
+    const int cVectorWidth = VTraits<v_uint16>::vlanes();
+    const int step = VTraits<v_float64>::vlanes();
+
+    if (!mask)
+    {
+        int size = len * cn;
+        for (; x <= size - cVectorWidth; x += cVectorWidth)
+        {
+            v_uint16 v_src  = vx_load(src + x);
+            v_uint32 v_int_0, v_int_1;
+            v_expand(v_src, v_int_0, v_int_1);
+
+            v_int32 v_int0 = v_reinterpret_as_s32(v_int_0);
+            v_int32 v_int1 = v_reinterpret_as_s32(v_int_1);
+
+            v_float64 v_src0 = v_cvt_f64(v_int0);
+            v_float64 v_src1 = v_cvt_f64_high(v_int0);
+            v_float64 v_src2 = v_cvt_f64(v_int1);
+            v_float64 v_src3 = v_cvt_f64_high(v_int1);
+
+            v_float64 v_dst0 = vx_load(dst + x);
+            v_float64 v_dst1 = vx_load(dst + x + step);
+            v_float64 v_dst2 = vx_load(dst + x + step * 2);
+            v_float64 v_dst3 = vx_load(dst + x + step * 3);
+
+            v_dst0 = v_fma(v_src0, v_src0, v_dst0);
+            v_dst1 = v_fma(v_src1, v_src1, v_dst1);
+            v_dst2 = v_fma(v_src2, v_src2, v_dst2);
+            v_dst3 = v_fma(v_src3, v_src3, v_dst3);
+
+            v_store(dst + x, v_dst0);
+            v_store(dst + x + step, v_dst1);
+            v_store(dst + x + step * 2, v_dst2);
+            v_store(dst + x + step * 3, v_dst3);
+        }
+    }
+    else
+    {
+        v_uint16 v_0 = vx_setzero_u16();
+        if (cn == 1)
+        {
+            for (; x <= len - cVectorWidth; x += cVectorWidth)
+            {
+                v_uint16 v_mask = vx_load_expand(mask + x);
+                v_mask = v_not(v_eq(v_mask, v_0));
+                v_uint16 v_src = vx_load(src + x);
+                v_src = v_and(v_src, v_mask);
+                v_uint32 v_int_0, v_int_1;
+                v_expand(v_src, v_int_0, v_int_1);
+
+                v_int32 v_int0 = v_reinterpret_as_s32(v_int_0);
+                v_int32 v_int1 = v_reinterpret_as_s32(v_int_1);
+
+                v_float64 v_src0 = v_cvt_f64(v_int0);
+                v_float64 v_src1 = v_cvt_f64_high(v_int0);
+                v_float64 v_src2 = v_cvt_f64(v_int1);
+                v_float64 v_src3 = v_cvt_f64_high(v_int1);
+
+                v_float64 v_dst0 = vx_load(dst + x);
+                v_float64 v_dst1 = vx_load(dst + x + step);
+                v_float64 v_dst2 = vx_load(dst + x + step * 2);
+                v_float64 v_dst3 = vx_load(dst + x + step * 3);
+
+                v_dst0 = v_fma(v_src0, v_src0, v_dst0);
+                v_dst1 = v_fma(v_src1, v_src1, v_dst1);
+                v_dst2 = v_fma(v_src2, v_src2, v_dst2);
+                v_dst3 = v_fma(v_src3, v_src3, v_dst3);
+
+                v_store(dst + x, v_dst0);
+                v_store(dst + x + step, v_dst1);
+                v_store(dst + x + step * 2, v_dst2);
+                v_store(dst + x + step * 3, v_dst3);
+            }
+        }
+        else if (cn == 3)
+        {
+            for (; x <= len - cVectorWidth; x += cVectorWidth)
+            {
+                v_uint16 v_mask = vx_load_expand(mask + x);
+                v_mask = v_not(v_eq(v_mask, v_0));
+                v_uint16 v_src0, v_src1, v_src2;
+                v_load_deinterleave(src + x * cn, v_src0, v_src1, v_src2);
+                v_src0 = v_and(v_src0, v_mask);
+                v_src1 = v_and(v_src1, v_mask);
+                v_src2 = v_and(v_src2, v_mask);
+                v_uint32 v_int00, v_int01, v_int10, v_int11, v_int20, v_int21;
+                v_expand(v_src0, v_int00, v_int01);
+                v_expand(v_src1, v_int10, v_int11);
+                v_expand(v_src2, v_int20, v_int21);
+
+                v_float64 v_src00 = v_cvt_f64(v_reinterpret_as_s32(v_int00));
+                v_float64 v_src01 = v_cvt_f64_high(v_reinterpret_as_s32(v_int00));
+                v_float64 v_src02 = v_cvt_f64(v_reinterpret_as_s32(v_int01));
+                v_float64 v_src03 = v_cvt_f64_high(v_reinterpret_as_s32(v_int01));
+                v_float64 v_src10 = v_cvt_f64(v_reinterpret_as_s32(v_int10));
+                v_float64 v_src11 = v_cvt_f64_high(v_reinterpret_as_s32(v_int10));
+                v_float64 v_src12 = v_cvt_f64(v_reinterpret_as_s32(v_int11));
+                v_float64 v_src13 = v_cvt_f64_high(v_reinterpret_as_s32(v_int11));
+                v_float64 v_src20 = v_cvt_f64(v_reinterpret_as_s32(v_int20));
+                v_float64 v_src21 = v_cvt_f64_high(v_reinterpret_as_s32(v_int20));
+                v_float64 v_src22 = v_cvt_f64(v_reinterpret_as_s32(v_int21));
+                v_float64 v_src23 = v_cvt_f64_high(v_reinterpret_as_s32(v_int21));
+
+                v_float64 v_dst00, v_dst01, v_dst02, v_dst03;
+                v_float64 v_dst10, v_dst11, v_dst12, v_dst13;
+                v_float64 v_dst20, v_dst21, v_dst22, v_dst23;
+                v_load_deinterleave(dst + x * cn, v_dst00, v_dst10, v_dst20);
+                v_load_deinterleave(dst + (x + step)* cn, v_dst01, v_dst11, v_dst21);
+                v_load_deinterleave(dst + (x + step * 2)* cn, v_dst02, v_dst12, v_dst22);
+                v_load_deinterleave(dst + (x + step * 3)* cn, v_dst03, v_dst13, v_dst23);
+
+                v_dst00 = v_fma(v_src00, v_src00, v_dst00);
+                v_dst01 = v_fma(v_src01, v_src01, v_dst01);
+                v_dst02 = v_fma(v_src02, v_src02, v_dst02);
+                v_dst03 = v_fma(v_src03, v_src03, v_dst03);
+                v_dst10 = v_fma(v_src10, v_src10, v_dst10);
+                v_dst11 = v_fma(v_src11, v_src11, v_dst11);
+                v_dst12 = v_fma(v_src12, v_src12, v_dst12);
+                v_dst13 = v_fma(v_src13, v_src13, v_dst13);
+                v_dst20 = v_fma(v_src20, v_src20, v_dst20);
+                v_dst21 = v_fma(v_src21, v_src21, v_dst21);
+                v_dst22 = v_fma(v_src22, v_src22, v_dst22);
+                v_dst23 = v_fma(v_src23, v_src23, v_dst23);
+
+                v_store_interleave(dst + x * cn, v_dst00, v_dst10, v_dst20);
+                v_store_interleave(dst + (x + step) * cn, v_dst01, v_dst11, v_dst21);
+                v_store_interleave(dst + (x + step * 2) * cn, v_dst02, v_dst12, v_dst22);
+                v_store_interleave(dst + (x + step * 3) * cn, v_dst03, v_dst13, v_dst23);
+            }
+        }
+    }
+#endif // CV_SIMD_64F
+    accSqr_general_(src, dst, mask, len, cn, x);
+}
+
+void accSqr_simd_(const float* src, double* dst, const uchar* mask, int len, int cn)
+{
+    int x = 0;
+#if (CV_SIMD_64F || CV_SIMD_SCALABLE_64F)
+    const int cVectorWidth = VTraits<v_float32>::vlanes();
+    const int step = VTraits<v_float64>::vlanes();
+
+    if (!mask)
+    {
+        int size = len * cn;
+        #if CV_AVX && !CV_AVX2
+        for (; x <= size - 8 ; x += 8)
+        {
+            __m256 v_src = _mm256_loadu_ps(src + x);
+            __m256d v_src0 = _mm256_cvtps_pd(_mm256_extractf128_ps(v_src,0));
+            __m256d v_src1 = _mm256_cvtps_pd(_mm256_extractf128_ps(v_src,1));
+            __m256d v_dst0 = _mm256_loadu_pd(dst + x);
+            __m256d v_dst1 = _mm256_loadu_pd(dst + x + 4);
+            v_src0 = _mm256_mul_pd(v_src0, v_src0);
+            v_src1 = _mm256_mul_pd(v_src1, v_src1);
+            v_dst0 = _mm256_add_pd(v_src0, v_dst0);
+            v_dst1 = _mm256_add_pd(v_src1, v_dst1);
+            _mm256_storeu_pd(dst + x, v_dst0);
+            _mm256_storeu_pd(dst + x + 4, v_dst1);
+        }
+        #else
+        for (; x <= size - cVectorWidth; x += cVectorWidth)
+        {
+            v_float32 v_src = vx_load(src + x);
+            v_float64 v_src0 = v_cvt_f64(v_src);
+            v_float64 v_src1 = v_cvt_f64_high(v_src);
+
+            v_store(dst + x, v_fma(v_src0, v_src0, vx_load(dst + x)));
+            v_store(dst + x + step, v_fma(v_src1, v_src1, vx_load(dst + x + step)));
+        }
+        #endif // CV_AVX && !CV_AVX2
+    }
+    else
+    {
+        v_uint32 v_0 = vx_setzero_u32();
+        if (cn == 1)
+        {
+            for (; x <= len - cVectorWidth; x += cVectorWidth)
+            {
+                v_uint32 v_mask = vx_load_expand_q(mask + x);;
+                v_mask = v_not(v_eq(v_mask, v_0));
+                v_float32 v_src = vx_load(src + x);
+                v_src = v_and(v_src, v_reinterpret_as_f32(v_mask));
+                v_float64 v_src0 = v_cvt_f64(v_src);
+                v_float64 v_src1 = v_cvt_f64_high(v_src);
+
+                v_store(dst + x, v_fma(v_src0, v_src0, vx_load(dst + x)));
+                v_store(dst + x + step, v_fma(v_src1, v_src1, vx_load(dst + x + step)));
+            }
+        }
+        else if (cn == 3)
+        {
+            for (; x <= len - cVectorWidth; x += cVectorWidth)
+            {
+                v_uint32 v_mask = vx_load_expand_q(mask + x);
+                v_mask = v_not(v_eq(v_mask, v_0));
+
+                v_float32 v_src0, v_src1, v_src2;
+                v_load_deinterleave(src + x * cn, v_src0, v_src1, v_src2);
+                v_src0 = v_and(v_src0, v_reinterpret_as_f32(v_mask));
+                v_src1 = v_and(v_src1, v_reinterpret_as_f32(v_mask));
+                v_src2 = v_and(v_src2, v_reinterpret_as_f32(v_mask));
+
+                v_float64 v_src00 = v_cvt_f64(v_src0);
+                v_float64 v_src01 = v_cvt_f64_high(v_src0);
+                v_float64 v_src10 = v_cvt_f64(v_src1);
+                v_float64 v_src11 = v_cvt_f64_high(v_src1);
+                v_float64 v_src20 = v_cvt_f64(v_src2);
+                v_float64 v_src21 = v_cvt_f64_high(v_src2);
+
+                v_float64 v_dst00, v_dst01, v_dst10, v_dst11, v_dst20, v_dst21;
+                v_load_deinterleave(dst + x * cn, v_dst00, v_dst10, v_dst20);
+                v_load_deinterleave(dst + (x + step) * cn, v_dst01, v_dst11, v_dst21);
+
+                v_dst00 = v_fma(v_src00, v_src00, v_dst00);
+                v_dst01 = v_fma(v_src01, v_src01, v_dst01);
+                v_dst10 = v_fma(v_src10, v_src10, v_dst10);
+                v_dst11 = v_fma(v_src11, v_src11, v_dst11);
+                v_dst20 = v_fma(v_src20, v_src20, v_dst20);
+                v_dst21 = v_fma(v_src21, v_src21, v_dst21);
+
+                v_store_interleave(dst + x * cn, v_dst00, v_dst10, v_dst20);
+                v_store_interleave(dst + (x + step) * cn, v_dst01, v_dst11, v_dst21);
+            }
+        }
+    }
+#endif // CV_SIMD_64F
+    accSqr_general_(src, dst, mask, len, cn, x);
+}
+
+void accSqr_simd_(const double* src, double* dst, const uchar* mask, int len, int cn)
+{
+    int x = 0;
+#if (CV_SIMD_64F || CV_SIMD_SCALABLE_64F)
+    const int cVectorWidth = VTraits<v_float64>::vlanes() * 2;
+    const int step = VTraits<v_float64>::vlanes();
+
+    if (!mask)
+    {
+        int size = len * cn;
+        #if CV_AVX && !CV_AVX2
+        for (; x <= size - 4 ; x += 4)
+        {
+            __m256d v_src = _mm256_loadu_pd(src + x);
+            __m256d v_dst = _mm256_loadu_pd(dst + x);
+            v_src = _mm256_mul_pd(v_src, v_src);
+            v_dst = _mm256_add_pd(v_dst, v_src);
+            _mm256_storeu_pd(dst + x, v_dst);
+        }
+        #else
+        for (; x <= size - cVectorWidth; x += cVectorWidth)
+        {
+            v_float64 v_src0 = vx_load(src + x);
+            v_float64 v_src1 = vx_load(src + x + step);
+            v_store(dst + x, v_fma(v_src0, v_src0, vx_load(dst + x)));
+            v_store(dst + x + step, v_fma(v_src1, v_src1, vx_load(dst + x + step)));
+        }
+        #endif // CV_AVX && !CV_AVX2
+    }
+    else
+    {
+        v_uint64 v_0 = vx_setzero_u64();
+        if (cn == 1)
+        {
+            for (; x <= len - cVectorWidth; x += cVectorWidth)
+            {
+                v_uint32 v_mask32 = vx_load_expand_q(mask + x);
+                v_uint64 v_masku640, v_masku641;
+                v_expand(v_mask32, v_masku640, v_masku641);
+                v_float64 v_mask0 = v_reinterpret_as_f64(v_not(v_eq(v_masku640, v_0)));
+                v_float64 v_mask1 = v_reinterpret_as_f64(v_not(v_eq(v_masku641, v_0)));
+                v_float64 v_src0 = vx_load(src + x);
+                v_float64 v_src1 = vx_load(src + x + step);
+                v_src0 = v_and(v_src0, v_mask0);
+                v_src1 = v_and(v_src1, v_mask1);
+                v_store(dst + x, v_fma(v_src0, v_src0, vx_load(dst + x)));
+                v_store(dst + x + step, v_fma(v_src1, v_src1, vx_load(dst + x + step)));
+            }
+        }
+        else if (cn == 3)
+        {
+            for (; x <= len - cVectorWidth; x += cVectorWidth)
+            {
+                v_uint32 v_mask32 = vx_load_expand_q(mask + x);
+                v_uint64 v_masku640, v_masku641;
+                v_expand(v_mask32, v_masku640, v_masku641);
+                v_float64 v_mask0 = v_reinterpret_as_f64(v_not(v_eq(v_masku640, v_0)));
+                v_float64 v_mask1 = v_reinterpret_as_f64(v_not(v_eq(v_masku641, v_0)));
+
+                v_float64 v_src00, v_src01, v_src10, v_src11, v_src20, v_src21;
+                v_load_deinterleave(src + x * cn, v_src00, v_src10, v_src20);
+                v_load_deinterleave(src + (x + step) * cn, v_src01, v_src11, v_src21);
+                v_src00 = v_and(v_src00, v_mask0);
+                v_src01 = v_and(v_src01, v_mask1);
+                v_src10 = v_and(v_src10, v_mask0);
+                v_src11 = v_and(v_src11, v_mask1);
+                v_src20 = v_and(v_src20, v_mask0);
+                v_src21 = v_and(v_src21, v_mask1);
+
+                v_float64 v_dst00, v_dst01, v_dst10, v_dst11, v_dst20, v_dst21;
+                v_load_deinterleave(dst + x * cn, v_dst00, v_dst10, v_dst20);
+                v_load_deinterleave(dst + (x + step) * cn, v_dst01, v_dst11, v_dst21);
+
+                v_dst00 = v_fma(v_src00, v_src00, v_dst00);
+                v_dst01 = v_fma(v_src01, v_src01, v_dst01);
+                v_dst10 = v_fma(v_src10, v_src10, v_dst10);
+                v_dst11 = v_fma(v_src11, v_src11, v_dst11);
+                v_dst20 = v_fma(v_src20, v_src20, v_dst20);
+                v_dst21 = v_fma(v_src21, v_src21, v_dst21);
+
+                v_store_interleave(dst + x * cn, v_dst00, v_dst10, v_dst20);
+                v_store_interleave(dst + (x + step) * cn, v_dst01, v_dst11, v_dst21);
+            }
+        }
+    }
+#endif // CV_SIMD_64F
+    accSqr_general_(src, dst, mask, len, cn, x);
+}
+
+// product accumulate optimized by universal intrinsic
+void accProd_simd_(const uchar* src1, const uchar* src2, float* dst, const uchar* mask, int len, int cn)
+{
+    int x = 0;
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+    const int cVectorWidth = VTraits<v_uint8>::vlanes();
+    const int step = VTraits<v_uint32>::vlanes();
+
+    if (!mask)
+    {
+        int size = len * cn;
+        for (; x <= size - cVectorWidth; x += cVectorWidth)
+        {
+            v_uint8 v_1src = vx_load(src1 + x);
+            v_uint8 v_2src = vx_load(src2 + x);
+
+            v_uint16 v_src0, v_src1;
+            v_mul_expand(v_1src, v_2src, v_src0, v_src1);
+
+            v_uint32 v_src00, v_src01, v_src10, v_src11;
+            v_expand(v_src0, v_src00, v_src01);
+            v_expand(v_src1, v_src10, v_src11);
+
+            v_store(dst + x, v_add(vx_load(dst + x), v_cvt_f32(v_reinterpret_as_s32(v_src00))));
+            v_store(dst + x + step, v_add(vx_load(dst + x + step), v_cvt_f32(v_reinterpret_as_s32(v_src01))));
+            v_store(dst + x + step * 2, v_add(vx_load(dst + x + step * 2), v_cvt_f32(v_reinterpret_as_s32(v_src10))));
+            v_store(dst + x + step * 3, v_add(vx_load(dst + x + step * 3), v_cvt_f32(v_reinterpret_as_s32(v_src11))));
+        }
+    }
+    else
+    {
+        v_uint8 v_0 = vx_setzero_u8();
+        if (cn == 1)
+        {
+            for (; x <= len - cVectorWidth; x += cVectorWidth)
+            {
+                v_uint8 v_mask = vx_load(mask + x);
+                v_mask = v_not(v_eq(v_mask, v_0));
+                v_uint8 v_1src = vx_load(src1 + x);
+                v_uint8 v_2src = vx_load(src2 + x);
+                v_1src = v_and(v_1src, v_mask);
+                v_2src = v_and(v_2src, v_mask);
+
+                v_uint16 v_src0, v_src1;
+                v_mul_expand(v_1src, v_2src, v_src0, v_src1);
+
+                v_uint32 v_src00, v_src01, v_src10, v_src11;
+                v_expand(v_src0, v_src00, v_src01);
+                v_expand(v_src1, v_src10, v_src11);
+
+                v_store(dst + x, v_add(vx_load(dst + x), v_cvt_f32(v_reinterpret_as_s32(v_src00))));
+                v_store(dst + x + step, v_add(vx_load(dst + x + step), v_cvt_f32(v_reinterpret_as_s32(v_src01))));
+                v_store(dst + x + step * 2, v_add(vx_load(dst + x + step * 2), v_cvt_f32(v_reinterpret_as_s32(v_src10))));
+                v_store(dst + x + step * 3, v_add(vx_load(dst + x + step * 3), v_cvt_f32(v_reinterpret_as_s32(v_src11))));
+            }
+        }
+        else if (cn == 3)
+        {
+            for (; x <= len - cVectorWidth; x += cVectorWidth)
+            {
+                v_uint8 v_mask = vx_load(mask + x);
+                v_mask = v_not(v_eq(v_mask, v_0));
+                v_uint8 v_1src0, v_1src1, v_1src2, v_2src0, v_2src1, v_2src2;
+                v_load_deinterleave(src1 + x * cn, v_1src0, v_1src1, v_1src2);
+                v_load_deinterleave(src2 + x * cn, v_2src0, v_2src1, v_2src2);
+                v_1src0 = v_and(v_1src0, v_mask);
+                v_1src1 = v_and(v_1src1, v_mask);
+                v_1src2 = v_and(v_1src2, v_mask);
+                v_2src0 = v_and(v_2src0, v_mask);
+                v_2src1 = v_and(v_2src1, v_mask);
+                v_2src2 = v_and(v_2src2, v_mask);
+
+                v_uint16 v_src00, v_src01, v_src10, v_src11, v_src20, v_src21;
+                v_mul_expand(v_1src0, v_2src0, v_src00, v_src01);
+                v_mul_expand(v_1src1, v_2src1, v_src10, v_src11);
+                v_mul_expand(v_1src2, v_2src2, v_src20, v_src21);
+
+                v_uint32 v_src000, v_src001, v_src002, v_src003, v_src100, v_src101, v_src102, v_src103, v_src200, v_src201, v_src202, v_src203;
+                v_expand(v_src00, v_src000, v_src001);
+                v_expand(v_src01, v_src002, v_src003);
+                v_expand(v_src10, v_src100, v_src101);
+                v_expand(v_src11, v_src102, v_src103);
+                v_expand(v_src20, v_src200, v_src201);
+                v_expand(v_src21, v_src202, v_src203);
+
+                v_float32 v_dst000, v_dst001, v_dst002, v_dst003, v_dst100, v_dst101, v_dst102, v_dst103, v_dst200, v_dst201, v_dst202, v_dst203;
+                v_load_deinterleave(dst + x * cn, v_dst000, v_dst100, v_dst200);
+                v_load_deinterleave(dst + (x + step) * cn, v_dst001, v_dst101, v_dst201);
+                v_load_deinterleave(dst + (x + step * 2) * cn, v_dst002, v_dst102, v_dst202);
+                v_load_deinterleave(dst + (x + step * 3) * cn, v_dst003, v_dst103, v_dst203);
+                v_dst000 = v_add(v_dst000, v_cvt_f32(v_reinterpret_as_s32(v_src000)));
+                v_dst001 = v_add(v_dst001, v_cvt_f32(v_reinterpret_as_s32(v_src001)));
+                v_dst002 = v_add(v_dst002, v_cvt_f32(v_reinterpret_as_s32(v_src002)));
+                v_dst003 = v_add(v_dst003, v_cvt_f32(v_reinterpret_as_s32(v_src003)));
+                v_dst100 = v_add(v_dst100, v_cvt_f32(v_reinterpret_as_s32(v_src100)));
+                v_dst101 = v_add(v_dst101, v_cvt_f32(v_reinterpret_as_s32(v_src101)));
+                v_dst102 = v_add(v_dst102, v_cvt_f32(v_reinterpret_as_s32(v_src102)));
+                v_dst103 = v_add(v_dst103, v_cvt_f32(v_reinterpret_as_s32(v_src103)));
+                v_dst200 = v_add(v_dst200, v_cvt_f32(v_reinterpret_as_s32(v_src200)));
+                v_dst201 = v_add(v_dst201, v_cvt_f32(v_reinterpret_as_s32(v_src201)));
+                v_dst202 = v_add(v_dst202, v_cvt_f32(v_reinterpret_as_s32(v_src202)));
+                v_dst203 = v_add(v_dst203, v_cvt_f32(v_reinterpret_as_s32(v_src203)));
+
+                v_store_interleave(dst + x * cn, v_dst000, v_dst100, v_dst200);
+                v_store_interleave(dst + (x + step) * cn, v_dst001, v_dst101, v_dst201);
+                v_store_interleave(dst + (x + step * 2) * cn, v_dst002, v_dst102, v_dst202);
+                v_store_interleave(dst + (x + step * 3) * cn, v_dst003, v_dst103, v_dst203);
+            }
+        }
+    }
+#endif // CV_SIMD
+    accProd_general_(src1, src2, dst, mask, len, cn, x);
+}
+
+void accProd_simd_(const ushort* src1, const ushort* src2, float* dst, const uchar* mask, int len, int cn)
+{
+    int x = 0;
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+    const int cVectorWidth = VTraits<v_uint16>::vlanes();
+    const int step = VTraits<v_float32>::vlanes();
+
+    if (!mask)
+    {
+        int size = len * cn;
+        for (; x <= size - cVectorWidth; x += cVectorWidth)
+        {
+            v_uint16 v_1src = vx_load(src1 + x);
+            v_uint16 v_2src = vx_load(src2 + x);
+
+            v_uint32 v_1src0, v_1src1, v_2src0, v_2src1;
+            v_expand(v_1src, v_1src0, v_1src1);
+            v_expand(v_2src, v_2src0, v_2src1);
+
+            v_float32 v_1float0 = v_cvt_f32(v_reinterpret_as_s32(v_1src0));
+            v_float32 v_1float1 = v_cvt_f32(v_reinterpret_as_s32(v_1src1));
+            v_float32 v_2float0 = v_cvt_f32(v_reinterpret_as_s32(v_2src0));
+            v_float32 v_2float1 = v_cvt_f32(v_reinterpret_as_s32(v_2src1));
+
+            v_store(dst + x, v_fma(v_1float0, v_2float0, vx_load(dst + x)));
+            v_store(dst + x + step, v_fma(v_1float1, v_2float1, vx_load(dst + x + step)));
+        }
+    }
+    else
+    {
+        v_uint16 v_0 = vx_setzero_u16();
+        if (cn == 1)
+        {
+            for (; x <= len - cVectorWidth; x += cVectorWidth)
+            {
+                v_uint16 v_mask = vx_load_expand(mask + x);
+                v_mask = v_not(v_eq(v_0, v_mask));
+
+                v_uint16 v_1src = v_and(vx_load(src1 + x), v_mask);
+                v_uint16 v_2src = v_and(vx_load(src2 + x), v_mask);
+
+                v_uint32 v_1src0, v_1src1, v_2src0, v_2src1;
+                v_expand(v_1src, v_1src0, v_1src1);
+                v_expand(v_2src, v_2src0, v_2src1);
+
+                v_float32 v_1float0 = v_cvt_f32(v_reinterpret_as_s32(v_1src0));
+                v_float32 v_1float1 = v_cvt_f32(v_reinterpret_as_s32(v_1src1));
+                v_float32 v_2float0 = v_cvt_f32(v_reinterpret_as_s32(v_2src0));
+                v_float32 v_2float1 = v_cvt_f32(v_reinterpret_as_s32(v_2src1));
+
+                v_store(dst + x, v_fma(v_1float0, v_2float0, vx_load(dst + x)));
+                v_store(dst + x + step, v_fma(v_1float1, v_2float1, vx_load(dst + x + step)));
+            }
+        }
+        else if (cn == 3)
+        {
+            for (; x <= len - cVectorWidth; x += cVectorWidth)
+            {
+                v_uint16 v_mask = vx_load_expand(mask + x);
+                v_mask = v_not(v_eq(v_0, v_mask));
+
+                v_uint16 v_1src0, v_1src1, v_1src2, v_2src0, v_2src1, v_2src2;
+                v_load_deinterleave(src1 + x * cn, v_1src0, v_1src1, v_1src2);
+                v_load_deinterleave(src2 + x * cn, v_2src0, v_2src1, v_2src2);
+                v_1src0 = v_and(v_1src0, v_mask);
+                v_1src1 = v_and(v_1src1, v_mask);
+                v_1src2 = v_and(v_1src2, v_mask);
+                v_2src0 = v_and(v_2src0, v_mask);
+                v_2src1 = v_and(v_2src1, v_mask);
+                v_2src2 = v_and(v_2src2, v_mask);
+
+                v_uint32 v_1src00, v_1src01, v_1src10, v_1src11, v_1src20, v_1src21, v_2src00, v_2src01, v_2src10, v_2src11, v_2src20, v_2src21;
+                v_expand(v_1src0, v_1src00, v_1src01);
+                v_expand(v_1src1, v_1src10, v_1src11);
+                v_expand(v_1src2, v_1src20, v_1src21);
+                v_expand(v_2src0, v_2src00, v_2src01);
+                v_expand(v_2src1, v_2src10, v_2src11);
+                v_expand(v_2src2, v_2src20, v_2src21);
+
+                v_float32 v_1float00 = v_cvt_f32(v_reinterpret_as_s32(v_1src00));
+                v_float32 v_1float01 = v_cvt_f32(v_reinterpret_as_s32(v_1src01));
+                v_float32 v_1float10 = v_cvt_f32(v_reinterpret_as_s32(v_1src10));
+                v_float32 v_1float11 = v_cvt_f32(v_reinterpret_as_s32(v_1src11));
+                v_float32 v_1float20 = v_cvt_f32(v_reinterpret_as_s32(v_1src20));
+                v_float32 v_1float21 = v_cvt_f32(v_reinterpret_as_s32(v_1src21));
+                v_float32 v_2float00 = v_cvt_f32(v_reinterpret_as_s32(v_2src00));
+                v_float32 v_2float01 = v_cvt_f32(v_reinterpret_as_s32(v_2src01));
+                v_float32 v_2float10 = v_cvt_f32(v_reinterpret_as_s32(v_2src10));
+                v_float32 v_2float11 = v_cvt_f32(v_reinterpret_as_s32(v_2src11));
+                v_float32 v_2float20 = v_cvt_f32(v_reinterpret_as_s32(v_2src20));
+                v_float32 v_2float21 = v_cvt_f32(v_reinterpret_as_s32(v_2src21));
+
+                v_float32 v_dst00, v_dst01, v_dst10, v_dst11, v_dst20, v_dst21;
+                v_load_deinterleave(dst + x * cn, v_dst00, v_dst10, v_dst20);
+                v_load_deinterleave(dst + (x + step) * cn, v_dst01, v_dst11, v_dst21);
+
+                v_dst00 = v_fma(v_1float00, v_2float00, v_dst00);
+                v_dst01 = v_fma(v_1float01, v_2float01, v_dst01);
+                v_dst10 = v_fma(v_1float10, v_2float10, v_dst10);
+                v_dst11 = v_fma(v_1float11, v_2float11, v_dst11);
+                v_dst20 = v_fma(v_1float20, v_2float20, v_dst20);
+                v_dst21 = v_fma(v_1float21, v_2float21, v_dst21);
+
+                v_store_interleave(dst + x * cn, v_dst00, v_dst10, v_dst20);
+                v_store_interleave(dst + (x + step) * cn, v_dst01, v_dst11, v_dst21);
+            }
+        }
+    }
+#endif // CV_SIMD
+    accProd_general_(src1, src2, dst, mask, len, cn, x);
+}
+
+void accProd_simd_(const float* src1, const float* src2, float* dst, const uchar* mask, int len, int cn)
+{
+    int x = 0;
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+    const int cVectorWidth = VTraits<v_uint16>::vlanes();
+    const int step = VTraits<v_float32>::vlanes();
+
+    if (!mask)
+    {
+        int size = len * cn;
+        #if CV_AVX && !CV_AVX2
+        for (; x <= size - 8 ; x += 8)
+        {
+            __m256 v_src0 = _mm256_loadu_ps(src1 + x);
+            __m256 v_src1 = _mm256_loadu_ps(src2 + x);
+            __m256 v_dst = _mm256_loadu_ps(dst + x);
+            __m256 v_src = _mm256_mul_ps(v_src0, v_src1);
+            v_dst = _mm256_add_ps(v_src, v_dst);
+            _mm256_storeu_ps(dst + x, v_dst);
+        }
+        #else
+        for (; x <= size - cVectorWidth; x += cVectorWidth)
+        {
+            v_store(dst + x, v_fma(vx_load(src1 + x), vx_load(src2 + x), vx_load(dst + x)));
+            v_store(dst + x + step, v_fma(vx_load(src1 + x + step), vx_load(src2 + x + step), vx_load(dst + x + step)));
+        }
+        #endif // CV_AVX && !CV_AVX2
+    }
+    else
+    {
+        v_uint32 v_0 = vx_setzero_u32();
+        if (cn == 1)
+        {
+            for (; x <= len - cVectorWidth; x += cVectorWidth)
+            {
+                v_uint32 v_mask32_0 = vx_load_expand_q(mask + x);
+                v_uint32 v_mask32_1 = vx_load_expand_q(mask + x + step);
+                v_float32 v_mask0 = v_reinterpret_as_f32(v_not(v_eq(v_mask32_0, v_0)));
+                v_float32 v_mask1 = v_reinterpret_as_f32(v_not(v_eq(v_mask32_1, v_0)));
+
+                v_store(dst + x, v_add(vx_load(dst + x), v_and(v_mul(vx_load(src1 + x), vx_load(src2 + x)), v_mask0)));
+                v_store(dst + x + step, v_add(vx_load(dst + x + step), v_and(v_mul(vx_load(src1 + x + step), vx_load(src2 + x + step)), v_mask1)));
+            }
+        }
+        else if (cn == 3)
+        {
+            for (; x <= len - cVectorWidth; x += cVectorWidth)
+            {
+                v_uint32 v_mask32_0 = vx_load_expand_q(mask + x);
+                v_uint32 v_mask32_1 = vx_load_expand_q(mask + x + step);
+                v_float32 v_mask0 = v_reinterpret_as_f32(v_not(v_eq(v_mask32_0, v_0)));
+                v_float32 v_mask1 = v_reinterpret_as_f32(v_not(v_eq(v_mask32_1, v_0)));
+
+                v_float32 v_1src00, v_1src01, v_1src10, v_1src11, v_1src20, v_1src21;
+                v_float32 v_2src00, v_2src01, v_2src10, v_2src11, v_2src20, v_2src21;
+                v_load_deinterleave(src1 + x * cn, v_1src00, v_1src10, v_1src20);
+                v_load_deinterleave(src2 + x * cn, v_2src00, v_2src10, v_2src20);
+                v_load_deinterleave(src1 + (x + step) * cn, v_1src01, v_1src11, v_1src21);
+                v_load_deinterleave(src2 + (x + step) * cn, v_2src01, v_2src11, v_2src21);
+
+                v_float32 v_dst00, v_dst01, v_dst10, v_dst11, v_dst20, v_dst21;
+                v_load_deinterleave(dst + x * cn, v_dst00, v_dst10, v_dst20);
+                v_load_deinterleave(dst + (x + step) * cn, v_dst01, v_dst11, v_dst21);
+
+                v_store_interleave(dst + x * cn, v_add(v_dst00, v_and(v_mul(v_1src00, v_2src00), v_mask0)), v_add(v_dst10, v_and(v_mul(v_1src10, v_2src10), v_mask0)), v_add(v_dst20, v_and(v_mul(v_1src20, v_2src20), v_mask0)));
+                v_store_interleave(dst + (x + step) * cn, v_add(v_dst01, v_and(v_mul(v_1src01, v_2src01), v_mask1)), v_add(v_dst11, v_and(v_mul(v_1src11, v_2src11), v_mask1)), v_add(v_dst21, v_and(v_mul(v_1src21, v_2src21), v_mask1)));
+            }
+        }
+    }
+#endif // CV_SIMD
+    accProd_general_(src1, src2, dst, mask, len, cn, x);
+}
+
+void accProd_simd_(const uchar* src1, const uchar* src2, double* dst, const uchar* mask, int len, int cn)
+{
+    int x = 0;
+#if (CV_SIMD_64F || CV_SIMD_SCALABLE_64F)
+    const int cVectorWidth = VTraits<v_uint16>::vlanes();
+    const int step = VTraits<v_float64>::vlanes();
+
+    if (!mask)
+    {
+        int size = len * cn;
+        for (; x <= size - cVectorWidth; x += cVectorWidth)
+        {
+            v_uint16 v_1int  = vx_load_expand(src1 + x);
+            v_uint16 v_2int  = vx_load_expand(src2 + x);
+
+            v_uint32 v_1int_0, v_1int_1, v_2int_0, v_2int_1;
+            v_expand(v_1int, v_1int_0, v_1int_1);
+            v_expand(v_2int, v_2int_0, v_2int_1);
+
+            v_int32 v_1int0 = v_reinterpret_as_s32(v_1int_0);
+            v_int32 v_1int1 = v_reinterpret_as_s32(v_1int_1);
+            v_int32 v_2int0 = v_reinterpret_as_s32(v_2int_0);
+            v_int32 v_2int1 = v_reinterpret_as_s32(v_2int_1);
+
+            v_float64 v_dst0 = vx_load(dst + x);
+            v_float64 v_dst1 = vx_load(dst + x + step);
+            v_float64 v_dst2 = vx_load(dst + x + step * 2);
+            v_float64 v_dst3 = vx_load(dst + x + step * 3);
+
+            v_dst0 = v_fma(v_cvt_f64(v_1int0), v_cvt_f64(v_2int0), v_dst0);
+            v_dst1 = v_fma(v_cvt_f64_high(v_1int0), v_cvt_f64_high(v_2int0), v_dst1);
+            v_dst2 = v_fma(v_cvt_f64(v_1int1), v_cvt_f64(v_2int1), v_dst2);
+            v_dst3 = v_fma(v_cvt_f64_high(v_1int1), v_cvt_f64_high(v_2int1), v_dst3);
+
+            v_store(dst + x, v_dst0);
+            v_store(dst + x + step, v_dst1);
+            v_store(dst + x + step * 2, v_dst2);
+            v_store(dst + x + step * 3, v_dst3);
+        }
+    }
+    else
+    {
+        v_uint16 v_0 = vx_setzero_u16();
+        if (cn == 1)
+        {
+            for (; x <= len - cVectorWidth; x += cVectorWidth)
+            {
+                v_uint16 v_mask = vx_load_expand(mask + x);
+                v_mask = v_not(v_eq(v_mask, v_0));
+                v_uint16 v_1int = v_and(vx_load_expand(src1 + x), v_mask);
+                v_uint16 v_2int = v_and(vx_load_expand(src2 + x), v_mask);
+
+                v_uint32 v_1int_0, v_1int_1, v_2int_0, v_2int_1;
+                v_expand(v_1int, v_1int_0, v_1int_1);
+                v_expand(v_2int, v_2int_0, v_2int_1);
+
+                v_int32 v_1int0 = v_reinterpret_as_s32(v_1int_0);
+                v_int32 v_1int1 = v_reinterpret_as_s32(v_1int_1);
+                v_int32 v_2int0 = v_reinterpret_as_s32(v_2int_0);
+                v_int32 v_2int1 = v_reinterpret_as_s32(v_2int_1);
+
+                v_float64 v_dst0 = vx_load(dst + x);
+                v_float64 v_dst1 = vx_load(dst + x + step);
+                v_float64 v_dst2 = vx_load(dst + x + step * 2);
+                v_float64 v_dst3 = vx_load(dst + x + step * 3);
+
+                v_dst0 = v_fma(v_cvt_f64(v_1int0), v_cvt_f64(v_2int0), v_dst0);
+                v_dst1 = v_fma(v_cvt_f64_high(v_1int0), v_cvt_f64_high(v_2int0), v_dst1);
+                v_dst2 = v_fma(v_cvt_f64(v_1int1), v_cvt_f64(v_2int1), v_dst2);
+                v_dst3 = v_fma(v_cvt_f64_high(v_1int1), v_cvt_f64_high(v_2int1), v_dst3);
+
+                v_store(dst + x, v_dst0);
+                v_store(dst + x + step, v_dst1);
+                v_store(dst + x + step * 2, v_dst2);
+                v_store(dst + x + step * 3, v_dst3);
+            }
+        }
+        else if (cn == 3)
+        {
+            for (; x <= len - cVectorWidth * 2; x += cVectorWidth)
+            {
+                v_uint8 v_1src0, v_1src1, v_1src2, v_2src0, v_2src1, v_2src2;
+                v_load_deinterleave(src1 + x * cn, v_1src0, v_1src1, v_1src2);
+                v_load_deinterleave(src2 + x * cn, v_2src0, v_2src1, v_2src2);
+
+                v_uint16 v_1int0 = v_expand_low(v_1src0);
+                v_uint16 v_1int1 = v_expand_low(v_1src1);
+                v_uint16 v_1int2 = v_expand_low(v_1src2);
+                v_uint16 v_2int0 = v_expand_low(v_2src0);
+                v_uint16 v_2int1 = v_expand_low(v_2src1);
+                v_uint16 v_2int2 = v_expand_low(v_2src2);
+
+                v_uint16 v_mask = vx_load_expand(mask + x);
+                v_mask = v_not(v_eq(v_mask, v_0));
+                v_1int0 = v_and(v_1int0, v_mask);
+                v_1int1 = v_and(v_1int1, v_mask);
+                v_1int2 = v_and(v_1int2, v_mask);
+                v_2int0 = v_and(v_2int0, v_mask);
+                v_2int1 = v_and(v_2int1, v_mask);
+                v_2int2 = v_and(v_2int2, v_mask);
+
+                v_uint32 v_1int00, v_1int01, v_1int10, v_1int11, v_1int20, v_1int21;
+                v_uint32 v_2int00, v_2int01, v_2int10, v_2int11, v_2int20, v_2int21;
+                v_expand(v_1int0, v_1int00, v_1int01);
+                v_expand(v_1int1, v_1int10, v_1int11);
+                v_expand(v_1int2, v_1int20, v_1int21);
+                v_expand(v_2int0, v_2int00, v_2int01);
+                v_expand(v_2int1, v_2int10, v_2int11);
+                v_expand(v_2int2, v_2int20, v_2int21);
+
+                v_float64 v_dst00, v_dst01, v_dst02, v_dst03, v_dst10, v_dst11, v_dst12, v_dst13, v_dst20, v_dst21, v_dst22, v_dst23;
+                v_load_deinterleave(dst + x * cn, v_dst00, v_dst10, v_dst20);
+                v_load_deinterleave(dst + (x + step) * cn, v_dst01, v_dst11, v_dst21);
+                v_load_deinterleave(dst + (x + step * 2) * cn, v_dst02, v_dst12, v_dst22);
+                v_load_deinterleave(dst + (x + step * 3) * cn, v_dst03, v_dst13, v_dst23);
+
+                v_dst00 = v_fma(v_cvt_f64(v_reinterpret_as_s32(v_1int00)), v_cvt_f64(v_reinterpret_as_s32(v_2int00)), v_dst00);
+                v_dst01 = v_fma(v_cvt_f64_high(v_reinterpret_as_s32(v_1int00)), v_cvt_f64_high(v_reinterpret_as_s32(v_2int00)), v_dst01);
+                v_dst02 = v_fma(v_cvt_f64(v_reinterpret_as_s32(v_1int01)), v_cvt_f64(v_reinterpret_as_s32(v_2int01)), v_dst02);
+                v_dst03 = v_fma(v_cvt_f64_high(v_reinterpret_as_s32(v_1int01)), v_cvt_f64_high(v_reinterpret_as_s32(v_2int01)), v_dst03);
+                v_dst10 = v_fma(v_cvt_f64(v_reinterpret_as_s32(v_1int10)), v_cvt_f64(v_reinterpret_as_s32(v_2int10)), v_dst10);
+                v_dst11 = v_fma(v_cvt_f64_high(v_reinterpret_as_s32(v_1int10)), v_cvt_f64_high(v_reinterpret_as_s32(v_2int10)), v_dst11);
+                v_dst12 = v_fma(v_cvt_f64(v_reinterpret_as_s32(v_1int11)), v_cvt_f64(v_reinterpret_as_s32(v_2int11)), v_dst12);
+                v_dst13 = v_fma(v_cvt_f64_high(v_reinterpret_as_s32(v_1int11)), v_cvt_f64_high(v_reinterpret_as_s32(v_2int11)), v_dst13);
+                v_dst20 = v_fma(v_cvt_f64(v_reinterpret_as_s32(v_1int20)), v_cvt_f64(v_reinterpret_as_s32(v_2int20)), v_dst20);
+                v_dst21 = v_fma(v_cvt_f64_high(v_reinterpret_as_s32(v_1int20)), v_cvt_f64_high(v_reinterpret_as_s32(v_2int20)), v_dst21);
+                v_dst22 = v_fma(v_cvt_f64(v_reinterpret_as_s32(v_1int21)), v_cvt_f64(v_reinterpret_as_s32(v_2int21)), v_dst22);
+                v_dst23 = v_fma(v_cvt_f64_high(v_reinterpret_as_s32(v_1int21)), v_cvt_f64_high(v_reinterpret_as_s32(v_2int21)), v_dst23);
+
+                v_store_interleave(dst + x * cn, v_dst00, v_dst10, v_dst20);
+                v_store_interleave(dst + (x + step) * cn, v_dst01, v_dst11, v_dst21);
+                v_store_interleave(dst + (x + step * 2) * cn, v_dst02, v_dst12, v_dst22);
+                v_store_interleave(dst + (x + step * 3) * cn, v_dst03, v_dst13, v_dst23);
+            }
+        }
+    }
+#endif // CV_SIMD_64F
+    accProd_general_(src1, src2, dst, mask, len, cn, x);
+}
+
+void accProd_simd_(const ushort* src1, const ushort* src2, double* dst, const uchar* mask, int len, int cn)
+{
+    int x = 0;
+#if (CV_SIMD_64F || CV_SIMD_SCALABLE_64F)
+    const int cVectorWidth = VTraits<v_uint16>::vlanes();
+    const int step = VTraits<v_float64>::vlanes();
+
+    if (!mask)
+    {
+        int size = len * cn;
+        for (; x <= size - cVectorWidth; x += cVectorWidth)
+        {
+            v_uint16 v_1src  = vx_load(src1 + x);
+            v_uint16 v_2src  = vx_load(src2 + x);
+
+            v_uint32 v_1int_0, v_1int_1, v_2int_0, v_2int_1;
+            v_expand(v_1src, v_1int_0, v_1int_1);
+            v_expand(v_2src, v_2int_0, v_2int_1);
+
+            v_int32 v_1int0 = v_reinterpret_as_s32(v_1int_0);
+            v_int32 v_1int1 = v_reinterpret_as_s32(v_1int_1);
+            v_int32 v_2int0 = v_reinterpret_as_s32(v_2int_0);
+            v_int32 v_2int1 = v_reinterpret_as_s32(v_2int_1);
+
+            v_float64 v_dst0 = vx_load(dst + x);
+            v_float64 v_dst1 = vx_load(dst + x + step);
+            v_float64 v_dst2 = vx_load(dst + x + step * 2);
+            v_float64 v_dst3 = vx_load(dst + x + step * 3);
+
+            v_dst0 = v_fma(v_cvt_f64(v_1int0), v_cvt_f64(v_2int0), v_dst0);
+            v_dst1 = v_fma(v_cvt_f64_high(v_1int0), v_cvt_f64_high(v_2int0), v_dst1);
+            v_dst2 = v_fma(v_cvt_f64(v_1int1), v_cvt_f64(v_2int1), v_dst2);
+            v_dst3 = v_fma(v_cvt_f64_high(v_1int1), v_cvt_f64_high(v_2int1), v_dst3);
+
+            v_store(dst + x, v_dst0);
+            v_store(dst + x + step, v_dst1);
+            v_store(dst + x + step * 2, v_dst2);
+            v_store(dst + x + step * 3, v_dst3);
+        }
+    }
+    else
+    {
+        v_uint16 v_0 = vx_setzero_u16();
+        if (cn == 1)
+        {
+            for (; x <= len - cVectorWidth; x += cVectorWidth)
+            {
+                v_uint16 v_mask = vx_load_expand(mask + x);
+                v_mask = v_not(v_eq(v_mask, v_0));
+                v_uint16 v_1src = vx_load(src1 + x);
+                v_uint16 v_2src = vx_load(src2 + x);
+                v_1src = v_and(v_1src, v_mask);
+                v_2src = v_and(v_2src, v_mask);
+
+                v_uint32 v_1int_0, v_1int_1, v_2int_0, v_2int_1;
+                v_expand(v_1src, v_1int_0, v_1int_1);
+                v_expand(v_2src, v_2int_0, v_2int_1);
+
+                v_int32 v_1int0 = v_reinterpret_as_s32(v_1int_0);
+                v_int32 v_1int1 = v_reinterpret_as_s32(v_1int_1);
+                v_int32 v_2int0 = v_reinterpret_as_s32(v_2int_0);
+                v_int32 v_2int1 = v_reinterpret_as_s32(v_2int_1);
+
+                v_float64 v_dst0 = vx_load(dst + x);
+                v_float64 v_dst1 = vx_load(dst + x + step);
+                v_float64 v_dst2 = vx_load(dst + x + step * 2);
+                v_float64 v_dst3 = vx_load(dst + x + step * 3);
+
+                v_dst0 = v_fma(v_cvt_f64(v_1int0), v_cvt_f64(v_2int0), v_dst0);
+                v_dst1 = v_fma(v_cvt_f64_high(v_1int0), v_cvt_f64_high(v_2int0), v_dst1);
+                v_dst2 = v_fma(v_cvt_f64(v_1int1), v_cvt_f64(v_2int1), v_dst2);
+                v_dst3 = v_fma(v_cvt_f64_high(v_1int1), v_cvt_f64_high(v_2int1), v_dst3);
+
+                v_store(dst + x, v_dst0);
+                v_store(dst + x + step, v_dst1);
+                v_store(dst + x + step * 2, v_dst2);
+                v_store(dst + x + step * 3, v_dst3);
+            }
+        }
+        else if (cn == 3)
+        {
+            for (; x <= len - cVectorWidth; x += cVectorWidth)
+            {
+                v_uint16 v_mask = vx_load_expand(mask + x);
+                v_mask = v_not(v_eq(v_mask, v_0));
+                v_uint16 v_1src0, v_1src1, v_1src2, v_2src0, v_2src1, v_2src2;
+                v_load_deinterleave(src1 + x * cn, v_1src0, v_1src1, v_1src2);
+                v_load_deinterleave(src2 + x * cn, v_2src0, v_2src1, v_2src2);
+                v_1src0 = v_and(v_1src0, v_mask);
+                v_1src1 = v_and(v_1src1, v_mask);
+                v_1src2 = v_and(v_1src2, v_mask);
+                v_2src0 = v_and(v_2src0, v_mask);
+                v_2src1 = v_and(v_2src1, v_mask);
+                v_2src2 = v_and(v_2src2, v_mask);
+
+                v_uint32 v_1int_00, v_1int_01, v_2int_00, v_2int_01;
+                v_uint32 v_1int_10, v_1int_11, v_2int_10, v_2int_11;
+                v_uint32 v_1int_20, v_1int_21, v_2int_20, v_2int_21;
+                v_expand(v_1src0, v_1int_00, v_1int_01);
+                v_expand(v_1src1, v_1int_10, v_1int_11);
+                v_expand(v_1src2, v_1int_20, v_1int_21);
+                v_expand(v_2src0, v_2int_00, v_2int_01);
+                v_expand(v_2src1, v_2int_10, v_2int_11);
+                v_expand(v_2src2, v_2int_20, v_2int_21);
+
+                v_int32 v_1int00 = v_reinterpret_as_s32(v_1int_00);
+                v_int32 v_1int01 = v_reinterpret_as_s32(v_1int_01);
+                v_int32 v_1int10 = v_reinterpret_as_s32(v_1int_10);
+                v_int32 v_1int11 = v_reinterpret_as_s32(v_1int_11);
+                v_int32 v_1int20 = v_reinterpret_as_s32(v_1int_20);
+                v_int32 v_1int21 = v_reinterpret_as_s32(v_1int_21);
+                v_int32 v_2int00 = v_reinterpret_as_s32(v_2int_00);
+                v_int32 v_2int01 = v_reinterpret_as_s32(v_2int_01);
+                v_int32 v_2int10 = v_reinterpret_as_s32(v_2int_10);
+                v_int32 v_2int11 = v_reinterpret_as_s32(v_2int_11);
+                v_int32 v_2int20 = v_reinterpret_as_s32(v_2int_20);
+                v_int32 v_2int21 = v_reinterpret_as_s32(v_2int_21);
+
+                v_float64 v_dst00, v_dst01, v_dst02, v_dst03;
+                v_float64 v_dst10, v_dst11, v_dst12, v_dst13;
+                v_float64 v_dst20, v_dst21, v_dst22, v_dst23;
+                v_load_deinterleave(dst + x * cn, v_dst00, v_dst10, v_dst20);
+                v_load_deinterleave(dst + (x + step) * cn, v_dst01, v_dst11, v_dst21);
+                v_load_deinterleave(dst + (x + step * 2) * cn, v_dst02, v_dst12, v_dst22);
+                v_load_deinterleave(dst + (x + step * 3) * cn, v_dst03, v_dst13, v_dst23);
+
+                v_dst00 = v_fma(v_cvt_f64(v_1int00), v_cvt_f64(v_2int00), v_dst00);
+                v_dst01 = v_fma(v_cvt_f64_high(v_1int00), v_cvt_f64_high(v_2int00), v_dst01);
+                v_dst02 = v_fma(v_cvt_f64(v_1int01), v_cvt_f64(v_2int01), v_dst02);
+                v_dst03 = v_fma(v_cvt_f64_high(v_1int01), v_cvt_f64_high(v_2int01), v_dst03);
+                v_dst10 = v_fma(v_cvt_f64(v_1int10), v_cvt_f64(v_2int10), v_dst10);
+                v_dst11 = v_fma(v_cvt_f64_high(v_1int10), v_cvt_f64_high(v_2int10), v_dst11);
+                v_dst12 = v_fma(v_cvt_f64(v_1int11), v_cvt_f64(v_2int11), v_dst12);
+                v_dst13 = v_fma(v_cvt_f64_high(v_1int11), v_cvt_f64_high(v_2int11), v_dst13);
+                v_dst20 = v_fma(v_cvt_f64(v_1int20), v_cvt_f64(v_2int20), v_dst20);
+                v_dst21 = v_fma(v_cvt_f64_high(v_1int20), v_cvt_f64_high(v_2int20), v_dst21);
+                v_dst22 = v_fma(v_cvt_f64(v_1int21), v_cvt_f64(v_2int21), v_dst22);
+                v_dst23 = v_fma(v_cvt_f64_high(v_1int21), v_cvt_f64_high(v_2int21), v_dst23);
+
+                v_store_interleave(dst + x * cn, v_dst00, v_dst10, v_dst20);
+                v_store_interleave(dst + (x + step) * cn, v_dst01, v_dst11, v_dst21);
+                v_store_interleave(dst + (x + step * 2) * cn, v_dst02, v_dst12, v_dst22);
+                v_store_interleave(dst + (x + step * 3) * cn, v_dst03, v_dst13, v_dst23);
+            }
+        }
+    }
+#endif // CV_SIMD_64F
+    accProd_general_(src1, src2, dst, mask, len, cn, x);
+}
+
+void accProd_simd_(const float* src1, const float* src2, double* dst, const uchar* mask, int len, int cn)
+{
+    int x = 0;
+#if (CV_SIMD_64F || CV_SIMD_SCALABLE_64F)
+    const int cVectorWidth = VTraits<v_float32>::vlanes();
+    const int step = VTraits<v_float64>::vlanes();
+
+    if (!mask)
+    {
+        int size = len * cn;
+        #if CV_AVX && !CV_AVX2
+        for ( ; x <= size - 8 ; x += 8)
+        {
+            __m256 v_1src = _mm256_loadu_ps(src1 + x);
+            __m256 v_2src = _mm256_loadu_ps(src2 + x);
+            __m256d v_src00 = _mm256_cvtps_pd(_mm256_extractf128_ps(v_1src,0));
+            __m256d v_src01 = _mm256_cvtps_pd(_mm256_extractf128_ps(v_1src,1));
+            __m256d v_src10 = _mm256_cvtps_pd(_mm256_extractf128_ps(v_2src,0));
+            __m256d v_src11 = _mm256_cvtps_pd(_mm256_extractf128_ps(v_2src,1));
+            __m256d v_dst0 = _mm256_loadu_pd(dst + x);
+            __m256d v_dst1 = _mm256_loadu_pd(dst + x + 4);
+            __m256d v_src0 = _mm256_mul_pd(v_src00, v_src10);
+            __m256d v_src1 = _mm256_mul_pd(v_src01, v_src11);
+            v_dst0 = _mm256_add_pd(v_src0, v_dst0);
+            v_dst1 = _mm256_add_pd(v_src1, v_dst1);
+            _mm256_storeu_pd(dst + x, v_dst0);
+            _mm256_storeu_pd(dst + x + 4, v_dst1);
+        }
+        #else
+        for (; x <= size - cVectorWidth; x += cVectorWidth)
+        {
+            v_float32 v_1src  = vx_load(src1 + x);
+            v_float32 v_2src  = vx_load(src2 + x);
+
+            v_float64 v_1src0 = v_cvt_f64(v_1src);
+            v_float64 v_1src1 = v_cvt_f64_high(v_1src);
+            v_float64 v_2src0 = v_cvt_f64(v_2src);
+            v_float64 v_2src1 = v_cvt_f64_high(v_2src);
+
+            v_store(dst + x, v_fma(v_1src0, v_2src0, vx_load(dst + x)));
+            v_store(dst + x + step, v_fma(v_1src1, v_2src1, vx_load(dst + x + step)));
+        }
+        #endif // CV_AVX && !CV_AVX2
+    }
+    else
+    {
+        v_uint32 v_0 = vx_setzero_u32();
+        if (cn == 1)
+        {
+            for (; x <= len - cVectorWidth; x += cVectorWidth)
+            {
+                v_uint32 v_mask = vx_load_expand_q(mask + x);
+                v_mask = v_not(v_eq(v_mask, v_0));
+                v_float32 v_1src = vx_load(src1 + x);
+                v_float32 v_2src = vx_load(src2 + x);
+                v_1src = v_and(v_1src, v_reinterpret_as_f32(v_mask));
+                v_2src = v_and(v_2src, v_reinterpret_as_f32(v_mask));
+
+                v_float64 v_1src0 = v_cvt_f64(v_1src);
+                v_float64 v_1src1 = v_cvt_f64_high(v_1src);
+                v_float64 v_2src0 = v_cvt_f64(v_2src);
+                v_float64 v_2src1 = v_cvt_f64_high(v_2src);
+
+                v_store(dst + x, v_fma(v_1src0, v_2src0, vx_load(dst + x)));
+                v_store(dst + x + step, v_fma(v_1src1, v_2src1, vx_load(dst + x + step)));
+            }
+        }
+        else if (cn == 3)
+        {
+            for (; x <= len - cVectorWidth; x += cVectorWidth)
+            {
+                v_uint32 v_mask = vx_load_expand_q(mask + x);
+                v_mask = v_not(v_eq(v_mask, v_0));
+                v_float32 v_1src0, v_1src1, v_1src2, v_2src0, v_2src1, v_2src2;
+                v_load_deinterleave(src1 + x * cn, v_1src0, v_1src1, v_1src2);
+                v_load_deinterleave(src2 + x * cn, v_2src0, v_2src1, v_2src2);
+                v_1src0 = v_and(v_1src0, v_reinterpret_as_f32(v_mask));
+                v_1src1 = v_and(v_1src1, v_reinterpret_as_f32(v_mask));
+                v_1src2 = v_and(v_1src2, v_reinterpret_as_f32(v_mask));
+                v_2src0 = v_and(v_2src0, v_reinterpret_as_f32(v_mask));
+                v_2src1 = v_and(v_2src1, v_reinterpret_as_f32(v_mask));
+                v_2src2 = v_and(v_2src2, v_reinterpret_as_f32(v_mask));
+
+                v_float64 v_dst00, v_dst01, v_dst10, v_dst11, v_dst20, v_dst21;
+                v_load_deinterleave(dst + x * cn, v_dst00, v_dst10, v_dst20);
+                v_load_deinterleave(dst + (x + step) * cn, v_dst01, v_dst11, v_dst21);
+
+                v_dst00 = v_fma(v_cvt_f64(v_1src0), v_cvt_f64(v_2src0), v_dst00);
+                v_dst01 = v_fma(v_cvt_f64_high(v_1src0), v_cvt_f64_high(v_2src0), v_dst01);
+                v_dst10 = v_fma(v_cvt_f64(v_1src1), v_cvt_f64(v_2src1), v_dst10);
+                v_dst11 = v_fma(v_cvt_f64_high(v_1src1), v_cvt_f64_high(v_2src1), v_dst11);
+                v_dst20 = v_fma(v_cvt_f64(v_1src2), v_cvt_f64(v_2src2), v_dst20);
+                v_dst21 = v_fma(v_cvt_f64_high(v_1src2), v_cvt_f64_high(v_2src2), v_dst21);
+
+                v_store_interleave(dst + x * cn, v_dst00, v_dst10, v_dst20);
+                v_store_interleave(dst + (x + step) * cn, v_dst01, v_dst11, v_dst21);
+            }
+        }
+    }
+#endif // CV_SIMD_64F
+    accProd_general_(src1, src2, dst, mask, len, cn, x);
+}
+
+void accProd_simd_(const double* src1, const double* src2, double* dst, const uchar* mask, int len, int cn)
+{
+    int x = 0;
+#if (CV_SIMD_64F || CV_SIMD_SCALABLE_64F)
+    const int cVectorWidth = VTraits<v_float64>::vlanes() * 2;
+    const int step = VTraits<v_float64>::vlanes();
+
+    if (!mask)
+    {
+        int size = len * cn;
+        #if CV_AVX && !CV_AVX2
+        for ( ; x <= size - 4 ; x += 4)
+        {
+            __m256d v_src0 = _mm256_loadu_pd(src1 + x);
+            __m256d v_src1 = _mm256_loadu_pd(src2 + x);
+            __m256d v_dst = _mm256_loadu_pd(dst + x);
+            v_src0 = _mm256_mul_pd(v_src0, v_src1);
+            v_dst = _mm256_add_pd(v_dst, v_src0);
+            _mm256_storeu_pd(dst + x, v_dst);
+        }
+        #else
+        for (; x <= size - cVectorWidth; x += cVectorWidth)
+        {
+            v_float64 v_src00 = vx_load(src1 + x);
+            v_float64 v_src01 = vx_load(src1 + x + step);
+            v_float64 v_src10 = vx_load(src2 + x);
+            v_float64 v_src11 = vx_load(src2 + x + step);
+
+            v_store(dst + x, v_fma(v_src00, v_src10, vx_load(dst + x)));
+            v_store(dst + x + step, v_fma(v_src01, v_src11, vx_load(dst + x + step)));
+        }
+        #endif
+    }
+    else
+    {
+        // todo: try fma
+        v_uint64 v_0 = vx_setzero_u64();
+        if (cn == 1)
+        {
+            for (; x <= len - cVectorWidth; x += cVectorWidth)
+            {
+                v_uint32 v_mask32 = vx_load_expand_q(mask + x);
+                v_uint64 v_masku640, v_masku641;
+                v_expand(v_mask32, v_masku640, v_masku641);
+                v_float64 v_mask0 = v_reinterpret_as_f64(v_not(v_eq(v_masku640, v_0)));
+                v_float64 v_mask1 = v_reinterpret_as_f64(v_not(v_eq(v_masku641, v_0)));
+
+                v_float64 v_src00 = vx_load(src1 + x);
+                v_float64 v_src01 = vx_load(src1 + x + step);
+                v_float64 v_src10 = vx_load(src2 + x);
+                v_float64 v_src11 = vx_load(src2 + x + step);
+
+                v_store(dst + x, v_add(vx_load(dst + x), v_and(v_mul(v_src00, v_src10), v_mask0)));
+                v_store(dst + x + step, v_add(vx_load(dst + x + step), v_and(v_mul(v_src01, v_src11), v_mask1)));
+            }
+        }
+        else if (cn == 3)
+        {
+            for (; x <= len - cVectorWidth; x += cVectorWidth)
+            {
+                v_uint32 v_mask32 = vx_load_expand_q(mask + x);
+                v_uint64 v_masku640, v_masku641;
+                v_expand(v_mask32, v_masku640, v_masku641);
+                v_float64 v_mask0 = v_reinterpret_as_f64(v_not(v_eq(v_masku640, v_0)));
+                v_float64 v_mask1 = v_reinterpret_as_f64(v_not(v_eq(v_masku641, v_0)));
+
+                v_float64 v_1src00, v_1src01, v_1src10, v_1src11, v_1src20, v_1src21;
+                v_float64 v_2src00, v_2src01, v_2src10, v_2src11, v_2src20, v_2src21;
+                v_load_deinterleave(src1 + x * cn, v_1src00, v_1src10, v_1src20);
+                v_load_deinterleave(src1 + (x + step) * cn, v_1src01, v_1src11, v_1src21);
+                v_load_deinterleave(src2 + x * cn, v_2src00, v_2src10, v_2src20);
+                v_load_deinterleave(src2 + (x + step) * cn, v_2src01, v_2src11, v_2src21);
+                v_float64 v_src00 = v_mul(v_and(v_1src00, v_mask0), v_2src00);
+                v_float64 v_src01 = v_mul(v_and(v_1src01, v_mask1), v_2src01);
+                v_float64 v_src10 = v_mul(v_and(v_1src10, v_mask0), v_2src10);
+                v_float64 v_src11 = v_mul(v_and(v_1src11, v_mask1), v_2src11);
+                v_float64 v_src20 = v_mul(v_and(v_1src20, v_mask0), v_2src20);
+                v_float64 v_src21 = v_mul(v_and(v_1src21, v_mask1), v_2src21);
+
+                v_float64 v_dst00, v_dst01, v_dst10, v_dst11, v_dst20, v_dst21;
+                v_load_deinterleave(dst + x * cn, v_dst00, v_dst10, v_dst20);
+                v_load_deinterleave(dst + (x + step) * cn, v_dst01, v_dst11, v_dst21);
+
+                v_store_interleave(dst + x * cn, v_add(v_dst00, v_src00), v_add(v_dst10, v_src10), v_add(v_dst20, v_src20));
+                v_store_interleave(dst + (x + step) * cn, v_add(v_dst01, v_src01), v_add(v_dst11, v_src11), v_add(v_dst21, v_src21));
+            }
+        }
+    }
+#endif // CV_SIMD_64F
+    accProd_general_(src1, src2, dst, mask, len, cn, x);
+}
+
+// running weight accumulate optimized by universal intrinsic
+void accW_simd_(const uchar* src, float* dst, const uchar* mask, int len, int cn, double alpha)
+{
+    int x = 0;
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+    const v_float32 v_alpha = vx_setall_f32((float)alpha);
+    const v_float32 v_beta = vx_setall_f32((float)(1.0f - alpha));
+    const int cVectorWidth = VTraits<v_uint8>::vlanes();
+    const int step = VTraits<v_float32>::vlanes();
+
+    if (!mask)
+    {
+        int size = len * cn;
+        for (; x <= size - cVectorWidth; x += cVectorWidth)
+        {
+            v_uint8 v_src = vx_load(src + x);
+
+            v_uint16 v_src0, v_src1;
+            v_expand(v_src, v_src0, v_src1);
+
+            v_uint32 v_src00, v_src01, v_src10, v_src11;
+            v_expand(v_src0, v_src00, v_src01);
+            v_expand(v_src1, v_src10, v_src11);
+
+            v_float32 v_dst00 = vx_load(dst + x);
+            v_float32 v_dst01 = vx_load(dst + x + step);
+            v_float32 v_dst10 = vx_load(dst + x + step * 2);
+            v_float32 v_dst11 = vx_load(dst + x + step * 3);
+
+            v_dst00 = v_fma(v_dst00, v_beta, v_mul(v_cvt_f32(v_reinterpret_as_s32(v_src00)), v_alpha));
+            v_dst01 = v_fma(v_dst01, v_beta, v_mul(v_cvt_f32(v_reinterpret_as_s32(v_src01)), v_alpha));
+            v_dst10 = v_fma(v_dst10, v_beta, v_mul(v_cvt_f32(v_reinterpret_as_s32(v_src10)), v_alpha));
+            v_dst11 = v_fma(v_dst11, v_beta, v_mul(v_cvt_f32(v_reinterpret_as_s32(v_src11)), v_alpha));
+
+            v_store(dst + x           , v_dst00);
+            v_store(dst + x + step    , v_dst01);
+            v_store(dst + x + step * 2, v_dst10);
+            v_store(dst + x + step * 3, v_dst11);
+        }
+    } else {
+        const v_float32 zero = vx_setall_f32((float)0);
+        int size = len * cn;
+
+        if ( cn == 1 ){
+            for (; x <= size - cVectorWidth; x += cVectorWidth)
+            {
+                v_uint8 v_src = vx_load(src + x);
+                v_uint8 v_mask = vx_load(mask + x);
+
+                v_uint16 v_m0, v_m1;
+                v_expand(v_mask, v_m0, v_m1);
+                v_uint32 v_m00, v_m01, v_m10, v_m11;
+                v_expand(v_m0, v_m00, v_m01);
+                v_expand(v_m1, v_m10, v_m11);
+
+                v_float32 v_mf00, v_mf01, v_mf10, v_mf11;
+                v_mf00 = v_cvt_f32(v_reinterpret_as_s32(v_m00));
+                v_mf01 = v_cvt_f32(v_reinterpret_as_s32(v_m01));
+                v_mf10 = v_cvt_f32(v_reinterpret_as_s32(v_m10));
+                v_mf11 = v_cvt_f32(v_reinterpret_as_s32(v_m11));
+
+                v_uint16 v_src0, v_src1;
+                v_expand(v_src, v_src0, v_src1);
+
+                v_uint32 v_src00, v_src01, v_src10, v_src11;
+                v_expand(v_src0, v_src00, v_src01);
+                v_expand(v_src1, v_src10, v_src11);
+
+                v_float32 v_dst00 = vx_load(dst + x);
+                v_float32 v_dst01 = vx_load(dst + x + step);
+                v_float32 v_dst10 = vx_load(dst + x + step * 2);
+                v_float32 v_dst11 = vx_load(dst + x + step * 3);
+
+                v_mf00 = v_ne(v_mf00, zero);
+                v_mf01 = v_ne(v_mf01, zero);
+                v_mf10 = v_ne(v_mf10, zero);
+                v_mf11 = v_ne(v_mf11, zero);
+
+                v_dst00 = v_select(v_mf00, v_fma(v_dst00, v_beta, v_mul(v_cvt_f32(v_reinterpret_as_s32(v_src00)), v_alpha)), v_dst00);
+                v_dst01 = v_select(v_mf01, v_fma(v_dst01, v_beta, v_mul(v_cvt_f32(v_reinterpret_as_s32(v_src01)), v_alpha)), v_dst01);
+                v_dst10 = v_select(v_mf10, v_fma(v_dst10, v_beta, v_mul(v_cvt_f32(v_reinterpret_as_s32(v_src10)), v_alpha)), v_dst10);
+                v_dst11 = v_select(v_mf11, v_fma(v_dst11, v_beta, v_mul(v_cvt_f32(v_reinterpret_as_s32(v_src11)), v_alpha)), v_dst11);
+
+                v_store(dst + x           , v_dst00);
+                v_store(dst + x + step    , v_dst01);
+                v_store(dst + x + step * 2, v_dst10);
+                v_store(dst + x + step * 3, v_dst11);
+            }
+        } else if ( cn == 3 )
+        {
+            for (; x*cn <= size - cVectorWidth*cn; x += cVectorWidth )
+            {
+                v_uint8 v_src0, v_src1, v_src2;
+                v_load_deinterleave(src + x * cn, v_src0, v_src1, v_src2);
+
+                v_uint16 v_src00, v_src01, v_src10, v_src11, v_src20, v_src21;
+                v_expand(v_src0, v_src00, v_src01);
+                v_expand(v_src1, v_src10, v_src11);
+                v_expand(v_src2, v_src20, v_src21);
+
+                v_uint32 v_src000, v_src001, v_src010, v_src011, v_src100, v_src101, v_src110, v_src111, v_src200, v_src201, v_src210, v_src211;
+                v_expand(v_src00, v_src000, v_src001);
+                v_expand(v_src01, v_src010, v_src011);
+                v_expand(v_src10, v_src100, v_src101);
+                v_expand(v_src11, v_src110, v_src111);
+                v_expand(v_src20, v_src200, v_src201);
+                v_expand(v_src21, v_src210, v_src211);
+
+                v_float32 v_dst00, v_dst01, v_dst02, v_dst03, v_dst10, v_dst11, v_dst12, v_dst13;
+                v_float32 v_dst20, v_dst21, v_dst22, v_dst23;
+                v_load_deinterleave(dst + x * cn             , v_dst00, v_dst10, v_dst20);
+                v_load_deinterleave(dst + (x +     step) * cn, v_dst01, v_dst11, v_dst21);
+                v_load_deinterleave(dst + (x + 2 * step) * cn, v_dst02, v_dst12, v_dst22);
+                v_load_deinterleave(dst + (x + 3 * step) * cn, v_dst03, v_dst13, v_dst23);
+
+                v_uint8 v_mask = vx_load(mask + x);
+
+                v_uint16 v_m0, v_m1;
+                v_expand(v_mask, v_m0, v_m1);
+                v_uint32 v_m00, v_m01, v_m10, v_m11;
+                v_expand(v_m0, v_m00, v_m01);
+                v_expand(v_m1, v_m10, v_m11);
+
+                v_float32 v_mf00, v_mf01, v_mf10, v_mf11;
+                v_mf00 = v_cvt_f32(v_reinterpret_as_s32(v_m00));
+                v_mf01 = v_cvt_f32(v_reinterpret_as_s32(v_m01));
+                v_mf10 = v_cvt_f32(v_reinterpret_as_s32(v_m10));
+                v_mf11 = v_cvt_f32(v_reinterpret_as_s32(v_m11));
+
+                v_mf00 = v_ne(v_mf00, zero);
+                v_mf01 = v_ne(v_mf01, zero);
+                v_mf10 = v_ne(v_mf10, zero);
+                v_mf11 = v_ne(v_mf11, zero);
+
+                v_dst00 = v_select(v_mf00, v_fma(v_dst00, v_beta, v_mul(v_cvt_f32(v_reinterpret_as_s32(v_src000)), v_alpha)), v_dst00);
+                v_dst01 = v_select(v_mf01, v_fma(v_dst01, v_beta, v_mul(v_cvt_f32(v_reinterpret_as_s32(v_src001)), v_alpha)), v_dst01);
+                v_dst02 = v_select(v_mf10, v_fma(v_dst02, v_beta, v_mul(v_cvt_f32(v_reinterpret_as_s32(v_src010)), v_alpha)), v_dst02);
+                v_dst03 = v_select(v_mf11, v_fma(v_dst03, v_beta, v_mul(v_cvt_f32(v_reinterpret_as_s32(v_src011)), v_alpha)), v_dst03);
+
+                v_dst10 = v_select(v_mf00, v_fma(v_dst10, v_beta, v_mul(v_cvt_f32(v_reinterpret_as_s32(v_src100)), v_alpha)), v_dst10);
+                v_dst11 = v_select(v_mf01, v_fma(v_dst11, v_beta, v_mul(v_cvt_f32(v_reinterpret_as_s32(v_src101)), v_alpha)), v_dst11);
+                v_dst12 = v_select(v_mf10, v_fma(v_dst12, v_beta, v_mul(v_cvt_f32(v_reinterpret_as_s32(v_src110)), v_alpha)), v_dst12);
+                v_dst13 = v_select(v_mf11, v_fma(v_dst13, v_beta, v_mul(v_cvt_f32(v_reinterpret_as_s32(v_src111)), v_alpha)), v_dst13);
+
+                v_dst20 = v_select(v_mf00, v_fma(v_dst20, v_beta, v_mul(v_cvt_f32(v_reinterpret_as_s32(v_src200)), v_alpha)), v_dst20);
+                v_dst21 = v_select(v_mf01, v_fma(v_dst21, v_beta, v_mul(v_cvt_f32(v_reinterpret_as_s32(v_src201)), v_alpha)), v_dst21);
+                v_dst22 = v_select(v_mf10, v_fma(v_dst22, v_beta, v_mul(v_cvt_f32(v_reinterpret_as_s32(v_src210)), v_alpha)), v_dst22);
+                v_dst23 = v_select(v_mf11, v_fma(v_dst23, v_beta, v_mul(v_cvt_f32(v_reinterpret_as_s32(v_src211)), v_alpha)), v_dst23);
+
+                v_store_interleave(dst + x * cn               , v_dst00, v_dst10, v_dst20);
+                v_store_interleave(dst + ( x + step     ) * cn, v_dst01, v_dst11, v_dst21);
+                v_store_interleave(dst + ( x + step * 2 ) * cn, v_dst02, v_dst12, v_dst22);
+                v_store_interleave(dst + ( x + step * 3 ) * cn, v_dst03, v_dst13, v_dst23);
+            }
+        }
+    }
+#endif // CV_SIMD
+    accW_general_(src, dst, mask, len, cn, alpha, x);
+}
+
+void accW_simd_(const ushort* src, float* dst, const uchar* mask, int len, int cn, double alpha)
+{
+    int x = 0;
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+    const v_float32 v_alpha = vx_setall_f32((float)alpha);
+    const v_float32 v_beta = vx_setall_f32((float)(1.0f - alpha));
+    const int cVectorWidth = VTraits<v_uint16>::vlanes();
+    const int step = VTraits<v_float32>::vlanes();
+
+    if (!mask)
+    {
+        int size = len * cn;
+        for (; x <= size - cVectorWidth; x += cVectorWidth)
+        {
+            v_uint16 v_src = vx_load(src + x);
+            v_uint32 v_int0, v_int1;
+            v_expand(v_src, v_int0, v_int1);
+
+            v_float32 v_dst0 = vx_load(dst + x);
+            v_float32 v_dst1 = vx_load(dst + x + step);
+            v_dst0 = v_fma(v_dst0, v_beta, v_mul(v_cvt_f32(v_reinterpret_as_s32(v_int0)), v_alpha));
+            v_dst1 = v_fma(v_dst1, v_beta, v_mul(v_cvt_f32(v_reinterpret_as_s32(v_int1)), v_alpha));
+
+            v_store(dst + x       , v_dst0);
+            v_store(dst + x + step, v_dst1);
+        }
+    } else {
+        const v_float32 zero = vx_setall_f32((float)0);
+        int size = len * cn;
+        if ( cn == 1 )
+        {
+            for (; x <= size - cVectorWidth; x += cVectorWidth)
+            {
+                v_uint16 v_src = vx_load(src + x);
+                v_uint16 v_mask = v_reinterpret_as_u16(vx_load_expand(mask + x));
+
+                v_uint32 v_m0, v_m1;
+                v_expand(v_mask, v_m0, v_m1);
+
+                v_float32 v_mf0, v_mf1;
+                v_mf0 = v_cvt_f32(v_reinterpret_as_s32(v_m0));
+                v_mf1 = v_cvt_f32(v_reinterpret_as_s32(v_m1));
+
+                v_uint32 v_src0, v_src1;
+                v_expand(v_src, v_src0, v_src1);
+
+                v_float32 v_dst0 = vx_load(dst + x);
+                v_float32 v_dst1 = vx_load(dst + x + step);
+
+                v_mf0 = v_ne(v_mf0, zero);
+                v_mf1 = v_ne(v_mf1, zero);
+
+                v_dst0 = v_select(v_mf0, v_fma(v_dst0, v_beta, v_mul(v_cvt_f32(v_reinterpret_as_s32(v_src0)), v_alpha)), v_dst0);
+                v_dst1 = v_select(v_mf1, v_fma(v_dst1, v_beta, v_mul(v_cvt_f32(v_reinterpret_as_s32(v_src1)), v_alpha)), v_dst1);
+
+                v_store(dst + x       , v_dst0);
+                v_store(dst + x + step, v_dst1);
+            }
+        } else if ( cn == 3 )
+        {
+            for (; x*cn <= size - cVectorWidth*cn; x += cVectorWidth )
+            {
+                v_uint16 v_src0, v_src1, v_src2;
+                v_load_deinterleave(src + x * cn, v_src0, v_src1, v_src2);
+
+                v_uint16 v_mask = v_reinterpret_as_u16(vx_load_expand(mask + x));
+
+                v_uint32 v_m0, v_m1;
+                v_expand(v_mask, v_m0, v_m1);
+
+                v_uint32 v_src00, v_src01, v_src10, v_src11, v_src20, v_src21;
+                v_expand(v_src0, v_src00, v_src01);
+                v_expand(v_src1, v_src10, v_src11);
+                v_expand(v_src2, v_src20, v_src21);
+
+                v_float32 v_dst00, v_dst01, v_dst10, v_dst11, v_dst20, v_dst21;
+                v_load_deinterleave(dst + x * cn             , v_dst00, v_dst10, v_dst20);
+                v_load_deinterleave(dst + (x +     step) * cn, v_dst01, v_dst11, v_dst21);
+
+                v_float32 v_mf0, v_mf1;
+                v_mf0 = v_cvt_f32(v_reinterpret_as_s32(v_m0));
+                v_mf1 = v_cvt_f32(v_reinterpret_as_s32(v_m1));
+
+                v_mf0 = v_ne(v_mf0, zero);
+                v_mf1 = v_ne(v_mf1, zero);
+
+                v_dst00 = v_select(v_mf0, v_fma(v_dst00, v_beta, v_mul(v_cvt_f32(v_reinterpret_as_s32(v_src00)), v_alpha)), v_dst00);
+                v_dst10 = v_select(v_mf0, v_fma(v_dst10, v_beta, v_mul(v_cvt_f32(v_reinterpret_as_s32(v_src10)), v_alpha)), v_dst10);
+                v_dst20 = v_select(v_mf0, v_fma(v_dst20, v_beta, v_mul(v_cvt_f32(v_reinterpret_as_s32(v_src20)), v_alpha)), v_dst20);
+
+                v_dst01 = v_select(v_mf1, v_fma(v_dst01, v_beta, v_mul(v_cvt_f32(v_reinterpret_as_s32(v_src01)), v_alpha)), v_dst01);
+                v_dst11 = v_select(v_mf1, v_fma(v_dst11, v_beta, v_mul(v_cvt_f32(v_reinterpret_as_s32(v_src11)), v_alpha)), v_dst11);
+                v_dst21 = v_select(v_mf1, v_fma(v_dst21, v_beta, v_mul(v_cvt_f32(v_reinterpret_as_s32(v_src21)), v_alpha)), v_dst21);
+
+                v_store_interleave(dst + x * cn               , v_dst00, v_dst10, v_dst20);
+                v_store_interleave(dst + ( x + step     ) * cn, v_dst01, v_dst11, v_dst21);
+            }
+        }
+    }
+#endif // CV_SIMD
+    accW_general_(src, dst, mask, len, cn, alpha, x);
+}
+
+void accW_simd_(const float* src, float* dst, const uchar* mask, int len, int cn, double alpha)
+{
+    int x = 0;
+#if CV_AVX && !CV_AVX2
+    const __m256 v_alpha = _mm256_set1_ps((float)alpha);
+    const __m256 v_beta = _mm256_set1_ps((float)(1.0f - alpha));
+    const int cVectorWidth = 16;
+
+    if (!mask)
+    {
+        int size = len * cn;
+        for ( ; x <= size - cVectorWidth ; x += cVectorWidth)
+        {
+            _mm256_storeu_ps(dst + x, _mm256_add_ps(_mm256_mul_ps(_mm256_loadu_ps(dst + x), v_beta), _mm256_mul_ps(_mm256_loadu_ps(src + x), v_alpha)));
+            _mm256_storeu_ps(dst + x + 8, _mm256_add_ps(_mm256_mul_ps(_mm256_loadu_ps(dst + x + 8), v_beta), _mm256_mul_ps(_mm256_loadu_ps(src + x + 8), v_alpha)));
+        }
+    }
+#elif (CV_SIMD || CV_SIMD_SCALABLE)
+    const v_float32 v_alpha = vx_setall_f32((float)alpha);
+    const v_float32 v_beta = vx_setall_f32((float)(1.0f - alpha));
+    const int cVectorWidth = VTraits<v_uint16>::vlanes();
+    const int step = VTraits<v_float32>::vlanes();
+
+    if (!mask)
+    {
+        int size = len * cn;
+        for (; x <= size - cVectorWidth; x += cVectorWidth)
+        {
+            v_float32 v_dst0 = vx_load(dst + x);
+            v_float32 v_dst1 = vx_load(dst + x + step);
+
+            v_dst0 = v_fma(v_dst0, v_beta, v_mul(vx_load(src + x), v_alpha));
+            v_dst1 = v_fma(v_dst1, v_beta, v_mul(vx_load(src + x + step), v_alpha));
+
+            v_store(dst + x, v_dst0);
+            v_store(dst + x + step, v_dst1);
+        }
+    }
+#endif // CV_SIMD
+    accW_general_(src, dst, mask, len, cn, alpha, x);
+}
+
+void accW_simd_(const uchar* src, double* dst, const uchar* mask, int len, int cn, double alpha)
+{
+    int x = 0;
+#if (CV_SIMD_64F || CV_SIMD_SCALABLE_64F)
+    const v_float64 v_alpha = vx_setall_f64(alpha);
+    const v_float64 v_beta = vx_setall_f64(1.0f - alpha);
+    const int cVectorWidth = VTraits<v_uint16>::vlanes();
+    const int step = VTraits<v_float64>::vlanes();
+
+    if (!mask)
+    {
+        int size = len * cn;
+        for (; x <= size - cVectorWidth; x += cVectorWidth)
+        {
+            v_uint16 v_src16 = vx_load_expand(src + x);
+
+            v_uint32 v_int_0, v_int_1;
+            v_expand(v_src16, v_int_0, v_int_1);
+
+            v_int32 v_int0 = v_reinterpret_as_s32(v_int_0);
+            v_int32 v_int1 = v_reinterpret_as_s32(v_int_1);
+
+            v_float64 v_src0 = v_cvt_f64(v_int0);
+            v_float64 v_src1 = v_cvt_f64_high(v_int0);
+            v_float64 v_src2 = v_cvt_f64(v_int1);
+            v_float64 v_src3 = v_cvt_f64_high(v_int1);
+
+            v_float64 v_dst0 = vx_load(dst + x);
+            v_float64 v_dst1 = vx_load(dst + x + step);
+            v_float64 v_dst2 = vx_load(dst + x + step * 2);
+            v_float64 v_dst3 = vx_load(dst + x + step * 3);
+
+            v_dst0 = v_fma(v_dst0, v_beta, v_mul(v_src0, v_alpha));
+            v_dst1 = v_fma(v_dst1, v_beta, v_mul(v_src1, v_alpha));
+            v_dst2 = v_fma(v_dst2, v_beta, v_mul(v_src2, v_alpha));
+            v_dst3 = v_fma(v_dst3, v_beta, v_mul(v_src3, v_alpha));
+
+            v_store(dst + x, v_dst0);
+            v_store(dst + x + step, v_dst1);
+            v_store(dst + x + step * 2, v_dst2);
+            v_store(dst + x + step * 3, v_dst3);
+        }
+    }
+#endif // CV_SIMD_64F
+    accW_general_(src, dst, mask, len, cn, alpha, x);
+}
+
+void accW_simd_(const ushort* src, double* dst, const uchar* mask, int len, int cn, double alpha)
+{
+    int x = 0;
+#if (CV_SIMD_64F || CV_SIMD_SCALABLE_64F)
+    const v_float64 v_alpha = vx_setall_f64(alpha);
+    const v_float64 v_beta = vx_setall_f64(1.0f - alpha);
+    const int cVectorWidth = VTraits<v_uint16>::vlanes();
+    const int step = VTraits<v_float64>::vlanes();
+
+    if (!mask)
+    {
+        int size = len * cn;
+        for (; x <= size - cVectorWidth; x += cVectorWidth)
+        {
+            v_uint16 v_src = vx_load(src + x);
+            v_uint32 v_int_0, v_int_1;
+            v_expand(v_src, v_int_0, v_int_1);
+
+            v_int32 v_int0 = v_reinterpret_as_s32(v_int_0);
+            v_int32 v_int1 = v_reinterpret_as_s32(v_int_1);
+
+            v_float64 v_src00 = v_cvt_f64(v_int0);
+            v_float64 v_src01 = v_cvt_f64_high(v_int0);
+            v_float64 v_src10 = v_cvt_f64(v_int1);
+            v_float64 v_src11 = v_cvt_f64_high(v_int1);
+
+            v_float64 v_dst00 = vx_load(dst + x);
+            v_float64 v_dst01 = vx_load(dst + x + step);
+            v_float64 v_dst10 = vx_load(dst + x + step * 2);
+            v_float64 v_dst11 = vx_load(dst + x + step * 3);
+
+            v_dst00 = v_fma(v_dst00, v_beta, v_mul(v_src00, v_alpha));
+            v_dst01 = v_fma(v_dst01, v_beta, v_mul(v_src01, v_alpha));
+            v_dst10 = v_fma(v_dst10, v_beta, v_mul(v_src10, v_alpha));
+            v_dst11 = v_fma(v_dst11, v_beta, v_mul(v_src11, v_alpha));
+
+            v_store(dst + x, v_dst00);
+            v_store(dst + x + step, v_dst01);
+            v_store(dst + x + step * 2, v_dst10);
+            v_store(dst + x + step * 3, v_dst11);
+        }
+    }
+#endif // CV_SIMD_64F
+    accW_general_(src, dst, mask, len, cn, alpha, x);
+}
+
+void accW_simd_(const float* src, double* dst, const uchar* mask, int len, int cn, double alpha)
+{
+    int x = 0;
+#if CV_AVX && !CV_AVX2
+    const __m256d v_alpha = _mm256_set1_pd(alpha);
+    const __m256d v_beta = _mm256_set1_pd(1.0f - alpha);
+    const int cVectorWidth = 16;
+
+    if (!mask)
+    {
+        int size = len * cn;
+        for ( ; x <= size - cVectorWidth ; x += cVectorWidth)
+        {
+            __m256 v_src0 = _mm256_loadu_ps(src + x);
+            __m256 v_src1 = _mm256_loadu_ps(src + x + 8);
+            __m256d v_src00 = _mm256_cvtps_pd(_mm256_extractf128_ps(v_src0,0));
+            __m256d v_src01 = _mm256_cvtps_pd(_mm256_extractf128_ps(v_src0,1));
+            __m256d v_src10 = _mm256_cvtps_pd(_mm256_extractf128_ps(v_src1,0));
+            __m256d v_src11 = _mm256_cvtps_pd(_mm256_extractf128_ps(v_src1,1));
+
+            _mm256_storeu_pd(dst + x, _mm256_add_pd(_mm256_mul_pd(_mm256_loadu_pd(dst + x), v_beta), _mm256_mul_pd(v_src00, v_alpha)));
+            _mm256_storeu_pd(dst + x + 4, _mm256_add_pd(_mm256_mul_pd(_mm256_loadu_pd(dst + x + 4), v_beta), _mm256_mul_pd(v_src01, v_alpha)));
+            _mm256_storeu_pd(dst + x + 8, _mm256_add_pd(_mm256_mul_pd(_mm256_loadu_pd(dst + x + 8), v_beta), _mm256_mul_pd(v_src10, v_alpha)));
+            _mm256_storeu_pd(dst + x + 12, _mm256_add_pd(_mm256_mul_pd(_mm256_loadu_pd(dst + x + 12), v_beta), _mm256_mul_pd(v_src11, v_alpha)));
+        }
+    }
+#elif (CV_SIMD_64F || CV_SIMD_SCALABLE_64F)
+    const v_float64 v_alpha = vx_setall_f64(alpha);
+    const v_float64 v_beta = vx_setall_f64(1.0f - alpha);
+    const int cVectorWidth = VTraits<v_float32>::vlanes() * 2;
+    const int step = VTraits<v_float64>::vlanes();
+
+    if (!mask)
+    {
+        int size = len * cn;
+        for (; x <= size - cVectorWidth; x += cVectorWidth)
+        {
+            v_float32 v_src0 = vx_load(src + x);
+            v_float32 v_src1 = vx_load(src + x + VTraits<v_float32>::vlanes());
+            v_float64 v_src00 = v_cvt_f64(v_src0);
+            v_float64 v_src01 = v_cvt_f64_high(v_src0);
+            v_float64 v_src10 = v_cvt_f64(v_src1);
+            v_float64 v_src11 = v_cvt_f64_high(v_src1);
+
+            v_float64 v_dst00 = vx_load(dst + x);
+            v_float64 v_dst01 = vx_load(dst + x + step);
+            v_float64 v_dst10 = vx_load(dst + x + step * 2);
+            v_float64 v_dst11 = vx_load(dst + x + step * 3);
+
+            v_dst00 = v_fma(v_dst00, v_beta, v_mul(v_src00, v_alpha));
+            v_dst01 = v_fma(v_dst01, v_beta, v_mul(v_src01, v_alpha));
+            v_dst10 = v_fma(v_dst10, v_beta, v_mul(v_src10, v_alpha));
+            v_dst11 = v_fma(v_dst11, v_beta, v_mul(v_src11, v_alpha));
+
+            v_store(dst + x, v_dst00);
+            v_store(dst + x + step, v_dst01);
+            v_store(dst + x + step * 2, v_dst10);
+            v_store(dst + x + step * 3, v_dst11);
+        }
+    }
+#endif // CV_SIMD_64F
+    accW_general_(src, dst, mask, len, cn, alpha, x);
+}
+
+void accW_simd_(const double* src, double* dst, const uchar* mask, int len, int cn, double alpha)
+{
+    int x = 0;
+#if CV_AVX && !CV_AVX2
+    const __m256d v_alpha = _mm256_set1_pd(alpha);
+    const __m256d v_beta = _mm256_set1_pd(1.0f - alpha);
+    const int cVectorWidth = 8;
+
+    if (!mask)
+    {
+        int size = len * cn;
+        for ( ; x <= size - cVectorWidth ; x += cVectorWidth)
+        {
+            __m256d v_src0 = _mm256_loadu_pd(src + x);
+            __m256d v_src1 = _mm256_loadu_pd(src + x + 4);
+
+            _mm256_storeu_pd(dst + x, _mm256_add_pd(_mm256_mul_pd(_mm256_loadu_pd(dst + x), v_beta), _mm256_mul_pd(v_src0, v_alpha)));
+            _mm256_storeu_pd(dst + x + 4, _mm256_add_pd(_mm256_mul_pd(_mm256_loadu_pd(dst + x + 4), v_beta), _mm256_mul_pd(v_src1, v_alpha)));
+        }
+    }
+#elif (CV_SIMD_64F || CV_SIMD_SCALABLE_64F)
+    const v_float64 v_alpha = vx_setall_f64(alpha);
+    const v_float64 v_beta = vx_setall_f64(1.0f - alpha);
+    const int cVectorWidth = VTraits<v_float64>::vlanes() * 2;
+    const int step = VTraits<v_float64>::vlanes();
+
+    if (!mask)
+    {
+        int size = len * cn;
+        for (; x <= size - cVectorWidth; x += cVectorWidth)
+        {
+            v_float64 v_src0 = vx_load(src + x);
+            v_float64 v_src1 = vx_load(src + x + step);
+
+            v_float64 v_dst0 = vx_load(dst + x);
+            v_float64 v_dst1 = vx_load(dst + x + step);
+
+            v_dst0 = v_fma(v_dst0, v_beta, v_mul(v_src0, v_alpha));
+            v_dst1 = v_fma(v_dst1, v_beta, v_mul(v_src1, v_alpha));
+
+            v_store(dst + x, v_dst0);
+            v_store(dst + x + step, v_dst1);
+        }
+    }
+#endif // CV_SIMD_64F
+    accW_general_(src, dst, mask, len, cn, alpha, x);
+}
+
+#endif // CV_CPU_OPTIMIZATION_DECLARATIONS_ONLY
+
+CV_CPU_OPTIMIZATION_NAMESPACE_END
+
+} // namespace cv
+
+///* End of file. */

--- a/modules/ximgproc/src/opencl/accumulate.cl
+++ b/modules/ximgproc/src/opencl/accumulate.cl
@@ -1,0 +1,90 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+// Copyright (C) 2014, Advanced Micro Devices, Inc., all rights reserved.
+// Third party copyrights are property of their respective owners.
+
+#ifdef DOUBLE_SUPPORT
+#ifdef cl_amd_fp64
+#pragma OPENCL EXTENSION cl_amd_fp64:enable
+#elif defined (cl_khr_fp64)
+#pragma OPENCL EXTENSION cl_khr_fp64:enable
+#endif
+#endif
+
+#define SRC_TSIZE cn * (int)sizeof(srcT1)
+#define DST_TSIZE cn * (int)sizeof(dstT1)
+
+#define noconvert
+
+__kernel void accumulate(__global const uchar * srcptr, int src_step, int src_offset,
+#ifdef ACCUMULATE_PRODUCT
+                         __global const uchar * src2ptr, int src2_step, int src2_offset,
+#endif
+                         __global uchar * dstptr, int dst_step, int dst_offset, int dst_rows, int dst_cols
+#ifdef ACCUMULATE_WEIGHTED
+                         , dstT1 alpha
+#endif
+#ifdef HAVE_MASK
+                         , __global const uchar * mask, int mask_step, int mask_offset
+#endif
+                         )
+{
+    int x = get_global_id(0);
+    int y = get_global_id(1) * rowsPerWI;
+
+    if (x < dst_cols)
+    {
+        int src_index = mad24(y, src_step, mad24(x, SRC_TSIZE, src_offset));
+#ifdef HAVE_MASK
+        int mask_index = mad24(y, mask_step, mask_offset + x);
+        mask += mask_index;
+#endif
+#ifdef ACCUMULATE_PRODUCT
+        int src2_index = mad24(y, src2_step, mad24(x, SRC_TSIZE, src2_offset));
+#endif
+        int dst_index = mad24(y, dst_step, mad24(x, DST_TSIZE, dst_offset));
+
+        #pragma unroll
+        for (int i = 0; i < rowsPerWI; ++i)
+            if (y < dst_rows)
+            {
+                __global const srcT1 * src = (__global const srcT1 *)(srcptr + src_index);
+#ifdef ACCUMULATE_PRODUCT
+                __global const srcT1 * src2 = (__global const srcT1 *)(src2ptr + src2_index);
+#endif
+                __global dstT1 * dst = (__global dstT1 *)(dstptr + dst_index);
+
+#ifdef HAVE_MASK
+                if (mask[0])
+#endif
+                    #pragma unroll
+                    for (int c = 0; c < cn; ++c)
+                    {
+#ifdef ACCUMULATE
+                        dst[c] += convertToDT(src[c]);
+#elif defined ACCUMULATE_SQUARE
+                        dstT1 val = convertToDT(src[c]);
+                        dst[c] = fma(val, val, dst[c]);
+#elif defined ACCUMULATE_PRODUCT
+                        dst[c] = fma(convertToDT(src[c]), convertToDT(src2[c]), dst[c]);
+#elif defined ACCUMULATE_WEIGHTED
+                        dst[c] = fma(1 - alpha, dst[c], src[c] * alpha);
+#else
+#error "Unknown accumulation type"
+#endif
+                    }
+
+                src_index += src_step;
+#ifdef ACCUMULATE_PRODUCT
+                src2_index += src2_step;
+#endif
+#ifdef HAVE_MASK
+                mask += mask_step;
+#endif
+                dst_index += dst_step;
+                ++y;
+            }
+    }
+}

--- a/modules/ximgproc/test/test_accumulate.cpp
+++ b/modules/ximgproc/test/test_accumulate.cpp
@@ -1,0 +1,317 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "test_precomp.hpp"
+#include "opencv2/ts/ocl_test.hpp"
+
+namespace opencv_test { namespace {
+
+//////////////////////////////// CPU accuracy /////////////////////////////////
+// Multi-channel masked accumulate against a scalar reference implementation.
+
+typedef testing::TestWithParam<tuple<Size, int, int> > Ximgproc_Accumulate;
+
+TEST_P(Ximgproc_Accumulate, accuracy)
+{
+    const Size size = get<0>(GetParam());
+    const int pattern = get<1>(GetParam());
+    const int srcType = get<2>(GetParam());
+
+    RNG& rng = theRNG();
+
+    Mat src(size, srcType);
+    Mat dst(size, CV_32FC4);
+    Mat mask(size, CV_8UC1);
+
+    if (srcType == CV_8UC4)
+        rng.fill(src, RNG::UNIFORM, Scalar::all(0), Scalar::all(256));
+    else
+        rng.fill(src, RNG::UNIFORM, Scalar::all(-10.0), Scalar::all(10.0));
+
+    rng.fill(dst, RNG::UNIFORM, Scalar::all(-1000.0), Scalar::all(1000.0));
+
+    for (int y = 0; y < mask.rows; ++y)
+    {
+        uchar* row = mask.ptr<uchar>(y);
+
+        for (int x = 0; x < mask.cols; ++x)
+        {
+            switch (pattern)
+            {
+            case 0:
+                row[x] = 0;
+                break;
+            case 1:
+                row[x] = 255;
+                break;
+            case 2:
+                row[x] = ((x + y) % 2) ? 255 : 0;
+                break;
+            case 3:
+                row[x] = ((x * 13 + y * 7) % 5) ? 255 : 0;
+                break;
+            default:
+                row[x] = ((x * 17 + y * 11) % 3) ? 255 : 0;
+                break;
+            }
+        }
+    }
+
+    Mat dstRef = dst.clone();
+
+    if (srcType == CV_32FC4)
+    {
+        for (int y = 0; y < src.rows; ++y)
+        {
+            const Vec4f* srcRow = src.ptr<Vec4f>(y);
+            Vec4f* dstRefRow = dstRef.ptr<Vec4f>(y);
+            const uchar* maskRow = mask.ptr<uchar>(y);
+
+            for (int x = 0; x < src.cols; ++x)
+            {
+                if (maskRow[x])
+                {
+                    for (int c = 0; c < 4; ++c)
+                        dstRefRow[x][c] += srcRow[x][c];
+                }
+            }
+        }
+    }
+    else
+    {
+        CV_Assert(srcType == CV_8UC4);
+
+        for (int y = 0; y < src.rows; ++y)
+        {
+            const Vec4b* srcRow = src.ptr<Vec4b>(y);
+            Vec4f* dstRefRow = dstRef.ptr<Vec4f>(y);
+            const uchar* maskRow = mask.ptr<uchar>(y);
+
+            for (int x = 0; x < src.cols; ++x)
+            {
+                if (maskRow[x])
+                {
+                    for (int c = 0; c < 4; ++c)
+                        dstRefRow[x][c] += static_cast<float>(srcRow[x][c]);
+                }
+            }
+        }
+    }
+
+    cv::ximgproc::accumulate(src, dst, mask);
+
+    const double err = cv::norm(dst, dstRef, NORM_INF);
+
+    EXPECT_EQ(0.0, err)
+        << "size=" << size
+        << ", pattern=" << pattern
+        << ", srcType=" << srcType;
+}
+
+INSTANTIATE_TEST_CASE_P(, Ximgproc_Accumulate,
+    testing::Combine(
+        testing::Values(Size(1, 1),
+                        Size(3, 5),
+                        Size(17, 7),
+                        Size(37, 19),
+                        Size(128, 16),
+                        Size(641, 37)),
+        testing::Values(0, 1, 2, 3, 4),
+        testing::Values(CV_32FC4, CV_8UC4)));
+
+}} // namespace opencv_test::<anonymous>
+
+//////////////////////////////// OpenCL accuracy //////////////////////////////
+
+#ifdef HAVE_OPENCL
+
+namespace opencv_test {
+namespace ocl {
+
+PARAM_TEST_CASE(AccumulateBase, std::pair<MatDepth, MatDepth>, Channels, bool)
+{
+    int sdepth, ddepth, channels;
+    bool useRoi;
+    double alpha;
+
+    TEST_DECLARE_INPUT_PARAMETER(src);
+    TEST_DECLARE_INPUT_PARAMETER(mask);
+    TEST_DECLARE_INPUT_PARAMETER(src2);
+    TEST_DECLARE_OUTPUT_PARAMETER(dst);
+
+    virtual void SetUp()
+    {
+        const std::pair<MatDepth, MatDepth> depths = GET_PARAM(0);
+        sdepth = depths.first, ddepth = depths.second;
+        channels = GET_PARAM(1);
+        useRoi = GET_PARAM(2);
+    }
+
+    void random_roi()
+    {
+        const int stype = CV_MAKE_TYPE(sdepth, channels),
+                dtype = CV_MAKE_TYPE(ddepth, channels);
+
+        Size roiSize = randomSize(1, 10);
+        Border srcBorder = randomBorder(0, useRoi ? MAX_VALUE : 0);
+        randomSubMat(src, src_roi, roiSize, srcBorder, stype, -MAX_VALUE, MAX_VALUE);
+
+        Border maskBorder = randomBorder(0, useRoi ? MAX_VALUE : 0);
+        randomSubMat(mask, mask_roi, roiSize, maskBorder, CV_8UC1, -MAX_VALUE, MAX_VALUE);
+        cvtest::threshold(mask, mask, 80, 255, THRESH_BINARY);
+
+        Border src2Border = randomBorder(0, useRoi ? MAX_VALUE : 0);
+        randomSubMat(src2, src2_roi, roiSize, src2Border, stype, -MAX_VALUE, MAX_VALUE);
+
+        Border dstBorder = randomBorder(0, useRoi ? MAX_VALUE : 0);
+        randomSubMat(dst, dst_roi, roiSize, dstBorder, dtype, -MAX_VALUE, MAX_VALUE);
+
+        UMAT_UPLOAD_INPUT_PARAMETER(src);
+        UMAT_UPLOAD_INPUT_PARAMETER(mask);
+        UMAT_UPLOAD_INPUT_PARAMETER(src2);
+        UMAT_UPLOAD_OUTPUT_PARAMETER(dst);
+
+        alpha = randomDouble(-5, 5);
+    }
+};
+
+/////////////////////////////////// Accumulate ///////////////////////////////////
+
+typedef AccumulateBase Accumulate;
+
+OCL_TEST_P(Accumulate, Mat)
+{
+    for (int i = 0; i < test_loop_times; ++i)
+    {
+        random_roi();
+
+        OCL_OFF(cv::ximgproc::accumulate(src_roi, dst_roi));
+        OCL_ON(cv::ximgproc::accumulate(usrc_roi, udst_roi));
+
+        OCL_EXPECT_MATS_NEAR(dst, 1e-6);
+    }
+}
+
+OCL_TEST_P(Accumulate, Mask)
+{
+    for (int i = 0; i < test_loop_times; ++i)
+    {
+        random_roi();
+
+        OCL_OFF(cv::ximgproc::accumulate(src_roi, dst_roi, mask_roi));
+        OCL_ON(cv::ximgproc::accumulate(usrc_roi, udst_roi, umask_roi));
+
+        OCL_EXPECT_MATS_NEAR(dst, 1e-6);
+    }
+}
+
+/////////////////////////////////// AccumulateSquare ///////////////////////////////////
+
+typedef AccumulateBase AccumulateSquare;
+
+OCL_TEST_P(AccumulateSquare, Mat)
+{
+    for (int i = 0; i < test_loop_times; ++i)
+    {
+        random_roi();
+
+        OCL_OFF(cv::ximgproc::accumulateSquare(src_roi, dst_roi));
+        OCL_ON(cv::ximgproc::accumulateSquare(usrc_roi, udst_roi));
+
+        OCL_EXPECT_MATS_NEAR(dst, 1e-2);
+    }
+}
+
+OCL_TEST_P(AccumulateSquare, Mask)
+{
+    for (int i = 0; i < test_loop_times; ++i)
+    {
+        random_roi();
+
+        OCL_OFF(cv::ximgproc::accumulateSquare(src_roi, dst_roi, mask_roi));
+        OCL_ON(cv::ximgproc::accumulateSquare(usrc_roi, udst_roi, umask_roi));
+
+        OCL_EXPECT_MATS_NEAR(dst, 1e-2);
+    }
+}
+
+/////////////////////////////////// AccumulateProduct ///////////////////////////////////
+
+typedef AccumulateBase AccumulateProduct;
+
+OCL_TEST_P(AccumulateProduct, Mat)
+{
+    for (int i = 0; i < test_loop_times; ++i)
+    {
+        random_roi();
+
+        OCL_OFF(cv::ximgproc::accumulateProduct(src_roi, src2_roi, dst_roi));
+        OCL_ON(cv::ximgproc::accumulateProduct(usrc_roi, usrc2_roi, udst_roi));
+
+        OCL_EXPECT_MATS_NEAR(dst, 1e-2);
+    }
+}
+
+OCL_TEST_P(AccumulateProduct, Mask)
+{
+    for (int i = 0; i < test_loop_times; ++i)
+    {
+        random_roi();
+
+        OCL_OFF(cv::ximgproc::accumulateProduct(src_roi, src2_roi, dst_roi, mask_roi));
+        OCL_ON(cv::ximgproc::accumulateProduct(usrc_roi, usrc2_roi, udst_roi, umask_roi));
+
+        OCL_EXPECT_MATS_NEAR(dst, 1e-2);
+    }
+}
+
+/////////////////////////////////// AccumulateWeighted ///////////////////////////////////
+
+typedef AccumulateBase AccumulateWeighted;
+
+OCL_TEST_P(AccumulateWeighted, Mat)
+{
+    for (int i = 0; i < test_loop_times; ++i)
+    {
+        random_roi();
+
+        OCL_OFF(cv::ximgproc::accumulateWeighted(src_roi, dst_roi, alpha));
+        OCL_ON(cv::ximgproc::accumulateWeighted(usrc_roi, udst_roi, alpha));
+
+        OCL_EXPECT_MATS_NEAR(dst, 1e-2);
+    }
+}
+
+OCL_TEST_P(AccumulateWeighted, Mask)
+{
+    for (int i = 0; i < test_loop_times; ++i)
+    {
+        random_roi();
+
+        OCL_OFF(cv::ximgproc::accumulateWeighted(src_roi, dst_roi, alpha));
+        OCL_ON(cv::ximgproc::accumulateWeighted(usrc_roi, udst_roi, alpha));
+
+        OCL_EXPECT_MATS_NEAR(dst, 1e-2);
+    }
+}
+
+/////////////////////////////////// Instantiation ///////////////////////////////////
+
+#define OCL_DEPTH_ALL_COMBINATIONS \
+    testing::Values(std::make_pair<MatDepth, MatDepth>(CV_8U, CV_32F), \
+    std::make_pair<MatDepth, MatDepth>(CV_16U, CV_32F), \
+    std::make_pair<MatDepth, MatDepth>(CV_32F, CV_32F), \
+    std::make_pair<MatDepth, MatDepth>(CV_8U, CV_64F), \
+    std::make_pair<MatDepth, MatDepth>(CV_16U, CV_64F), \
+    std::make_pair<MatDepth, MatDepth>(CV_32F, CV_64F), \
+    std::make_pair<MatDepth, MatDepth>(CV_64F, CV_64F))
+
+OCL_INSTANTIATE_TEST_CASE_P(Ximgproc, Accumulate, Combine(OCL_DEPTH_ALL_COMBINATIONS, OCL_ALL_CHANNELS, Bool()));
+OCL_INSTANTIATE_TEST_CASE_P(Ximgproc, AccumulateSquare, Combine(OCL_DEPTH_ALL_COMBINATIONS, OCL_ALL_CHANNELS, Bool()));
+OCL_INSTANTIATE_TEST_CASE_P(Ximgproc, AccumulateProduct, Combine(OCL_DEPTH_ALL_COMBINATIONS, OCL_ALL_CHANNELS, Bool()));
+OCL_INSTANTIATE_TEST_CASE_P(Ximgproc, AccumulateWeighted, Combine(OCL_DEPTH_ALL_COMBINATIONS, OCL_ALL_CHANNELS, Bool()));
+
+} } // namespace opencv_test::ocl
+
+#endif // HAVE_OPENCL

--- a/modules/ximgproc/test/test_accumulate.cpp
+++ b/modules/ximgproc/test/test_accumulate.cpp
@@ -289,8 +289,8 @@ OCL_TEST_P(AccumulateWeighted, Mask)
     {
         random_roi();
 
-        OCL_OFF(cv::ximgproc::accumulateWeighted(src_roi, dst_roi, alpha));
-        OCL_ON(cv::ximgproc::accumulateWeighted(usrc_roi, udst_roi, alpha));
+        OCL_OFF(cv::ximgproc::accumulateWeighted(src_roi, dst_roi, alpha, mask_roi));
+        OCL_ON(cv::ximgproc::accumulateWeighted(usrc_roi, udst_roi, alpha, umask_roi));
 
         OCL_EXPECT_MATS_NEAR(dst, 1e-2);
     }


### PR DESCRIPTION
This adds accumulate, accumulateSquare, accumulateProduct and accumulateWeighted to the ximgproc module, as part of the imgproc cleanup in opencv/opencv#25001. These accumulator functions are rarely used and are largely covered by core arithmetic (accumulate and accumulateWeighted by add and addWeighted, the other two by multiply and add), so they are a good fit for opencv_contrib rather than the base imgproc module.

The change comes in two commits. The first is a faithful move of the implementation from imgproc, keeping the dispatched SIMD kernel, the OpenCL kernel and the IPP paths intact; the only differences are the namespace
(cv::ximgproc) and the OpenCL kernel source reference (ocl::ximgproc::accumulate_oclsrc). The second commit applies C++17 style to the portable code paths (using-aliases instead of function-pointer typedefs, reinterpret_cast for the dispatch tables, and nullptr), leaving the IPP integration untouched.

The functions keep their existing signatures and behavior under the new cv::ximgproc namespace. The accuracy and performance tests move with them: the CPU accuracy test that previously lived in the opencv video module and the OpenCL accuracy test from imgproc are combined into a single ximgproc test, and the CPU and OpenCL performance tests are brought over as well. The tests are self-contained and generate their own input, so no opencv_extra data is required.

Part of opencv/opencv#25001.

This is one half of a linked pair and is meant to be merged together with the opencv PR that removes the functions from imgproc, so they are never defined in both modules at once:

- Issue: opencv/opencv#25001
- opencv PR: opencv/opencv#29347

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
