### PR TITLE
dynafu: zero-initialize Voxel::n in TSDFVolumeCPU::reset()

### DIFF
--- a/modules/rgbd/src/dynafu_tsdf.cpp
+++ b/modules/rgbd/src/dynafu_tsdf.cpp
@@ -127,7 +127,7 @@ void TSDFVolumeCPU::reset()
     volume.forEach<VecT>([](VecT& vv, const int* /* position */)
     {
         Voxel& v = reinterpret_cast<Voxel&>(vv);
-        v.v = 0; v.weight = 0;
+        v.v = 0; v.weight = 0; v.n = 0;
     });
 }
 

--- a/modules/rgbd/test/test_dynafu.cpp
+++ b/modules/rgbd/test/test_dynafu.cpp
@@ -6,8 +6,20 @@
 
 #include "test_precomp.hpp"
 
-#ifdef HAVE_OPENGL
 namespace opencv_test { namespace {
+
+// integrate() before any warp field nodes exist used to crash with uninitialized Voxel::n
+TEST(DynamicFusion, firstFrameDoesNotCrashBeforeWarpNodesExist)
+{
+    Ptr<kinfu::Params> params = kinfu::Params::coarseParams();
+
+    Mat depth(params->frameSize, CV_16U, Scalar(static_cast<int>(1.5f * params->depthFactor)));
+
+    Ptr<dynafu::DynaFu> df = dynafu::DynaFu::create(params);
+    ASSERT_NO_THROW(df->update(depth));
+}
+
+#ifdef HAVE_OPENGL
 
 static std::vector<std::string> readDepth(std::string fileList)
 {
@@ -124,6 +136,6 @@ TEST(DynamicFusion, DISABLED)
     CV_UNUSED(flyTest);
 }
 
-}} // namespace
+#endif // HAVE_OPENGL
 
-#endif
+}} // namespace


### PR DESCRIPTION
`TSDFVolumeCPU::reset()` zeros `Voxel::v` and `Voxel::weight` but leaves `Voxel::n` uninitialized. `IntegrateInvoker::operator()` reads this uninitialized `n` and passes it straight into `WarpField::applyWarp()` whenever `warpfield->getNodeIndex()` is null - i.e. on any `integrate()` call before the warp field has registered its first node. `applyWarp()` then indexes `WarpField::nodes` (unchecked) `n` times, so garbage left over in the freshly-allocated `Mat` can produce an out-of-bounds/wild pointer access.

This reproduced as an intermittent SIGSEGV inside `applyWarp` on macOS arm64 CI in a downstream project ([OpenCvSharp](https://github.com/shimat/opencvsharp)), confirmed via crash report: `EXC_BAD_ACCESS KERN_INVALID_ADDRESS at 0x0`, faulting thread inside `cv::dynafu::WarpField::applyWarp` called from `cv::dynafu::IntegrateInvoker::operator()` via `parallel_for_` (`dispatch_apply`).

Fix: zero-initialize `Voxel::n` alongside `v`/`weight` in `reset()`.

Added a regression test in `test_dynafu.cpp` that exercises the vulnerable code path (a single synthetic depth frame, no OpenGL or external test data required, unlike the module's existing disabled `DynamicFusion` tests). Since this is an uninitialized-memory bug, the test can't deterministically reproduce the crash on every run, but it does guard the specific "first frame, no warp nodes yet" scenario going forward.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake