### PR TITLE
Fix out-of-bounds access in EdgeAwareInterpolator when k exceeds match count

### DIFF
--- a/modules/optflow/test/test_OF_accuracy.cpp
+++ b/modules/optflow/test/test_OF_accuracy.cpp
@@ -287,6 +287,25 @@ TEST(DenseOpticalFlow_SparseToDenseFlow, ReferenceAccuracy)
     EXPECT_LE(calcRMSE(GT, flow), target_RMSE);
 }
 
+TEST(DenseOpticalFlow_SparseToDenseFlow, Regression_4195)
+{
+    // https://github.com/opencv/opencv_contrib/issues/4195
+    RNG rng(1);
+    Mat from(48, 64, CV_8UC1);
+    rng.fill(from, RNG::UNIFORM, 0, 255);
+    Mat to = from.clone();
+    Mat flow;
+
+    // The default k of 128 exceeds the 48 points sampled with grid_step 8.
+    ASSERT_NO_THROW(calcOpticalFlowSparseToDense(from, to, flow));
+    EXPECT_EQ(from.size(), flow.size());
+    EXPECT_EQ(CV_32FC2, flow.type());
+    EXPECT_TRUE(checkRange(flow));
+
+    Mat small = from(Rect(0, 0, 8, 8)).clone();
+    EXPECT_THROW(calcOpticalFlowSparseToDense(small, small, flow), cv::Exception);
+}
+
 TEST(DenseOpticalFlow_PCAFlow, ReferenceAccuracy)
 {
     Mat frame1, frame2, GT;

--- a/modules/ximgproc/src/sparse_match_interpolators.cpp
+++ b/modules/ximgproc/src/sparse_match_interpolators.cpp
@@ -173,10 +173,11 @@ Ptr<EdgeAwareInterpolatorImpl> EdgeAwareInterpolatorImpl::create()
 void EdgeAwareInterpolatorImpl::interpolate(InputArray from_image, InputArray from_points, InputArray, InputArray to_points, OutputArray dense_flow)
 {
     CV_Assert( !from_image.empty() && (from_image.depth() == CV_8U) && (from_image.channels() == 3 || from_image.channels() == 1) );
-    CV_Assert( !from_points.empty() && !to_points.empty() && from_points.sameSize(to_points) );
+    if (from_points.empty() || to_points.empty())
+        CV_Error(Error::StsBadArg, "EdgeAwareInterpolator requires at least 3 matches");
+    CV_Assert(from_points.sameSize(to_points));
     CV_Assert((from_points.isVector() || from_points.isMat()) && from_points.depth() == CV_32F);
     CV_Assert((to_points.isVector() || to_points.isMat()) && to_points.depth() == CV_32F);
-    CV_Assert(from_points.sameSize(to_points));
 
     w = from_image.cols();
     h = from_image.rows();
@@ -203,12 +204,19 @@ void EdgeAwareInterpolatorImpl::interpolate(InputArray from_image, InputArray fr
     match_num = (int)matches_vector.size();
     CV_Assert(match_num<SHRT_MAX);
 
+    if (match_num < 3)
+        CV_Error(Error::StsBadArg, "EdgeAwareInterpolator requires at least 3 unique matches");
+    if (k < 3)
+        CV_Error(Error::StsBadArg, "EdgeAwareInterpolator requires at least 3 neighbors");
+
+    const int num_neighbors = std::min(k, match_num);
+
     Mat src = from_image.getMat();
     labels = Mat(h,w,CV_32S);
     labels = Scalar(-1);
-    NNlabels = Mat(match_num,k,CV_32S);
+    NNlabels = Mat(match_num,num_neighbors,CV_32S);
     NNlabels = Scalar(-1);
-    NNdistances = Mat(match_num,k,CV_32F);
+    NNdistances = Mat(match_num,num_neighbors,CV_32F);
     NNdistances = Scalar(0.0f);
     g = new vector<node>[match_num];
 
@@ -575,6 +583,7 @@ void EdgeAwareInterpolatorImpl::GetKNNMatches_ParBody::operator() (const Range& 
 {
     int start = std::min(range.start * stripe_sz, inst->match_num);
     int end   = std::min(range.end   * stripe_sz, inst->match_num);
+    const int num_neighbors = inst->NNlabels.cols;
     nodeHeap q((int)inst->match_num);
     int num_expanded_vertices;
     unsigned char* expanded_flag = new unsigned char[inst->match_num];
@@ -591,7 +600,7 @@ void EdgeAwareInterpolatorImpl::GetKNNMatches_ParBody::operator() (const Range& 
         q.add(node((int)i,0.0f));
         int* NNlabels_row    = inst->NNlabels.ptr<int>(i);
         float* NNdistances_row = inst->NNdistances.ptr<float>(i);
-        while(num_expanded_vertices<inst->k && !q.empty())
+        while(num_expanded_vertices<num_neighbors && !q.empty())
         {
             node vert_for_expansion = q.getMin();
             expanded_flag[vert_for_expansion.label] = 1;
@@ -609,6 +618,8 @@ void EdgeAwareInterpolatorImpl::GetKNNMatches_ParBody::operator() (const Range& 
                     q.updateNode(node(neighbors[j].label,vert_for_expansion.dist+neighbors[j].dist));
             }
         }
+
+        CV_Assert(num_expanded_vertices == num_neighbors);
     }
     delete[] expanded_flag;
 }
@@ -774,11 +785,12 @@ void EdgeAwareInterpolatorImpl::RansacInterpolation_ParBody::operator() (const R
 
     int* KNNlabels;
     float* KNNdistances;
-    unsigned char* is_used = new unsigned char[inst->k];
+    const int num_neighbors = inst->NNlabels.cols;
+    unsigned char* is_used = new unsigned char[num_neighbors];
     Mat hypothesis_transform;
 
-    int* inlier_labels    = new int[inst->k];
-    float* inlier_distances = new float[inst->k];
+    int* inlier_labels    = new int[num_neighbors];
+    float* inlier_distances = new float[num_neighbors];
     float* tr;
     int num_inliers;
     Point2f a,b;
@@ -792,26 +804,26 @@ void EdgeAwareInterpolatorImpl::RansacInterpolation_ParBody::operator() (const R
         KNNdistances = inst->NNdistances.ptr<float>(i);
         if(inc>0) //forward pass
         {
-            cv::hal::exp32f(KNNdistances,KNNdistances,inst->k);
+            cv::hal::exp32f(KNNdistances,KNNdistances,num_neighbors);
 
             Point2f average = Point2f(0.0f,0.0f);
-            for(int j=0;j<inst->k;j++)
+            for(int j=0;j<num_neighbors;j++)
                 average += matches[KNNlabels[j]].target_image_pos - matches[KNNlabels[j]].reference_image_pos;
-            average/=inst->k;
+            average/=num_neighbors;
             float average_dist = 0.0;
             Point2f vec;
-            for(int j=0;j<inst->k;j++)
+            for(int j=0;j<num_neighbors;j++)
             {
                 vec = (matches[KNNlabels[j]].target_image_pos - matches[KNNlabels[j]].reference_image_pos);
                 average_dist += abs(vec.x-average.x) + abs(vec.y-average.y);
             }
-            eps[i] = min(0.5f*(average_dist/inst->k),2.0f);
+            eps[i] = min(0.5f*(average_dist/num_neighbors),2.0f);
         }
 
         for(int it=0;it<inst->ransac_interpolation_num_iter;it++)
         {
-            generateHypothesis(KNNlabels,inst->k,inst->rngs[range.start],is_used,matches,hypothesis_transform);
-            verifyHypothesis(KNNlabels,KNNdistances,inst->k,matches,eps[i],inst->regularization_coef,hypothesis_transform,transforms[i],weighted_inlier_nums[i]);
+            generateHypothesis(KNNlabels,num_neighbors,inst->rngs[range.start],is_used,matches,hypothesis_transform);
+            verifyHypothesis(KNNlabels,KNNdistances,num_neighbors,matches,eps[i],inst->regularization_coef,hypothesis_transform,transforms[i],weighted_inlier_nums[i]);
         }
 
         //propagate hypotheses from neighbors:
@@ -819,7 +831,7 @@ void EdgeAwareInterpolatorImpl::RansacInterpolation_ParBody::operator() (const R
         for(int j=0;j<(int)inst->g[i].size();j++)
         {
             if((inc*neighbors[j].label)<(inc*i) && (inc*neighbors[j].label)>=(inc*start)) //already processed this neighbor
-                verifyHypothesis(KNNlabels,KNNdistances,inst->k,matches,eps[i],inst->regularization_coef,transforms[neighbors[j].label],transforms[i],weighted_inlier_nums[i]);
+                verifyHypothesis(KNNlabels,KNNdistances,num_neighbors,matches,eps[i],inst->regularization_coef,transforms[neighbors[j].label],transforms[i],weighted_inlier_nums[i]);
         }
 
         if(inc<0) //backward pass
@@ -828,7 +840,7 @@ void EdgeAwareInterpolatorImpl::RansacInterpolation_ParBody::operator() (const R
             tr = transforms[i].ptr<float>(0);
             num_inliers = 0;
 
-            for(int j=0;j<inst->k;j++)
+            for(int j=0;j<num_neighbors;j++)
             {
                 a = matches[KNNlabels[j]].reference_image_pos;
                 b = matches[KNNlabels[j]].target_image_pos;

--- a/modules/ximgproc/test/test_sparse_match_interpolator.cpp
+++ b/modules/ximgproc/test/test_sparse_match_interpolator.cpp
@@ -216,5 +216,56 @@ TEST_P(InterpolatorTest, MultiThreadReproducibility)
 }
 INSTANTIATE_TEST_CASE_P(FullSet,InterpolatorTest, Combine(Values(szODD,szVGA), GuideTypes::all()));
 
+TEST(InterpolatorTest, RejectsTooFewMatches)
+{
+    // https://github.com/opencv/opencv_contrib/issues/4195
+    Mat src(16, 16, CV_8UC1, Scalar(0));
+    Ptr<EdgeAwareInterpolator> interpolator = createEdgeAwareInterpolator();
+
+    for (int count = 0; count < 3; count++)
+    {
+        vector<Point2f> from_points, to_points;
+        for (int i = 0; i < count; i++)
+        {
+            from_points.push_back(Point2f((float)i + 1, (float)i + 1));
+            to_points.push_back(from_points.back() + Point2f(1, 1));
+        }
+
+        Mat flow;
+        try
+        {
+            interpolator->interpolate(src, from_points, Mat(), to_points, flow);
+            FAIL() << "Expected cv::Exception for " << count << " matches";
+        }
+        catch (const cv::Exception& e)
+        {
+            EXPECT_EQ(Error::StsBadArg, e.code);
+        }
+    }
+}
+
+TEST(InterpolatorTest, KExceedsMatchCount)
+{
+    // https://github.com/opencv/opencv_contrib/issues/4195
+    Mat src(16, 16, CV_8UC1, Scalar(0));
+    const Point2f points[] = {
+        Point2f(1, 1), Point2f(8, 1), Point2f(14, 2), Point2f(2, 12), Point2f(12, 14)
+    };
+    vector<Point2f> from_points(points, points + 5);
+    vector<Point2f> to_points;
+    for (size_t i = 0; i < from_points.size(); i++)
+        to_points.push_back(from_points[i] + Point2f(1, 1));
+    Mat flow;
+
+    Ptr<EdgeAwareInterpolator> interpolator = createEdgeAwareInterpolator();
+    interpolator->setK(128);
+    interpolator->setUsePostProcessing(false);
+    interpolator->interpolate(src, from_points, Mat(), to_points, flow);
+
+    EXPECT_EQ(128, interpolator->getK());
+    EXPECT_EQ(src.size(), flow.size());
+    EXPECT_EQ(CV_32FC2, flow.type());
+    EXPECT_TRUE(checkRange(flow));
+}
 
 }} // namespace


### PR DESCRIPTION
### Pull Request Checklist

- [x] There are no new and unexpected changes
- [x] All existing and new tests pass
- [x] Code complies with [OpenCV coding style](https://github.com/opencv/opencv/wiki/Coding_Style_Guide)
- [x] This PR is submitted to the correct branch (`4.x`)

### Summary

Fixes #4195: `calcOpticalFlowSparseToDense` (or direct `EdgeAwareInterpolator` use) crashes when the configured `k` exceeds the actual number of sparse matches.

### Root cause

`EdgeAwareInterpolatorImpl::interpolate` allocates `NNlabels` as `match_num x k` and pre-fills it with the `-1` sentinel. The KNN pass only fills as many entries as it can actually expand, and the RANSAC pass reads exactly `k` entries per row. When `k > match_num` (e.g. the default `k=128` with the 48x64 / `grid_step=8` case from the issue, which samples only 48 grid points), the RANSAC pass reads the `-1` sentinels and dereferences `matches[-1]` / `transforms[-1]`, crashing.

### Fix

- Use `num_neighbors = min(k, match_num)` for the current call only; the user's `k` (and `getK()`) stays unchanged.
- Operate all KNN/RANSAC passes on `num_neighbors`, so the `-1` sentinels are never consumed.
- Reject degenerate input with a clear `cv::Exception`: fewer than 3 unique matches, or `k < 3` (the RANSAC affine fit needs 3 points).

### Tests

- `DenseOpticalFlow_SparseToDenseFlow.Regression_4195` (optflow): default 48x64 input no longer crashes; 8x8 input throws `cv::Exception`.
- `InterpolatorTest.RejectsTooFewMatches` (ximgproc): 0/1/2 matches throw `StsBadArg`.
- `InterpolatorTest.KExceedsMatchCount` (ximgproc): `k=128` with 5 matches produces valid flow and leaves `getK()==128` unchanged.

### Validation

Built `opencv_test_optflow` / `opencv_test_ximgproc` locally (ASan build) and ran the new regression tests plus the existing `InterpolatorTest.MultiThreadReproducibility` suite — all pass. The standalone repro from the issue no longer crashes under ASan. Data-dependent reference tests require `opencv_extra` and run in CI.