### PR TITLE
face: fix facemark landmarks returned as all zeros on OpenCV 5

### DIFF
--- a/modules/face/src/facemarkAAM.cpp
+++ b/modules/face/src/facemarkAAM.cpp
@@ -348,7 +348,6 @@ static void _copyVector2Output(std::vector< std::vector< Point2f > > &vec, Outpu
         for (unsigned int i = 0; i < vec.size(); i++) {
             out.create((int)vec[i].size(), 1, CV_32FC2, i);
             Mat m = out.getMat(i);
-            // Source must match m's shape or copyTo() reallocates m instead of writing through it.
             Mat(vec[i]).reshape(2, 1).copyTo(m);
         }
     }

--- a/modules/face/src/facemarkAAM.cpp
+++ b/modules/face/src/facemarkAAM.cpp
@@ -346,9 +346,16 @@ static void _copyVector2Output(std::vector< std::vector< Point2f > > &vec, Outpu
     }
     else if (out.kind() == _OutputArray::STD_VECTOR_VECTOR) {
         for (unsigned int i = 0; i < vec.size(); i++) {
-            out.create(68, 1, CV_32FC2, i);
+            out.create((int)vec[i].size(), 1, CV_32FC2, i);
             Mat m = out.getMat(i);
-            Mat(Mat(vec[i]).t()).copyTo(m);
+            // `m` is only a header over the destination vector's storage, so the
+            // source has to match its shape already: a copyTo() that needs to
+            // resize reallocates `m` instead of writing through it, and the
+            // landmarks are silently dropped. OpenCV 4 handed out a 1 x N header
+            // here while OpenCV 5 hands out a 1-D one, which is why transposing
+            // to a column left every landmark at (0,0) on 5.x -- see
+            // https://github.com/opencv/opencv/issues/29703
+            Mat(vec[i]).reshape(2, 1).copyTo(m);
         }
     }
     else {

--- a/modules/face/src/facemarkAAM.cpp
+++ b/modules/face/src/facemarkAAM.cpp
@@ -348,13 +348,7 @@ static void _copyVector2Output(std::vector< std::vector< Point2f > > &vec, Outpu
         for (unsigned int i = 0; i < vec.size(); i++) {
             out.create((int)vec[i].size(), 1, CV_32FC2, i);
             Mat m = out.getMat(i);
-            // `m` is only a header over the destination vector's storage, so the
-            // source has to match its shape already: a copyTo() that needs to
-            // resize reallocates `m` instead of writing through it, and the
-            // landmarks are silently dropped. OpenCV 4 handed out a 1 x N header
-            // here while OpenCV 5 hands out a 1-D one, which is why transposing
-            // to a column left every landmark at (0,0) on 5.x -- see
-            // https://github.com/opencv/opencv/issues/29703
+            // Source must match m's shape or copyTo() reallocates m instead of writing through it.
             Mat(vec[i]).reshape(2, 1).copyTo(m);
         }
     }

--- a/modules/face/src/facemarkLBF.cpp
+++ b/modules/face/src/facemarkLBF.cpp
@@ -395,7 +395,6 @@ static void _copyVector2Output(std::vector< std::vector< Point2f > > &vec, Outpu
         for (unsigned int i = 0; i < vec.size(); i++) {
             out.create((int)vec[i].size(), 1, CV_32FC2, i);
             Mat m = out.getMat(i);
-            // Source must match m's shape or copyTo() reallocates m instead of writing through it.
             Mat(vec[i]).reshape(2, 1).copyTo(m);
         }
     }

--- a/modules/face/src/facemarkLBF.cpp
+++ b/modules/face/src/facemarkLBF.cpp
@@ -395,13 +395,7 @@ static void _copyVector2Output(std::vector< std::vector< Point2f > > &vec, Outpu
         for (unsigned int i = 0; i < vec.size(); i++) {
             out.create((int)vec[i].size(), 1, CV_32FC2, i);
             Mat m = out.getMat(i);
-            // `m` is only a header over the destination vector's storage, so the
-            // source has to match its shape already: a copyTo() that needs to
-            // resize reallocates `m` instead of writing through it, and the
-            // landmarks are silently dropped. OpenCV 4 handed out a 1 x N header
-            // here while OpenCV 5 hands out a 1-D one, which is why transposing
-            // to a column left every landmark at (0,0) on 5.x -- see
-            // https://github.com/opencv/opencv/issues/29703
+            // Source must match m's shape or copyTo() reallocates m instead of writing through it.
             Mat(vec[i]).reshape(2, 1).copyTo(m);
         }
     }

--- a/modules/face/src/facemarkLBF.cpp
+++ b/modules/face/src/facemarkLBF.cpp
@@ -393,9 +393,16 @@ static void _copyVector2Output(std::vector< std::vector< Point2f > > &vec, Outpu
     }
     else if (out.kind() == _OutputArray::STD_VECTOR_VECTOR) {
         for (unsigned int i = 0; i < vec.size(); i++) {
-            out.create(68, 1, CV_32FC2, i);
+            out.create((int)vec[i].size(), 1, CV_32FC2, i);
             Mat m = out.getMat(i);
-            Mat(Mat(vec[i]).t()).copyTo(m);
+            // `m` is only a header over the destination vector's storage, so the
+            // source has to match its shape already: a copyTo() that needs to
+            // resize reallocates `m` instead of writing through it, and the
+            // landmarks are silently dropped. OpenCV 4 handed out a 1 x N header
+            // here while OpenCV 5 hands out a 1-D one, which is why transposing
+            // to a column left every landmark at (0,0) on 5.x -- see
+            // https://github.com/opencv/opencv/issues/29703
+            Mat(vec[i]).reshape(2, 1).copyTo(m);
         }
     }
     else {

--- a/modules/face/src/getlandmarks.cpp
+++ b/modules/face/src/getlandmarks.cpp
@@ -194,7 +194,6 @@ static void _copyVector2Output(std::vector< std::vector< Point2f > > &vec, Outpu
         for (unsigned int i = 0; i < vec.size(); i++) {
             out.create((int)vec[i].size(), 1, CV_32FC2, i);
             Mat m = out.getMat(i);
-            // Source must match m's shape or copyTo() reallocates m instead of writing through it.
             Mat(vec[i]).reshape(2, 1).copyTo(m);
         }
     }

--- a/modules/face/src/getlandmarks.cpp
+++ b/modules/face/src/getlandmarks.cpp
@@ -192,9 +192,16 @@ static void _copyVector2Output(std::vector< std::vector< Point2f > > &vec, Outpu
     }
     else if (out.kind() == _OutputArray::STD_VECTOR_VECTOR) {
         for (unsigned int i = 0; i < vec.size(); i++) {
-            out.create(68, 1, CV_32FC2, i);
+            out.create((int)vec[i].size(), 1, CV_32FC2, i);
             Mat m = out.getMat(i);
-            Mat(Mat(vec[i]).t()).copyTo(m);
+            // `m` is only a header over the destination vector's storage, so the
+            // source has to match its shape already: a copyTo() that needs to
+            // resize reallocates `m` instead of writing through it, and the
+            // landmarks are silently dropped. OpenCV 4 handed out a 1 x N header
+            // here while OpenCV 5 hands out a 1-D one, which is why transposing
+            // to a column left every landmark at (0,0) on 5.x -- see
+            // https://github.com/opencv/opencv/issues/29703
+            Mat(vec[i]).reshape(2, 1).copyTo(m);
         }
     }
     else {

--- a/modules/face/src/getlandmarks.cpp
+++ b/modules/face/src/getlandmarks.cpp
@@ -194,13 +194,7 @@ static void _copyVector2Output(std::vector< std::vector< Point2f > > &vec, Outpu
         for (unsigned int i = 0; i < vec.size(); i++) {
             out.create((int)vec[i].size(), 1, CV_32FC2, i);
             Mat m = out.getMat(i);
-            // `m` is only a header over the destination vector's storage, so the
-            // source has to match its shape already: a copyTo() that needs to
-            // resize reallocates `m` instead of writing through it, and the
-            // landmarks are silently dropped. OpenCV 4 handed out a 1 x N header
-            // here while OpenCV 5 hands out a 1-D one, which is why transposing
-            // to a column left every landmark at (0,0) on 5.x -- see
-            // https://github.com/opencv/opencv/issues/29703
+            // Source must match m's shape or copyTo() reallocates m instead of writing through it.
             Mat(vec[i]).reshape(2, 1).copyTo(m);
         }
     }

--- a/modules/face/test/test_facemark_aam.cpp
+++ b/modules/face/test/test_facemark_aam.cpp
@@ -132,6 +132,15 @@ TEST(CV_Face_FacemarkAAM, test_workflow) {
     EXPECT_TRUE(facemark->fit(image, rects, facial_points));
     EXPECT_TRUE(facial_points[0].size()>0);
 
+    // The fitted points must actually reach the caller's vector. A regression in
+    // the output copy used to hand back the right number of landmarks with every
+    // one of them left at (0,0), which the size check above does not catch.
+    // https://github.com/opencv/opencv/issues/29703
+    size_t nonzero = 0;
+    for (size_t i = 0; i < facial_points[0].size(); i++)
+        if (facial_points[0][i] != Point2f(0, 0)) nonzero++;
+    EXPECT_EQ(nonzero, facial_points[0].size());
+
     /*------------ Test getData ---------------*/
     FacemarkAAM::Data data;
     EXPECT_TRUE(facemark->getData(&data));

--- a/modules/face/test/test_facemark_aam.cpp
+++ b/modules/face/test/test_facemark_aam.cpp
@@ -132,7 +132,6 @@ TEST(CV_Face_FacemarkAAM, test_workflow) {
     EXPECT_TRUE(facemark->fit(image, rects, facial_points));
     EXPECT_TRUE(facial_points[0].size()>0);
 
-    // Points must not just have the right count, but actually reach the caller (issue #29703).
     size_t nonzero = 0;
     for (size_t i = 0; i < facial_points[0].size(); i++)
         if (facial_points[0][i] != Point2f(0, 0)) nonzero++;

--- a/modules/face/test/test_facemark_aam.cpp
+++ b/modules/face/test/test_facemark_aam.cpp
@@ -132,10 +132,7 @@ TEST(CV_Face_FacemarkAAM, test_workflow) {
     EXPECT_TRUE(facemark->fit(image, rects, facial_points));
     EXPECT_TRUE(facial_points[0].size()>0);
 
-    // The fitted points must actually reach the caller's vector. A regression in
-    // the output copy used to hand back the right number of landmarks with every
-    // one of them left at (0,0), which the size check above does not catch.
-    // https://github.com/opencv/opencv/issues/29703
+    // Points must not just have the right count, but actually reach the caller (issue #29703).
     size_t nonzero = 0;
     for (size_t i = 0; i < facial_points[0].size(); i++)
         if (facial_points[0][i] != Point2f(0, 0)) nonzero++;

--- a/modules/face/test/test_facemark_lbf.cpp
+++ b/modules/face/test/test_facemark_lbf.cpp
@@ -135,6 +135,15 @@ TEST(CV_Face_FacemarkLBF, test_workflow) {
     EXPECT_TRUE(rects.size()>0);
     EXPECT_TRUE(facemark->fit(image, rects, facial_points));
     EXPECT_TRUE(facial_points[0].size()>0);
+
+    // The fitted points must actually reach the caller's vector. A regression in
+    // the output copy used to hand back the right number of landmarks with every
+    // one of them left at (0,0), which the size check above does not catch.
+    // https://github.com/opencv/opencv/issues/29703
+    size_t nonzero = 0;
+    for (size_t i = 0; i < facial_points[0].size(); i++)
+        if (facial_points[0][i] != Point2f(0, 0)) nonzero++;
+    EXPECT_EQ(nonzero, facial_points[0].size());
 }
 
 }} // namespace

--- a/modules/face/test/test_facemark_lbf.cpp
+++ b/modules/face/test/test_facemark_lbf.cpp
@@ -136,10 +136,7 @@ TEST(CV_Face_FacemarkLBF, test_workflow) {
     EXPECT_TRUE(facemark->fit(image, rects, facial_points));
     EXPECT_TRUE(facial_points[0].size()>0);
 
-    // The fitted points must actually reach the caller's vector. A regression in
-    // the output copy used to hand back the right number of landmarks with every
-    // one of them left at (0,0), which the size check above does not catch.
-    // https://github.com/opencv/opencv/issues/29703
+    // Points must not just have the right count, but actually reach the caller (issue #29703).
     size_t nonzero = 0;
     for (size_t i = 0; i < facial_points[0].size(); i++)
         if (facial_points[0][i] != Point2f(0, 0)) nonzero++;

--- a/modules/face/test/test_facemark_lbf.cpp
+++ b/modules/face/test/test_facemark_lbf.cpp
@@ -136,7 +136,6 @@ TEST(CV_Face_FacemarkLBF, test_workflow) {
     EXPECT_TRUE(facemark->fit(image, rects, facial_points));
     EXPECT_TRUE(facial_points[0].size()>0);
 
-    // Points must not just have the right count, but actually reach the caller (issue #29703).
     size_t nonzero = 0;
     for (size_t i = 0; i < facial_points[0].size(); i++)
         if (facial_points[0][i] != Point2f(0, 0)) nonzero++;


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv/issues/29703

## Problem

`Facemark::fit()` returns the correct number of landmarks with every point left at `(0,0)` on OpenCV 5, while the same code works on 4.x. The reporter hit this with `FacemarkLBF` and the pretrained `lbfmodel.yaml`.

It only happens when the output is a `std::vector<std::vector<Point2f>>` — which is what the documentation, the samples and the reporter's code all pass — so `landmarks[i].size()` looks right (68) and every coordinate is zero.

## Root cause

`_copyVector2Output()` writes each result through a `Mat` header obtained from `OutputArray::getMat(i)`. That header only *aliases* the destination vector's storage, so the source has to match its shape already: `copyTo()` calls `create()` first, and when the shape differs the header is reallocated, so the copy lands in a fresh buffer that is discarded instead of in the caller's vector.

The source was built as `Mat(Mat(vec[i]).t())` to match the `1 x N` header OpenCV 4 hands out for a `vector<vector<T>>`:

```cpp
// modules/core/src/matrix_wrap.cpp, _InputArray::getMat_()
// 4.x
return v->empty() ? Mat() : Mat(1, int(v->size()), t, v->data());
// 5.x
int v_sz = int(v->size());
return v->empty() ? Mat() : Mat(1, &v_sz, t, v->data());
```

OpenCV 5 returns a **1-D** header there instead, so the transposed source no longer matches and every landmark is silently dropped.

## Fix

Build the source as a `1 x N` two-channel row with `reshape()`, which matches the destination header on both 4.x and 5.x, and size the destination from the actual landmark count instead of a hard-coded `68` (so models with a different number of landmarks work too).

The helper is duplicated in the LBF, AAM and Kazemi implementations and all three were affected, so all three are fixed.

The `Mat`/`UMat` output branches are left alone: they bind the real destination object rather than an aliasing header, so a reallocating `copyTo()` still delivers the data there. Changing them would alter their output shape without fixing a bug.

## Testing

Verified on a local Windows/MSVC build of 5.x + contrib (`5.1.0-dev`), using the reporter's exact sequence (cascade → `detectMultiScale` → `FacemarkLBF::create`/`loadModel`/`fit`) with the pretrained `lbfmodel.yaml` from the issue:

Before:
```
Faces: [136 x 136 from (235, 237)]
Number of landmarks: 68
Non-zero landmarks: 0 / 68
First 5 landmarks: [0, 0] [0, 0] [0, 0] [0, 0] [0, 0]
```

After:
```
Faces: [136 x 136 from (235, 237)]
Number of landmarks: 68
Non-zero landmarks: 68 / 68
First 5 landmarks: [213.177, 280.037] [213.544, 301.395] [214.891, 322.97] [218.014, 343.195] [227.687, 361.095]
```

I also reproduced the underlying shape mismatch in isolation against `opencv_core` 5.x and confirmed the replacement copies correctly for 5, 68 and 194 landmarks as well as the empty case.

The existing `CV_Face_FacemarkLBF.test_workflow` and `CV_Face_FacemarkAAM.test_workflow` only asserted the landmark *count*, which stayed correct throughout — that is why this went unnoticed. They now also assert the points actually reached the caller. Confirmed this is a real regression test: with the source fix reverted and only the test change applied, it fails with

```
  nonzero
    Which is: 0
  facial_points[0].size()
    Which is: 68
```

Full `opencv_test_face` suite passes with the fix (19/19, with `OPENCV_TEST_DATA_PATH` plus the `face_landmark_model.dat` the module downloads at configure time).