### PR TITLE
Fixed -Wmaybe-uninitialized warning on Ubuntu26.04.

### DIFF
--- a/modules/face/src/getlandmarks.cpp
+++ b/modules/face/src/getlandmarks.cpp
@@ -154,6 +154,9 @@ void FacemarkKazemiImpl :: loadModel(String filename){
                     vector<Point2f> leaf;
                     readLeaf(f,leaf);
                     node.leaf = leaf;
+                    node.split.index1 = 0;
+                    node.split.index2 = 0;
+                    node.split.thresh = 0.f;
                 }
                 else{
                     String error_message = "Data not saved properly.Aborting.....";


### PR DESCRIPTION
CI build warning:
```
[1036/3205] Building CXX object modules/face/CMakeFiles/opencv_face.dir/src/getlandmarks.cpp.o
  In file included from /home/ubuntu/opencv_contrib/modules/face/src/getlandmarks.cpp:6:
  In member function 'cv::face::tree_node& cv::face::tree_node::operator=(const cv::face::tree_node&)',
      inlined from 'virtual void cv::face::FacemarkKazemiImpl::loadModel(cv::String)' at /home/ubuntu/opencv_contrib/modules/face/src/getlandmarks.cpp:163:31:
  /home/ubuntu/opencv_contrib/modules/face/src/face_alignmentimpl.hpp:41:8: warning: 'node.cv::face::tree_node::split' may be used uninitialized [-Wmaybe-uninitialized]
     41 | struct tree_node{
        |        ^~~~~~~~~
  /home/ubuntu/opencv_contrib/modules/face/src/getlandmarks.cpp: In member function 'virtual void cv::face::FacemarkKazemiImpl::loadModel(cv::String)':
  /home/ubuntu/opencv_contrib/modules/face/src/getlandmarks.cpp:146:27: note: 'node' declared here
    146 |                 tree_node node;
        |                           ^~~~
  In member function 'cv::face::tree_node& cv::face::tree_node::operator=(const cv::face::tree_node&)',
      inlined from 'virtual void cv::face::FacemarkKazemiImpl::loadModel(cv::String)' at /home/ubuntu/opencv_contrib/modules/face/src/getlandmarks.cpp:163:31:
  /home/ubuntu/opencv_contrib/modules/face/src/face_alignmentimpl.hpp:41:8: warning: 'node.cv::face::tree_node::split' may be used uninitialized [-Wmaybe-uninitialized]
     41 | struct tree_node{
        |        ^~~~~~~~~
  /home/ubuntu/opencv_contrib/modules/face/src/getlandmarks.cpp: In member function 'virtual void cv::face::FacemarkKazemiImpl::loadModel(cv::String)':
  /home/ubuntu/opencv_contrib/modules/face/src/getlandmarks.cpp:146:27: note: 'node' declared here
    146 |                 tree_node node;
        |                           ^~~~
  [1037/3205] Building CXX object modules/face/CMakeFiles/opencv_face.dir/src/predict_collector.cpp.o
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
