### PR TITLE
ximgproc: fix heap buffer overflow in EdgeDrawing::detectLines()

### DIFF
--- a/modules/ximgproc/src/edge_drawing.cpp
+++ b/modules/ximgproc/src/edge_drawing.cpp
@@ -1393,9 +1393,15 @@ void EdgeDrawingImpl::detectLines(OutputArray _lines)
     if (min_line_len < 9) // avoids small line segments in the result. Might be deleted!
         min_line_len = 9;
 
-    // Temporary buffers used during line fitting
-    double* x = new double[(width + height) * 8];
-    double* y = new double[(width + height) * 8];
+    // Temporary buffers used during line fitting.
+    // A segment is a 1-pixel-wide chain that can wind through the whole image,
+    // so its length is bounded by the pixel count, not by the image perimeter.
+    size_t buffer_size = (size_t)(width + height) * 8;
+    for (size_t i = 0; i < segmentPoints.size(); i++)
+        buffer_size = std::max(buffer_size, segmentPoints[i].size());
+
+    double* x = new double[buffer_size];
+    double* y = new double[buffer_size];
 
     lines.clear();
     linesNo = 0;

--- a/modules/ximgproc/test/test_fld.cpp
+++ b/modules/ximgproc/test/test_fld.cpp
@@ -328,4 +328,42 @@ TEST_F(ximgproc_ED, detectLinesAndEllipses)
     EXPECT_GE(ellipses.size(), ellipses_size);
     EXPECT_LE(ellipses.size(), ellipses_size + 2);
 }
+
+// Regression test for the detectLines() heap buffer overflow. The line-fitting
+// scratch buffers are sized (width+height)*8, but a single edge segment is a
+// 1-pixel-wide chain that can wind through the whole image, so its length is
+// bounded by width*height, not by the perimeter. A segment longer than the
+// buffer overflowed it at the "x[k]=segment[k].x" fill loop (heap corruption,
+// reported by AddressSanitizer). The image below is one long serpentine stroke
+// that yields a single segment far larger than the buffer.
+TEST_F(ximgproc_ED, detectLinesLongWindingSegment)
+{
+    Mat img(400, 400, CV_8UC1, Scalar(255));
+    const int pitch = 16, margin = 20;
+    Point prev(margin, margin);
+    bool down = true;
+    for (int x = margin; x < img.cols - margin; x += pitch)
+    {
+        Point p1(x, down ? margin : img.rows - margin);
+        Point p2(x, down ? img.rows - margin : margin);
+        line(img, prev, p1, Scalar(0), 2, LINE_8);
+        line(img, p1, p2, Scalar(0), 2, LINE_8);
+        prev = p2;
+        down = !down;
+    }
+    detector->detectEdges(img);
+
+    // Precondition: at least one segment is longer than the (width+height)*8
+    // scratch buffer that detectLines() allocates. Otherwise the test would not
+    // exercise the overflow.
+    size_t max_seg = 0;
+    for (const std::vector<Point>& s : detector->getSegments())
+        max_seg = std::max(max_seg, s.size());
+    EXPECT_GT(max_seg, size_t((img.cols + img.rows) * 8))
+        << "test image did not produce an over-long segment; adjust the image";
+
+    // Before the fix this overflowed the line-fitting buffers (heap-buffer-overflow
+    // under AddressSanitizer); after the fix it completes cleanly.
+    detector->detectLines(lines);
+}
 }} // namespace


### PR DESCRIPTION
### Root cause
`detectLines()` allocated its line-fitting scratch buffers `x`/`y` as
`(width + height) * 8` doubles, then copied every pixel of each edge segment into
them. An edge segment is a 1-pixel-wide chain that can wind through the whole
image, so its length is bounded by `width * height`, not by the image perimeter.
A segment longer than the buffer overflows it at the fill loop — heap corruption;
AddressSanitizer reports a WRITE past the end at edge_drawing.cpp:1409.

### Fix
Size the buffers to the longest segment, mirroring the reference implementation
ED_Lib (CihanTopal/ED_Lib@2778deb). The `(size_t)` cast avoids int overflow on
large images.

### Verification
Added `TEST_F(ximgproc_ED, detectLinesLongWindingSegment)`: a single serpentine
segment (~17k px, far larger than the (width+height)*8 buffer). It asserts the
oversized-segment precondition, then calls `detectLines()`. Under AddressSanitizer
this triggers a heap-buffer-overflow before the change and is clean after it; the
existing `opencv_test_ximgproc` `*ED*` tests still pass.

This may be the cause of #3429 (a detectLines segfault whose reproducibility
depends on heap layout, consistent with this overflow). Ordinary photographs do
not produce a segment large enough to overflow, so it could not be verified
against that reporter's specific input; the reporters have been asked to confirm.

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in the repository, if applicable
- [x] The feature is well documented and sample code can be built with the project CMake
