### PR TITLE
xfeatures2d: fix PCTSignatures::getSampleCount() copy-paste bug

### DIFF
--- a/modules/xfeatures2d/src/pct_signatures.cpp
+++ b/modules/xfeatures2d/src/pct_signatures.cpp
@@ -129,7 +129,7 @@ namespace cv
 
                 /**** sampler ****/
 
-                int getSampleCount() const CV_OVERRIDE                      { return mSampler->getGrayscaleBits(); }
+                int getSampleCount() const CV_OVERRIDE                      { return mSampler->getSampleCount(); }
                 int getGrayscaleBits() const CV_OVERRIDE                    { return mSampler->getGrayscaleBits(); }
                 int getWindowRadius() const CV_OVERRIDE                     { return mSampler->getWindowRadius(); }
                 float getWeightX() const CV_OVERRIDE                        { return mSampler->getWeightX(); }

--- a/modules/xfeatures2d/test/test_pct_signatures.cpp
+++ b/modules/xfeatures2d/test/test_pct_signatures.cpp
@@ -1,0 +1,24 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "test_precomp.hpp"
+
+namespace opencv_test { namespace {
+
+TEST(XFeatures2d_PCTSignatures, get_sample_count)
+{
+    std::vector<Point2f> initSamplingPoints;
+    for (int i = 0; i < 10; i++)
+    {
+        initSamplingPoints.push_back(Point2f(0.1f * i, 0.1f * i));
+    }
+
+    Ptr<PCTSignatures> pctSignatures = PCTSignatures::create(initSamplingPoints, 5);
+    ASSERT_FALSE(pctSignatures.empty());
+
+    ASSERT_EQ((int)initSamplingPoints.size(), pctSignatures->getSampleCount());
+    ASSERT_NE(pctSignatures->getSampleCount(), pctSignatures->getGrayscaleBits());
+}
+
+}} // namespace


### PR DESCRIPTION
`PCTSignatures_Impl::getSampleCount()` calls `mSampler->getGrayscaleBits()` instead of `mSampler->getSampleCount()`, so it always returns the grayscale bit depth (default 4) instead of the actual number of sampling points passed to `create()`. `PCTSampler_Impl::getSampleCount()` itself is correct, so this looks like a copy-paste mistake from the adjacent `getGrayscaleBits()` line.

Added a small regression test in `test_pct_signatures.cpp`.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake