### PR TITLE
rgbd: restore fetching colors for pointcloud in coloredkinfu

### DIFF
--- a/modules/rgbd/include/opencv2/rgbd/colored_kinfu.hpp
+++ b/modules/rgbd/include/opencv2/rgbd/colored_kinfu.hpp
@@ -225,15 +225,16 @@ public:
 
     CV_WRAP virtual void render(OutputArray image, const Matx44f& cameraPose) const = 0;
 
-    /** @brief Gets points and normals of current 3d mesh
+    /** @brief Gets points, normals and colors of current 3d mesh
 
       The order of normals corresponds to order of points.
       The order of points is undefined.
 
         @param points vector of points which are 4-float vectors
         @param normals vector of normals which are 4-float vectors
+        @param colors vector of colors which are 4-float vectors
      */
-    CV_WRAP virtual void getCloud(OutputArray points, OutputArray normals) const = 0;
+    CV_WRAP virtual void getCloud(OutputArray points, OutputArray normals, OutputArray colors = noArray()) const = 0;
 
     /** @brief Gets points of current 3d mesh
 

--- a/modules/rgbd/src/colored_kinfu.cpp
+++ b/modules/rgbd/src/colored_kinfu.cpp
@@ -141,7 +141,7 @@ public:
     void render(OutputArray image) const CV_OVERRIDE;
     void render(OutputArray image, const Matx44f& cameraPose) const CV_OVERRIDE;
 
-    virtual void getCloud(OutputArray points, OutputArray normals) const CV_OVERRIDE;
+    virtual void getCloud(OutputArray points, OutputArray normals, OutputArray colors) const CV_OVERRIDE;
     void getPoints(OutputArray points) const CV_OVERRIDE;
     void getNormals(InputArray points, OutputArray normals) const CV_OVERRIDE;
 
@@ -364,9 +364,9 @@ void ColoredKinFuImpl<MatType>::render(OutputArray image, const Matx44f& _camera
 
 
 template< typename MatType >
-void ColoredKinFuImpl<MatType>::getCloud(OutputArray p, OutputArray n) const
+void ColoredKinFuImpl<MatType>::getCloud(OutputArray p, OutputArray n, OutputArray c) const
 {
-    volume.fetchPointsNormals(p, n);
+    volume.fetchPointsNormalsColors(p, n, c);
 }
 
 


### PR DESCRIPTION
Cherry-picked from 04cafeb2447ce86cbc9bd291f59aefdbeafc032e (authored by @paroj). As pointed out by @alalek in https://github.com/opencv/opencv_contrib/pull/3121#issuecomment-1003111648, this 4.x patch never reached 5.x because of merge conflicts.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake