### PR TITLE
ximgproc: fix uninitialised read of ellipse periphery point in ValidateCircles

### DIFF
--- a/modules/ximgproc/src/edge_drawing.cpp
+++ b/modules/ximgproc/src/edge_drawing.cpp
@@ -3251,6 +3251,11 @@ void EdgeDrawingImpl::ValidateCircles(bool validate)
 
         if (circle->isEllipse)
         {
+            // ComputeEllipsePoints() fills exactly 2*(noPoints/2) points, so for an
+            // odd noPoints the last slot px/py[noPoints-1] is never written; drop it
+            // so the validation loop below does not read an uninitialised/stale value.
+            if (noPoints % 2)
+                noPoints--;
             ComputeEllipsePoints(circle->eq.coeff, px, py, noPoints);
         }
         else

--- a/modules/ximgproc/test/test_fld.cpp
+++ b/modules/ximgproc/test/test_fld.cpp
@@ -328,4 +328,24 @@ TEST_F(ximgproc_ED, detectLinesAndEllipses)
     EXPECT_GE(ellipses.size(), ellipses_size);
     EXPECT_LE(ellipses.size(), ellipses_size + 2);
 }
+
+// Exercises ValidateCircles() over ellipses of varied size/orientation so that
+// candidates with an ODD computed perimeter are processed. For those,
+// ComputeEllipsePoints() leaves px/py[noPoints-1] unwritten while the validation
+// loop reads it; before the fix this is an uninitialised/stale read (flagged by
+// valgrind/MSan at edge_drawing.cpp's ValidateCircles branches). This test guards
+// that path under memory-checking CI.
+TEST_F(ximgproc_ED, detectEllipsesOddPerimeterNoUninitRead)
+{
+    Mat img(400, 400, CV_8UC1, Scalar(255));
+    ellipse(img, Point(120, 120), Size(70, 45),  20, 0, 360, Scalar(0), 2, LINE_8);
+    ellipse(img, Point(280, 150), Size(55, 55),   0, 0, 360, Scalar(0), 2, LINE_8);
+    ellipse(img, Point(200, 300), Size(90, 40),  60, 0, 360, Scalar(0), 2, LINE_8);
+    ellipse(img, Point(320, 320), Size(33, 50), 130, 0, 360, Scalar(0), 2, LINE_8);
+    ellipse(img, Point(90,  320), Size(48, 27),  95, 0, 360, Scalar(0), 2, LINE_8);
+    detector->detectEdges(img);
+    vector<Vec6d> ellipses;
+    ASSERT_NO_THROW(detector->detectEllipses(ellipses));
+    EXPECT_GE(ellipses.size(), 1u);
+}
 }} // namespace


### PR DESCRIPTION
### Root cause
`ValidateCircles()` sets `noPoints = computeEllipsePerimeter(...)` (odd about half
the time) and calls `ComputeEllipsePoints(px, py, noPoints)`, which writes exactly
`2 * (noPoints/2)` points. For an odd `noPoints` the last slot `px/py[noPoints-1]`
is never written, yet the validation loop `for (j = 0; j < noPoints; j++)` reads
it — an uninitialised read for the first candidate, or a stale value from a
previous candidate (the buffers are reused). That phantom point is then fed into
`checkValidationByNFA(noPeripheryPixels, aligned)`.

### Fix
Drop the odd point before sampling (`if (noPoints % 2) noPoints--;`), matching the
reference implementation ED_Lib. The OpenCV port had adopted the
`points_buffer_size` bound from the same upstream fix but missed this odd-count
guard.

### Behavior change
This is not a neutral change of output — it removes a phantom sample from the NFA
statistics for odd-perimeter ellipses. The phantom point holds an indeterminate
value (uninitialised for the first candidate, stale for later ones); it is counted
as a periphery sample and, depending on that value, is either skipped by the bounds
check (when it falls outside the image) or fully processed (when it falls inside,
where it can also change `aligned`), so it perturbs the validation of every
odd-perimeter ellipse in an unpredictable direction. The effect is usually small:
over 93 OpenCV sample images plus a synthetic case, the fix changed the
detected-ellipse count on 6 of them (in both directions) and left the other 87
unchanged. Where an ellipse does change, the post-fix computation uses only the real
periphery points (the never-written slot is no longer read); we did not assess which
output is closer to ground truth. Reading the unwritten slot is also undefined
behaviour, flagged by memory sanitizers.

### Verification
On stock OpenCV, `valgrind --track-origins` on `detectEllipses()` over an image
with several ellipses reports "uninitialised value" in `ValidateCircles`
(`ERROR SUMMARY: 2 errors`) before the change and `0 errors` after it. A
deterministic, layout-independent confirmation (temporary source instrumentation,
not part of this change) writes a sentinel to `px/py[noPoints-1]` before the call
and observes it left unwritten for odd `noPoints` (e.g. 375, 229). Added
`TEST_F(ximgproc_ED, detectEllipsesOddPerimeterNoUninitRead)` to exercise the
odd-perimeter path under memory-checking CI. (valgrind flags only the
first-candidate uninitialised reads; the stale-reuse case is covered by the
write-count-vs-read-count argument above.)

Fixes #4207

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in the repository, if applicable
- [x] The feature is well documented and sample code can be built with the project CMake
