### PR TITLE
rgbd(linemod): fix segfault in unaligned memory access

### DIFF
--- a/modules/rgbd/src/linemod.cpp
+++ b/modules/rgbd/src/linemod.cpp
@@ -913,27 +913,28 @@ void DepthNormal::write(FileStorage& fs) const
 *                                 Response maps                                          *
 \****************************************************************************************/
 
-static void orUnaligned8u(const uchar * src, const int src_stride,
-                          uchar * dst, const int dst_stride,
-                          const int width, const int height)
+static void orUnaligned8u(const uchar* src, int src_step,
+                          uchar* dst, int dst_step,
+                          int width, int height)
 {
-  for (int r = 0; r < height; ++r)
-  {
-    int c = 0;
-
-    for ( ; c <= width - v_uint8::nlanes; c += v_uint8::nlanes)
+    for (int r = 0; r < height; ++r)
     {
-      v_uint8 v_src = v_load_unaligned(src + c);
-      v_uint8 v_dst = v_load_unaligned(dst + c);
-      v_store_unaligned(dst + c, v_src | v_dst);
+        int c = 0;
+        for (; c <= width - cv::v_uint8::nlanes; c += cv::v_uint8::nlanes)
+        {
+            cv::v_uint8 v_src = cv::vx_load(src + c);
+            cv::v_uint8 v_dst = cv::vx_load(dst + c);
+            cv::vx_store(dst + c, cv::v_or(v_src, v_dst));
+        }
+
+        for (; c < width; ++c)
+        {
+            dst[c] |= src[c];
+        }
+
+        src += src_step;
+        dst += dst_step;
     }
-
-    for ( ; c < width; ++c)
-      dst[c] |= src[c];
-
-    src += src_stride;
-    dst += dst_stride;
-  }
 }
 /**
  * \brief Spread binary labels in a quantized image.

--- a/modules/rgbd/src/linemod.cpp
+++ b/modules/rgbd/src/linemod.cpp
@@ -3,7 +3,7 @@
 // of this distribution and at http://opencv.org/license.html
 
 // This code is also subject to the license terms in the LICENSE_WillowGarage.md file found in this module's directory
-
+#include "opencv2/core/hal/intrin.hpp"
 #include "precomp.hpp"
 
 namespace cv
@@ -914,64 +914,27 @@ void DepthNormal::write(FileStorage& fs) const
 \****************************************************************************************/
 
 static void orUnaligned8u(const uchar * src, const int src_stride,
-                   uchar * dst, const int dst_stride,
-                   const int width, const int height)
+                          uchar * dst, const int dst_stride,
+                          const int width, const int height)
 {
-#if CV_SSE2
-  volatile bool haveSSE2 = checkHardwareSupport(CPU_SSE2);
-#if CV_SSE3
-  volatile bool haveSSE3 = checkHardwareSupport(CPU_SSE3);
-#endif
-  bool src_aligned = reinterpret_cast<unsigned long long>(src) % 16 == 0;
-#endif
-
   for (int r = 0; r < height; ++r)
   {
     int c = 0;
 
-#if CV_SSE2
-    // Use aligned loads if possible
-    if (haveSSE2 && src_aligned)
+    for ( ; c <= width - v_uint8::nlanes; c += v_uint8::nlanes)
     {
-      for ( ; c < width - 15; c += 16)
-      {
-        const __m128i* src_ptr = reinterpret_cast<const __m128i*>(src + c);
-        __m128i* dst_ptr = reinterpret_cast<__m128i*>(dst + c);
-        *dst_ptr = _mm_or_si128(*dst_ptr, *src_ptr);
-      }
+      v_uint8 v_src = v_load_unaligned(src + c);
+      v_uint8 v_dst = v_load_unaligned(dst + c);
+      v_store_unaligned(dst + c, v_src | v_dst);
     }
-#if CV_SSE3
-    // Use LDDQU for fast unaligned load
-    else if (haveSSE3)
-    {
-      for ( ; c < width - 15; c += 16)
-      {
-        __m128i val = _mm_lddqu_si128(reinterpret_cast<const __m128i*>(src + c));
-        __m128i* dst_ptr = reinterpret_cast<__m128i*>(dst + c);
-        *dst_ptr = _mm_or_si128(*dst_ptr, val);
-      }
-    }
-#endif
-    // Fall back to MOVDQU
-    else if (haveSSE2)
-    {
-      for ( ; c < width - 15; c += 16)
-      {
-        __m128i val = _mm_loadu_si128(reinterpret_cast<const __m128i*>(src + c));
-        __m128i* dst_ptr = reinterpret_cast<__m128i*>(dst + c);
-        *dst_ptr = _mm_or_si128(*dst_ptr, val);
-      }
-    }
-#endif
+
     for ( ; c < width; ++c)
       dst[c] |= src[c];
 
-    // Advance to next row
     src += src_stride;
     dst += dst_stride;
   }
 }
