### PR TITLE
ximgproc: EdgeDrawing must not modify the caller's input when Sigma < 1.0

### DIFF
--- a/modules/ximgproc/src/edge_drawing.cpp
+++ b/modules/ximgproc/src/edge_drawing.cpp
@@ -408,7 +408,7 @@ void EdgeDrawingImpl::detectEdges(InputArray src)
     if (srcImage.type() == CV_8UC1)
     {
         if (params.Sigma < 1.0)
-            smoothImage = srcImage;
+            smoothImage = srcImage.clone(); // must not alias the caller's input: the PFmode path and detectEllipses() blur into smoothImage in place
         else if (params.Sigma == 1.0)
             GaussianBlur(srcImage, smoothImage, Size(5, 5), params.Sigma);
         else

--- a/modules/ximgproc/test/test_fld.cpp
+++ b/modules/ximgproc/test/test_fld.cpp
@@ -328,4 +328,23 @@ TEST_F(ximgproc_ED, detectLinesAndEllipses)
     EXPECT_GE(ellipses.size(), ellipses_size);
     EXPECT_LE(ellipses.size(), ellipses_size + 2);
 }
+
+// Regression test for the input-image aliasing bug: with Params::Sigma < 1.0,
+// detectEdges() set smoothImage = srcImage (aliasing the caller's Mat), and
+// detectEllipses()'s internal in-place GaussianBlur then overwrote the user's
+// input image. The input must be treated as read-only.
+TEST_F(ximgproc_ED, detectEllipsesDoesNotModifyInput)
+{
+    Mat img(200, 200, CV_8UC1, Scalar(255));
+    circle(img, Point(100, 100), 60, Scalar(0), 2, LINE_8);
+    Mat backup = img.clone();
+
+    detector->params.Sigma = 0.0;   // Sigma < 1.0 takes the aliasing path
+    detector->detectEdges(img);
+    vector<Vec6d> ellipses;
+    detector->detectEllipses(ellipses);
+
+    EXPECT_EQ(0, countNonZero(img != backup))
+        << "detectEllipses() modified the caller's input image in place";
+}
 }} // namespace


### PR DESCRIPTION
### Root cause
When `Params::Sigma < 1.0`, `detectEdges()` set `smoothImage = srcImage`, aliasing
the caller's input Mat. `detectEllipses()` then runs an in-place `GaussianBlur`
into `smoothImage` (the PFmode path in `detectEdges()` does the same), silently
overwriting the user's input image and any later reads of it.

### Fix
Clone the image so the input stays read-only, matching the reference implementation
ED_Lib (which always blurs into a separately allocated buffer). Cost is one
`width*height` copy when `Sigma < 1.0`; correctness takes priority.

### Verification
Added `TEST_F(ximgproc_ED, detectEllipsesDoesNotModifyInput)`: with `Sigma = 0.0`
it asserts the input Mat is unchanged after `detectEdges()` + `detectEllipses()`.
Fails before this change (1916 input pixels modified) and passes after it;
existing `*ED*` tests still pass.

Fixes #4203

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in the repository, if applicable
- [x] The feature is well documented and sample code can be built with the project CMake
