### PR TITLE
xfeatures2d: fix DAISY roi descriptor buffer overflow

### DIFF
--- a/modules/xfeatures2d/src/daisy.cpp
+++ b/modules/xfeatures2d/src/daisy.cpp
@@ -1033,6 +1033,7 @@ struct ComputeDescriptorsInvoker : ParallelLoopBody
     {
       x_off = _roi->x;
       x_end = _roi->x + _roi->width;
+      y_off = _roi->y;
       image = _image;
       layers = _layers;
       th_q_no = _th_q_no;
@@ -1050,7 +1051,7 @@ struct ComputeDescriptorsInvoker : ParallelLoopBody
       {
         for( int x = x_off; x < x_end; x++ )
         {
-          index = y*image->cols + x;
+          index = (y - y_off)*(x_end - x_off) + (x - x_off);
           orientation = 0;
           if( !orientation_map->empty() )
               orientation = (int) orientation_map->at<ushort>( y, x );
@@ -1065,6 +1066,7 @@ struct ComputeDescriptorsInvoker : ParallelLoopBody
 
     int th_q_no;
     int x_off, x_end;
+    int y_off;
     std::vector<Mat>* layers;
     Mat *descriptors;
     Mat *orientation_map;

--- a/modules/xfeatures2d/test/test_daisy.cpp
+++ b/modules/xfeatures2d/test/test_daisy.cpp
@@ -1,0 +1,52 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "test_precomp.hpp"
+
+namespace opencv_test { namespace {
+
+TEST(XFeatures2d_DAISY, compute_roi_matches_full_image)
+{
+    // Deterministic, non-flat texture so descriptors are not trivially zero.
+    Mat image(100, 100, CV_8UC1);
+    for (int y = 0; y < image.rows; y++)
+    {
+        for (int x = 0; x < image.cols; x++)
+        {
+            image.at<uchar>(y, x) = static_cast<uchar>((x * 3 + y * 7) % 256);
+        }
+    }
+
+    Ptr<DAISY> daisy = DAISY::create();
+    ASSERT_FALSE(daisy.empty());
+
+    Mat fullDescriptors;
+    daisy->compute(image, fullDescriptors);
+    ASSERT_EQ(image.rows * image.cols, fullDescriptors.rows);
+
+    // roi offset away from the image origin, well clear of the border.
+    Rect roi(30, 25, 10, 8);
+    Mat roiDescriptors;
+    daisy->compute(image, roi, roiDescriptors);
+    ASSERT_EQ(roi.width * roi.height, roiDescriptors.rows);
+
+    // Sampling at a given absolute pixel must produce the same descriptor regardless
+    // of roi, only its storage row (roi-relative) differs. Before the fix, the roi
+    // descriptors buffer was indexed with the full-image absolute offset, which for
+    // any roi not starting at (0,0) writes past the end of the roi-sized buffer and
+    // leaves the correct relative rows at their zero-initialized value.
+    for (int y = roi.y; y < roi.y + roi.height; y++)
+    {
+        for (int x = roi.x; x < roi.x + roi.width; x++)
+        {
+            int fullIndex = y * image.cols + x;
+            int roiIndex = (y - roi.y) * roi.width + (x - roi.x);
+
+            double diff = cv::norm(fullDescriptors.row(fullIndex), roiDescriptors.row(roiIndex), NORM_INF);
+            EXPECT_NEAR(0.0, diff, 1e-5) << "pixel (" << x << ", " << y << ")";
+        }
+    }
+}
+
+}} // namespace


### PR DESCRIPTION
`ComputeDescriptorsInvoker` computed the output row index as an absolute image offset (`y*image->cols + x`), but the descriptors buffer passed to `DAISY::compute(image, roi, descriptors)` is only `roi.width*roi.height` rows, addressed relative to the roi. Unless roi covers the whole image, this writes past the end of the allocated buffer.

Store the roi's y offset alongside the existing x offset and compute the row index relative to the roi. The absolute `(y, x)` passed to `get_unnormalized_descriptor()` is unchanged, since sampling is done against the full-image gradient layers regardless of roi.

Added a regression test in `test_daisy.cpp` comparing descriptors computed via a roi against the same pixels computed via the full image.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake