### PR TITLE
xfeatures2d: fix matchLOGOS crash with fewer than N neighbors

### DIFF
--- a/modules/xfeatures2d/src/logos/Point.cpp
+++ b/modules/xfeatures2d/src/logos/Point.cpp
@@ -75,11 +75,12 @@ void Point::nearestNeighboursNaive(const std::vector<Point*>& vP, int index, int
     }
 
     std::sort(minMatch.begin(), minMatch.end(), cMP);
-    nnVector.resize(static_cast<size_t>(N));
-    int count = 0;
-    for (std::vector<MatchPoint>::const_iterator mmit = minMatch.begin(); count < N; ++mmit, count++)
+    // A safer handle:
+    const size_t nnCount = std::min(static_cast<size_t>(N), minMatch.size());
+    nnVector.resize(nnCount);
+    for (size_t count = 0; count < nnCount; count++)
     {
-        nnVector[static_cast<size_t>(count)] = vP[static_cast<size_t>(mmit->index)];
+        nnVector[count] = vP[static_cast<size_t>(minMatch[count].index)];
     }
 
     nnFound = true;

--- a/modules/xfeatures2d/test/test_logos_matcher.cpp
+++ b/modules/xfeatures2d/test/test_logos_matcher.cpp
@@ -149,4 +149,24 @@ TEST(XFeatures2d_LogosMatcher, logos_matcher_regression)
             << " ; correctMatches: " << correctMatches;
 }
 
+TEST(XFeatures2d_LogosMatcher, regression_4174_small_label_group) {
+    std::vector<cv::KeyPoint> keypoints1, keypoints2;
+    for (int i = 0; i < 3; i++) {
+        keypoints1.emplace_back(cv::KeyPoint(10.f * i, 10.f * i, 1));
+        keypoints2.emplace_back(cv::KeyPoint(10.f * i, 10.f * i, 1));
+    }
+    std::vector<int> nn1 = {0, 0, 0};
+    std::vector<int> nn2 = {0, 0, 0};
+    std::vector<cv::DMatch> matches;
+
+    cv::xfeatures2d::matchLOGOS(keypoints1, keypoints2, nn1, nn2, matches);
+
+    for (size_t i = 0; i < matches.size(); i++) {
+        EXPECT_GE(matches[i].queryIdx, 0);
+        EXPECT_LT(matches[i].queryIdx, static_cast<int>(keypoints1.size()));
+        EXPECT_GE(matches[i].trainIdx, 0);
+        EXPECT_LT(matches[i].trainIdx, static_cast<int>(keypoints2.size()));
+    }
+}
+
 }} // namespace


### PR DESCRIPTION
# Fixes #4174

- Fix out-of-bounds access in `Point::nearestNeighboursNaive()` when fewer than `N` neighbors are available.
- Resize `nnVector` to the actual neighbor count to avoid invalid trailing neighbor entries.
- Add a regression test for the 3-keypoint same-label `matchLOGOS` reproducer.

## Tested:
- Built `opencv_test_xfeatures2d` on Windows with OpenCV 5.x + opencv_contrib 5.x
- Ran LOGOS-related tests with `OPENCV_TEST_DATA_PATH` set to `C:\dev\opencv_extra\testdata`

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

> **NOTE:** No new test data or performance test is needed for this bug fix; the regression test uses synthetic keypoints.
