### PR TITLE
cudafilters SeparableLinearFilter: handle inputs exceeding CUDA grid …

### DIFF
--- a/modules/cudafilters/src/cuda/column_filter.hpp
+++ b/modules/cudafilters/src/cuda/column_filter.hpp
@@ -40,6 +40,7 @@
 //
 //M*/
 
+#include "opencv2/core/cuda.hpp"
 #include "opencv2/core/cuda/common.hpp"
 #include "opencv2/core/cuda/saturate_cast.hpp"
 #include "opencv2/core/cuda/vec_math.hpp"
@@ -71,16 +72,18 @@ namespace column_filter
 
         __shared__ sum_t smem[(PATCH_PER_BLOCK + 2 * HALO_SIZE) * BLOCK_DIM_Y][BLOCK_DIM_X];
 
-        const int x = blockIdx.x * BLOCK_DIM_X + threadIdx.x;
+        // Use Y grid dimension to index the columns of the image
+        const int x = blockIdx.y * BLOCK_DIM_X + threadIdx.x;
 
         if (x >= src.cols)
             return;
 
         const T* src_col = src.ptr() + x;
 
-        const int yStart = blockIdx.y * (BLOCK_DIM_Y * PATCH_PER_BLOCK) + threadIdx.y;
+        // Use X grid dimension to index the rows of the image
+        const int yStart = blockIdx.x * (BLOCK_DIM_Y * PATCH_PER_BLOCK) + threadIdx.y;
 
-        if (blockIdx.y > 0)
+        if (blockIdx.x > 0)
         {
             //Upper halo
             #pragma unroll
@@ -95,7 +98,7 @@ namespace column_filter
                 smem[threadIdx.y + j * BLOCK_DIM_Y][threadIdx.x] = saturate_cast<sum_t>(brd.at_low(yStart - (HALO_SIZE - j) * BLOCK_DIM_Y, src_col, src.step));
         }
 
-        if (blockIdx.y + 2 < gridDim.y)
+        if (blockIdx.x + 2 < gridDim.x)
         {
             //Main data
             #pragma unroll
@@ -160,14 +163,42 @@ namespace column_filter
             PATCH_PER_BLOCK = 2;
         }
 
+        // Process the image in chunks of rows such that the number of blocks in y-direction does not exceed the maximum grid size
+        DeviceInfo devInfo;
+        const int maxGridY = devInfo.maxGridSize()[1];
+        const int nBlocksX = divUp(src.rows, BLOCK_DIM_Y * PATCH_PER_BLOCK);
+        const int nBlocksY = divUp(src.cols, BLOCK_DIM_X);
+        const int nGrids = divUp(nBlocksY, maxGridY); // Number of launches required to process the whole image
+
         const dim3 block(BLOCK_DIM_X, BLOCK_DIM_Y);
-        const dim3 grid(divUp(src.cols, BLOCK_DIM_X), divUp(src.rows, BLOCK_DIM_Y * PATCH_PER_BLOCK));
 
         B<T> brd(src.rows);
 
-        linearColumnFilter<KSIZE, T, D><<<grid, block, 0, stream>>>(src, dst, kernel, anchor, brd);
+        for(int i = 0; i < nGrids; ++i )
+        {
+            const int startColumn = i * maxGridY * BLOCK_DIM_X;
+            const int endColumn =
+                std::min(startColumn + maxGridY * BLOCK_DIM_X, src.cols);
 
-        cudaSafeCall( cudaGetLastError() );
+            const int chunkCols = endColumn - startColumn;
+
+            const dim3 grid(
+                nBlocksX,
+                divUp(chunkCols, BLOCK_DIM_X)
+            );
+
+            // Get the chunks as views of the original matrices
+            PtrStepSz<T> srcView = src;
+            srcView.data = src.ptr() + startColumn;
+            srcView.cols = chunkCols;
+
+            PtrStepSz<D> dstView = dst;
+            dstView.data = dst.ptr() + startColumn;
+            dstView.cols = chunkCols;
+
+            linearColumnFilter<KSIZE, T, D><<<grid, block, 0, stream>>>(srcView, dstView, kernel, anchor, brd);
+            cudaSafeCall( cudaGetLastError() );
+        }
 
         if (stream == 0)
             cudaSafeCall( cudaDeviceSynchronize() );

--- a/modules/cudafilters/src/cuda/row_filter.hpp
+++ b/modules/cudafilters/src/cuda/row_filter.hpp
@@ -40,6 +40,7 @@
 //
 //M*/
 
+#include "opencv2/core/cuda.hpp"
 #include "opencv2/core/cuda/common.hpp"
 #include "opencv2/core/cuda/saturate_cast.hpp"
 #include "opencv2/core/cuda/vec_math.hpp"
@@ -160,13 +161,41 @@ namespace row_filter
             PATCH_PER_BLOCK = 4;
         }
 
-        const dim3 block(BLOCK_DIM_X, BLOCK_DIM_Y);
-        const dim3 grid(divUp(src.cols, BLOCK_DIM_X * PATCH_PER_BLOCK), divUp(src.rows, BLOCK_DIM_Y));
+        // Process the image in chunks of rows such that the number of blocks in y-direction does not exceed the maximum grid size
+        DeviceInfo devInfo;
+        const int maxGridY = devInfo.maxGridSize()[1];
+        const int nBlocksX = divUp(src.cols, BLOCK_DIM_X * PATCH_PER_BLOCK);
+        const int nBlocksY = divUp(src.rows, BLOCK_DIM_Y);
+        const int nGrids = divUp(nBlocksY, maxGridY); // Number of launches required to process the whole image
 
+        const dim3 block(BLOCK_DIM_X, BLOCK_DIM_Y);
         B<T> brd(src.cols);
 
-        linearRowFilter<KSIZE, T, D><<<grid, block, 0, stream>>>(src, dst, kernel, anchor, brd);
-        cudaSafeCall( cudaGetLastError() );
+        for(int i = 0; i < nGrids; ++i )
+        {
+            const int startRow = i * maxGridY * BLOCK_DIM_Y;
+            const int endRow =
+                std::min(startRow + maxGridY * BLOCK_DIM_Y, src.rows);
+
+            const int chunkRows = endRow - startRow;
+
+            const dim3 grid(
+                nBlocksX,
+                divUp(chunkRows, BLOCK_DIM_Y)
+            );
+
+            // Get the chunks as views of the original matrices
+            PtrStepSz<T> srcView = src;
+            srcView.data = src.ptr(startRow);
+            srcView.rows = chunkRows;
+
+            PtrStepSz<D> dstView = dst;
+            dstView.data = dst.ptr(startRow);
+            dstView.rows = chunkRows;
+
+            linearRowFilter<KSIZE, T, D><<<grid, block, 0, stream>>>(srcView, dstView, kernel, anchor, brd);
+            cudaSafeCall( cudaGetLastError() );
+        }
 
         if (stream == 0)
             cudaSafeCall( cudaDeviceSynchronize() );

--- a/modules/cudafilters/test/test_filters.cpp
+++ b/modules/cudafilters/test/test_filters.cpp
@@ -361,6 +361,130 @@ INSTANTIATE_TEST_CASE_P(CUDA_Filters, SeparableLinearFilterWithEmptyKernels, tes
     testing::Values(false, true)//use col kernel
     ));
 
