### PR TITLE
fix heap buffer overflow in EdgeDrawing()

### DIFF
--- a/modules/line_descriptor/src/binary_descriptor.cpp
+++ b/modules/line_descriptor/src/binary_descriptor.cpp
@@ -1568,6 +1568,7 @@ int BinaryDescriptor::EDLineDetector::EdgeDrawing( cv::Mat &image, EdgeChains &e
       while ( pgImg[indexInArray] > 0 && !pEdgeImg[indexInArray] )
       {
         pEdgeImg[indexInArray] = 1;        // Mark this pixel as an edge pixel
+        if( offsetPFirst >= edgePixelArraySize ) break; 
         pFirstPartEdgeX_[offsetPFirst] = x;
         pFirstPartEdgeY_[offsetPFirst++] = y;
         shouldGoDirection = 0;        //unknown
@@ -1719,6 +1720,7 @@ int BinaryDescriptor::EDLineDetector::EdgeDrawing( cv::Mat &image, EdgeChains &e
       while ( pgImg[indexInArray] > 0 && !pEdgeImg[indexInArray] )
       {
         pEdgeImg[indexInArray] = 1;        // Mark this pixel as an edge pixel
+        if( offsetPFirst >= edgePixelArraySize ) break;
         pSecondPartEdgeX_[offsetPSecond] = x;
         pSecondPartEdgeY_[offsetPSecond++] = y;
         shouldGoDirection = 0;        //unknown
@@ -1869,6 +1871,7 @@ int BinaryDescriptor::EDLineDetector::EdgeDrawing( cv::Mat &image, EdgeChains &e
       while ( pgImg[indexInArray] > 0 && !pEdgeImg[indexInArray] )
       {
         pEdgeImg[indexInArray] = 1;        // Mark this pixel as an edge pixel
+        if( offsetPFirst >= edgePixelArraySize ) break;
         pFirstPartEdgeX_[offsetPFirst] = x;
         pFirstPartEdgeY_[offsetPFirst++] = y;
         shouldGoDirection = 0;        //unknown
@@ -2020,6 +2023,7 @@ int BinaryDescriptor::EDLineDetector::EdgeDrawing( cv::Mat &image, EdgeChains &e
       while ( pgImg[indexInArray] > 0 && !pEdgeImg[indexInArray] )
       {
         pEdgeImg[indexInArray] = 1;        // Mark this pixel as an edge pixel
+        if( offsetPFirst >= edgePixelArraySize ) break;
         pSecondPartEdgeX_[offsetPSecond] = x;
         pSecondPartEdgeY_[offsetPSecond++] = y;
         shouldGoDirection = 0;        //unknown


### PR DESCRIPTION
line_descriptor: fix heap buffer overflow in EdgeDrawing()  EdgeDrawing() allocates edge pixel buffers of size pixelNum/5, but writes without checking bounds. When the image has high edge density, offsetPFirst/offsetPSecond exceed the buffer, corrupting the heap.  Add bounds checks before each write to prevent overflow. This fixes the crash reported in #1999 And #4167.