### PR TITLE
wechat_qrcode: fix Counted reference count data race

### DIFF
--- a/modules/wechat_qrcode/src/zxing/common/counted.hpp
+++ b/modules/wechat_qrcode/src/zxing/common/counted.hpp
@@ -13,12 +13,13 @@
 
 #include <cstddef>
 #include <algorithm>
+#include <atomic>
 namespace zxing {
 
 /* base class for reference-counted objects */
 class Counted {
 private:
-    unsigned int count_;
+    std::atomic<unsigned int> count_;
 
 public:
     Counted() : count_(0) {}
@@ -28,15 +29,14 @@ public:
         return this;
     }
     void release() {
-        count_--;
-        if (count_ == 0) {
+        if (--count_ == 0) {
             count_ = 0xDEADF001;
             delete this;
         }
     }
 
     /* return the current count for denugging purposes or similar */
-    int count() const { return count_; }
+    int count() const { return count_.load(); }
 };
 
 /* counting reference to reference-counted objects */


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

### Description

The reference counter in `zxing::Counted` was not safe for concurrent access.

Under concurrent usage, the reference count could become inconsistent during
`retain()` / `release()` operations, potentially causing invalid object
lifetime management and heap corruption.

The issue was observed when using `wechat_qrcode` as a service. Both C++ and
Python bindings could trigger the crash under concurrent workloads, with errors
such as:
malloc(): unsorted double linked list corrupted
corrupted double-linked list

#### Fix
This change:
- changes the reference counter from `unsigned int` to `std::atomic<unsigned int>`;
- makes the decrement and zero-check in `release()` a single atomic operation.

#### Crash stack
``` text
corrupted double-linked list
/app/main.cpp:206
std::vector<short, std::allocator<short>>::~vector() at /usr/include/c++/9/bits/stl_vector.h:677
zxing::BitMatrix::~BitMatrix() at /app/dep/opencv_contrib/modules/wechat_qrcode/src/zxing/common/bitmatrix.cpp:114
zxing::Ref<zxing::LuminanceSource>::~Ref() at /app/dep/opencv_contrib/modules/wechat_qrcode/src/zxing/../zxing/common/counted.hpp:57
zxing::AdaptiveThresholdMeanBinarizer::~AdaptiveThresholdMeanBinarizer() at /app/dep/opencv_contrib/modules/wechat_qrcode/src/zxing/common/binarizer/adaptive_threshold_mean_binarizer.cpp:19
zxing::Counted::release() at /app/dep/opencv_contrib/modules/wechat_qrcode/src/zxing/common/counted.hpp:34
zxing::Ref<zxing::LuminanceSource>::~Ref() at /app/dep/opencv_contrib/modules/wechat_qrcode/src/zxing/common/counted.hpp:57
cv::wechat_qrcode::WeChatQRCode::Impl::decode[abi:cxx11](cv::Mat const&, std::vector<cv::Mat, std::allocator<cv::Mat>> const&, std::vector<cv::Mat, std::allocator<cv::Mat>>&)+0x28a)[0x7f676efa436a] at /app/dep/opencv_contrib/modules/wechat_qrcode/src/wechat_qrcode.cpp:160
/app/dep/opencv_build/lib/libopencv_wechat_qrcode.so.410(cv::wechat_qrcode::WeChatQRCode::detectAndDecode[abi:cxx11](cv::_InputArray const&, cv::_OutputArray const&)+0x18b)[0x7f676efa50bb]
```
#### Validation

The issue was observed in production. Before this change, the crash happened
intermittently (approximately once every few days under our workload).

After applying this change, the same workload has been running for about two
years without observing this heap corruption issue.