+// Test for issue #4153 row filter
+PARAM_TEST_CASE(SeparableLinearFilterWithRowViewsRowFilter, cv::cuda::DeviceInfo, bool)
+{
+    cv::cuda::DeviceInfo devInfo;
+    bool inPlace;
+
+    cv::Size size;
+    cv::Size ksize;
+    cv::Point anchor;
+    int BLOCK_DIM_Y;
+
+    virtual void SetUp()
+    {
+        devInfo = GET_PARAM(0);
+        inPlace = GET_PARAM(1);
+
+        const int maxGridSizeY = devInfo.maxGridSize()[1];
+        const int cc = devInfo.majorVersion() * 10 + devInfo.minorVersion();
+
+        BLOCK_DIM_Y = (cc >= 20) ? 8 : 4;
+
+        size = cv::Size(3, maxGridSizeY*BLOCK_DIM_Y + 1);
+        ksize = cv::Size(3, 1);
+        anchor = cv::Point(-1, -1);
+
+        cv::cuda::setDevice(devInfo.deviceID());
+    }
+};
+
+CUDA_TEST_P(SeparableLinearFilterWithRowViewsRowFilter, Accuracy)
+{
+    const int srcType = CV_32FC1;
+    cv::Mat src = randomMat(size, srcType);
+    cv::Mat rowKernel = (cv::Mat_<float>(ksize) << -1.0f, 0.0f, 1.0f);
+    cv::Mat colKernel = (cv::Mat_<float>(1, 1) << 1.0f);
+
+    cv::Ptr<cv::cuda::Filter> sepFilterWithRowViews =
+        cv::cuda::createSeparableLinearFilter(srcType, -1,
+            rowKernel,
+            cv::Mat(),
+            cv::Point(-1, -1), cv::BORDER_REPLICATE, cv::BORDER_REPLICATE);
+
+
+    cv::cuda::GpuMat gpuSrc = loadMat(src);
+    cv::cuda::GpuMat gpuDst = inPlace ? gpuSrc : cv::cuda::GpuMat();
+
+    sepFilterWithRowViews->apply(gpuSrc, gpuDst);
+
+    cv::Mat dst_gold;
+    cv::sepFilter2D(src, dst_gold, -1, rowKernel, colKernel, anchor, 0, cv::BORDER_REPLICATE);
+
+    EXPECT_MAT_NEAR(dst_gold, gpuDst, src.depth() < CV_32F ? 1.0 : 1e-2);
+}
+
+INSTANTIATE_TEST_CASE_P(CUDA_Filters, SeparableLinearFilterWithRowViewsRowFilter, testing::Combine(
+    ALL_DEVICES,
+    testing::Values(false, true)//in-place
+    ));
+
+// Test for issue #4153 column filter
+PARAM_TEST_CASE(SeparableLinearFilterWithRowViewsColumnFilter, cv::cuda::DeviceInfo, bool, int)
+{
+    cv::cuda::DeviceInfo devInfo;
+    bool inPlace;
+
+    cv::Size size;
+    cv::Size ksize;
+    cv::Point anchor;
+    int dimension;
+    int BLOCK_DIM_Y;
+    int PATCH_PER_BLOCK;
+    const int BLOCK_DIM_X = 16;
+
+    virtual void SetUp()
+    {
+        devInfo = GET_PARAM(0);
+        inPlace = GET_PARAM(1);
+        dimension = GET_PARAM(2);
+
+        const int maxGridSizeY = devInfo.maxGridSize()[1];
+        const int cc = devInfo.majorVersion() * 10 + devInfo.minorVersion();
+
+        BLOCK_DIM_Y = (cc >= 20) ? 16 : 8;
+        PATCH_PER_BLOCK = (cc >= 20) ? 4 : 2;
+
+        size = (dimension == 0) ? cv::Size(maxGridSizeY*BLOCK_DIM_X + 1, 3) : cv::Size(3, maxGridSizeY*BLOCK_DIM_Y*PATCH_PER_BLOCK + 1);
+        ksize = cv::Size(1, 3);
+        anchor = cv::Point(-1, -1);
+
+        cv::cuda::setDevice(devInfo.deviceID());
+    }
+};
+
+CUDA_TEST_P(SeparableLinearFilterWithRowViewsColumnFilter, Accuracy)
+{
+    const int srcType = CV_32FC1;
+    cv::Mat src = randomMat(size, srcType);
+    cv::Mat colKernel = (cv::Mat_<float>(ksize) << -1.0f, 0.0f, 1.0f);
+    cv::Mat rowKernel = (cv::Mat_<float>(1, 1) << 1.0f);
+
+    cv::Ptr<cv::cuda::Filter> sepFilterWithRowViews =
+        cv::cuda::createSeparableLinearFilter(srcType, -1,
+            cv::Mat(),
+            colKernel.t(),
+            cv::Point(-1, -1), cv::BORDER_REPLICATE, cv::BORDER_REPLICATE);
+
+
+    cv::cuda::GpuMat gpuSrc = loadMat(src);
+    cv::cuda::GpuMat gpuDst = inPlace ? gpuSrc : cv::cuda::GpuMat();
+
+    sepFilterWithRowViews->apply(gpuSrc, gpuDst);
+
+    cv::Mat dst_gold;
+    cv::sepFilter2D(src, dst_gold, -1, rowKernel, colKernel.t(), anchor, 0, cv::BORDER_REPLICATE);
+
+    EXPECT_MAT_NEAR(dst_gold, gpuDst, src.depth() < CV_32F ? 1.0 : 1e-2);
+}
+
+INSTANTIATE_TEST_CASE_P(CUDA_Filters, SeparableLinearFilterWithRowViewsColumnFilter, testing::Combine(
+    ALL_DEVICES,
+    testing::Values(false, true),//in-place
+    testing::Values(0, 1) // excess of elements on 0: rows or 1: columns
+    ));
+
 /////////////////////////////////////////////////////////////////////////////////////////////////
 // Sobel
 


### PR DESCRIPTION
…Y limit
Fixes #4153 CUDA SeparableLinearFilter might fail because of too large grid dimensions

Prevents `SeparableLinearFilter` from launching CUDA kernels with a Y grid dimension larger than the device limit.

The row filter processes oversized inputs in row chunks, while the column filter maps the input row index to grid X dimension, the column index to grid Y dimension and chunks columns.

Added accuracy tests for oversized inputs.

Note: very tall or wide inputs requiring an intermediate type conversion may still hit an independent CUDA grid-size limitation in `GpuMat::convertTo()`, resulting in `(-217:Gpu API call) invalid configuration argument` in `modules/cudev/include/opencv2/cudev/grid/detail/transform.hpp`.  This issue is independent of the row/column filter grid-size limitation addressed by this PR and is therefore outside its scope.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
