### PR TITLE
ccalib: fix misleading assertion when no calibration views survive

### DIFF
--- a/modules/ccalib/src/omnidir.cpp
+++ b/modules/ccalib/src/omnidir.cpp
@@ -766,9 +766,20 @@ void cv::omnidir::internal::initializeStereoCalibration(InputArrayOfArrays objec
     Mat interIdx1, interIdx2, interOri;
 
     getInterset(idx1, idx2, interIdx1, interIdx2, interOri);
+
+    if (interOri.empty())
+    {
+        CV_Error(cv::Error::StsBadArg,
+            "omnidir::stereoCalibrate: no calibration views are valid for both cameras. "
+            "Each camera individually may have views that survived initial pose estimation, "
+            "but the sets of valid views for camera 1 and camera 2 do not overlap (their "
+            "intersection is empty). Check that the same views are usable for both cameras, "
+            "or verify the object/image point correspondences for every input view.");
+    }
+
     if (idx.empty())
         idx.create(1, (int)interOri.total(), CV_32S);
-    interOri.copyTo(idx.getMat());
+    interOri.copyTo(idx);
 
     int n_inter = (int)interIdx1.total();
 
@@ -1112,6 +1123,18 @@ double cv::omnidir::calibrate(InputArrayOfArrays patternPoints, InputArrayOfArra
         _imagePoints.push_back(_imagePointsTmp[_idx.at<int>(i)]);
     }
 
+    if (_patternPoints.empty())
+    {
+        CV_Error(cv::Error::StsBadArg,
+            "omnidir::calibrate: no calibration views survived initial pose estimation. "
+            "Every input view was rejected because its estimated initial pose reprojection "
+            "error exceeded the internal threshold. This usually means the object points and "
+            "image points for every view do not correspond to a consistent, real calibration "
+            "target (e.g. mismatched or randomly generated correspondences), or the image size "
+            "passed to calibrate() does not match the points. Check the object/image point "
+            "correspondences for every input view.");
+    }
+
     int n = (int)_patternPoints.size();
     Mat finalParam(1, 10 + 6*n, CV_64F);
     Mat currentParam(1, 10 + 6*n, CV_64F);
@@ -1252,7 +1275,7 @@ double cv::omnidir::stereoCalibrate(InputOutputArrayOfArrays objectPoints, Input
     if(idx.needed())
     {
         idx.create(1, (int)_idx.total(), CV_32S);
-        _idx.copyTo(idx.getMat());
+        _idx.copyTo(idx);
     }
 	for (int i = 0; i < (int)_idx.total(); ++i)
 	{
@@ -1260,6 +1283,9 @@ double cv::omnidir::stereoCalibrate(InputOutputArrayOfArrays objectPoints, Input
 		_imagePoints1Filt.push_back(_imagePoints1[_idx.at<int>(i)]);
 		_imagePoints2Filt.push_back(_imagePoints2[_idx.at<int>(i)]);
 	}
+
+    // Upheld by internal::initializeStereoCalibration()'s interOri.empty() guard.
+    CV_Assert(!_objectPointsFilt.empty());
 
     int n = (int)_objectPointsFilt.size();
     Mat finalParam(1, 10 + 6*n, CV_64F);

--- a/modules/ccalib/src/omnidir.cpp
+++ b/modules/ccalib/src/omnidir.cpp
@@ -1224,7 +1224,7 @@ double cv::omnidir::calibrate(InputArrayOfArrays patternPoints, InputArrayOfArra
     if (idx.needed())
     {
         idx.create(1, (int)_idx.total(), CV_32S);
-        _idx.copyTo(idx.getMat());
+        _idx.copyTo(idx);
     }
 
     Vec2d std_error;

--- a/modules/ccalib/test/test_main.cpp
+++ b/modules/ccalib/test/test_main.cpp
@@ -1,0 +1,6 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+#include "test_precomp.hpp"
+
+CV_TEST_MAIN("cv")

--- a/modules/ccalib/test/test_omnidir.cpp
+++ b/modules/ccalib/test/test_omnidir.cpp
@@ -1,0 +1,167 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+#include "test_precomp.hpp"
+
+namespace opencv_test { namespace {
+
+// Regression coverage for opencv/opencv#28462: cv::omnidir::calibrate() /
+// cv::omnidir::stereoCalibrate() used to fail with a misleading
+// "objectPoints.type() == CV_64FC3" assertion when the filtered point
+// vectors ended up empty after initial-pose-estimation view filtering.
+// The real cause is emptiness, not a type mismatch. These tests verify the
+// clearer, actionable error introduced to replace that misleading message.
+
+static Mat randomPoints3f(int n, RNG& rng)
+{
+    Mat pts(n, 1, CV_32FC3);
+    for (int i = 0; i < n; ++i)
+        pts.at<Vec3f>(i) = Vec3f(rng.uniform(-1.f, 1.f), rng.uniform(-1.f, 1.f), rng.uniform(-1.f, 1.f));
+    return pts;
+}
+
+static Mat randomPoints2f(int n, RNG& rng)
+{
+    Mat pts(n, 1, CV_32FC2);
+    for (int i = 0; i < n; ++i)
+        pts.at<Vec2f>(i) = Vec2f(rng.uniform(0.f, 640.f), rng.uniform(0.f, 480.f));
+    return pts;
+}
+
+// Builds a small planar grid of object points and their exact projections
+// under the given camera model / pose, so the pair is self-consistent and
+// initializeCalibration()'s closed-form pose estimate should succeed.
+static void generateValidView(const Matx33d& K, double xi, const Matx14d& D,
+    const Vec3d& rvec, const Vec3d& tvec, Mat& objPoints, Mat& imgPoints)
+{
+    const int gridSize = 6; // 36 points, well above the minimum needed for the linear pose solve
+    objPoints = Mat(gridSize * gridSize, 1, CV_32FC3);
+    int idx = 0;
+    for (int r = 0; r < gridSize; ++r)
+        for (int c = 0; c < gridSize; ++c)
+            objPoints.at<Vec3f>(idx++) = Vec3f(0.1f * c, 0.1f * r, 0.f);
+
+    Mat imgPointsD;
+    cv::omnidir::projectPoints(objPoints, imgPointsD, rvec, tvec, K, xi, D, cv::noArray());
+    imgPointsD.convertTo(imgPoints, CV_32FC2);
+}
+
+TEST(CV_OmnidirCalibrate, throws_clear_error_when_no_views_survive_initialization)
+{
+    RNG& rng = cv::theRNG();
+    std::vector<Mat> objectPoints, imagePoints;
+    const int nViews = 5;
+    const int nPointsPerView = 30;
+    for (int v = 0; v < nViews; ++v)
+    {
+        // Fully independent random object/image points: not a real calibration
+        // target, so every view is expected to fail initial pose estimation.
+        objectPoints.push_back(randomPoints3f(nPointsPerView, rng));
+        imagePoints.push_back(randomPoints2f(nPointsPerView, rng));
+    }
+
+    Mat K, xi, D;
+    std::vector<Mat> rvecs, tvecs;
+    bool threw = false;
+    std::string message;
+    try
+    {
+        cv::omnidir::calibrate(objectPoints, imagePoints, Size(640, 480), K, xi, D,
+            rvecs, tvecs, 0, TermCriteria(3, 100, 1e-6), cv::noArray());
+    }
+    catch (const cv::Exception& e)
+    {
+        threw = true;
+        message = e.what();
+    }
+
+    ASSERT_TRUE(threw) << "calibrate() should throw when no views survive initialization";
+    EXPECT_NE(message.find("no calibration views survived"), std::string::npos)
+        << "exception message should explain the actual cause, got: " << message;
+    EXPECT_EQ(message.find("CV_64FC3"), std::string::npos)
+        << "exception message should not resurface the misleading type-assertion text, got: " << message;
+}
+
+TEST(CV_OmnidirCalibrate, succeeds_with_a_valid_synthetic_view)
+{
+    Matx33d K(400, 0, 320, 0, 400, 240, 0, 0, 1);
+    double xi = 1.0;
+    Matx14d D(0, 0, 0, 0);
+
+    std::vector<Mat> objectPoints, imagePoints;
+    Mat objPts, imgPts;
+    generateValidView(K, xi, D, Vec3d(0.05, -0.02, 0.01), Vec3d(0, 0, 3), objPts, imgPts);
+    objectPoints.push_back(objPts);
+    imagePoints.push_back(imgPts);
+    // A second, slightly different valid view so calibration has more than one sample.
+    generateValidView(K, xi, D, Vec3d(-0.03, 0.04, 0.0), Vec3d(0.1, -0.05, 3.2), objPts, imgPts);
+    objectPoints.push_back(objPts);
+    imagePoints.push_back(imgPts);
+
+    Mat Kout, xiOut, Dout;
+    std::vector<Mat> rvecs, tvecs;
+    Mat idx;
+    ASSERT_NO_THROW(
+        cv::omnidir::calibrate(objectPoints, imagePoints, Size(640, 480), Kout, xiOut, Dout,
+            rvecs, tvecs, 0, TermCriteria(3, 100, 1e-6), idx)
+    ) << "calibrate() should not throw the new guard error for a valid, self-consistent view";
+    EXPECT_GT((int)idx.total(), 0) << "at least one synthetic view should survive initialization";
+}
+
+TEST(CV_OmnidirStereoCalibrate, throws_clear_error_when_camera_valid_view_sets_do_not_intersect)
+{
+    Matx33d K1(400, 0, 320, 0, 400, 240, 0, 0, 1);
+    Matx33d K2(410, 0, 330, 0, 410, 250, 0, 0, 1);
+    double xi1 = 1.0, xi2 = 1.0;
+    Matx14d D1(0, 0, 0, 0), D2(0, 0, 0, 0);
+    RNG& rng = cv::theRNG();
+
+    std::vector<Mat> objectPoints, imagePoints1, imagePoints2;
+
+    // Views 0,1: camera 1 sees a valid, self-consistent pattern; camera 2 sees
+    // unrelated random points for the same nominal views.
+    for (int v = 0; v < 2; ++v)
+    {
+        Mat objPts, img1;
+        generateValidView(K1, xi1, D1, Vec3d(0.02 * v, -0.01, 0.0), Vec3d(0.0, 0.0, 3.0 + 0.1 * v), objPts, img1);
+        objectPoints.push_back(objPts);
+        imagePoints1.push_back(img1);
+        imagePoints2.push_back(randomPoints2f(objPts.rows, rng));
+    }
+
+    // Views 2,3: camera 2 sees a valid, self-consistent pattern (reusing the
+    // same object points as their matching view); camera 1 sees unrelated
+    // random points instead.
+    for (int v = 0; v < 2; ++v)
+    {
+        Mat objPts, img2;
+        generateValidView(K2, xi2, D2, Vec3d(-0.02 * v, 0.03, 0.0), Vec3d(0.05, 0.0, 3.2 + 0.1 * v), objPts, img2);
+        objectPoints.push_back(objPts);
+        imagePoints2.push_back(img2);
+        imagePoints1.push_back(randomPoints2f(objPts.rows, rng));
+    }
+
+    Mat Kout1, xiOut1, Dout1, Kout2, xiOut2, Dout2, rvec, tvec;
+    std::vector<Mat> rvecsL, tvecsL;
+    bool threw = false;
+    std::string message;
+    try
+    {
+        cv::omnidir::stereoCalibrate(objectPoints, imagePoints1, imagePoints2, Size(640, 480), Size(640, 480),
+            Kout1, xiOut1, Dout1, Kout2, xiOut2, Dout2, rvec, tvec, rvecsL, tvecsL,
+            0, TermCriteria(3, 100, 1e-6), cv::noArray());
+    }
+    catch (const cv::Exception& e)
+    {
+        threw = true;
+        message = e.what();
+    }
+
+    ASSERT_TRUE(threw) << "stereoCalibrate() should throw when the per-camera valid-view sets do not intersect";
+    EXPECT_NE(message.find("no calibration views are valid for both cameras"), std::string::npos)
+        << "exception message should name the intersection-specific cause, got: " << message;
+    EXPECT_EQ(message.find("CV_64FC3"), std::string::npos)
+        << "exception message should not resurface the misleading type-assertion text, got: " << message;
+}
+
+}} // namespace

--- a/modules/ccalib/test/test_omnidir.cpp
+++ b/modules/ccalib/test/test_omnidir.cpp
@@ -48,7 +48,7 @@ static void generateValidView(const Matx33d& K, double xi, const Matx14d& D,
 
 TEST(CV_OmnidirCalibrate, throws_clear_error_when_no_views_survive_initialization)
 {
-    RNG& rng = cv::theRNG();
+    RNG rng(12345); // fixed seed: reproducible independent of run order / other tests' RNG draws
     std::vector<Mat> objectPoints, imagePoints;
     const int nViews = 5;
     const int nPointsPerView = 30;
@@ -114,7 +114,7 @@ TEST(CV_OmnidirStereoCalibrate, throws_clear_error_when_camera_valid_view_sets_d
     Matx33d K2(410, 0, 330, 0, 410, 250, 0, 0, 1);
     double xi1 = 1.0, xi2 = 1.0;
     Matx14d D1(0, 0, 0, 0), D2(0, 0, 0, 0);
-    RNG& rng = cv::theRNG();
+    RNG rng(67890); // fixed seed: reproducible independent of run order / other tests' RNG draws
 
     std::vector<Mat> objectPoints, imagePoints1, imagePoints2;
 
@@ -162,6 +162,38 @@ TEST(CV_OmnidirStereoCalibrate, throws_clear_error_when_camera_valid_view_sets_d
         << "exception message should name the intersection-specific cause, got: " << message;
     EXPECT_EQ(message.find("CV_64FC3"), std::string::npos)
         << "exception message should not resurface the misleading type-assertion text, got: " << message;
+}
+
+TEST(CV_OmnidirStereoCalibrate, succeeds_with_valid_overlapping_views)
+{
+    Matx33d K1(400, 0, 320, 0, 400, 240, 0, 0, 1);
+    Matx33d K2(410, 0, 330, 0, 410, 250, 0, 0, 1);
+    double xi1 = 1.0, xi2 = 1.0;
+    Matx14d D1(0, 0, 0, 0), D2(0, 0, 0, 0);
+
+    std::vector<Mat> objectPoints, imagePoints1, imagePoints2;
+
+    // Both cameras see a valid, self-consistent projection of the same object
+    // points for every view, so the per-camera valid-view sets fully overlap.
+    for (int v = 0; v < 2; ++v)
+    {
+        Mat objPts, img1, img2;
+        generateValidView(K1, xi1, D1, Vec3d(0.02 * v, -0.01, 0.0), Vec3d(0.0, 0.0, 3.0 + 0.1 * v), objPts, img1);
+        generateValidView(K2, xi2, D2, Vec3d(0.02 * v, -0.01, 0.0), Vec3d(0.05, 0.0, 3.0 + 0.1 * v), objPts, img2);
+        objectPoints.push_back(objPts);
+        imagePoints1.push_back(img1);
+        imagePoints2.push_back(img2);
+    }
+
+    Mat Kout1, xiOut1, Dout1, Kout2, xiOut2, Dout2, rvec, tvec;
+    std::vector<Mat> rvecsL, tvecsL;
+    Mat idx;
+    ASSERT_NO_THROW(
+        cv::omnidir::stereoCalibrate(objectPoints, imagePoints1, imagePoints2, Size(640, 480), Size(640, 480),
+            Kout1, xiOut1, Dout1, Kout2, xiOut2, Dout2, rvec, tvec, rvecsL, tvecsL,
+            0, TermCriteria(3, 100, 1e-6), idx)
+    ) << "stereoCalibrate() should not throw the new intersection guard for overlapping valid views";
+    EXPECT_GT((int)idx.total(), 0) << "at least one view should survive for both cameras";
 }
 
 }} // namespace

--- a/modules/ccalib/test/test_precomp.hpp
+++ b/modules/ccalib/test/test_precomp.hpp
@@ -1,0 +1,10 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+#ifndef __OPENCV_TEST_PRECOMP_HPP__
+#define __OPENCV_TEST_PRECOMP_HPP__
+
+#include "opencv2/ts.hpp"
+#include "opencv2/ccalib/omnidir.hpp"
+
+#endif


### PR DESCRIPTION
`cv2.omnidir.calibrate` failed with a confusing assertion that looked like a type bug even when the input arrays had the correct type, shape, and were non-empty:

```
CV_Assert(!objectPoints.empty() && objectPoints.type() == CV_64FC3)
```

The actual cause has nothing to do with types. `omnidir::calibrate()` filters out any calibration view whose initial-pose reprojection error exceeds an internal threshold; if every view fails that filter (e.g. the object/image point correspondences don't come from a real calibration target), the point vectors end up empty and the code still proceeds into `computeJacobian()`, tripping the assertion above on its emptiness half only — the type half was never actually false.

This PR replaces that misleading assertion with two explicit, actionable errors:

- `omnidir::calibrate()` now reports "no calibration views survived initial pose estimation" when every view is rejected.
- `omnidir::stereoCalibrate()` has an independent failure mode not covered by the first fix: two per-camera views can each individually survive filtering, yet their surviving-view sets can fail to intersect. That path used to crash even earlier, via `Mat::copyTo()` on a fixed-size `OutputArray::getMat()` temporary that refuses to "reallocate" an empty array even to the same size. Both issues are fixed together — the intersection-empty case is now a clear "no calibration views are valid for both cameras" error.

`modules/ccalib` had no test suite at all before this change; this PR adds its first one, covering the error path for both functions plus a synthetic-projection-based happy-path regression test proving valid calibration is unaffected.

Fixes opencv/opencv#28462

### Validation

Built and ran the new test suite locally (`opencv_test_ccalib`, scoped build of `core, imgproc, geometry, calib, objdetect, features, xfeatures2d, highgui, imgcodecs, ccalib, ts`): all 4 tests pass, including the happy-path tests that confirm valid single-camera and stereo calibration are unaffected.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
