### PR TITLE
cudaarithm: do not reinterpret misaligned rows in bitwise ops

### DIFF
--- a/modules/cudaarithm/src/cuda/bitwise_mat.cu
+++ b/modules/cudaarithm/src/cuda/bitwise_mat.cu
@@ -77,7 +77,14 @@ void cv::cuda::bitwise_not(InputArray _src, OutputArray _dst, InputArray _mask, 
     {
         const int bcols = (int) (src.cols * src.elemSize());
 
-        if ((bcols & 3) == 0)
+        // the wider paths reinterpret whole rows, so on top of bcols every
+        // operand needs an aligned data pointer, which a ROI offset can
+        // break, and an aligned step, which createContinuous() can break
+        const size_t align = static_cast<size_t>(bcols)
+                           | reinterpret_cast<size_t>(src.data) | src.step
+                           | reinterpret_cast<size_t>(dst.data) | dst.step;
+
+        if ((align & 3) == 0)
         {
             const int vcols = bcols >> 2;
 
@@ -86,7 +93,7 @@ void cv::cuda::bitwise_not(InputArray _src, OutputArray _dst, InputArray _mask, 
 
             gridTransformUnary(vsrc, vdst, bit_not<uint>(), stream);
         }
-        else if ((bcols & 1) == 0)
+        else if ((align & 1) == 0)
         {
             const int vcols = bcols >> 1;
 
@@ -181,7 +188,15 @@ void bitMat(const GpuMat& src1, const GpuMat& src2, GpuMat& dst, const GpuMat& m
     {
         const int bcols = (int) (src1.cols * src1.elemSize());
 
-        if ((bcols & 3) == 0)
+        // the wider paths reinterpret whole rows, so on top of bcols every
+        // operand needs an aligned data pointer, which a ROI offset can
+        // break, and an aligned step, which createContinuous() can break
+        const size_t align = static_cast<size_t>(bcols)
+                           | reinterpret_cast<size_t>(src1.data) | src1.step
+                           | reinterpret_cast<size_t>(src2.data) | src2.step
+                           | reinterpret_cast<size_t>(dst.data) | dst.step;
+
+        if ((align & 3) == 0)
         {
             const int vcols = bcols >> 2;
 
@@ -191,7 +206,7 @@ void bitMat(const GpuMat& src1, const GpuMat& src2, GpuMat& dst, const GpuMat& m
 
             funcs32[op](vsrc1, vsrc2, vdst, GpuMat(), stream);
         }
-        else if ((bcols & 1) == 0)
+        else if ((align & 1) == 0)
         {
             const int vcols = bcols >> 1;
 

--- a/modules/cudaarithm/test/test_element_operations.cpp
+++ b/modules/cudaarithm/test/test_element_operations.cpp
@@ -2073,6 +2073,152 @@ INSTANTIATE_TEST_CASE_P(CUDA_Arithm, Bitwise_Array, testing::Combine(
     TYPES(CV_8U, CV_32S, 1, 4)));
 
 //////////////////////////////////////////////////////////////////////////////
+// Bitwise_Array_Misaligned
+
+namespace
+{
+    // How the rows of an operand are made to start at an address the 32-bit
+    // and 16-bit paths may not read: MISALIGN_OFFSET shifts the first row with
+    // a ROI, MISALIGN_STEP leaves the first row aligned and shifts every later
+    // one with a step that is not a multiple of the word size.
+    enum { MISALIGN_OFFSET = 0, MISALIGN_STEP = 1 };
+
+    // Which operands are built that way. The others are whole matrices, so an
+    // alignment check that forgets one operand still meets a misaligned row.
+    enum { MISALIGN_SRC1 = 1, MISALIGN_SRC2 = 2, MISALIGN_DST = 4, MISALIGN_ALL = 7 };
+
+    IMPLEMENT_PARAM_CLASS(MisalignKind, int)
+    IMPLEMENT_PARAM_CLASS(MisalignOperands, int)
+}
+
+PARAM_TEST_CASE(Bitwise_Array_Misaligned, cv::cuda::DeviceInfo, cv::Size, MatType, MisalignKind, MisalignOperands)
+{
+    cv::cuda::DeviceInfo devInfo;
+    cv::Size size;
+    int type;
+    int kind;
+    int operands;
+
+    cv::Mat src1;
+    cv::Mat src2;
+
+    virtual void SetUp()
+    {
+        devInfo = GET_PARAM(0);
+        size = GET_PARAM(1);
+        type = GET_PARAM(2);
+        kind = GET_PARAM(3);
+        operands = GET_PARAM(4);
+
+        cv::cuda::setDevice(devInfo.deviceID());
+
+        // randomMat() saturates to the type, so the 0..INT_MAX range used by
+        // Bitwise_Array would make every 8-bit element 0xFF and the expected
+        // result independent of the data.
+        const double maxVal = CV_MAT_DEPTH(type) == CV_8U ? 256.0 : 65536.0;
+
+        src1 = randomMat(size, type, 0.0, maxVal);
+        src2 = randomMat(size, type, 0.0, maxVal);
+    }
+
+    // Both kinds depend on how GpuMat allocates, which nothing else here
+    // pins down, so check the operand really is misaligned rather than let
+    // the tests keep passing while testing nothing.
+    void checkMisaligned(const cv::cuda::GpuMat& m) const
+    {
+        if (kind == MISALIGN_OFFSET)
+            ASSERT_NE(0u, reinterpret_cast<size_t>(m.data) % 4);
+        else
+            ASSERT_NE(0u, m.step % 4);
+    }
+
+    cv::cuda::GpuMat createMisaligned(int operand) const
+    {
+        if ((operands & operand) == 0)
+            return cv::cuda::GpuMat(size, type);
+
+        if (kind == MISALIGN_OFFSET)
+        {
+            cv::cuda::GpuMat parent(size.height, size.width + 1, type);
+            cv::cuda::GpuMat m = parent(cv::Rect(1, 0, size.width, size.height));
+            checkMisaligned(m);
+            return m;
+        }
+
+        // createContinuous() sets step to cols * elemSize(), which the extra
+        // column makes odd here, so the rows are misaligned at x offset 0
+        cv::cuda::GpuMat parent;
+        cv::cuda::createContinuous(size.height, size.width + 1, type, parent);
+        cv::cuda::GpuMat m = parent(cv::Rect(0, 0, size.width, size.height));
+        checkMisaligned(m);
+        return m;
+    }
+
+    cv::cuda::GpuMat loadMisaligned(const cv::Mat& m, int operand) const
+    {
+        cv::cuda::GpuMat d_m = createMisaligned(operand);
+        d_m.upload(m);
+        return d_m;
+    }
+};
+
+CUDA_TEST_P(Bitwise_Array_Misaligned, Not)
+{
+    cv::cuda::GpuMat dst = createMisaligned(MISALIGN_DST);
+    // bitwise_not has one source, so either source bit selects it
+    cv::cuda::bitwise_not(loadMisaligned(src1, MISALIGN_SRC1 | MISALIGN_SRC2), dst);
+
+    cv::Mat dst_gold = ~src1;
+
+    EXPECT_MAT_NEAR(dst_gold, dst, 0.0);
+}
+
+CUDA_TEST_P(Bitwise_Array_Misaligned, Or)
+{
+    cv::cuda::GpuMat dst = createMisaligned(MISALIGN_DST);
+    cv::cuda::bitwise_or(loadMisaligned(src1, MISALIGN_SRC1), loadMisaligned(src2, MISALIGN_SRC2), dst);
+
+    cv::Mat dst_gold = src1 | src2;
+
+    EXPECT_MAT_NEAR(dst_gold, dst, 0.0);
+}
+
+CUDA_TEST_P(Bitwise_Array_Misaligned, And)
+{
+    cv::cuda::GpuMat dst = createMisaligned(MISALIGN_DST);
+    cv::cuda::bitwise_and(loadMisaligned(src1, MISALIGN_SRC1), loadMisaligned(src2, MISALIGN_SRC2), dst);
+
+    cv::Mat dst_gold = src1 & src2;
+
+    EXPECT_MAT_NEAR(dst_gold, dst, 0.0);
+}
+
+CUDA_TEST_P(Bitwise_Array_Misaligned, Xor)
+{
+    cv::cuda::GpuMat dst = createMisaligned(MISALIGN_DST);
+    cv::cuda::bitwise_xor(loadMisaligned(src1, MISALIGN_SRC1), loadMisaligned(src2, MISALIGN_SRC2), dst);
+
+    cv::Mat dst_gold = src1 ^ src2;
+
+    EXPECT_MAT_NEAR(dst_gold, dst, 0.0);
+}
+
+INSTANTIATE_TEST_CASE_P(CUDA_Arithm, Bitwise_Array_Misaligned, testing::Combine(
+    ALL_DEVICES,
+    // 128 columns make the row width in bytes a multiple of 4 for every type
+    // below; 114 makes it a multiple of 2 only for the 8-bit types, so both
+    // the 32-bit and the 16-bit path are entered; DIFFERENT_SIZES uses 113,
+    // where the width in bytes is odd for CV_8U and the byte path is taken
+    // whatever the addresses are
+    testing::Values(cv::Size(128, 128), cv::Size(114, 114)),
+    // an element is 1, 3 and 2 bytes wide, so a one element offset covers all
+    // three misaligned remainders modulo 4
+    testing::Values(MatType(CV_8UC1), MatType(CV_8UC3), MatType(CV_16UC1)),
+    testing::Values(MisalignKind(MISALIGN_OFFSET), MisalignKind(MISALIGN_STEP)),
+    testing::Values(MisalignOperands(MISALIGN_SRC1), MisalignOperands(MISALIGN_SRC2),
+                    MisalignOperands(MISALIGN_DST), MisalignOperands(MISALIGN_ALL))));
+
+//////////////////////////////////////////////////////////////////////////////
 // Bitwise_Scalar
 
 PARAM_TEST_CASE(Bitwise_Scalar, cv::cuda::DeviceInfo, cv::Size, MatDepth, Channels)


### PR DESCRIPTION
`cv::cuda::bitwise_and`, `bitwise_or`, `bitwise_xor` and `bitwise_not` without a
mask choose a 32-bit or a 16-bit word path from the row width in bytes alone,
without looking at the data pointers or at the steps. Two kinds of ordinary
matrix break that.

A ROI whose x offset is not a multiple of the word size misaligns every row;
that is the reported case. And a matrix from `cv::cuda::createContinuous()` has
`step = cols * elemSize()`, which need not be a multiple of the word size
either, so rows after the first can be misaligned even at x offset 0:
`createContinuous(8, 17, CV_8UC1)` gives step 17 and crashes today with no ROI
involved. Both end in a `misaligned address` CUDA error that is sticky: it also
breaks every later CUDA call in the process, so one fault can turn a whole test
run red.

Take a word path only when the row width and the data pointer and step of every
operand are aligned to that word size, and fall back to the 16-bit path, or to
the byte path when even that does not hold. This is the check
`cudev::TransformDispatcher` makes on data and step before it vectorises
(`modules/cudev/include/opencv2/cudev/grid/detail/transform.hpp`). Its own
fallback does not help here, because that fallback still dereferences the type
the caller reinterpreted the row as, which is why the fault surfaces inside
`TransformDispatcher<false>` rather than at the call site. Inputs whose pointers
and steps are already aligned keep the path they had.

`Bitwise_Array_Misaligned` covers the four operations on CV_8UC1, CV_8UC3 and
CV_16UC1, with the misalignment coming either from a one-element ROI x offset or
from a `createContinuous()` step, applied to `src1`, to `src2`, to the
destination, or to all three, so that a check which misses one operand is not
enough. 192 instances, all 192 of which fail without the change.

One thing worth knowing before reading a CI result. `opencv_test_cudaarithm`
shares a single `cv::theRNG()` stream across the whole process (`CUDA_TEST_P`
does not call `cvtest::testSetUp()`, so `--test_seed` does not move it), and a
few `CUDA_Arithm` tests compare a GPU result against a CPU one on random data
that can land on a tie. Adding any test that draws from that stream shifts where
those tests sample it. On an unmodified library, with no change to
`bitwise_mat.cu` and no test added to it, a throwaway test that consumes 47
bytes of random data is enough to turn the suite red on
`CUDA_Arithm/ThresholdOtsu.Accuracy/8`; 4 of the first 100 draw offsets I tried
do it, and `CUDA_Arithm/PolarToCart.Accuracy` is sensitive in the same way. The
suite is green here with this patch and its tests, but if you see either of
those fail on this PR, it is that pre-existing sensitivity and not this change.
I am happy to hand over the reproducer.

Fixes #4211

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