-
 /**
  * \brief Spread binary labels in a quantized image.
  *

--- a/modules/rgbd/test/test_linemod.cpp
+++ b/modules/rgbd/test/test_linemod.cpp
@@ -7,14 +7,14 @@ TEST(RGBD_Linemod, MatchUnaligned)
     cv::Mat unaligned_mat(100, 17, CV_8UC1);
     unaligned_mat.setTo(0);
 
-    cv::linemod::Detector detector;
-    
+    cv::Ptr<cv::linemod::Detector> detector = cv::linemod::getDefaultLINEMOD();
+
     std::vector<cv::Mat> sources;
     sources.push_back(unaligned_mat);
 
     std::vector<cv::linemod::Match> matches;
-    
-    EXPECT_NO_THROW(detector.match(sources, 80.0f, matches));
+
+    EXPECT_NO_THROW(detector->match(sources, 80.0f, matches));
 }
 
 }}

--- a/modules/rgbd/test/test_linemod.cpp
+++ b/modules/rgbd/test/test_linemod.cpp
@@ -20,7 +20,6 @@ TEST(RGBD_Linemod, MatchUnaligned)
 
     std::vector<cv::linemod::Match> matches;
 
-    // التنفيذ للتأكد من عدم حدوث Segfault عند المعالجة
     EXPECT_NO_THROW(detector->match(sources, 80.0f, matches));
 }
 

--- a/modules/rgbd/test/test_linemod.cpp
+++ b/modules/rgbd/test/test_linemod.cpp
@@ -4,16 +4,23 @@ namespace opencv_test { namespace {
 
 TEST(RGBD_Linemod, MatchUnaligned)
 {
-    cv::Mat unaligned_mat(100, 17, CV_8UC1);
-    unaligned_mat.setTo(0);
+    cv::Mat color(128, 128, CV_8UC3, cv::Scalar(0, 0, 0));
+    cv::Mat depth(128, 128, CV_16UC1, cv::Scalar(0));
+
+    cv::rectangle(color, cv::Rect(32, 32, 64, 64), cv::Scalar(255, 255, 255), -1);
+    cv::rectangle(depth, cv::Rect(32, 32, 64, 64), cv::Scalar(10000), -1);
 
     cv::Ptr<cv::linemod::Detector> detector = cv::linemod::getDefaultLINEMOD();
 
     std::vector<cv::Mat> sources;
-    sources.push_back(unaligned_mat);
+    sources.push_back(color);
+    sources.push_back(depth);
+
+    detector->addTemplate(sources, "object", cv::Mat());
 
     std::vector<cv::linemod::Match> matches;
 
+    // التنفيذ للتأكد من عدم حدوث Segfault عند المعالجة
     EXPECT_NO_THROW(detector->match(sources, 80.0f, matches));
 }
 

--- a/modules/rgbd/test/test_linemod.cpp
+++ b/modules/rgbd/test/test_linemod.cpp
@@ -4,19 +4,17 @@ namespace opencv_test { namespace {
 
 TEST(RGBD_Linemod, MatchUnaligned)
 {
-    cv::Mat color(128, 128, CV_8UC3, cv::Scalar(0, 0, 0));
-    cv::Mat depth(128, 128, CV_16UC1, cv::Scalar(0));
+    cv::Mat color_full(480, 641, CV_8UC3, cv::Scalar(0, 0, 0));
+    cv::Mat depth_full(480, 641, CV_16UC1, cv::Scalar(0));
 
-    cv::rectangle(color, cv::Rect(32, 32, 64, 64), cv::Scalar(255, 255, 255), -1);
-    cv::rectangle(depth, cv::Rect(32, 32, 64, 64), cv::Scalar(10000), -1);
+    cv::Mat color_unaligned = color_full(cv::Rect(1, 0, 640, 480));
+    cv::Mat depth_unaligned = depth_full(cv::Rect(1, 0, 640, 480));
 
     cv::Ptr<cv::linemod::Detector> detector = cv::linemod::getDefaultLINEMOD();
 
     std::vector<cv::Mat> sources;
-    sources.push_back(color);
-    sources.push_back(depth);
-
-    detector->addTemplate(sources, "object", cv::Mat());
+    sources.push_back(color_unaligned);
+    sources.push_back(depth_unaligned);
 
     std::vector<cv::linemod::Match> matches;
 

--- a/modules/rgbd/test/test_linemod.cpp
+++ b/modules/rgbd/test/test_linemod.cpp
@@ -1,0 +1,20 @@
+#include "test_precomp.hpp"
+
+namespace opencv_test { namespace {
+
+TEST(RGBD_Linemod, MatchUnaligned)
+{
+    cv::Mat unaligned_mat(100, 17, CV_8UC1);
+    unaligned_mat.setTo(0);
+
+    cv::linemod::Detector detector;
+    
+    std::vector<cv::Mat> sources;
+    sources.push_back(unaligned_mat);
+
+    std::vector<cv::linemod::Match> matches;
+    
+    EXPECT_NO_THROW(detector.match(sources, 80.0f, matches));
+}
+
+}}


### PR DESCRIPTION
### Bug Description
Calling `linemod::match` with unaligned memory buffers (such as sub-matrices generated via `cv::Rect` offsets) caused a `SIGSEGV` crash inside `orUnaligned8u`. 
The issue stemmed from raw pointer casting that assumed strict memory alignment constraints.

### Fix Details
- Replaced manual pointer arithmetic and unsafe type casting in `orUnaligned8u` with OpenCV Universal Intrinsics (`vx_load`, `vx_store`, and `v_or`).
- Ensures safe and platform-agnostic memory access for non-16-byte aligned buffers across supported architectures.
- Added a regression test (`RGBD_Linemod.MatchUnaligned`) to verify stability when executing matches on unaligned inputs.

### Testing
Ran the standalone test target:
`./bin/opencv_test_rgbd --gtest_filter=*MatchUnaligned*`
Result: `[ PASSED ] 1 test.`