### PR TITLE
cudaimgproc: derive histogram alignment from each row pointer

### DIFF
--- a/modules/cudaimgproc/src/cuda/hist.cu
+++ b/modules/cudaimgproc/src/cuda/hist.cu
@@ -52,28 +52,36 @@ using namespace cv::cuda::device;
 
 namespace hist
 {
-    template<bool fourByteAligned>
-    __global__ void histogram256Kernel(const uchar* src, int cols, int rows, size_t step, int* hist, const int offsetX = 0)
+    // Number of leading bytes of a row that have to be read one at a time before the rest of the row
+    // can be read as 32-bit words. Deriving it from the row pointer keeps it correct whatever the x
+    // offset of the ROI, the step of the matrix and the alignment of its base address are. The cast is
+    // the one cv::isAligned() uses, see core/include/opencv2/core/utility.hpp.
+    __device__ __forceinline__ int calcAlignedOffset(const uchar* rowPtr)
+    {
+        return (int)((4u - ((size_t)rowPtr & 3u)) & 3u);
+    }
+
+    __global__ void histogram256Kernel(const uchar* src, int cols, int rows, size_t step, int* hist)
     {
         __shared__ int shist[256];
 
         const int y = blockIdx.x * blockDim.y + threadIdx.y;
         const int tid = threadIdx.y * blockDim.x + threadIdx.x;
-        const int alignedOffset = fourByteAligned ? 0 : 4 - offsetX;
         shist[tid] = 0;
         __syncthreads();
 
         if (y < rows) {
             const uchar* rowPtr = &src[y * step];
+            const int alignedOffset = calcAlignedOffset(rowPtr);
             // load uncoalesced head
-            if (!fourByteAligned && threadIdx.x == 0) {
+            if (threadIdx.x == 0) {
                 for (int x = 0; x < min(alignedOffset, cols); x++)
                     Emulation::smem::atomicAdd(&shist[static_cast<int>(rowPtr[x])], 1);
             }
 
             // coalesced loads
-            const unsigned int* rowPtrIntAligned = (const unsigned int*)(fourByteAligned ? &src[y * step] : &src[alignedOffset + y * step]);
-            const int cols_4 = fourByteAligned ? cols / 4 : (cols - alignedOffset) / 4;
+            const unsigned int* rowPtrIntAligned = (const unsigned int*)(rowPtr + alignedOffset);
+            const int cols_4 = (cols - alignedOffset) / 4;
             for (int x = threadIdx.x; x < cols_4; x += blockDim.x) {
                 const unsigned int data = rowPtrIntAligned[x];
                 Emulation::smem::atomicAdd(&shist[(data >> 0) & 0xFFU], 1);
@@ -84,7 +92,7 @@ namespace hist
 
             // load uncoalesced tail
             if (threadIdx.x == 0) {
-                const int iTailStart = fourByteAligned ? cols_4 * 4 : cols_4 * 4 + alignedOffset;
+                const int iTailStart = cols_4 * 4 + alignedOffset;
                 for (int x = iTailStart; x < cols; x++)
                     Emulation::smem::atomicAdd(&shist[static_cast<int>(rowPtr[x])], 1);
             }
@@ -97,28 +105,23 @@ namespace hist
             ::atomicAdd(hist + tid, histVal);
     }
 
-    void histogram256(PtrStepSzb src, int* hist, const int offsetX, cudaStream_t stream)
+    void histogram256(PtrStepSzb src, int* hist, cudaStream_t stream)
     {
         const dim3 block(32, 8);
         const dim3 grid(divUp(src.rows, block.y));
-        if(offsetX)
-            histogram256Kernel<false><<<grid, block, 0, stream>>>(src.data, src.cols, src.rows, src.step, hist, offsetX);
-        else
-            histogram256Kernel<true><<<grid, block, 0, stream>>>(src.data, src.cols, src.rows, src.step, hist, offsetX);
+        histogram256Kernel<<<grid, block, 0, stream>>>(src.data, src.cols, src.rows, src.step, hist);
         cudaSafeCall( cudaGetLastError() );
 
         if (stream == 0)
             cudaSafeCall( cudaDeviceSynchronize() );
     }
 
-    template<bool fourByteAligned>
-    __global__ void histogram256Kernel(const uchar* src, int cols, int rows, size_t srcStep, const uchar* mask, size_t maskStep, int* hist, const int offsetX = 0)
+    __global__ void histogram256Kernel(const uchar* src, int cols, int rows, size_t srcStep, const uchar* mask, size_t maskStep, int* hist, const bool maskWordAligned)
     {
         __shared__ int shist[256];
 
         const int y = blockIdx.x * blockDim.y + threadIdx.y;
         const int tid = threadIdx.y * blockDim.x + threadIdx.x;
-        const int alignedOffset = fourByteAligned ? 0 : 4 - offsetX;
         shist[tid] = 0;
         __syncthreads();
 
@@ -126,8 +129,9 @@ namespace hist
         {
             const uchar* rowPtr = &src[y * srcStep];
             const uchar* maskRowPtr = &mask[y * maskStep];
+            const int alignedOffset = calcAlignedOffset(rowPtr);
             // load uncoalesced head
-            if (!fourByteAligned && threadIdx.x == 0) {
+            if (threadIdx.x == 0) {
                 for (int x = 0; x < min(alignedOffset, cols); x++) {
                     if (maskRowPtr[x])
                         Emulation::smem::atomicAdd(&shist[rowPtr[x]], 1);
@@ -135,12 +139,19 @@ namespace hist
             }
 
             // coalesced loads
-            const unsigned int* rowPtrIntAligned = (const unsigned int*)(fourByteAligned ? &src[y * srcStep] : &src[alignedOffset + y * maskStep]);
-            const unsigned int* maskRowPtrIntAligned = (const unsigned int*)(fourByteAligned ? &mask[y * maskStep] : &mask[alignedOffset + y * maskStep]);
-            const int cols_4 = fourByteAligned ? cols / 4 : (cols - alignedOffset) / 4;
+            const unsigned int* rowPtrIntAligned = (const unsigned int*)(rowPtr + alignedOffset);
+            const uchar* maskRowPtrAligned = maskRowPtr + alignedOffset;
+            const int cols_4 = (cols - alignedOffset) / 4;
             for (int x = threadIdx.x; x < cols_4; x += blockDim.x) {
                 const unsigned int data = rowPtrIntAligned[x];
-                const unsigned int m = maskRowPtrIntAligned[x];
+                unsigned int m;
+                if (maskWordAligned)
+                    m = ((const unsigned int*)maskRowPtrAligned)[x];
+                else {
+                    // the mask rows do not become 4-byte aligned where the source rows do, read them byte by byte
+                    const uchar* maskPtr = maskRowPtrAligned + 4 * x;
+                    m = (unsigned int)maskPtr[0] | ((unsigned int)maskPtr[1] << 8) | ((unsigned int)maskPtr[2] << 16) | ((unsigned int)maskPtr[3] << 24);
+                }
 
                 if ((m >> 0) & 0xFFU)
                     Emulation::smem::atomicAdd(&shist[(data >> 0) & 0xFFU], 1);
@@ -157,7 +168,7 @@ namespace hist
 
             // load uncoalesced tail
             if (threadIdx.x == 0) {
-                const int iTailStart = fourByteAligned ? cols_4 * 4 : cols_4 * 4 + alignedOffset;
+                const int iTailStart = cols_4 * 4 + alignedOffset;
                 for (int x = iTailStart; x < cols; x++) {
                     if (maskRowPtr[x])
                         Emulation::smem::atomicAdd(&shist[static_cast<int>(rowPtr[x])], 1);
@@ -172,15 +183,19 @@ namespace hist
             ::atomicAdd(hist + tid, histVal);
     }
 
-    void histogram256(PtrStepSzb src, PtrStepSzb mask, int* hist, const int offsetX, cudaStream_t stream)
+    void histogram256(PtrStepSzb src, PtrStepSzb mask, int* hist, cudaStream_t stream)
     {
         const dim3 block(32, 8);
         const dim3 grid(divUp(src.rows, block.y));
 
-        if(offsetX)
-            histogram256Kernel<false><<<grid, block, 0, stream>>>(src.data, src.cols, src.rows, src.step, mask.data, mask.step, hist, offsetX);
-        else
-            histogram256Kernel<true><<<grid, block, 0, stream>>>(src.data, src.cols, src.rows, src.step, mask.data, mask.step, hist, offsetX);
+        // The kernel skips (-srcRowPtr) mod 4 leading bytes of every source row before it starts reading
+        // words, so the mask word pointer of row y is mask.data + y*mask.step + ((-(src.data + y*src.step)) mod 4),
+        // whose residue mod 4 is ((mask.data - src.data) + y*(mask.step - src.step)) mod 4. Both terms have to
+        // vanish before the mask can be read as words too; otherwise it is read byte by byte.
+        const bool maskWordAligned = (((mask.step - src.step) & 3) == 0) &&
+                                     ((((size_t)mask.data - (size_t)src.data) & 3) == 0);
+
+        histogram256Kernel<<<grid, block, 0, stream>>>(src.data, src.cols, src.rows, src.step, mask.data, mask.step, hist, maskWordAligned);
         cudaSafeCall( cudaGetLastError() );
 
         if (stream == 0)
@@ -201,15 +216,13 @@ namespace hist
         }
     }
 
-    template<bool fourByteAligned>
     __global__ void histEven8u(const uchar* src, const size_t step, const int rows, const int cols, int* hist, const int binCount, const int binSize,
-        const int lowerLevel, const int upperLevel, const int offsetX)
+        const int lowerLevel, const int upperLevel)
     {
         extern __shared__ int shist[];
 
         const int y = blockIdx.x * blockDim.y + threadIdx.y;
         const int tid = threadIdx.y * blockDim.x + threadIdx.x;
-        const int alignedOffset = fourByteAligned ? 0 : 4 - offsetX;
         if (tid < binCount)
             shist[tid] = 0;
         __syncthreads();
@@ -217,15 +230,16 @@ namespace hist
         if (y < rows)
         {
             const uchar* rowPtr = &src[y * step];
+            const int alignedOffset = calcAlignedOffset(rowPtr);
             // load uncoalesced head
-            if (!fourByteAligned && threadIdx.x == 0) {
+            if (threadIdx.x == 0) {
                 for (int x = 0; x < min(alignedOffset, cols); x++)
                     histEvenInc(shist, rowPtr[x], binSize, lowerLevel, upperLevel);
             }
 
             // coalesced loads
-            const unsigned int* rowPtrIntAligned = (const unsigned int*)(fourByteAligned ? &src[y * step] : &src[alignedOffset + y * step]);
-            const int cols_4 = fourByteAligned ? cols / 4 : (cols - alignedOffset) / 4;
+            const unsigned int* rowPtrIntAligned = (const unsigned int*)(rowPtr + alignedOffset);
+            const int cols_4 = (cols - alignedOffset) / 4;
             for (int x = threadIdx.x; x < cols_4; x += blockDim.x) {
                 const unsigned int data = rowPtrIntAligned[x];
                 histEvenInc(shist, (data >> 0) & 0xFFU, binSize, lowerLevel, upperLevel);
@@ -236,7 +250,7 @@ namespace hist
 
             // load uncoalesced tail
             if (threadIdx.x == 0) {
-                const int iTailStart = fourByteAligned ? cols_4 * 4 : cols_4 * 4 + alignedOffset;
+                const int iTailStart = cols_4 * 4 + alignedOffset;
                 for (int x = iTailStart; x < cols; x++)
                     histEvenInc(shist, rowPtr[x], binSize, lowerLevel, upperLevel);
             }
@@ -253,7 +267,7 @@ namespace hist
         }
     }
 
-    void histEven8u(PtrStepSzb src, int* hist, int binCount, int lowerLevel, int upperLevel, const int offsetX, cudaStream_t stream)
+    void histEven8u(PtrStepSzb src, int* hist, int binCount, int lowerLevel, int upperLevel, cudaStream_t stream)
     {
         const dim3 block(32, 8);
         const dim3 grid(divUp(src.rows, block.y));
@@ -262,10 +276,7 @@ namespace hist
 
         const size_t smem_size = binCount * sizeof(int);
 
-        if(offsetX)
-            histEven8u<false><<<grid, block, smem_size, stream>>>(src.data, src.step, src.rows, src.cols, hist, binCount, binSize, lowerLevel, upperLevel, offsetX);
-        else
-            histEven8u<true><<<grid, block, smem_size, stream>>>(src.data, src.step, src.rows, src.cols, hist, binCount, binSize, lowerLevel, upperLevel, offsetX);
+        histEven8u<<<grid, block, smem_size, stream>>>(src.data, src.step, src.rows, src.cols, hist, binCount, binSize, lowerLevel, upperLevel);
         cudaSafeCall( cudaGetLastError() );
 
         if (stream == 0)

--- a/modules/cudaimgproc/src/histogram.cpp
+++ b/modules/cudaimgproc/src/histogram.cpp
@@ -71,8 +71,8 @@ void cv::cuda::histRange(InputArray, GpuMat*, const GpuMat*, Stream&) { throw_no
 
 namespace hist
 {
-    void histogram256(PtrStepSzb src, int* hist, const int offsetX, cudaStream_t stream);
-    void histogram256(PtrStepSzb src, PtrStepSzb mask, int* hist, const int offsetX, cudaStream_t stream);
+    void histogram256(PtrStepSzb src, int* hist, cudaStream_t stream);
+    void histogram256(PtrStepSzb src, PtrStepSzb mask, int* hist, cudaStream_t stream);
 }
 
 void cv::cuda::calcHist(InputArray _src, OutputArray _hist, Stream& stream)
@@ -94,12 +94,10 @@ void cv::cuda::calcHist(InputArray _src, InputArray _mask, OutputArray _hist, St
 
     hist.setTo(Scalar::all(0), stream);
 
-    Point ofs; Size wholeSize;
-    src.locateROI(wholeSize, ofs);
     if (mask.empty())
-        hist::histogram256(src, hist.ptr<int>(), ofs.x, StreamAccessor::getStream(stream));
+        hist::histogram256(src, hist.ptr<int>(), StreamAccessor::getStream(stream));
     else
-        hist::histogram256(src, mask, hist.ptr<int>(), ofs.x, StreamAccessor::getStream(stream));
+        hist::histogram256(src, mask, hist.ptr<int>(), StreamAccessor::getStream(stream));
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -585,18 +583,16 @@ void cv::cuda::evenLevels(OutputArray _levels, int nLevels, int lowerLevel, int 
 
 namespace hist
 {
-    void histEven8u(PtrStepSzb src, int* hist, int binCount, int lowerLevel, int upperLevel, const int offsetX, cudaStream_t stream);
+    void histEven8u(PtrStepSzb src, int* hist, int binCount, int lowerLevel, int upperLevel, cudaStream_t stream);
 }
 
 namespace
 {
     void histEven8u(const GpuMat& src, GpuMat& hist, int histSize, int lowerLevel, int upperLevel, cudaStream_t stream)
     {
-        Point ofs; Size wholeSize;
-        src.locateROI(wholeSize, ofs);
         hist.create(1, histSize, CV_32S);
         cudaSafeCall( cudaMemsetAsync(hist.data, 0, histSize * sizeof(int), stream) );
-        hist::histEven8u(src, hist.ptr<int>(), histSize, lowerLevel, upperLevel, ofs.x, stream);
+        hist::histEven8u(src, hist.ptr<int>(), histSize, lowerLevel, upperLevel, stream);
     }
 }
 

--- a/modules/cudaimgproc/test/test_histogram.cpp
+++ b/modules/cudaimgproc/test/test_histogram.cpp
@@ -69,7 +69,20 @@ const hist_size_to_roi_offset_params_t hist_size_to_roi_offset_params[] =
     hist_size_to_roi_offset_params_t(Size(129,32), 2),
     hist_size_to_roi_offset_params_t(Size(129,32), 3),
     // int reads only
-    hist_size_to_roi_offset_params_t(Size(128,32), 0)
+    hist_size_to_roi_offset_params_t(Size(128,32), 0),
+    // ROI offsets past the first 4-byte word: the parent's pixels to the left of the ROI must not be counted
+    hist_size_to_roi_offset_params_t(Size(129,32), 4),
+    hist_size_to_roi_offset_params_t(Size(129,32), 5),
+    hist_size_to_roi_offset_params_t(Size(129,32), 6),
+    hist_size_to_roi_offset_params_t(Size(129,32), 7),
+    hist_size_to_roi_offset_params_t(Size(129,32), 8),
+    hist_size_to_roi_offset_params_t(Size(129,32), 9),
+    hist_size_to_roi_offset_params_t(Size(129,32), 10),
+    hist_size_to_roi_offset_params_t(Size(129,32), 11),
+    hist_size_to_roi_offset_params_t(Size(129,32), 12),
+    hist_size_to_roi_offset_params_t(Size(129,32), 13),
+    hist_size_to_roi_offset_params_t(Size(128,32), 5),
+    hist_size_to_roi_offset_params_t(Size(128,32), 8)
 };
 
 PARAM_TEST_CASE(HistEven, cv::cuda::DeviceInfo, hist_size_to_roi_offset_params_t)
@@ -210,15 +223,57 @@ CUDA_TEST_P(CalcHistWithMask, Accuracy)
     EXPECT_MAT_NEAR(hist_gold, hist, 0.0);
 }
 
+CUDA_TEST_P(CalcHistWithMask, MaskWithDifferentOffset)
+{
+    // The mask is a ROI of a wider matrix taken at its own x offset, so its rows do not become 4-byte
+    // aligned where the source rows do and it has to be read one byte at a time. The mask values are 0
+    // and 255 rather than 0 and 1 so that the top byte of each mask word is exercised as well.
+    cv::Mat src = randomMat(size, CV_8UC1);
+    const Rect roi = Rect(roiOffsetX, 0, src.cols - roiOffsetX, src.rows);
+    cv::Mat maskParent = randomMat(Size(size.width + 8, size.height), CV_8UC1, 0, 2) * 255;
+
+    GpuMat srcDevice = loadMat(src);
+    GpuMat maskParentDevice = loadMat(maskParent);
+
+    for (int maskOffsetX = 0; maskOffsetX < 8; ++maskOffsetX)
+    {
+        SCOPED_TRACE(cv::format("mask x offset %d", maskOffsetX));
+
+        const Rect maskRoi = Rect(maskOffsetX, 0, roi.width, roi.height);
+
+        cv::cuda::GpuMat hist;
+        cv::cuda::calcHist(srcDevice(roi), maskParentDevice(maskRoi), hist);
+
+        cv::Mat hist_gold;
+
+        const int hbins = 256;
+        const float hranges[] = {0.0f, 256.0f};
+        const int histSize[] = {hbins};
+        const float* ranges[] = {hranges};
+        const int channels[] = {0};
+
+        const Mat srcRoi = src(roi);
+        cv::calcHist(&srcRoi, 1, channels, maskParent(maskRoi), hist_gold, 1, histSize, ranges);
+        hist_gold = hist_gold.reshape(1, 1);
+        hist_gold.convertTo(hist_gold, CV_32S);
+
+        EXPECT_MAT_NEAR(hist_gold, hist, 0.0);
+    }
+}
+
 INSTANTIATE_TEST_CASE_P(CUDA_ImgProc, CalcHistWithMask, testing::Combine(
     ALL_DEVICES, testing::ValuesIn(hist_size_to_roi_offset_params)));
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
-// EqualizeHist
+// HistogramRowAlignment
 
-PARAM_TEST_CASE(EqualizeHist, cv::cuda::DeviceInfo, cv::Size)
+// cv::cuda::createContinuous() gives a matrix whose step equals its width, so when the width is not a
+// multiple of four its rows do not all start at the same 4-byte alignment and the position at which a
+// row can start being read as 32-bit words differs from row to row.
+PARAM_TEST_CASE(HistogramRowAlignment, cv::cuda::DeviceInfo, cv::Size)
 {
     cv::cuda::DeviceInfo devInfo;
+
     cv::Size size;
 
     virtual void SetUp()
@@ -228,21 +283,134 @@ PARAM_TEST_CASE(EqualizeHist, cv::cuda::DeviceInfo, cv::Size)
 
         cv::cuda::setDevice(devInfo.deviceID());
     }
+
+    cv::cuda::GpuMat uploadContinuous(const cv::Mat& m)
+    {
+        cv::cuda::GpuMat d;
+        cv::cuda::createContinuous(m.rows, m.cols, m.type(), d);
+        d.upload(m);
+        return d;
+    }
+};
+
+CUDA_TEST_P(HistogramRowAlignment, CalcHist)
+{
+    cv::Mat src = randomMat(size, CV_8UC1);
+
+    cv::cuda::GpuMat srcDevice = uploadContinuous(src);
+    ASSERT_EQ(static_cast<size_t>(size.width), srcDevice.step);
+
+    cv::cuda::GpuMat hist;
+    cv::cuda::calcHist(srcDevice, hist);
+
+    cv::Mat hist_gold;
+
+    const int hbins = 256;
+    const float hranges[] = {0.0f, 256.0f};
+    const int histSize[] = {hbins};
+    const float* ranges[] = {hranges};
+    const int channels[] = {0};
+
+    cv::calcHist(&src, 1, channels, cv::Mat(), hist_gold, 1, histSize, ranges);
+    hist_gold = hist_gold.reshape(1, 1);
+    hist_gold.convertTo(hist_gold, CV_32S);
+
+    EXPECT_MAT_NEAR(hist_gold, hist, 0.0);
+}
+
+CUDA_TEST_P(HistogramRowAlignment, CalcHistWithMask)
+{
+    // the source is continuous and the mask is pitched, so their steps differ modulo four and the mask
+    // cannot be read as words at the offsets at which the source is
+    cv::Mat src = randomMat(size, CV_8UC1);
+    cv::Mat mask = randomMat(size, CV_8UC1, 0, 2) * 255;
+
+    cv::cuda::GpuMat srcDevice = uploadContinuous(src);
+    ASSERT_EQ(static_cast<size_t>(size.width), srcDevice.step);
+    GpuMat maskDevice = loadMat(mask);
+
+    cv::cuda::GpuMat hist;
+    cv::cuda::calcHist(srcDevice, maskDevice, hist);
+
+    cv::Mat hist_gold;
+
+    const int hbins = 256;
+    const float hranges[] = {0.0f, 256.0f};
+    const int histSize[] = {hbins};
+    const float* ranges[] = {hranges};
+    const int channels[] = {0};
+
+    cv::calcHist(&src, 1, channels, mask, hist_gold, 1, histSize, ranges);
+    hist_gold = hist_gold.reshape(1, 1);
+    hist_gold.convertTo(hist_gold, CV_32S);
+
+    EXPECT_MAT_NEAR(hist_gold, hist, 0.0);
+}
+
+CUDA_TEST_P(HistogramRowAlignment, HistEven)
+{
+    cv::Mat src = randomMat(size, CV_8UC1);
+    int hbins = 30;
+    float hranges[] = {50.0f, 200.0f};
+
+    cv::cuda::GpuMat srcDevice = uploadContinuous(src);
+    ASSERT_EQ(static_cast<size_t>(size.width), srcDevice.step);
+
+    cv::cuda::GpuMat hist;
+    cv::cuda::histEven(srcDevice, hist, hbins, (int)hranges[0], (int)hranges[1]);
+
+    cv::Mat hist_gold;
+
+    int histSize[] = {hbins};
+    const float* ranges[] = {hranges};
+    int channels[] = {0};
+    cv::calcHist(&src, 1, channels, cv::Mat(), hist_gold, 1, histSize, ranges);
+
+    hist_gold = hist_gold.t();
+    hist_gold.convertTo(hist_gold, CV_32S);
+
+    EXPECT_MAT_NEAR(hist_gold, hist, 0.0);
+}
+
+INSTANTIATE_TEST_CASE_P(CUDA_ImgProc, HistogramRowAlignment, testing::Combine(
+    ALL_DEVICES,
+    testing::Values(cv::Size(128, 32), cv::Size(129, 32), cv::Size(130, 32), cv::Size(131, 32))));
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+// EqualizeHist
+
+PARAM_TEST_CASE(EqualizeHist, cv::cuda::DeviceInfo, cv::Size, int)
+{
+    cv::cuda::DeviceInfo devInfo;
+    cv::Size size;
+    int roiOffsetX;
+
+    virtual void SetUp()
+    {
+        devInfo = GET_PARAM(0);
+        size = GET_PARAM(1);
+        roiOffsetX = GET_PARAM(2);
+
+        cv::cuda::setDevice(devInfo.deviceID());
+    }
 };
 
 CUDA_TEST_P(EqualizeHist, Async)
 {
     cv::Mat src = randomMat(size, CV_8UC1);
+    const Rect roi = Rect(roiOffsetX, 0, src.cols - roiOffsetX, src.rows);
 
     cv::cuda::Stream stream;
 
+    cv::cuda::GpuMat srcDevice = loadMat(src);
     cv::cuda::GpuMat dst;
-    cv::cuda::equalizeHist(loadMat(src), dst, stream);
+    cv::cuda::equalizeHist(srcDevice(roi), dst, stream);
 
     stream.waitForCompletion();
 
     cv::Mat dst_gold;
-    cv::equalizeHist(src, dst_gold);
+    const Mat srcRoi = src(roi);
+    cv::equalizeHist(srcRoi, dst_gold);
 
     EXPECT_MAT_NEAR(dst_gold, dst, 0.0);
 }
@@ -250,19 +418,23 @@ CUDA_TEST_P(EqualizeHist, Async)
 CUDA_TEST_P(EqualizeHist, Accuracy)
 {
     cv::Mat src = randomMat(size, CV_8UC1);
+    const Rect roi = Rect(roiOffsetX, 0, src.cols - roiOffsetX, src.rows);
 
+    cv::cuda::GpuMat srcDevice = loadMat(src);
     cv::cuda::GpuMat dst;
-    cv::cuda::equalizeHist(loadMat(src), dst);
+    cv::cuda::equalizeHist(srcDevice(roi), dst);
 
     cv::Mat dst_gold;
-    cv::equalizeHist(src, dst_gold);
+    const Mat srcRoi = src(roi);
+    cv::equalizeHist(srcRoi, dst_gold);
 
     EXPECT_MAT_NEAR(dst_gold, dst, 0.0);
 }
 
 INSTANTIATE_TEST_CASE_P(CUDA_ImgProc, EqualizeHist, testing::Combine(
     ALL_DEVICES,
-    DIFFERENT_SIZES));
+    DIFFERENT_SIZES,
+    testing::Values(0, 1, 2, 3, 5, 8)));
 
 TEST(EqualizeHistIssue, Issue18035)
 {


### PR DESCRIPTION
`cv::cuda::calcHist()`, `cv::cuda::histEven()`, and
`cv::cuda::equalizeHist()` included pixels to the left of an ROI when
its x offset was greater than four, and threw `misaligned address` on
matrices whose rows do not all begin at the same alignment.

`histogram.cpp` passed the absolute ROI offset from `locateROI()` to the
kernels. The kernels then calculated the number of leading bytes as
`4 - offsetX`. For offsets greater than four this became negative,
causing the 32-bit reads to begin before the ROI. Existing tests covered
only offsets from zero through three.

Compute the leading-byte count directly from each row pointer:

    (4 - (rowPtr & 3)) & 3

This removes the dependency on the ROI offset and correctly handles rows
that do not share the same alignment. The unused `offsetX` argument,
its two `locateROI()` call sites, and the `fourByteAligned` template
parameter are removed.

For masked histograms, 32-bit mask reads are safe only when the mask and
source rows have matching alignment. The host checks the differences
between their data pointers and steps. If both are multiples of four,
the kernel uses word reads; otherwise, it reads the mask byte by byte.

The two paths remain separate in generated code. The word-read path is
36 SASS instructions, compared with 40 before this change, and paired
benchmarks show no measurable performance difference. Mask bytes are
assembled with unsigned arithmetic to avoid signed overflow in the top
byte.

Tests cover:

- ROI x offsets beyond the first word for `histEven`, `calcHist`, and
  masked `calcHist`
- a mask with an independent x offset
- `createContinuous()` widths 128 through 131
- ROI x offsets for `equalizeHist`

Fixes #4210.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
