### PR TITLE
viz: Add iostream include to precomp.hpp

### DIFF
--- a/modules/viz/src/precomp.hpp
+++ b/modules/viz/src/precomp.hpp
@@ -52,6 +52,7 @@
 #include <vector>
 #include <iomanip>
 #include <limits>
+#include <iostream>
 
 #include <vtkVersionMacros.h>
 #include <vtkAppendPolyData.h>

--- a/modules/viz/src/vtk/vtkVizInteractorStyle.cpp
+++ b/modules/viz/src/vtk/vtkVizInteractorStyle.cpp
@@ -96,7 +96,7 @@ void cv::viz::vtkVizInteractorStyle::saveScreenshot(const String &file)
     snapshot_writer->SetFileName(file.c_str());
     snapshot_writer->Write();
 
-    cout << "Screenshot successfully captured (" << file.c_str() << ")" << endl;
+    std::cout << "Screenshot successfully captured (" << file.c_str() << ")" << endl;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -118,7 +118,7 @@ void cv::viz::vtkVizInteractorStyle::exportScene(const String &file)
     exporter->SetInput(Interactor->GetRenderWindow());
     exporter->Write();
 
-    cout << "Scene successfully exported (" << file.c_str() << ")" << endl;
+    std::cout << "Scene successfully exported (" << file.c_str() << ")" << endl;
 }
 
 void cv::viz::vtkVizInteractorStyle::exportScene()


### PR DESCRIPTION
With upgrading to OpenCV 5, compiling opencv_viz with MSVC 19.51 results in build errors: `std::cout` and `std::cerr` are undefined, as well as two `std::` prefixes are missing. This minor patch resolves both.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
