### PR TITLE
xfeatures2d: fix out-of-bounds read in PCTSignaturesSQFD::computeQuadraticFormDistances

### DIFF
--- a/modules/xfeatures2d/src/pct_signatures_sqfd.cpp
+++ b/modules/xfeatures2d/src/pct_signatures_sqfd.cpp
@@ -138,7 +138,7 @@ namespace cv
 
                     for (int i = range.start; i < range.end; i++)
                     {
-                        if (mImageSignatures[i].empty())
+                        if ((*mImageSignatures)[i].empty())
                         {
                             CV_Error_(Error::StsBadArg, ("Signature ID: %d is empty!", i));
                         }

--- a/modules/xfeatures2d/test/test_pct_signatures_sqfd.cpp
+++ b/modules/xfeatures2d/test/test_pct_signatures_sqfd.cpp
@@ -1,0 +1,34 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "test_precomp.hpp"
+
+namespace opencv_test { namespace {
+
+TEST(XFeatures2d_PCTSignaturesSQFD, compute_quadratic_form_distances_multiple_signatures)
+{
+    Ptr<PCTSignaturesSQFD> sqfd = PCTSignaturesSQFD::create();
+    ASSERT_FALSE(sqfd.empty());
+
+    Mat source = (Mat_<float>(1, 8) << 1.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f);
+
+    std::vector<Mat> imageSignatures;
+    imageSignatures.push_back((Mat_<float>(1, 8) << 1.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f));
+    imageSignatures.push_back((Mat_<float>(1, 8) << 1.f, 1.f, 1.f, 0.f, 0.f, 0.f, 0.f, 0.f));
+    imageSignatures.push_back((Mat_<float>(1, 8) << 1.f, 2.f, 2.f, 0.f, 0.f, 0.f, 0.f, 0.f));
+
+    std::vector<float> distances;
+    sqfd->computeQuadraticFormDistances(source, imageSignatures, distances);
+    ASSERT_EQ(imageSignatures.size(), distances.size());
+
+    // Each entry (including index > 0) must match the same computation done directly,
+    // i.e. none of the non-first signatures may be treated as empty/garbage.
+    for (size_t i = 0; i < imageSignatures.size(); i++)
+    {
+        float expected = sqfd->computeQuadraticFormDistance(source, imageSignatures[i]);
+        EXPECT_NEAR(expected, distances[i], 1e-5) << "signature index " << i;
+    }
+}
+
+}} // namespace


### PR DESCRIPTION
`Parallel_computeSQFDs::operator()` in `pct_signatures_sqfd.cpp` indexes `mImageSignatures` (a `const std::vector<Mat>*`) as `mImageSignatures[i]` instead of `(*mImageSignatures)[i]`. This happens to work for `i == 0`, but for `i >= 1` it reads past the pointed-to vector as unallocated memory, which is undefined behavior and in practice throws a spurious `Signature ID: N is empty!` once `imageSignatures` has 2 or more elements.

Added a regression test in `test_pct_signatures_sqfd.cpp` that calls `computeQuadraticFormDistances` with 3 signatures and checks each result against a direct `computeQuadraticFormDistance` call.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake